### PR TITLE
Fix triples factor splitting bug

### DIFF
--- a/notebooks/learn_from_bel/Learning from BEL.ipynb
+++ b/notebooks/learn_from_bel/Learning from BEL.ipynb
@@ -1,0 +1,1847 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Learning from BEL\n",
+    "\n",
+    "This notebook is about learning from BEL graphs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "import sys\n",
+    "import time\n",
+    "\n",
+    "import numpy as np\n",
+    "import pykeen\n",
+    "from pykeen.pipeline import pipeline\n",
+    "from pykeen.triples.leakage import Sealant\n",
+    "from pykeen.triples import TriplesFactory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.8.3 (default, May 27 2020, 20:54:22) \n",
+      "[Clang 11.0.3 (clang-1103.0.32.59)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sys.version)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fri Jul  3 01:04:22 2020\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(time.asctime())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cthoyt\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(getpass.getuser())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.0.2-dev-62325ee4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(pykeen.get_version(with_git_hash=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ras_triples_path = 'ras_machine_triples.tsv'\n",
+    "missing_ras_triples = not os.path.exists(ras_triples_path)\n",
+    "missing_ras_triples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if missing_ras_triples:\n",
+    "    import pybel\n",
+    "    print(pybel.get_version(with_git_hash=True))\n",
+    "    graph = pybel.from_emmaa('rasmachine')\n",
+    "    graph.summarize()\n",
+    "    triples = pybel.to_triples(graph)\n",
+    "    np.savetxt(ras_triples_path, triples, fmt='%s', delimiter='\\t')\n",
+    "else:\n",
+    "    triples = np.loadtxt(ras_triples_path, dtype=str, delimiter='\\t')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf = TriplesFactory(triples=triples)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training, testing = tf.split(random_state=1234)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b858aabb16f94fe6bca924337deadc9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training epochs on cpu', style=ProgressStyle(description_…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pykeen.training.training_loop:using stopper: <pykeen.stoppers.stopper.NopStopper object at 0x1473aec10>\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Training batches on cpu', max=26.0, style=ProgressStyle(d…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pykeen.evaluation.evaluator:Starting batch_size search for evaluation now...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pykeen.evaluation.evaluator:Concluded batch_size search with batch_size=2048.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e7c1831e3a144a24b25a836e7c7fb661",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, description='Evaluating on cpu', max=1173.0, style=ProgressStyle(descr…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:pykeen.evaluation.evaluator:Evaluation took 79.32s seconds\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = pipeline(\n",
+    "    training_triples_factory=training,\n",
+    "    testing_triples_factory=testing,\n",
+    "    model='RotatE',\n",
+    "    training_kwargs=dict(num_epochs=100),\n",
+    "    random_seed=1235,\n",
+    "    device='cpu',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Type</th>\n",
+       "      <th>Metric</th>\n",
+       "      <th>Value</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>avg</td>\n",
+       "      <td>adjusted_mean_rank</td>\n",
+       "      <td>0.533801</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>worst</td>\n",
+       "      <td>mean_rank</td>\n",
+       "      <td>1079.968031</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>worst</td>\n",
+       "      <td>mean_reciprocal_rank</td>\n",
+       "      <td>0.035180</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>worst</td>\n",
+       "      <td>hits_at_1</td>\n",
+       "      <td>0.011935</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>worst</td>\n",
+       "      <td>hits_at_3</td>\n",
+       "      <td>0.025575</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>worst</td>\n",
+       "      <td>hits_at_5</td>\n",
+       "      <td>0.040494</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>worst</td>\n",
+       "      <td>hits_at_10</td>\n",
+       "      <td>0.061381</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>avg</td>\n",
+       "      <td>mean_rank</td>\n",
+       "      <td>1079.967391</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>avg</td>\n",
+       "      <td>mean_reciprocal_rank</td>\n",
+       "      <td>0.035180</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>avg</td>\n",
+       "      <td>hits_at_1</td>\n",
+       "      <td>0.011935</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>avg</td>\n",
+       "      <td>hits_at_3</td>\n",
+       "      <td>0.025575</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>avg</td>\n",
+       "      <td>hits_at_5</td>\n",
+       "      <td>0.040494</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>avg</td>\n",
+       "      <td>hits_at_10</td>\n",
+       "      <td>0.061381</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>best</td>\n",
+       "      <td>mean_rank</td>\n",
+       "      <td>1079.966752</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>best</td>\n",
+       "      <td>mean_reciprocal_rank</td>\n",
+       "      <td>0.035180</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>best</td>\n",
+       "      <td>hits_at_1</td>\n",
+       "      <td>0.011935</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>best</td>\n",
+       "      <td>hits_at_3</td>\n",
+       "      <td>0.025575</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>best</td>\n",
+       "      <td>hits_at_5</td>\n",
+       "      <td>0.040494</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>best</td>\n",
+       "      <td>hits_at_10</td>\n",
+       "      <td>0.061381</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     Type                Metric        Value\n",
+       "0     avg    adjusted_mean_rank     0.533801\n",
+       "1   worst             mean_rank  1079.968031\n",
+       "2   worst  mean_reciprocal_rank     0.035180\n",
+       "3   worst             hits_at_1     0.011935\n",
+       "4   worst             hits_at_3     0.025575\n",
+       "5   worst             hits_at_5     0.040494\n",
+       "6   worst            hits_at_10     0.061381\n",
+       "7     avg             mean_rank  1079.967391\n",
+       "8     avg  mean_reciprocal_rank     0.035180\n",
+       "9     avg             hits_at_1     0.011935\n",
+       "10    avg             hits_at_3     0.025575\n",
+       "11    avg             hits_at_5     0.040494\n",
+       "12    avg            hits_at_10     0.061381\n",
+       "13   best             mean_rank  1079.966752\n",
+       "14   best  mean_reciprocal_rank     0.035180\n",
+       "15   best             hits_at_1     0.011935\n",
+       "16   best             hits_at_3     0.025575\n",
+       "17   best             hits_at_5     0.040494\n",
+       "18   best            hits_at_10     0.061381"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results.metric_results.to_df()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/learn_from_bel/ras_machine_triples.tsv
+++ b/notebooks/learn_from_bel/ras_machine_triples.tsv
@@ -1,0 +1,7747 @@
+CHEBI:101355	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:101355	activityNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:101355	partOf	complex(a(CHEBI:101355 ! "IPA-3"), p(HGNC:8590 ! PAK1))
+CHEBI:104872	activityPositivelyRegulatesActivityOf	HGNC:3064
+CHEBI:114785	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:114785	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:114785	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:114785	partOf	complex(a(CHEBI:114785 ! erlotinib), p(HGNC:3236 ! EGFR))
+CHEBI:124914	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:124914	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:124914	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:124914	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:124930	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:125628	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:125628	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:125628	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:125628	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:125628	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:125628	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:131173	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:131173	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:133818	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:133818	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:133818	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:143127	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:143127	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:143127	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1577
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8591
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9378
+CHEBI:15738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+CHEBI:15996	partOf	complex(a(CHEBI:15996 ! GTP), p(HGNC:10011 ! RHEB))
+CHEBI:15996	partOf	complex(a(CHEBI:15996 ! GTP), p(HGNC:6407 ! KRAS))
+CHEBI:15996	partOf	complex(a(CHEBI:15996 ! GTP), p(HGNC:667 ! RHOA))
+CHEBI:15996	partOf	complex(a(CHEBI:15996 ! GTP), p(HGNC:9801 ! RAC1))
+CHEBI:16243	partOf	complex(a(CHEBI:16243 ! quercetin), p(HGNC:3236 ! EGFR))
+CHEBI:17303	activityPositivelyRegulatesActivityOf	HGNC:667
+CHEBI:17552	partOf	complex(a(CHEBI:17552 ! GDP), p(HGNC:6407 ! KRAS))
+CHEBI:207229	activityNegativelyRegulatesActivityOf	HGNC:9840
+CHEBI:26523	activityNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:26523	activityNegativelyRegulatesActivityOf	HGNC:1725
+CHEBI:26523	activityNegativelyRegulatesActivityOf	HGNC:3064
+CHEBI:26523	activityNegativelyRegulatesActivityOf	HGNC:9281
+CHEBI:26523	activityNegativelyRegulatesActivityOf	HGNC:9644
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:10436
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:1508
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:1509
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:16262
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:3489
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:7553
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:9588
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:9644
+CHEBI:26523	activityPositivelyRegulatesActivityOf	HGNC:9801
+CHEBI:26523	increasesAmountOf	HGNC:11805
+CHEBI:26523	increasesAmountOf	HGNC:6204
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:11389 ! STK11))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:11998 ! TP53))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:1504 ! CASP3))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:3236 ! EGFR))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:3942 ! MTOR))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:6407 ! KRAS))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:7029 ! MET))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:7782 ! NFE2L2))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:7889 ! NOX1))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:7989 ! NRAS))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:9588 ! PTEN))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:9801 ! RAC1))
+CHEBI:26523	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:9802 ! RAC2))
+CHEBI:27899	partOf	complex(a(CHEBI:27899 ! cisplatin), p(HGNC:6973 ! MDM2))
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:11998
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:12003
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:1504
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:1509
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:16262
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:1784
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:391
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:6871
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:7553
+CHEBI:28748	activityPositivelyRegulatesActivityOf	HGNC:9801
+CHEBI:28748	increasesAmountOf	p(HGNC:11998 ! TP53, pmod(Ac))
+CHEBI:28748	increasesAmountOf	p(HGNC:9824 ! RAD52, pmod(Ac))
+CHEBI:28748	partOf	complex(a(CHEBI:28748 ! doxorubicin), p(HGNC:11998 ! TP53))
+CHEBI:28748	partOf	complex(a(CHEBI:28748 ! doxorubicin), p(HGNC:1504 ! CASP3))
+CHEBI:28748	partOf	complex(a(CHEBI:28748 ! doxorubicin), p(HGNC:3430 ! ERBB2))
+CHEBI:28748	partOf	complex(a(CHEBI:28748 ! doxorubicin), p(HGNC:7782 ! NFE2L2))
+CHEBI:31521	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12441
+CHEBI:33699	activityNegativelyRegulatesActivityOf	HGNC:7553
+CHEBI:35472	activityPositivelyRegulatesActivityOf	HGNC:3064
+CHEBI:3815	activityNegativelyRegulatesActivityOf	HGNC:9801
+CHEBI:38912	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:38912	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:39112	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:3962	activityPositivelyRegulatesActivityOf	HGNC:11998
+CHEBI:44185	activityDirectlyNegativelyRegulatesActivityOf	HGNC:2861
+CHEBI:44185	partOf	complex(a(CHEBI:44185 ! methotrexate), p(HGNC:2861 ! DHFR))
+CHEBI:45307	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1577
+CHEBI:45307	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+CHEBI:45307	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:45713	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:45783	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:45783	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:46345	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12441
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1577
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1583
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1585
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+CHEBI:47344	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:47600	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1577
+CHEBI:47600	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+CHEBI:47600	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+CHEBI:47600	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:47600	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:47600	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:49375	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:49375	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:49375	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:49375	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:49375	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:49375	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:49603	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:49603	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:49603	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:49603	partOf	complex(a(CHEBI:49603 ! lapatinib), p(HGNC:3236 ! EGFR))
+CHEBI:49603	partOf	complex(a(CHEBI:49603 ! lapatinib), p(HGNC:3430 ! ERBB2))
+CHEBI:49668	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:49668	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:49668	partOf	complex(a(CHEBI:49668 ! gefitinib), p(HGNC:3236 ! EGFR))
+CHEBI:49960	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:49960	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:49960	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:49960	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:49960	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:49960	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:49960	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:50924	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:50924	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:50924	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:50924	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:50924	partOf	complex(a(CHEBI:50924 ! sorafenib), p(HGNC:1097 ! BRAF))
+CHEBI:51098	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:51098	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:51098	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:51098	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+CHEBI:51913	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:52172	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:52172	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:52717	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7794
+CHEBI:61115	increasesAmountOf	p(HGNC:3113 ! E2F1, pmod(Ac))
+CHEBI:61390	partOf	complex(a(CHEBI:61390 ! afatinib), p(HGNC:3236 ! EGFR))
+CHEBI:61390	partOf	complex(a(CHEBI:61390 ! afatinib), p(HGNC:3430 ! ERBB2))
+CHEBI:61399	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:61399	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:61400	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:61400	partOf	complex(a(CHEBI:61400 ! WZ4002), p(HGNC:3236 ! EGFR))
+CHEBI:62166	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:63448	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:63448	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:63448	partOf	complex(a(CHEBI:63448 ! PD173074), p(HGNC:3690 ! FGFR3))
+CHEBI:63450	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:63450	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:63451	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:63451	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:63451	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:63453	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:63453	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:63453	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:63453	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:63453	partOf	complex(a(CHEBI:63453 ! AZD4547), p(HGNC:3688 ! FGFR1, var("p.Val561Met")))
+CHEBI:63453	partOf	complex(a(CHEBI:63453 ! AZD4547), p(HGNC:3690 ! FGFR3))
+CHEBI:63616	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12441
+CHEBI:63616	activityDirectlyNegativelyRegulatesActivityOf	HGNC:2861
+CHEBI:63637	activityDirectlyNegativelyRegulatesActivityOf	HGNC:646
+CHEBI:63637	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:63637	partOf	complex(a(CHEBI:63637 ! vemurafenib), p(HGNC:1097 ! BRAF))
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:64310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:64310	partOf	complex(a(CHEBI:64310 ! crizotinib), p(HGNC:427 ! ALK))
+CHEBI:65310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:65310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:65310	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+CHEBI:65326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:65326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:65326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:65326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:65326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:65326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:65329	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:65329	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:65329	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:66910	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:66910	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:66910	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:66910	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:66910	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:66910	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:66919	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:66919	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:66919	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:66919	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:66919	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:67271	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:67271	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:67271	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+CHEBI:68647	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:68647	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:68647	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:68647	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:71200	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:71200	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:71200	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:71200	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:71219	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:71219	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:71219	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:71219	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:71219	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:71219	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:71219	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:71219	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:71952	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:71952	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:71952	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:71952	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:71952	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:71952	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:71952	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8979
+CHEBI:71954	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:71954	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:71954	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:71955	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:71955	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:71955	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:71955	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:71958	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:71958	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:71958	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:71958	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:72317	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:72317	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:72317	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:75045	activityDirectlyNegativelyRegulatesActivityOf	HGNC:646
+CHEBI:75045	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:75045	partOf	complex(a(CHEBI:75045 ! dabrafenib), p(HGNC:1097 ! BRAF))
+CHEBI:75404	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:75998	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:75998	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:77954	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:77954	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:78031	activityPositivelyRegulatesActivityOf	HGNC:1582
+CHEBI:78031	activityPositivelyRegulatesActivityOf	HGNC:7553
+CHEBI:78432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:78432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:78432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:78432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:78432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:78432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9378
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9385
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9386
+CHEBI:78510	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9387
+CHEBI:78543	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:78543	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:78543	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:78543	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:78543	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:78543	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:78543	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:78543	partOf	complex(a(CHEBI:78543 ! ponatinib), p(HGNC:3688 ! FGFR1))
+CHEBI:78543	partOf	complex(a(CHEBI:78543 ! ponatinib), p(HGNC:3691 ! FGFR4))
+CHEBI:80961	partOf	complex(a(CHEBI:80961 ! "5-formyluracil"), p(HGNC:12441 ! TYMS))
+CHEBI:80961	partOf	complex(a(CHEBI:80961 ! "5-formyluracil"), p(HGNC:9839 ! RALA))
+CHEBI:82701	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:82701	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:82701	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:82708	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:82708	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10437
+CHEBI:82708	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:82708	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:82708	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+CHEBI:83620	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3785
+CHEBI:84327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:84327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:84327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:84327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:84327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:84327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8979
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1583
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1585
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:85993	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:86007	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:88249	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:88249	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:88339	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:90217	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:90217	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:90217	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:90217	partOf	complex(a(CHEBI:90217 ! quizartinib), p(HGNC:3765 ! FLT3))
+CHEBI:90227	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:90227	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:90295	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:90295	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:90295	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:90295	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:90524	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:90524	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:90524	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:90524	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:90524	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8979
+CHEBI:90524	partOf	complex(a(CHEBI:90524 ! "PI-103"), p(HGNC:8975 ! PIK3CA))
+CHEBI:90531	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:90531	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:90531	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:90531	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:90545	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:90545	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:90545	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:90545	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:90624	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:90682	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:90682	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:90682	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:90682	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:90682	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8979
+CHEBI:90693	activityNegativelyRegulatesActivityOf	HGNC:7553
+CHEBI:90705	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:90705	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:90705	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:90705	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:90943	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:90943	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:90943	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91324	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:91324	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91324	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91325	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91325	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1577
+CHEBI:91326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+CHEBI:91326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+CHEBI:91326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1585
+CHEBI:91326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+CHEBI:91327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91328	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91328	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91328	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91328	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91328	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91328	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91328	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91328	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91329	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:91331	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91331	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91332	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91332	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91332	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91333	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91333	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:91333	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91334	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91334	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91334	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91335	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91335	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91335	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91335	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91335	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91335	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91335	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:91335	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8591
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91336	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91338	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91339	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91339	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:91341	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:91346	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:91346	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:91347	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8591
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91348	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:91351	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91351	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:91351	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:91351	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+CHEBI:91353	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91353	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91354	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:91354	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91354	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91354	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:91355	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:91356	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:91356	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:91356	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:91357	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91357	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91357	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91357	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:91358	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91358	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+CHEBI:91359	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:91359	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:91359	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:91360	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91361	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:91361	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:91361	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:91362	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91363	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:91364	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:91367	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91367	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91368	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:91368	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91368	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:91368	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91371	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1577
+CHEBI:91371	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+CHEBI:91371	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+CHEBI:91371	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91371	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91373	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:91374	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:91374	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:91376	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91376	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91376	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91376	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91376	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91378	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91379	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91383	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+CHEBI:91383	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+CHEBI:91386	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91387	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91387	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91387	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91387	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91387	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91387	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9378
+CHEBI:91387	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+CHEBI:91389	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91390	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91390	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91393	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91394	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91394	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91394	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91394	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91394	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91394	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91395	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91396	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91396	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91396	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:91396	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:91396	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:91396	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+CHEBI:91396	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:91396	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8591
+CHEBI:91397	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91397	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91397	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91397	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91397	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91399	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+CHEBI:91399	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1583
+CHEBI:91399	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1585
+CHEBI:91399	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91399	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91401	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91402	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91402	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9378
+CHEBI:91403	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91408	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91409	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91409	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91409	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91411	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:91412	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91412	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91413	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91418	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91419	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+CHEBI:91419	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1585
+CHEBI:91419	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91419	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91420	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91420	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91420	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91420	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91421	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1577
+CHEBI:91421	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+CHEBI:91421	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91424	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91424	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91425	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91426	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91426	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91426	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91426	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91426	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91426	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91426	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91427	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+CHEBI:91428	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:91429	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:91429	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91429	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9378
+CHEBI:91430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+CHEBI:91431	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91431	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91431	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91431	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91431	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91431	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9378
+CHEBI:91431	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+CHEBI:91432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:91432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91432	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91433	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91433	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:91434	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:91434	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:91435	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91435	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91435	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91435	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91438	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91438	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91438	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91439	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91439	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91441	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91443	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91449	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:91450	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:91451	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:91451	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91451	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91452	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91454	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91456	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91457	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91457	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:91457	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91457	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91457	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91457	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91457	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91459	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91459	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91459	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91459	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91459	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91459	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9378
+CHEBI:91459	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+CHEBI:91463	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91463	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91464	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:91465	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:91466	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91466	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91467	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8591
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:91471	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:9168	partOf	complex(a(CHEBI:9168 ! sirolimus), p(HGNC:3942 ! MTOR))
+CHEBI:92053	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9378
+CHEBI:92257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+CHEBI:93751	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16059
+CHEBI:93751	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+CHEBI:93751	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8591
+CHEBI:93751	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+CHEBI:93752	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:93752	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:93752	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:93753	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:93753	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:93753	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:93753	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:93754	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:93758	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:93758	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:93765	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+CHEBI:93768	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:93768	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+CHEBI:93768	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+CHEBI:93768	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:93768	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:93768	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:93773	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+CHEBI:93773	activityDirectlyNegativelyRegulatesActivityOf	HGNC:646
+CHEBI:93773	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+CHEBI:93784	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:94486	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:94486	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:94664	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:94664	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:94698	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:94698	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:94782	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:94782	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:94782	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+CHEBI:94782	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+CHEBI:94782	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:94782	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+CHEBI:94782	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+CHEBI:94782	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:94800	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:95049	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:95049	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+CHEBI:95058	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:95058	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+CHEBI:95058	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:95060	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:95061	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:95064	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9644
+CHEBI:95088	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+CHEBI:95088	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+CHEBI:95089	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+CHEBI:95089	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+CHEBI:95089	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6093
+CHEBI:95092	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+CHEBI:95093	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:95093	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+CHEBI:95093	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+CHEBI:95093	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+CHEBI:95096	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+CHEBI:95096	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+CHEBI:95098	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:95099	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+CHEBI:95340	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+CHEBI:95341	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+CHEBI:95341	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+FPLX:"AMPK_alpha"	hasVariant	p(FPLX:"AMPK_alpha" ! "AMPK_alpha", pmod(Ph))
+FPLX:"CAMK2_complex"	partOf	complex(p(FPLX:"CAMK2_complex" ! "CAMK2_complex"), p(HGNC:11805 ! TIAM1))
+FPLX:"CAMK2_complex"	partOf	complex(p(FPLX:"CAMK2_complex" ! "CAMK2_complex"), p(HGNC:8988 ! PIN1))
+FPLX:"Cyclin_A"	activityPositivelyRegulatesActivityOf	HGNC:1725
+FPLX:"Cyclin_A"	activityPositivelyRegulatesActivityOf	HGNC:6871
+FPLX:"Cyclin_A"	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2))
+FPLX:"Cyclin_A"	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1582 ! CCND1))
+FPLX:"Cyclin_A"	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1744 ! CDC6), p(HGNC:1771 ! CDK2))
+FPLX:"Cyclin_A"	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:1771 ! CDK2))
+FPLX:"Cyclin_A"	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))
+FPLX:"Cyclin_A"	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:3113 ! E2F1))
+FPLX:"Cyclin_A"	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:9884 ! RB1))
+FPLX:"Cyclin_A"	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:6950 ! MCM7))
+FPLX:"Cyclin_E"	partOf	complex(p(FPLX:"Cyclin_E" ! "Cyclin_E"), p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+FPLX:"Cyclin_E"	partOf	complex(p(FPLX:"Cyclin_E" ! "Cyclin_E"), p(HGNC:1771 ! CDK2))
+FPLX:"FOS_family"	activityPositivelyRegulatesActivityOf	HGNC:3796
+FPLX:"FOS_family"	partOf	complex(p(FPLX:"FOS_family" ! "FOS_family"), p(HGNC:3321 ! ELK1), p(HGNC:3321 ! ELK1))
+FPLX:"JUN_family"	partOf	complex(p(FPLX:"JUN_family" ! "JUN_family"), p(HGNC:1583 ! CCND2))
+FPLX:"JUN_family"	partOf	complex(p(FPLX:"JUN_family" ! "JUN_family"), p(HGNC:3064 ! DUSP1))
+FPLX:"RNApo_II"	partOf	complex(p(FPLX:"RNApo_II" ! "RNApo_II"), p(HGNC:1784 ! CDKN1A))
+FPLX:"p14_3_3"	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:11998 ! TP53))
+FPLX:"p14_3_3"	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:16262 ! YAP1))
+FPLX:"p14_3_3"	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:25550 ! RMDN3), p(HGNC:9829 ! RAF1))
+FPLX:"p14_3_3"	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:9801 ! RAC1))
+FPLX:"p53_family"	partOf	complex(p(FPLX:"p53_family" ! "p53_family"), p(HGNC:11998 ! TP53), p(HGNC:21270 ! GRWD1))
+FPLX:AKT	hasVariant	p(FPLX:AKT ! AKT, pmod(Ph))
+FPLX:AKT	hasVariant	p(FPLX:AKT ! AKT, pmod(Ph, Thr, 308))
+FPLX:AKT	partOf	complex(p(FPLX:AKT ! AKT), p(FPLX:PI3K ! PI3K), p(HGNC:3942 ! MTOR))
+FPLX:AKT	partOf	complex(p(FPLX:AKT ! AKT), p(FPLX:PI3K ! PI3K), p(HGNC:9588 ! PTEN))
+FPLX:AKT	partOf	complex(p(FPLX:AKT ! AKT), p(HGNC:3430 ! ERBB2))
+FPLX:AKT	partOf	complex(p(FPLX:AKT ! AKT), p(HGNC:7029 ! MET))
+FPLX:AKT	partOf	complex(p(FPLX:AKT ! AKT), p(HGNC:7553 ! MYC))
+FPLX:AMPK	partOf	complex(p(FPLX:AMPK ! AMPK), p(HGNC:392 ! AKT2))
+FPLX:AMPK	partOf	complex(p(FPLX:AMPK ! AMPK), p(HGNC:7782 ! NFE2L2))
+FPLX:AMPK	partOf	complex(p(FPLX:AMPK ! AMPK), p(HGNC:9588 ! PTEN))
+FPLX:AP1	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:11998 ! TP53), p(HGNC:6204 ! JUN))
+FPLX:AP1	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+FPLX:AP1	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN), p(HGNC:6204 ! JUN))
+FPLX:AP1	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:9802 ! RAC2))
+FPLX:C1	partOf	complex(p(FPLX:C1 ! C1), p(HGNC:3942 ! MTOR))
+FPLX:CDC25	hasVariant	p(FPLX:CDC25 ! CDC25, pmod(Ph))
+FPLX:CDC25	partOf	complex(p(FPLX:CDC25 ! CDC25), p(HGNC:11187 ! SOS1))
+FPLX:CDC25	partOf	complex(p(FPLX:CDC25 ! CDC25), p(HGNC:11998 ! TP53))
+FPLX:CDK	partOf	complex(p(FPLX:CDK ! CDK), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+FPLX:CDKN2	partOf	complex(p(FPLX:CDKN2 ! CDKN2), p(HGNC:1773 ! CDK4))
+FPLX:CREB	hasVariant	p(FPLX:CREB ! CREB, pmod(Ph))
+FPLX:E2F	activityPositivelyRegulatesActivityOf	HGNC:8988
+FPLX:E2F	partOf	complex(p(FPLX:E2F ! E2F), p(FPLX:E2F ! E2F), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+FPLX:E2F	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:11998 ! TP53), p(HGNC:9884 ! RB1))
+FPLX:E2F	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:1773 ! CDK4))
+FPLX:E2F	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:2861 ! DHFR))
+FPLX:E2F	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:3113 ! E2F1), p(HGNC:3113 ! E2F1))
+FPLX:E2F	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+FPLX:E2F	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+FPLX:ERK	hasVariant	p(FPLX:ERK ! ERK, pmod(Ph))
+FPLX:ERK	partOf	complex(p(FPLX:ERK ! ERK), p(HGNC:9801 ! RAC1))
+FPLX:ETS	partOf	complex(p(FPLX:ETS ! ETS), p(FPLX:ETS ! ETS), p(HGNC:7553 ! MYC))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:10011 ! RHEB))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:12362 ! TSC1))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:12363 ! TSC2))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:1784 ! CDKN1A))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:3236 ! EGFR))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:4566 ! GRB2))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:5173 ! HRAS))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:6091 ! INSR))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:6407 ! KRAS))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:667 ! RHOA))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:9801 ! RAC1))
+FPLX:GAP	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:9839 ! RALA))
+FPLX:GEF	activityPositivelyRegulatesActivityOf	HGNC:667
+FPLX:GEF	partOf	complex(p(FPLX:GEF ! GEF), p(HGNC:9801 ! RAC1))
+FPLX:GST	partOf	complex(p(FPLX:GST ! GST), p(HGNC:7029 ! MET))
+FPLX:GTPase	activityNegativelyRegulatesActivityOf	HGNC:667
+FPLX:HDAC	partOf	complex(p(FPLX:HDAC ! HDAC), p(HGNC:9588 ! PTEN))
+FPLX:HSP90	partOf	complex(p(FPLX:HSP90 ! HSP90), p(HGNC:11998 ! TP53))
+FPLX:HSPA	partOf	complex(p(FPLX:HSPA ! HSPA), p(HGNC:11998 ! TP53))
+FPLX:HSPA	partOf	complex(p(FPLX:HSPA ! HSPA), p(HGNC:391 ! AKT1))
+FPLX:Integrins	partOf	complex(p(FPLX:Integrins ! Integrins), p(HGNC:3236 ! EGFR))
+FPLX:Interferon	partOf	complex(p(FPLX:Interferon ! Interferon), p(HGNC:11584 ! TBK1))
+FPLX:KSR	partOf	complex(p(FPLX:KSR ! KSR), p(HGNC:3942 ! MTOR))
+FPLX:KSR	partOf	complex(p(FPLX:KSR ! KSR), p(HGNC:6871 ! MAPK1))
+FPLX:MAPK	partOf	complex(p(FPLX:MAPK ! MAPK), p(HGNC:3942 ! MTOR))
+FPLX:NFkappaB	hasVariant	p(FPLX:NFkappaB ! NFkappaB, pmod(Ph))
+FPLX:NFkappaB	hasVariant	p(FPLX:NFkappaB ! NFkappaB, pmod(Ph, Ser, 276))
+FPLX:NFkappaB	partOf	complex(p(FPLX:NFkappaB ! NFkappaB), p(HGNC:7553 ! MYC))
+FPLX:NFkappaB	partOf	complex(p(FPLX:NFkappaB ! NFkappaB), p(HGNC:7782 ! NFE2L2))
+FPLX:Notch	partOf	complex(p(FPLX:Notch ! Notch), p(HGNC:3942 ! MTOR))
+FPLX:PDGFR	activityPositivelyRegulatesActivityOf	HGNC:391
+FPLX:PDGFR	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+FPLX:PDGFR	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET))
+FPLX:PDGFR	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:3765 ! FLT3))
+FPLX:PDGFR	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:646 ! ARAF))
+FPLX:PDH	hasVariant	p(FPLX:PDH ! PDH, pmod(Ph))
+FPLX:PI3K	activityPositivelyRegulatesActivityOf	HGNC:6091
+FPLX:PI3K	partOf	complex(p(FPLX:AKT ! AKT), p(FPLX:PI3K ! PI3K), p(HGNC:3942 ! MTOR))
+FPLX:PI3K	partOf	complex(p(FPLX:AKT ! AKT), p(FPLX:PI3K ! PI3K), p(HGNC:9588 ! PTEN))
+FPLX:PI3K	partOf	complex(p(FPLX:PI3K ! PI3K), p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+FPLX:RAS	partOf	complex(p(FPLX:RAS ! RAS), p(HGNC:9840 ! RALB))
+FPLX:RAS	partOf	complex(p(FPLX:RAS ! RAS), p(HGNC:9878 ! RASGRP1))
+FPLX:ROCK	partOf	complex(p(FPLX:ROCK ! ROCK), p(HGNC:1784 ! CDKN1A))
+FPLX:ROCK	partOf	complex(p(FPLX:ROCK ! ROCK), p(HGNC:6125 ! IRS1))
+FPLX:ROCK	partOf	complex(p(FPLX:ROCK ! ROCK), p(HGNC:667 ! RHOA), p(HGNC:667 ! RHOA))
+FPLX:RSK	activityNegativelyRegulatesActivityOf	HGNC:12362
+FPLX:SHC	hasVariant	p(FPLX:SHC ! SHC, pmod(Ph))
+FPLX:SHC	hasVariant	p(FPLX:SHC ! SHC, pmod(Ph, Tyr))
+FPLX:SHC	hasVariant	p(FPLX:SHC ! SHC, pmod(Ph, Tyr, 317))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3430 ! ERBB2), p(HGNC:4566 ! GRB2))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:4566 ! GRB2), p(HGNC:4566 ! GRB2))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:4566 ! GRB2), p(HGNC:9644 ! PTPN11))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:5173 ! HRAS))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:6125 ! IRS1))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:8988 ! PIN1))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:9588 ! PTEN))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:9644 ! PTPN11))
+FPLX:SHC	partOf	complex(p(FPLX:SHC ! SHC, pmod(Ph, Tyr)), p(HGNC:4566 ! GRB2))
+FPLX:SMAD	partOf	complex(p(FPLX:SMAD ! SMAD), p(HGNC:11577 ! TAZ), p(HGNC:16262 ! YAP1))
+FPLX:VAV	partOf	complex(p(FPLX:VAV ! VAV), p(HGNC:7553 ! MYC))
+FPLX:VAV	partOf	complex(p(FPLX:VAV ! VAV), p(HGNC:9644 ! PTPN11))
+FPLX:VAV	partOf	complex(p(FPLX:VAV ! VAV), p(HGNC:9878 ! RASGRP1))
+FPLX:VEGF	activityPositivelyRegulatesActivityOf	HGNC:9801
+FPLX:Wnt	partOf	complex(p(FPLX:Wnt ! Wnt), p(HGNC:3942 ! MTOR))
+GO:"GO:0016310"	activityNegativelyRegulatesActivityOf	HGNC:8988
+GO:"GO:0016491"	activityPositivelyRegulatesActivityOf	HGNC:3236
+GO:"GO:0120200"	partOf	complex(bp(GO:"GO:0120200" ! "rod photoreceptor outer segment"), p(HGNC:391 ! AKT1))
+HGNC:10011	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+HGNC:10011	activityPositivelyRegulatesActivityOf	HGNC:1097
+HGNC:10011	hasVariant	p(HGNC:10011 ! RHEB, pmod(Ph))
+HGNC:10011	hasVariant	p(HGNC:10011 ! RHEB, var("p.Tyr35Asn"))
+HGNC:10011	partOf	complex(a(CHEBI:15996 ! GTP), p(HGNC:10011 ! RHEB))
+HGNC:10011	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:10011 ! RHEB))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:10011 ! RHEB))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:10011 ! RHEB), p(HGNC:3942 ! MTOR))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:10436 ! RPS6KB1))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:11368 ! STAT6))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:12362 ! TSC1))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:12363 ! TSC2))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:21166 ! RHEBL1))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:30287 ! RPTOR))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:5173 ! HRAS))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:6499 ! LAMP1))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9588 ! PTEN))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9801 ! RAC1))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9829 ! RAF1))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9878 ! RASGRP1))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9882 ! RASSF1))
+HGNC:10011	partOf	complex(p(HGNC:10011 ! RHEB, var("p.Tyr35Asn")), p(HGNC:1097 ! BRAF))
+HGNC:10071	activityPositivelyRegulatesActivityOf	HGNC:7553
+HGNC:10251	activityDirectlyNegativelyRegulatesActivityOf	HGNC:4591
+HGNC:10251	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9588
+HGNC:10251	decreasesAmountOf	GO:"GO:0006915"
+HGNC:10251	hasVariant	p(HGNC:10251 ! ROCK1, pmod(Ph, Ser, 1333))
+HGNC:10251	increasesAmountOf	p(HGNC:8816 ! PDPK1, pmod(Ph))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:10251 ! ROCK1))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:10252 ! ROCK2))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:10252 ! ROCK2), p(HGNC:667 ! RHOA))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:11998 ! TP53))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:1504 ! CASP3))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:1508 ! CASP7))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:1725 ! CDC25A))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:667 ! RHOA))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:669 ! RHOC))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:6871 ! MAPK1))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:7553 ! MYC))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:8816 ! PDPK1))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:9588 ! PTEN))
+HGNC:10251	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:9801 ! RAC1))
+HGNC:10252	hasVariant	p(HGNC:10252 ! ROCK2, pmod(Ph))
+HGNC:10252	hasVariant	p(HGNC:10252 ! ROCK2, pmod(Ph, Ser, 1366))
+HGNC:10252	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:10252 ! ROCK2))
+HGNC:10252	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:10252 ! ROCK2), p(HGNC:667 ! RHOA))
+HGNC:10252	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:1101 ! BRCA2))
+HGNC:10252	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:1725 ! CDC25A))
+HGNC:10252	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:392 ! AKT2))
+HGNC:10252	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:667 ! RHOA))
+HGNC:10252	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:9801 ! RAC1))
+HGNC:10252	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:9829 ! RAF1))
+HGNC:10261	hasVariant	p(HGNC:10261 ! ROS1, pmod(Ph))
+HGNC:10261	hasVariant	p(HGNC:10261 ! ROS1, pmod(Ph, Tyr, 2110))
+HGNC:10261	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:10261 ! ROS1))
+HGNC:10261	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:17643 ! GOPC))
+HGNC:10261	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:427 ! ALK))
+HGNC:10261	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:4566 ! GRB2))
+HGNC:10261	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:9644 ! PTPN11))
+HGNC:10316	partOf	complex(p(HGNC:10316 ! RPL23), p(HGNC:6973 ! MDM2))
+HGNC:10404	hasVariant	p(HGNC:10404 ! RPS2, pmod(Ub))
+HGNC:10404	partOf	complex(p(HGNC:10404 ! RPS2), p(HGNC:6973 ! MDM2))
+HGNC:10430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+HGNC:10430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12363
+HGNC:10430	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+HGNC:10430	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+HGNC:10430	activityPositivelyRegulatesActivityOf	HGNC:3489
+HGNC:10430	hasVariant	p(HGNC:10430 ! RPS6KA1, pmod(Ph, Ser, 221))
+HGNC:10430	hasVariant	p(HGNC:10430 ! RPS6KA1, pmod(Ph, Ser, 363))
+HGNC:10430	hasVariant	p(HGNC:10430 ! RPS6KA1, pmod(Ph, Ser, 380))
+HGNC:10430	hasVariant	p(HGNC:10430 ! RPS6KA1, pmod(Ph, Ser, 732))
+HGNC:10430	hasVariant	p(HGNC:10430 ! RPS6KA1, pmod(Ph, Thr, 359))
+HGNC:10430	hasVariant	p(HGNC:10430 ! RPS6KA1, pmod(Ph, Thr, 573))
+HGNC:10430	increasesAmountOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2, pmod(Ph)))
+HGNC:10430	increasesAmountOf	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:10431 ! RPS6KA2))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:10432 ! RPS6KA3))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:11998 ! TP53))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:12362 ! TSC1))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:12363 ! TSC2))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:1508 ! CASP7))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:30287 ! RPTOR))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:3321 ! ELK1))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:3688 ! FGFR1))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:3689 ! FGFR2))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:6871 ! MAPK1))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:6877 ! MAPK3))
+HGNC:10430	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:8816 ! PDPK1))
+HGNC:10431	hasVariant	p(HGNC:10431 ! RPS6KA2, pmod(Ph))
+HGNC:10431	hasVariant	p(HGNC:10431 ! RPS6KA2, pmod(Ph, Ser, 360))
+HGNC:10431	hasVariant	p(HGNC:10431 ! RPS6KA2, pmod(Ph, Ser, 377))
+HGNC:10431	hasVariant	p(HGNC:10431 ! RPS6KA2, pmod(Ph, Thr))
+HGNC:10431	hasVariant	p(HGNC:10431 ! RPS6KA2, pmod(Ph, Thr, 570))
+HGNC:10431	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:10431 ! RPS6KA2))
+HGNC:10431	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:10431 ! RPS6KA2))
+HGNC:10431	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:17722 ! SPRED2))
+HGNC:10431	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:3689 ! FGFR2))
+HGNC:10431	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:3796 ! FOS))
+HGNC:10431	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:3942 ! MTOR))
+HGNC:10431	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:6204 ! JUN))
+HGNC:10431	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:6871 ! MAPK1))
+HGNC:10431	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:6877 ! MAPK3))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Ser, 227))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Ser, 227), pmod(Ph, Ser, 369), pmod(Ph, Ser, 386), pmod(Ph, Tyr, 529))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Ser, 369))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Ser, 369), pmod(Ph, Ser, 386), pmod(Ph, Tyr, 529))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Ser, 386))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Thr))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Thr, 577))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Tyr, 529))
+HGNC:10432	hasVariant	p(HGNC:10432 ! RPS6KA3, pmod(Ph, Tyr, 707))
+HGNC:10432	increasesAmountOf	p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 146))
+HGNC:10432	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:10432 ! RPS6KA3))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:10432 ! RPS6KA3))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:17722 ! SPRED2))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:3236 ! EGFR))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:3688 ! FGFR1))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:3689 ! FGFR2))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:3690 ! FGFR3))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:667 ! RHOA))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:6871 ! MAPK1))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:6877 ! MAPK3))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:8816 ! PDPK1))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:8822 ! PEA15))
+HGNC:10432	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:9873 ! RASAL1))
+HGNC:10435	hasVariant	p(HGNC:10435 ! RPS6KA6, pmod(Ph))
+HGNC:10435	partOf	complex(p(HGNC:10435 ! RPS6KA6), p(HGNC:6877 ! MAPK3))
+HGNC:10436	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3942
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 394))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 394), pmod(Ph, Ser, 434), pmod(Ph, Ser, 441), pmod(Ph, Ser, 447), pmod(Ph, Thr, 252), pmod(Ph, Thr, 412), pmod(Ph, Thr, 444))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 434))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 441))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 447))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 252))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 390))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 412))
+HGNC:10436	hasVariant	p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 444))
+HGNC:10436	increasesAmountOf	GO:"GO:0016310"
+HGNC:10436	increasesAmountOf	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 392))
+HGNC:10436	increasesAmountOf	p(HGNC:6126 ! IRS2, pmod(Ph))
+HGNC:10436	increasesAmountOf	p(HGNC:6973 ! MDM2, pmod(Ph))
+HGNC:10436	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:10436 ! RPS6KB1))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:10436 ! RPS6KB1))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:10437 ! RPS6KB2))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:11389 ! STK11))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:12362 ! TSC1))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:12363 ! TSC2))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:30287 ! RPTOR))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:3288 ! EIF4EBP1))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:391 ! AKT1))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:3942 ! MTOR, pmod(Ph)))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:6125 ! IRS1))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:6973 ! MDM2))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:8816 ! PDPK1))
+HGNC:10436	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:9588 ! PTEN))
+HGNC:10437	hasVariant	p(HGNC:10437 ! RPS6KB2, pmod(Ph))
+HGNC:10437	hasVariant	p(HGNC:10437 ! RPS6KB2, pmod(Ph, Ser, 15))
+HGNC:10437	hasVariant	p(HGNC:10437 ! RPS6KB2, pmod(Ph, Ser, 356))
+HGNC:10437	hasVariant	p(HGNC:10437 ! RPS6KB2, pmod(Ph, Ser, 370))
+HGNC:10437	hasVariant	p(HGNC:10437 ! RPS6KB2, pmod(Ph, Ser, 473))
+HGNC:10437	hasVariant	p(HGNC:10437 ! RPS6KB2, pmod(Ph, Thr, 228))
+HGNC:10437	hasVariant	p(HGNC:10437 ! RPS6KB2, pmod(Ph, Thr, 388))
+HGNC:10437	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:10437 ! RPS6KB2))
+HGNC:10437	partOf	complex(p(HGNC:10437 ! RPS6KB2), p(HGNC:1097 ! BRAF))
+HGNC:10437	partOf	complex(p(HGNC:10437 ! RPS6KB2), p(HGNC:3942 ! MTOR))
+HGNC:10437	partOf	complex(p(HGNC:10437 ! RPS6KB2), p(HGNC:6945 ! MCM3))
+HGNC:1046	activityPositivelyRegulatesActivityOf	HGNC:8975
+HGNC:1046	partOf	complex(p(HGNC:1046 ! BHLHE40), p(HGNC:11998 ! TP53))
+HGNC:10471	hasVariant	p(HGNC:10471 ! RUNX1, pmod(Ph, Thr, 207))
+HGNC:10471	partOf	complex(p(HGNC:10471 ! RUNX1), p(HGNC:16059 ! PAK4))
+HGNC:10471	partOf	complex(p(HGNC:10471 ! RUNX1), p(HGNC:3796 ! FOS))
+HGNC:10486	partOf	complex(p(HGNC:10486 ! S100A1), p(HGNC:6973 ! MDM2))
+HGNC:1052	partOf	complex(p(HGNC:1052 ! BIN1), p(HGNC:7553 ! MYC))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:10696 ! EXOC5))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:23196 ! EXOC6))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:23214 ! EXOC7))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:24659 ! EXOC8))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:24968 ! EXOC2))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:24968 ! EXOC2), p(HGNC:30389 ! EXOC4))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:30378 ! EXOC3))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:30380 ! EXOC1))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:30389 ! EXOC4))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:3236 ! EGFR))
+HGNC:10696	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:952 ! BARD1))
+HGNC:10840	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11187
+HGNC:10840	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:10840	hasVariant	p(HGNC:10840 ! SHC1, pmod(Ph))
+HGNC:10840	hasVariant	p(HGNC:10840 ! SHC1, pmod(Ph, Ser, 139))
+HGNC:10840	hasVariant	p(HGNC:10840 ! SHC1, pmod(Ph, Tyr, 349))
+HGNC:10840	hasVariant	p(HGNC:10840 ! SHC1, pmod(Ph, Tyr, 350))
+HGNC:10840	hasVariant	p(HGNC:10840 ! SHC1, pmod(Ph, Tyr, 427))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:10840 ! SHC1))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:11187 ! SOS1))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:11188 ! SOS2))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:1541 ! CBL))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:1542 ! CBLB))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:15961 ! CBLC))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:18181 ! SHC3))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:29869 ! SHC2))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:3236 ! EGFR))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:3430 ! ERBB2))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:427 ! ALK))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:4566 ! GRB2))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:4568 ! RAPGEF1))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:6091 ! INSR))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:6840 ! MAP2K1))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:6871 ! MAPK1))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:7029 ! MET))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:8804 ! PDGFRB))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:8979 ! PIK3R1))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:8980 ! PIK3R2))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:8981 ! PIK3R3))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:9874 ! RASAL2))
+HGNC:10840	partOf	complex(p(HGNC:10840 ! SHC1, pmod(Ph)), p(HGNC:4566 ! GRB2))
+HGNC:10845	partOf	complex(p(HGNC:10845 ! SEM1), p(HGNC:9824 ! RAD52))
+HGNC:10894	partOf	complex(p(HGNC:10894 ! PRMT5), p(HGNC:7553 ! MYC))
+HGNC:10905	partOf	complex(p(HGNC:10905 ! SLC10A1), p(HGNC:3236 ! EGFR))
+HGNC:1097	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+HGNC:1097	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6842
+HGNC:1097	activityNegativelyRegulatesActivityOf	CHEBI:26523
+HGNC:1097	activityPositivelyRegulatesActivityOf	FPLX:RAC
+HGNC:1097	activityPositivelyRegulatesActivityOf	HGNC:7553
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 151))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 364))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 365))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 428))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 429))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 446))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 446), pmod(Ph, Ser, 602))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 446), pmod(Ph, Thr, 599))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 579))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 750))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Thr, 373))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Thr, 401))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Thr, 440))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ph, Thr, 753))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, pmod(Ub))
+HGNC:1097	hasVariant	p(HGNC:1097 ! BRAF, var("p.Val600Glu"))
+HGNC:1097	increasesAmountOf	p(HGNC:11270 ! SPRY2, pmod(Ph))
+HGNC:1097	increasesAmountOf	p(HGNC:11728 ! TERF1, pmod(Ph))
+HGNC:1097	increasesAmountOf	p(HGNC:9884 ! RB1, pmod(Ph))
+HGNC:1097	partOf	complex(a(CHEBI:50924 ! sorafenib), p(HGNC:1097 ! BRAF))
+HGNC:1097	partOf	complex(a(CHEBI:63637 ! vemurafenib), p(HGNC:1097 ! BRAF))
+HGNC:1097	partOf	complex(a(CHEBI:75045 ! dabrafenib), p(HGNC:1097 ! BRAF))
+HGNC:1097	partOf	complex(p(HGNC:10011 ! RHEB, var("p.Tyr35Asn")), p(HGNC:1097 ! BRAF))
+HGNC:1097	partOf	complex(p(HGNC:10437 ! RPS6KB2), p(HGNC:1097 ! BRAF))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:1097 ! BRAF))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:1097 ! BRAF), p(HGNC:9829 ! RAF1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11270 ! SPRY2))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11389 ! STK11), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11406 ! STK3))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11998 ! TP53))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11998 ! TP53), p(HGNC:6407 ! KRAS))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:15533 ! SPRY4))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:16262 ! YAP1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:17175 ! PLCE1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18547 ! CDC42SE2))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:21869 ! AGK))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:22219 ! KIAA1549))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:30287 ! RPTOR))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3430 ! ERBB2))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3467 ! ESR1), p(HGNC:370 ! AKAP12), p(HGNC:7112 ! MKRN1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:391 ! AKT1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3942 ! MTOR))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:5173 ! HRAS))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:5173 ! HRAS), p(HGNC:9829 ! RAF1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:5394 ! CFI))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:9829 ! RAF1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:646 ! ARAF))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:646 ! ARAF), p(HGNC:9829 ! RAF1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6465 ! KSR1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6842 ! MAP2K2))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6871 ! MAPK1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6877 ! MAPK3))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:7112 ! MKRN1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:7227 ! MRAS))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:7989 ! NRAS))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:8590 ! PAK1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:8591 ! PAK2))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:8630 ! PEBP1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:8975 ! PIK3CA))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:9281 ! PPP1CA))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:9588 ! PTEN))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:9829 ! RAF1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:9884 ! RB1))
+HGNC:1097	partOf	complex(p(HGNC:1097 ! BRAF, var("p.Val600Glu")), p(HGNC:6840 ! MAP2K1))
+HGNC:1100	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Me))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1143))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1191))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1280))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1330))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1387))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1423))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1466))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1497))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1524))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 632))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 694))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 988))
+HGNC:1100	hasVariant	p(HGNC:1100 ! BRCA1, pmod(Ph, Thr, 509))
+HGNC:1100	increasesAmountOf	p(HGNC:8100 ! OC90, pmod(Me))
+HGNC:1100	partOf	complex(bp(MESH:D011839 ! "Radiation, Ionizing"), p(HGNC:1100 ! BRCA1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1100 ! BRCA1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1100 ! BRCA1), p(HGNC:1100 ! BRCA1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1101 ! BRCA2))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1101 ! BRCA2), p(HGNC:11998 ! TP53))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11389 ! STK11))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11998 ! TP53))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11998 ! TP53), p(HGNC:1725 ! CDC25A))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11998 ! TP53), p(HGNC:9884 ! RB1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11999 ! TP53BP1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:12003 ! TP73))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1578 ! CCNA2))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1582 ! CCND1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1725 ! CDC25A))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1771 ! CDK2))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1773 ! CDK4))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1784 ! CDKN1A))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:19680 ! GPBAR1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:20473 ! BRIP1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:20473 ! BRIP1), p(HGNC:20473 ! BRIP1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:20473 ! BRIP1), p(HGNC:952 ! BARD1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:26144 ! PALB2))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:270 ! PARP1), p(HGNC:3433 ! ERCC1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:28833 ! OLA1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:30287 ! RPTOR))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:30298 ! UIMC1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3113 ! E2F1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3236 ! EGFR))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3430 ! ERBB2))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3438 ! ERCC6))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3488 ! ETS1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3582 ! FANCA))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:391 ! AKT1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3942 ! MTOR))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:4095 ! GADD45A))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:5009 ! HMGA2))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6204 ! JUN))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6407 ! KRAS))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6871 ! MAPK1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6877 ! MAPK3))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6945 ! MCM3))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6947 ! MCM4))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6948 ! MCM5))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6949 ! MCM6))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:7553 ! MYC))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:7782 ! NFE2L2))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:7794 ! NFKB1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:8979 ! PIK3R1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9281 ! PPP1CA))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9377 ! PRKAA2))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9387 ! PRKAG3))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:952 ! BARD1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9588 ! PTEN))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9824 ! RAD52))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9882 ! RASSF1))
+HGNC:1100	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9884 ! RB1))
+HGNC:1101	hasVariant	p(HGNC:1101 ! BRCA2, pmod(Ph))
+HGNC:1101	hasVariant	p(HGNC:1101 ! BRCA2, pmod(Ph, Ser, 193))
+HGNC:1101	hasVariant	p(HGNC:1101 ! BRCA2, pmod(Ph, Ser, 205))
+HGNC:1101	hasVariant	p(HGNC:1101 ! BRCA2, pmod(Ph, Ser, 206))
+HGNC:1101	hasVariant	p(HGNC:1101 ! BRCA2, pmod(Ph, Thr, 203))
+HGNC:1101	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:1101 ! BRCA2))
+HGNC:1101	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1101 ! BRCA2))
+HGNC:1101	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1101 ! BRCA2), p(HGNC:11998 ! TP53))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1101 ! BRCA2))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:11998 ! TP53))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1578 ! CCNA2))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1582 ! CCND1))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1771 ! CDK2))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1784 ! CDKN1A))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:19700 ! CNKSR1))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:20473 ! BRIP1))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:3582 ! FANCA))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:9077 ! PLK1))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:952 ! BARD1))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:9705 ! PVR))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:9817 ! RAD51))
+HGNC:1101	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:9824 ! RAD52))
+HGNC:11036	partOf	complex(p(HGNC:11036 ! SLC5A1), p(HGNC:3236 ! EGFR))
+HGNC:11036	partOf	complex(p(HGNC:11036 ! SLC5A1), p(HGNC:3430 ! ERBB2))
+HGNC:11128	partOf	complex(p(HGNC:11128 ! SNAI1), p(HGNC:8590 ! PAK1))
+HGNC:11187	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:11187	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+HGNC:11187	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7989
+HGNC:11187	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:11187	hasVariant	p(HGNC:11187 ! SOS1, pmod(Ph))
+HGNC:11187	hasVariant	p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1132))
+HGNC:11187	hasVariant	p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1167))
+HGNC:11187	hasVariant	p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1178))
+HGNC:11187	hasVariant	p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1193))
+HGNC:11187	hasVariant	p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1197))
+HGNC:11187	partOf	complex(p(FPLX:CDC25 ! CDC25), p(HGNC:11187 ! SOS1))
+HGNC:11187	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:11187 ! SOS1))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11188 ! SOS2))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11188 ! SOS2), p(HGNC:4566 ! GRB2))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11320 ! ABI1), p(HGNC:3420 ! EPS8))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11805 ! TIAM1))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:1541 ! CBL))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:28719 ! HAUS3))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3236 ! EGFR))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3420 ! EPS8))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3688 ! FGFR1))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:4566 ! GRB2))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:4566 ! GRB2), p(HGNC:4566 ! GRB2))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:5173 ! HRAS))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:6407 ! KRAS))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:7029 ! MET))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:8979 ! PIK3R1))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:9644 ! PTPN11))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:9801 ! RAC1))
+HGNC:11187	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:9878 ! RASGRP1))
+HGNC:11188	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:11188	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+HGNC:11188	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7989
+HGNC:11188	hasVariant	p(HGNC:11188 ! SOS2, pmod(Ph))
+HGNC:11188	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:11188 ! SOS2))
+HGNC:11188	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11188 ! SOS2))
+HGNC:11188	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11188 ! SOS2), p(HGNC:4566 ! GRB2))
+HGNC:11188	partOf	complex(p(HGNC:11188 ! SOS2), p(HGNC:3236 ! EGFR))
+HGNC:11188	partOf	complex(p(HGNC:11188 ! SOS2), p(HGNC:4566 ! GRB2))
+HGNC:11188	partOf	complex(p(HGNC:11188 ! SOS2), p(HGNC:6407 ! KRAS))
+HGNC:11195	partOf	complex(p(HGNC:11195 ! SOX2), p(HGNC:16262 ! YAP1))
+HGNC:11205	partOf	complex(p(HGNC:11205 ! SP1), p(HGNC:3113 ! E2F1))
+HGNC:11205	partOf	complex(p(HGNC:11205 ! SP1), p(HGNC:3236 ! EGFR))
+HGNC:11205	partOf	complex(p(HGNC:11205 ! SP1), p(HGNC:6204 ! JUN))
+HGNC:11205	partOf	complex(p(HGNC:11205 ! SP1), p(HGNC:7553 ! MYC))
+HGNC:11254	partOf	complex(p(HGNC:11254 ! SPOP), p(HGNC:9588 ! PTEN))
+HGNC:11269	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11187
+HGNC:11269	activityPositivelyRegulatesActivityOf	FPLX:ROCK
+HGNC:11269	hasVariant	p(HGNC:11269 ! SPRY1, pmod(Ph))
+HGNC:11269	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:11270 ! SPRY2))
+HGNC:11269	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:1541 ! CBL))
+HGNC:11269	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:1542 ! CBLB))
+HGNC:11269	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:15533 ! SPRY4))
+HGNC:11269	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:4566 ! GRB2))
+HGNC:11270	hasVariant	p(HGNC:11270 ! SPRY2, pmod(Ph))
+HGNC:11270	hasVariant	p(HGNC:11270 ! SPRY2, pmod(Ph, Ser, 112))
+HGNC:11270	hasVariant	p(HGNC:11270 ! SPRY2, pmod(Ph, Thr, 75))
+HGNC:11270	hasVariant	p(HGNC:11270 ! SPRY2, pmod(Ph, Tyr, 55))
+HGNC:11270	hasVariant	p(HGNC:11270 ! SPRY2, pmod(Ub))
+HGNC:11270	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11270 ! SPRY2))
+HGNC:11270	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:11270 ! SPRY2))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:11270 ! SPRY2))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1541 ! CBL))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1541 ! CBL), p(HGNC:1541 ! CBL))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1542 ! CBLB))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:15533 ! SPRY4))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:3236 ! EGFR))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:392 ! AKT2))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:4566 ! GRB2))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:5173 ! HRAS))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:7029 ! MET))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:9379 ! PRKAB2))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:9588 ! PTEN))
+HGNC:11270	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:9829 ! RAF1))
+HGNC:11280	hasVariant	p(HGNC:11280 ! SQSTM1, pmod(Ph, Ser, 366))
+HGNC:11280	partOf	complex(p(HGNC:11280 ! SQSTM1), p(HGNC:3236 ! EGFR))
+HGNC:11283	partOf	complex(p(HGNC:11283 ! SRC), p(HGNC:16262 ! YAP1))
+HGNC:11283	partOf	complex(p(HGNC:11283 ! SRC), p(HGNC:3236 ! EGFR))
+HGNC:11291	partOf	complex(p(HGNC:11291 ! SRF), p(HGNC:6950 ! MCM7))
+HGNC:11320	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11320 ! ABI1), p(HGNC:3420 ! EPS8))
+HGNC:11327	partOf	complex(p(HGNC:11327 ! SSRP1), p(HGNC:1771 ! CDK2))
+HGNC:11364	hasVariant	p(HGNC:11364 ! STAT3, pmod(Ph))
+HGNC:11364	increasesAmountOf	HGNC:1773
+HGNC:11364	partOf	complex(p(HGNC:11364 ! STAT3), p(HGNC:12363 ! TSC2))
+HGNC:11364	partOf	complex(p(HGNC:11364 ! STAT3), p(HGNC:3942 ! MTOR))
+HGNC:11364	partOf	complex(p(HGNC:11364 ! STAT3), p(HGNC:8590 ! PAK1))
+HGNC:11364	partOf	complex(p(HGNC:11364 ! STAT3), p(HGNC:9588 ! PTEN))
+HGNC:11368	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:11368 ! STAT6))
+HGNC:11389	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9588
+HGNC:11389	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9376
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Ser))
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Ser, 307))
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Ser, 404))
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Ser, 428))
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Thr, 185))
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Thr, 189))
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Thr, 336))
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Thr, 367))
+HGNC:11389	hasVariant	p(HGNC:11389 ! STK11, pmod(Ph, Thr, 402))
+HGNC:11389	increasesAmountOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:11389	increasesAmountOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2, pmod(Ph)), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:11389	increasesAmountOf	p(HGNC:10436 ! RPS6KB1, pmod(Ph))
+HGNC:11389	increasesAmountOf	p(HGNC:16262 ! YAP1, pmod(Ph))
+HGNC:11389	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:11389 ! STK11))
+HGNC:11389	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:11389 ! STK11))
+HGNC:11389	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11389 ! STK11), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:11389	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11389 ! STK11))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:11389 ! STK11))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:11389 ! STK11), p(HGNC:11998 ! TP53))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:11998 ! TP53))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:12003 ! TP73))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:16262 ! YAP1))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:1773 ! CDK4))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:1784 ! CDKN1A))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:3236 ! EGFR))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:3942 ! MTOR))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:6407 ! KRAS))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:667 ! RHOA))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:9376 ! PRKAA1))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:9377 ! PRKAA2))
+HGNC:11389	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:9588 ! PTEN))
+HGNC:11406	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11406
+HGNC:11406	activityDirectlyPositivelyRegulatesActivityOf	HGNC:17795
+HGNC:11406	hasVariant	p(HGNC:11406 ! STK3, pmod(Ph))
+HGNC:11406	hasVariant	p(HGNC:11406 ! STK3, pmod(Ph, Thr, 117))
+HGNC:11406	hasVariant	p(HGNC:11406 ! STK3, pmod(Ph, Thr, 180))
+HGNC:11406	hasVariant	p(HGNC:11406 ! STK3, pmod(Ph, Thr, 384))
+HGNC:11406	hasVariant	p(HGNC:11406 ! STK3, pmod(Ph, Tyr, 81))
+HGNC:11406	increasesAmountOf	p(HGNC:11406 ! STK3, pmod(Ph))
+HGNC:11406	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11406 ! STK3))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:11406 ! STK3))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:11408 ! STK4))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:14271 ! RASSF3))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:1504 ! CASP3))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:17609 ! RASSF5))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:17795 ! SAV1))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:19700 ! CNKSR1))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:20793 ! RASSF4))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:20796 ! RASSF6))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:3288 ! EIF4EBP1))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:391 ! AKT1))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:646 ! ARAF))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:9829 ! RAF1))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:9882 ! RASSF1))
+HGNC:11406	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:9883 ! RASSF2))
+HGNC:11408	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11408
+HGNC:11408	activityPositivelyRegulatesActivityOf	HGNC:1504
+HGNC:11408	hasVariant	p(HGNC:11408 ! STK4, pmod(Me))
+HGNC:11408	hasVariant	p(HGNC:11408 ! STK4, pmod(Ph, Ser, 327))
+HGNC:11408	hasVariant	p(HGNC:11408 ! STK4, pmod(Ph, Thr, 120))
+HGNC:11408	hasVariant	p(HGNC:11408 ! STK4, pmod(Ph, Thr, 177))
+HGNC:11408	hasVariant	p(HGNC:11408 ! STK4, pmod(Ph, Thr, 183))
+HGNC:11408	hasVariant	p(HGNC:11408 ! STK4, pmod(Ph, Thr, 387))
+HGNC:11408	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:11408 ! STK4))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:11408 ! STK4))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:11998 ! TP53))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:14271 ! RASSF3))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:1504 ! CASP3))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:17609 ! RASSF5))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:17795 ! SAV1))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:19700 ! CNKSR1))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:20793 ! RASSF4))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:20796 ! RASSF6))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:391 ! AKT1))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:6514 ! LATS1))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:9829 ! RAF1))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:9882 ! RASSF1))
+HGNC:11408	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:9883 ! RASSF2))
+HGNC:11427	increasesAmountOf	p(HGNC:16262 ! YAP1, pmod(Ub))
+HGNC:1148	hasVariant	p(HGNC:1148 ! BUB1, pmod(Ph))
+HGNC:1148	hasVariant	p(HGNC:1148 ! BUB1, pmod(Ph, Ser, 318))
+HGNC:1148	hasVariant	p(HGNC:1148 ! BUB1, pmod(Ph, Thr, 589))
+HGNC:1148	hasVariant	p(HGNC:1148 ! BUB1, pmod(Ph, Thr, 609))
+HGNC:1148	increasesAmountOf	p(HGNC:1148 ! BUB1, pmod(Ph))
+HGNC:1148	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:1148 ! BUB1))
+HGNC:1148	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:11998 ! TP53))
+HGNC:1148	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:12003 ! TP73))
+HGNC:1148	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:1771 ! CDK2))
+HGNC:1148	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:3288 ! EIF4EBP1))
+HGNC:11524	partOf	complex(p(HGNC:11524 ! TACC3), p(HGNC:3690 ! FGFR3))
+HGNC:11554	partOf	complex(p(HGNC:11554 ! TAGLN2), p(HGNC:9588 ! PTEN))
+HGNC:11577	partOf	complex(p(FPLX:SMAD ! SMAD), p(HGNC:11577 ! TAZ), p(HGNC:16262 ! YAP1))
+HGNC:11577	partOf	complex(p(HGNC:11577 ! TAZ), p(HGNC:16262 ! YAP1))
+HGNC:11584	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+HGNC:11584	activityPositivelyRegulatesActivityOf	FPLX:AP1
+HGNC:11584	hasVariant	p(HGNC:11584 ! TBK1, pmod(Ph))
+HGNC:11584	hasVariant	p(HGNC:11584 ! TBK1, pmod(Ph, Ser, 172))
+HGNC:11584	hasVariant	p(HGNC:11584 ! TBK1, pmod(Ub))
+HGNC:11584	increasesAmountOf	p(HGNC:17142 ! OPTN, pmod(Ph))
+HGNC:11584	partOf	complex(p(FPLX:Interferon ! Interferon), p(HGNC:11584 ! TBK1))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:11584 ! TBK1))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:12033 ! TRAF3))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:12033 ! TRAF3), p(HGNC:30766 ! TRAF3IP3))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:16262 ! YAP1))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:20967 ! NACC1))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:21578 ! RNF144B))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:24968 ! EXOC2))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:27962 ! STING1))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:28958 ! NUP93))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:29233 ! MAVS))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:30766 ! TRAF3IP3))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:3236 ! EGFR))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:391 ! AKT1))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:3942 ! MTOR))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:6091 ! INSR))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:6118 ! IRF3))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:6407 ! KRAS))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:682 ! ARHGEF2))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:7794 ! NFKB1))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:8630 ! PEBP1))
+HGNC:11584	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:9644 ! PTPN11))
+HGNC:11588	partOf	complex(p(HGNC:11588 ! TBP), p(HGNC:7553 ! MYC))
+HGNC:11641	partOf	complex(p(HGNC:11641 ! TCF7L2), p(HGNC:7553 ! MYC))
+HGNC:11653	partOf	complex(p(HGNC:11653 ! TCN2), p(HGNC:1541 ! CBL))
+HGNC:1166	partOf	complex(p(HGNC:1166 ! RASSF7), p(HGNC:15739 ! RASSF9))
+HGNC:1166	partOf	complex(p(HGNC:1166 ! RASSF7), p(HGNC:33984 ! RASSF10))
+HGNC:1166	partOf	complex(p(HGNC:1166 ! RASSF7), p(HGNC:9281 ! PPP1CA))
+HGNC:11714	partOf	complex(p(HGNC:11714 ! TEAD1), p(HGNC:16262 ! YAP1))
+HGNC:11717	partOf	complex(p(HGNC:11717 ! TEAD4), p(HGNC:16262 ! YAP1))
+HGNC:11728	hasVariant	p(HGNC:11728 ! TERF1, pmod(Ph))
+HGNC:11730	partOf	complex(p(HGNC:11730 ! TERT), p(HGNC:7553 ! MYC))
+HGNC:11749	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+HGNC:11749	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:11998 ! TP53))
+HGNC:11749	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:1771 ! CDK2))
+HGNC:11749	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:1777 ! CDK6))
+HGNC:11749	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:3113 ! E2F1))
+HGNC:11749	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:3114 ! E2F2))
+HGNC:11749	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:3115 ! E2F3))
+HGNC:11749	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:9884 ! RB1))
+HGNC:11751	partOf	complex(p(HGNC:11751 ! TFDP2), p(HGNC:3113 ! E2F1))
+HGNC:11751	partOf	complex(p(HGNC:11751 ! TFDP2), p(HGNC:3115 ! E2F3))
+HGNC:11751	partOf	complex(p(HGNC:11751 ! TFDP2), p(HGNC:9884 ! RB1))
+HGNC:11753	partOf	complex(p(HGNC:11753 ! TFEB), p(HGNC:3942 ! MTOR))
+HGNC:11760	partOf	complex(p(HGNC:11760 ! TFPI), p(HGNC:7553 ! MYC))
+HGNC:11764	partOf	complex(p(HGNC:11764 ! TG), p(HGNC:6973 ! MDM2))
+HGNC:11805	activityDirectlyPositivelyRegulatesActivityOf	HGNC:667
+HGNC:11805	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:11805	hasVariant	p(HGNC:11805 ! TIAM1, pmod(Ph))
+HGNC:11805	partOf	complex(p(FPLX:"CAMK2_complex" ! "CAMK2_complex"), p(HGNC:11805 ! TIAM1))
+HGNC:11805	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11805 ! TIAM1))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:11805 ! TIAM1))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:11806 ! TIAM2))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:12657 ! VAV1))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:5173 ! HRAS))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:6465 ! KSR1))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:7553 ! MYC))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:7765 ! NF1))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:9801 ! RAC1))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:9802 ! RAC2))
+HGNC:11805	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:9874 ! RASAL2))
+HGNC:11806	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:11806	hasVariant	p(HGNC:11806 ! TIAM2, pmod(Ph))
+HGNC:11806	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:11806 ! TIAM2))
+HGNC:11806	partOf	complex(p(HGNC:11806 ! TIAM2), p(HGNC:11830 ! TK1))
+HGNC:11806	partOf	complex(p(HGNC:11806 ! TIAM2), p(HGNC:9801 ! RAC1))
+HGNC:11827	hasVariant	p(HGNC:11827 ! TJP1, pmod(Ph))
+HGNC:11830	hasVariant	p(HGNC:11830 ! TK1, pmod(Ph, Ser, 13))
+HGNC:11830	partOf	complex(p(HGNC:11806 ! TIAM2), p(HGNC:11830 ! TK1))
+HGNC:11830	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:11830 ! TK1))
+HGNC:11830	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:11998 ! TP53))
+HGNC:11830	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:12363 ! TSC2))
+HGNC:11830	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:16262 ! YAP1))
+HGNC:11830	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:1773 ! CDK4))
+HGNC:11830	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:1784 ! CDKN1A))
+HGNC:11834	partOf	complex(p(HGNC:11834 ! TKT), p(HGNC:3236 ! EGFR))
+HGNC:11850	partOf	complex(p(HGNC:11850 ! TLR4), p(HGNC:9884 ! RB1))
+HGNC:11908	partOf	complex(p(HGNC:11908 ! TNFRSF11A), p(HGNC:1527 ! CAV1), p(HGNC:3236 ! EGFR))
+HGNC:11909	partOf	complex(p(HGNC:11909 ! TNFRSF11B), p(HGNC:7765 ! NF1))
+HGNC:11998	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10430
+HGNC:11998	activityNegativelyRegulatesActivityOf	HGNC:1582
+HGNC:11998	activityNegativelyRegulatesActivityOf	HGNC:4504
+HGNC:11998	activityPositivelyRegulatesActivityOf	FPLX:"Cyclin_A"
+HGNC:11998	activityPositivelyRegulatesActivityOf	HGNC:3489
+HGNC:11998	activityPositivelyRegulatesActivityOf	HGNC:9376
+HGNC:11998	decreasesAmountOf	GO:"GO:0046323"
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 120))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 120), pmod(Ac, Lys, 164), pmod(Ac, Lys, 370), pmod(Ac, Lys, 373), pmod(Ac, Lys, 381), pmod(Ac, Lys, 382), pmod(Ac, Lys, 386), pmod(Me, Lys, 372))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 164))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 370))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 373))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 381))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 382))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 386))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Me))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Me, Arg, 333))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Me, Arg, 333), pmod(Me, Arg, 335), pmod(Me, Arg, 337))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Me, Arg, 335))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Me, Arg, 337))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Me, Lys, 370))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Me, Lys, 372))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Me, Lys, 382))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, 15))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 106))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 15))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 20))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 215))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 315))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 33))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 366))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 37))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 371))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 376))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 378))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 392))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 46))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 9))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Thr, 18))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Thr, 211))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Thr, 284))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Thr, 55))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Thr, 81))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ph, Tyr, 327))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ub))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ub), pmod(Ub, Lys))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ub, 373))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ub, 382))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, pmod(Ub, Lys, 320))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.?"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Ala276Gly"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg156Pro"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg175His"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg181Gly"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg181His"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg248Gln"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg248Trp"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg249Ser"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg273His"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg282Trp"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Arg337Gly"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Asn239Ser"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Asp281Asn"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Asp281Glu"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Asp281Gly"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Cys238Trp"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Cys242Tyr"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Glu258Lys"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Glu286Lys"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Gly244Ser"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Gly245Asp"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Gly245Ser"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Gly266Glu"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Gly279Glu"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.His233Leu"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Leu145Arg"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Leu194Phe"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Leu308Met"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Leu323Pro"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Met246Leu"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Phe134Ile"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Pro151His"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Pro278Ser"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Pro309Ser"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Ser241Phe"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Ser241Thr"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Thr230Ser"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Tyr126Ser"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Tyr163His"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Tyr205Asn"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Tyr220Cys"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Tyr234His"))
+HGNC:11998	hasVariant	p(HGNC:11998 ! TP53, var("p.Val274Phe"))
+HGNC:11998	increasesAmountOf	CHEBI:28748
+HGNC:11998	increasesAmountOf	HGNC:1504
+HGNC:11998	increasesAmountOf	HGNC:1787
+HGNC:11998	increasesAmountOf	HGNC:6407
+HGNC:11998	increasesAmountOf	HGNC:990
+HGNC:11998	increasesAmountOf	MESH:D063646
+HGNC:11998	increasesAmountOf	p(HGNC:11998 ! TP53, pmod(Me, Lys, 370))
+HGNC:11998	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(a(CHEBI:28748 ! doxorubicin), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(bp(MESH:D011839 ! "Radiation, Ionizing"), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(FPLX:"p53_family" ! "p53_family"), p(HGNC:11998 ! TP53), p(HGNC:21270 ! GRWD1))
+HGNC:11998	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:11998 ! TP53), p(HGNC:6204 ! JUN))
+HGNC:11998	partOf	complex(p(FPLX:CDC25 ! CDC25), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:11998 ! TP53), p(HGNC:9884 ! RB1))
+HGNC:11998	partOf	complex(p(FPLX:HSP90 ! HSP90), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(FPLX:HSPA ! HSPA), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:1046 ! BHLHE40), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11998 ! TP53), p(HGNC:6407 ! KRAS))
+HGNC:11998	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1101 ! BRCA2), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11998 ! TP53), p(HGNC:1725 ! CDC25A))
+HGNC:11998	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11998 ! TP53), p(HGNC:9884 ! RB1))
+HGNC:11998	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:11389 ! STK11), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:12003 ! TP73))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:1784 ! CDKN1A))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12003 ! TP73), p(HGNC:12003 ! TP73))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12003 ! TP73), p(HGNC:6973 ! MDM2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12363 ! TSC2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12441 ! TYMS))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12441 ! TYMS), p(HGNC:7553 ! MYC))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:13718 ! FOSL1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:14929 ! SIRT1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1504 ! CASP3))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1509 ! CASP8))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1542 ! CBLB))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1578 ! CCNA2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1582 ! CCND1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1582 ! CCND1), p(HGNC:1784 ! CDKN1A))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1582 ! CCND1), p(HGNC:9884 ! RB1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:16059 ! PAK4))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:16262 ! YAP1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:16369 ! PARK7))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:17294 ! DAB2IP))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:17609 ! RASSF5))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1771 ! CDK2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1773 ! CDK4))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1773 ! CDK4), p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1784 ! CDKN1A), p(HGNC:6973 ! MDM2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1784 ! CDKN1A), p(HGNC:9884 ! RB1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:18683 ! EIF4A3))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:195 ! ADAM17))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:19950 ! RDM1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:20609 ! AIMP2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:20796 ! RASSF6))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:21270 ! GRWD1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:21399 ! FOXN4))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:23820 ! E2F7))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:2674 ! DAPK1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:2861 ! DHFR))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:29038 ! OTUD3))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:29233 ! MAVS))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:30064 ! PBRM1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3064 ! DUSP1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3113 ! E2F1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3155 ! ECT2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:31859 ! TRIM67))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3236 ! EGFR), p(HGNC:6973 ! MDM2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3373 ! EP300))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3430 ! ERBB2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:34410 ! NEURL4), p(HGNC:4868 ! HERC2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3467 ! ESR1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3468 ! ESR2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3527 ! EZH2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3690 ! FGFR3))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3765 ! FLT3))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3796 ! FOS))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3942 ! MTOR))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:4568 ! RAPGEF1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:5173 ! HRAS))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:5329 ! IAPP))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:576 ! APAF1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6204 ! JUN))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6407 ! KRAS))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6515 ! LATS2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:667 ! RHOA))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6871 ! MAPK1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6877 ! MAPK3))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6950 ! MCM7))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6974 ! MDM4))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:7553 ! MYC))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:8846 ! PER2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2, pmod(Ph)))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6974 ! MDM4))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7029 ! MET))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7399 ! MT1G))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7526 ! MMUT))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7545 ! MYB))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7765 ! NF1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7794 ! NFKB1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7989 ! NRAS))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8846 ! PER2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8975 ! PIK3CA))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8975 ! PIK3CA), p(HGNC:9588 ! PTEN))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8988 ! PIN1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9077 ! PLK1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9281 ! PPP1CA))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9376 ! PRKAA1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:952 ! BARD1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN), p(HGNC:9588 ! PTEN))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN), p(HGNC:9884 ! RB1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:959 ! BAX))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9801 ! RAC1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9841 ! RALBP1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9882 ! RASSF1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9884 ! RB1))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:990 ! BCL2))
+HGNC:11998	partOf	complex(p(HGNC:11998 ! TP53, var("p.Arg273His")), p(HGNC:3488 ! ETS1))
+HGNC:11999	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11999 ! TP53BP1))
+HGNC:12003	hasVariant	p(HGNC:12003 ! TP73, pmod(Ph))
+HGNC:12003	hasVariant	p(HGNC:12003 ! TP73, pmod(Ph, Thr, 27))
+HGNC:12003	hasVariant	p(HGNC:12003 ! TP73, pmod(Ph, Thr, 86))
+HGNC:12003	hasVariant	p(HGNC:12003 ! TP73, pmod(Ph, Tyr, 99))
+HGNC:12003	hasVariant	p(HGNC:12003 ! TP73, var("p.Arg263Trp"))
+HGNC:12003	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:12003 ! TP73))
+HGNC:12003	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:12003 ! TP73))
+HGNC:12003	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:12003 ! TP73))
+HGNC:12003	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:12003 ! TP73))
+HGNC:12003	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12003 ! TP73), p(HGNC:12003 ! TP73))
+HGNC:12003	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12003 ! TP73), p(HGNC:6973 ! MDM2))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:12003 ! TP73))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:1578 ! CCNA2))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:1582 ! CCND1))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:16262 ! YAP1))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:17294 ! DAB2IP))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:1771 ! CDK2))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:1784 ! CDKN1A))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:3113 ! E2F1))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:6973 ! MDM2))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:6974 ! MDM4))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:7553 ! MYC))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:8988 ! PIN1))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:9588 ! PTEN))
+HGNC:12003	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:9884 ! RB1))
+HGNC:12033	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:12033 ! TRAF3))
+HGNC:12033	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:12033 ! TRAF3), p(HGNC:30766 ! TRAF3IP3))
+HGNC:12307	partOf	complex(p(HGNC:12307 ! TRIP13), p(HGNC:3236 ! EGFR))
+HGNC:12313	hasVariant	p(HGNC:12313 ! JMJD1C, pmod(Ph, Thr, 505))
+HGNC:12347	partOf	complex(p(HGNC:12347 ! TRRAP), p(HGNC:7553 ! MYC))
+HGNC:12362	hasVariant	p(HGNC:12362 ! TSC1, pmod(Ph))
+HGNC:12362	hasVariant	p(HGNC:12362 ! TSC1, pmod(Ph, Ser, 487))
+HGNC:12362	hasVariant	p(HGNC:12362 ! TSC1, pmod(Ph, Ser, 584))
+HGNC:12362	hasVariant	p(HGNC:12362 ! TSC1, pmod(Ph, Thr, 1047))
+HGNC:12362	hasVariant	p(HGNC:12362 ! TSC1, pmod(Ph, Thr, 417))
+HGNC:12362	partOf	complex(complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2)), p(HGNC:12362 ! TSC1))
+HGNC:12362	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:12362 ! TSC1))
+HGNC:12362	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:12362 ! TSC1))
+HGNC:12362	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:12362 ! TSC1))
+HGNC:12362	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:12362 ! TSC1))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12362 ! TSC1))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2), p(HGNC:12363 ! TSC2))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2), p(HGNC:3942 ! MTOR))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2, pmod(Ph)))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:391 ! AKT1))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:3942 ! MTOR))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:9588 ! PTEN))
+HGNC:12362	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:9801 ! RAC1))
+HGNC:12363	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12362
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, 1130))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, 1132))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, 1462))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, 939))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, 981))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 1130))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 1387))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 1798))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 540))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 664))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 939))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, Thr, 1203))
+HGNC:12363	hasVariant	p(HGNC:12363 ! TSC2, pmod(Ph, Thr, 1462))
+HGNC:12363	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:11364 ! STAT3), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2), p(HGNC:3942 ! MTOR))
+HGNC:12363	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2, pmod(Ph)))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:12363 ! TSC2))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:1582 ! CCND1))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:1583 ! CCND2))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:1585 ! CCND3))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:1771 ! CDK2))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:391 ! AKT1))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:3942 ! MTOR))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:4566 ! GRB2))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:6871 ! MAPK1))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:7553 ! MYC))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:8988 ! PIN1))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:9376 ! PRKAA1))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:9588 ! PTEN))
+HGNC:12363	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:9839 ! RALA))
+HGNC:12441	activityNegativelyRegulatesActivityOf	CHEBI:26523
+HGNC:12441	activityNegativelyRegulatesActivityOf	HGNC:12441
+HGNC:12441	hasVariant	p(HGNC:12441 ! TYMS, pmod(Ph))
+HGNC:12441	partOf	complex(a(CHEBI:80961 ! "5-formyluracil"), p(HGNC:12441 ! TYMS))
+HGNC:12441	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12441 ! TYMS))
+HGNC:12441	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12441 ! TYMS), p(HGNC:7553 ! MYC))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:12441 ! TYMS))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:12441 ! TYMS), p(HGNC:12441 ! TYMS))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:12441 ! TYMS), p(HGNC:2861 ! DHFR), p(HGNC:2861 ! DHFR))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:1725 ! CDC25A), p(HGNC:3113 ! E2F1))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:2861 ! DHFR))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:3113 ! E2F1))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:3236 ! EGFR))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:3942 ! MTOR))
+HGNC:12441	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:7553 ! MYC))
+HGNC:12462	partOf	complex(p(HGNC:12462 ! UBASH3A), p(HGNC:1542 ! CBLB))
+HGNC:12476	partOf	complex(p(HGNC:12476 ! UBE2D3), p(HGNC:1541 ! CBL))
+HGNC:12513	partOf	complex(p(HGNC:12513 ! UCHL1), p(HGNC:3236 ! EGFR))
+HGNC:12558	hasVariant	p(HGNC:12558 ! ULK1, pmod(Ph))
+HGNC:12558	hasVariant	p(HGNC:12558 ! ULK1, pmod(Ph, Ser))
+HGNC:12558	increasesAmountOf	p(HGNC:11584 ! TBK1, pmod(Ph))
+HGNC:12572	partOf	complex(p(HGNC:12572 ! UNG), p(HGNC:12572 ! UNG))
+HGNC:12630	partOf	complex(p(HGNC:12630 ! USP7), p(HGNC:2681 ! DAXX), p(HGNC:6973 ! MDM2))
+HGNC:12657	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:12657	activityDirectlyPositivelyRegulatesActivityOf	HGNC:667
+HGNC:12657	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:12657	hasVariant	p(HGNC:12657 ! VAV1, pmod(Ph, Tyr))
+HGNC:12657	hasVariant	p(HGNC:12657 ! VAV1, pmod(Ph, Tyr, 142))
+HGNC:12657	hasVariant	p(HGNC:12657 ! VAV1, pmod(Ph, Tyr, 160))
+HGNC:12657	hasVariant	p(HGNC:12657 ! VAV1, pmod(Ph, Tyr, 174))
+HGNC:12657	hasVariant	p(HGNC:12657 ! VAV1, pmod(Ub))
+HGNC:12657	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:12657 ! VAV1))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:12657 ! VAV1))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:1541 ! CBL))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:1542 ! CBLB))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:3236 ! EGFR))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:3430 ! ERBB2))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:3688 ! FGFR1))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:4566 ! GRB2))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:6091 ! INSR))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:6204 ! JUN))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:667 ! RHOA, var("p.Gly17Val")))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:6840 ! MAP2K1))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:6871 ! MAPK1))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:8804 ! PDGFRB))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:8979 ! PIK3R1))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:9801 ! RAC1))
+HGNC:12657	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:9829 ! RAF1))
+HGNC:12669	partOf	complex(p(HGNC:12669 ! VDAC1), p(HGNC:6091 ! INSR))
+HGNC:12687	partOf	complex(p(HGNC:12687 ! VHL), p(HGNC:6973 ! MDM2))
+HGNC:12757	partOf	complex(p(HGNC:12757 ! WDR5), p(HGNC:7553 ! MYC))
+HGNC:12761	partOf	complex(p(HGNC:12761 ! WEE1), p(HGNC:8988 ! PIN1))
+HGNC:12932	partOf	complex(p(HGNC:12932 ! TRIM25), p(HGNC:9588 ! PTEN))
+HGNC:12936	partOf	complex(p(HGNC:12936 ! ZBTB17), p(HGNC:7553 ! MYC))
+HGNC:1316	partOf	complex(p(HGNC:1316 ! EML4), p(HGNC:427 ! ALK))
+HGNC:1323	partOf	complex(p(HGNC:1323 ! C4A), p(HGNC:9644 ! PTPN11))
+HGNC:13232	partOf	complex(p(HGNC:13232 ! RASSF8), p(HGNC:16262 ! YAP1))
+HGNC:13232	partOf	complex(p(HGNC:13232 ! RASSF8), p(HGNC:9281 ! PPP1CA))
+HGNC:13315	partOf	complex(p(HGNC:13315 ! HDAC8), p(HGNC:391 ! AKT1))
+HGNC:13518	partOf	complex(p(HGNC:13518 ! CLIC4), p(HGNC:667 ! RHOA))
+HGNC:13575	partOf	complex(p(HGNC:13575 ! BRD4), p(HGNC:7553 ! MYC))
+HGNC:13646	partOf	complex(p(HGNC:13646 ! LAPTM4B), p(HGNC:3236 ! EGFR))
+HGNC:13718	activityNegativelyRegulatesActivityOf	HGNC:8590
+HGNC:13718	hasVariant	p(HGNC:13718 ! FOSL1, pmod(Ph))
+HGNC:13718	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:13718 ! FOSL1))
+HGNC:13718	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:13718 ! FOSL1))
+HGNC:13718	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:3796 ! FOS))
+HGNC:13718	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:5100 ! HOXA10))
+HGNC:13718	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:6204 ! JUN))
+HGNC:13718	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:6205 ! JUNB))
+HGNC:13718	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:7553 ! MYC))
+HGNC:13748	partOf	complex(p(HGNC:13748 ! DLEU2), p(HGNC:14013 ! SMC4), p(HGNC:7553 ! MYC))
+HGNC:13759	partOf	complex(p(HGNC:13759 ! CYFIP1), p(HGNC:7553 ! MYC))
+HGNC:13787	partOf	complex(p(HGNC:13787 ! BCL2L12), p(HGNC:6973 ! MDM2))
+HGNC:13924	activityPositivelyRegulatesActivityOf	HGNC:10251
+HGNC:14000	partOf	complex(p(HGNC:14000 ! PRDM16), p(HGNC:8988 ! PIN1))
+HGNC:14013	partOf	complex(p(HGNC:13748 ! DLEU2), p(HGNC:14013 ! SMC4), p(HGNC:7553 ! MYC))
+HGNC:14067	partOf	complex(p(HGNC:14067 ! HDAC7), p(HGNC:7553 ! MYC))
+HGNC:14271	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:14271 ! RASSF3))
+HGNC:14271	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:14271 ! RASSF3))
+HGNC:14271	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:17609 ! RASSF5), p(HGNC:20796 ! RASSF6), p(HGNC:6973 ! MDM2), p(HGNC:9882 ! RASSF1))
+HGNC:14271	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:3236 ! EGFR))
+HGNC:14271	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:6973 ! MDM2))
+HGNC:14289	partOf	complex(p(HGNC:14289 ! NLGN3), p(HGNC:9588 ! PTEN))
+HGNC:14458	partOf	complex(p(HGNC:14458 ! GAB2), p(HGNC:9644 ! PTPN11))
+HGNC:14545	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:14545	hasVariant	p(HGNC:14545 ! RASGRP3, pmod(Ph, Thr, 133))
+HGNC:14545	partOf	complex(p(HGNC:14545 ! RASGRP3), p(HGNC:8975 ! PIK3CA))
+HGNC:14545	partOf	complex(p(HGNC:14545 ! RASGRP3), p(HGNC:9878 ! RASGRP1))
+HGNC:14581	partOf	complex(p(HGNC:14581 ! PINK1), p(HGNC:16262 ! YAP1))
+HGNC:14900	partOf	complex(p(HGNC:14900 ! IL22), p(HGNC:6407 ! KRAS))
+HGNC:14929	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:14929 ! SIRT1))
+HGNC:14929	partOf	complex(p(HGNC:14929 ! SIRT1), p(HGNC:270 ! PARP1), p(HGNC:3942 ! MTOR))
+HGNC:14929	partOf	complex(p(HGNC:14929 ! SIRT1), p(HGNC:3942 ! MTOR))
+HGNC:14935	activityPositivelyRegulatesActivityOf	HGNC:11998
+HGNC:14969	partOf	complex(p(HGNC:14969 ! SNX5), p(HGNC:3236 ! EGFR))
+HGNC:1504	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10251
+HGNC:1504	activityPositivelyRegulatesActivityOf	HGNC:11408
+HGNC:1504	activityPositivelyRegulatesActivityOf	HGNC:6204
+HGNC:1504	hasVariant	p(HGNC:1504 ! CASP3, pmod(Ph))
+HGNC:1504	hasVariant	p(HGNC:1504 ! CASP3, pmod(Ph, Ser, 150))
+HGNC:1504	hasVariant	p(HGNC:1504 ! CASP3, pmod(Ub))
+HGNC:1504	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(a(CHEBI:28748 ! doxorubicin), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(bp(MESH:D011839 ! "Radiation, Ionizing"), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(bp(MESH:D015427 ! "Reperfusion Injury"), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1504 ! CASP3))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1504 ! CASP3), p(HGNC:1509 ! CASP8))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1508 ! CASP7))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1508 ! CASP7), p(HGNC:1509 ! CASP8))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1509 ! CASP8))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1771 ! CDK2))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1784 ! CDKN1A))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:393 ! AKT3))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:576 ! APAF1))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:6125 ! IRS1))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:6204 ! JUN))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:6407 ! KRAS))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:6973 ! MDM2))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:7029 ! MET))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:7794 ! NFKB1))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:8591 ! PAK2))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:9588 ! PTEN))
+HGNC:1504	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:9884 ! RB1))
+HGNC:1505	activityPositivelyRegulatesActivityOf	HGNC:11998
+HGNC:1508	hasVariant	p(HGNC:1508 ! CASP7, pmod(Ph, Ser, 239))
+HGNC:1508	hasVariant	p(HGNC:1508 ! CASP7, pmod(Ph, Ser, 30))
+HGNC:1508	hasVariant	p(HGNC:1508 ! CASP7, pmod(Ph, Thr, 173))
+HGNC:1508	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:1508 ! CASP7))
+HGNC:1508	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:1508 ! CASP7))
+HGNC:1508	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1508 ! CASP7))
+HGNC:1508	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1508 ! CASP7), p(HGNC:1509 ! CASP8))
+HGNC:1508	partOf	complex(p(HGNC:1508 ! CASP7), p(HGNC:1508 ! CASP7))
+HGNC:1508	partOf	complex(p(HGNC:1508 ! CASP7), p(HGNC:1509 ! CASP8))
+HGNC:1508	partOf	complex(p(HGNC:1508 ! CASP7), p(HGNC:9884 ! RB1))
+HGNC:1509	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1504
+HGNC:1509	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1508
+HGNC:1509	activityPositivelyRegulatesActivityOf	HGNC:576
+HGNC:1509	hasVariant	p(HGNC:1509 ! CASP8, pmod(Ph, Ser, 347))
+HGNC:1509	hasVariant	p(HGNC:1509 ! CASP8, pmod(Ph, Ser, 387))
+HGNC:1509	hasVariant	p(HGNC:1509 ! CASP8, pmod(Ph, Thr, 263))
+HGNC:1509	hasVariant	p(HGNC:1509 ! CASP8, pmod(Ph, Tyr, 334))
+HGNC:1509	hasVariant	p(HGNC:1509 ! CASP8, pmod(Ph, Tyr, 380))
+HGNC:1509	hasVariant	p(HGNC:1509 ! CASP8, pmod(Ph, Tyr, 448))
+HGNC:1509	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1509 ! CASP8))
+HGNC:1509	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1504 ! CASP3), p(HGNC:1509 ! CASP8))
+HGNC:1509	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1508 ! CASP7), p(HGNC:1509 ! CASP8))
+HGNC:1509	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1509 ! CASP8))
+HGNC:1509	partOf	complex(p(HGNC:1508 ! CASP7), p(HGNC:1509 ! CASP8))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:1509 ! CASP8))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:1542 ! CBLB))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:4370 ! GMEB1))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:576 ! APAF1))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:667 ! RHOA))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:6871 ! MAPK1))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:8822 ! PEA15))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:8979 ! PIK3R1))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:9588 ! PTEN))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:9841 ! RALBP1))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:9842 ! RALGDS))
+HGNC:1509	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:9884 ! RB1))
+HGNC:1511	partOf	complex(p(HGNC:1511 ! CASP9), p(HGNC:576 ! APAF1))
+HGNC:1527	partOf	complex(p(HGNC:11908 ! TNFRSF11A), p(HGNC:1527 ! CAV1), p(HGNC:3236 ! EGFR))
+HGNC:1541	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8980
+HGNC:1541	decreasesAmountOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))
+HGNC:1541	hasVariant	p(HGNC:1541 ! CBL, pmod(Ph))
+HGNC:1541	hasVariant	p(HGNC:1541 ! CBL, pmod(Ph, Ser, 619))
+HGNC:1541	hasVariant	p(HGNC:1541 ! CBL, pmod(Ph, Tyr, 371))
+HGNC:1541	hasVariant	p(HGNC:1541 ! CBL, pmod(Ph, Tyr, 700))
+HGNC:1541	hasVariant	p(HGNC:1541 ! CBL, pmod(Ph, Tyr, 731))
+HGNC:1541	hasVariant	p(HGNC:1541 ! CBL, pmod(Ph, Tyr, 774))
+HGNC:1541	hasVariant	p(HGNC:1541 ! CBL, var("p.?"))
+HGNC:1541	increasesAmountOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ub)))
+HGNC:1541	increasesAmountOf	p(HGNC:11270 ! SPRY2, pmod(Ub))
+HGNC:1541	increasesAmountOf	p(HGNC:3430 ! ERBB2, pmod(Ub))
+HGNC:1541	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:1541	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:1541	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2))
+HGNC:1541	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1541 ! CBL), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:1541	partOf	complex(p(HGNC:11653 ! TCN2), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:12476 ! UBE2D3), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:1541 ! CBL))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:1541 ! CBL), p(HGNC:1542 ! CBLB))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:1542 ! CBLB))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:15533 ! SPRY4))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:15961 ! CBLC))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:17722 ! SPRED2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3430 ! ERBB2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3430 ! ERBB2), p(HGNC:4566 ! GRB2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3689 ! FGFR2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3765 ! FLT3))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2), p(HGNC:4566 ! GRB2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2), p(HGNC:7029 ! MET))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4568 ! RAPGEF1))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:5173 ! HRAS))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:6091 ! INSR))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:6125 ! IRS1))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:7029 ! MET))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8760 ! PDCD1))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8803 ! PDGFRA))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8804 ! PDGFRB))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8975 ! PIK3CA))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8979 ! PIK3R1))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8980 ! PIK3R2))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8981 ! PIK3R3))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:905 ! AXL))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:9588 ! PTEN))
+HGNC:1541	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:9644 ! PTPN11))
+HGNC:1542	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12657
+HGNC:1542	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:1542	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:12462 ! UBASH3A), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:1541 ! CBL), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:1542 ! CBLB))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:15961 ! CBLC))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:3236 ! EGFR))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:4566 ! GRB2))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:6125 ! IRS1))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:8804 ! PDGFRB))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:8979 ! PIK3R1))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:8980 ! PIK3R2))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:9588 ! PTEN))
+HGNC:1542	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:9644 ! PTPN11))
+HGNC:15454	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9281
+HGNC:15454	hasVariant	p(HGNC:15454 ! SHOC2, pmod(Ph, Thr, 507))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:30287 ! RPTOR))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:30377 ! SCRIB))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:5173 ! HRAS))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:6407 ! KRAS))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:7227 ! MRAS))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:7227 ! MRAS), p(HGNC:9829 ! RAF1))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:7553 ! MYC))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:9281 ! PPP1CA))
+HGNC:15454	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:9829 ! RAF1))
+HGNC:15533	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:15533 ! SPRY4))
+HGNC:15533	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:15533 ! SPRY4))
+HGNC:15533	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:15533 ! SPRY4))
+HGNC:15533	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:15533 ! SPRY4))
+HGNC:15533	partOf	complex(p(HGNC:15533 ! SPRY4), p(HGNC:28719 ! HAUS3))
+HGNC:15533	partOf	complex(p(HGNC:15533 ! SPRY4), p(HGNC:4566 ! GRB2))
+HGNC:15533	partOf	complex(p(HGNC:15533 ! SPRY4), p(HGNC:9829 ! RAF1))
+HGNC:15607	partOf	complex(p(HGNC:15607 ! ARHGEF7), p(HGNC:8590 ! PAK1))
+HGNC:15739	partOf	complex(p(HGNC:1166 ! RASSF7), p(HGNC:15739 ! RASSF9))
+HGNC:15739	partOf	complex(p(HGNC:15739 ! RASSF9), p(HGNC:9281 ! PPP1CA))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:1578 ! CCNA2))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:1725 ! CDC25A))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:1771 ! CDK2))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:1784 ! CDKN1A))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:3113 ! E2F1))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:6947 ! MCM4))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:6949 ! MCM6))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:9281 ! PPP1CA))
+HGNC:1577	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:9884 ! RB1))
+HGNC:1578	activityPositivelyRegulatesActivityOf	HGNC:11998
+HGNC:1578	hasVariant	p(HGNC:1578 ! CCNA2, pmod(Ph, Ser, 154))
+HGNC:1578	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1578 ! CCNA2))
+HGNC:1578	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1578 ! CCNA2))
+HGNC:1578	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1578 ! CCNA2))
+HGNC:1578	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:1578 ! CCNA2))
+HGNC:1578	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:1578 ! CCNA2))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1578 ! CCNA2))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1725 ! CDC25A))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1744 ! CDC6))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1771 ! CDK2))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1773 ! CDK4))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1777 ! CDK6))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1784 ! CDKN1A))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:3113 ! E2F1))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:3584 ! FANCC))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:667 ! RHOA))
+HGNC:1578	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:9884 ! RB1))
+HGNC:1582	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7545
+HGNC:1582	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1773
+HGNC:1582	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1777
+HGNC:1582	hasVariant	p(HGNC:1582 ! CCND1, pmod(Ph))
+HGNC:1582	hasVariant	p(HGNC:1582 ! CCND1, pmod(Ph, Thr, 286))
+HGNC:1582	hasVariant	p(HGNC:1582 ! CCND1, pmod(Ph, Thr, 288))
+HGNC:1582	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1582 ! CCND1))
+HGNC:1582	partOf	complex(p(FPLX:"Cyclin_E" ! "Cyclin_E"), p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+HGNC:1582	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1582 ! CCND1))
+HGNC:1582	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1582 ! CCND1))
+HGNC:1582	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1582 ! CCND1))
+HGNC:1582	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1582 ! CCND1), p(HGNC:1784 ! CDKN1A))
+HGNC:1582	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1582 ! CCND1), p(HGNC:9884 ! RB1))
+HGNC:1582	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:1582 ! CCND1))
+HGNC:1582	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:1582 ! CCND1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1582 ! CCND1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1583 ! CCND2))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1585 ! CCND3))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:1773 ! CDK4))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1777 ! CDK6))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1784 ! CDKN1A))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3113 ! E2F1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3236 ! EGFR))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3430 ! ERBB2))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3430 ! ERBB2), p(HGNC:9588 ! PTEN))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3796 ! FOS))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6204 ! JUN))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6871 ! MAPK1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6945 ! MCM3))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6949 ! MCM6))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6950 ! MCM7))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6973 ! MDM2))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:7553 ! MYC))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:8590 ! PAK1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:8988 ! PIN1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:9884 ! RB1))
+HGNC:1582	partOf	complex(p(HGNC:1582 ! CCND1, pmod(Ph)), p(HGNC:1773 ! CDK4))
+HGNC:1583	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7545
+HGNC:1583	activityPositivelyRegulatesActivityOf	HGNC:1771
+HGNC:1583	hasVariant	p(HGNC:1583 ! CCND2, pmod(Ph, Thr, 280))
+HGNC:1583	partOf	complex(p(FPLX:"JUN_family" ! "JUN_family"), p(HGNC:1583 ! CCND2))
+HGNC:1583	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:1583 ! CCND2))
+HGNC:1583	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1583 ! CCND2))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1585 ! CCND3))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1771 ! CDK2))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1773 ! CDK4))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1777 ! CDK6))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1784 ! CDKN1A))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:7553 ! MYC))
+HGNC:1583	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:9884 ! RB1))
+HGNC:1585	activityPositivelyRegulatesActivityOf	HGNC:1773
+HGNC:1585	hasVariant	p(HGNC:1585 ! CCND3, pmod(Ph, Thr, 283))
+HGNC:1585	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:1585 ! CCND3))
+HGNC:1585	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1585 ! CCND3))
+HGNC:1585	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:1773 ! CDK4))
+HGNC:1585	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1585 ! CCND3))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1771 ! CDK2))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1777 ! CDK6))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1784 ! CDKN1A))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:3113 ! E2F1))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:7545 ! MYB))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:9281 ! PPP1CA))
+HGNC:1585	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:9884 ! RB1))
+HGNC:15961	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:15961 ! CBLC))
+HGNC:15961	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:15961 ! CBLC))
+HGNC:15961	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:15961 ! CBLC))
+HGNC:15961	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:3236 ! EGFR))
+HGNC:15961	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:7029 ! MET))
+HGNC:15961	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:786 ! ATF4), p(HGNC:9967 ! RET))
+HGNC:15961	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:9967 ! RET))
+HGNC:1603	partOf	complex(p(HGNC:1603 ! CCR2), p(HGNC:667 ! RHOA))
+HGNC:16059	activityDirectlyPositivelyRegulatesActivityOf	HGNC:16059
+HGNC:16059	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+HGNC:16059	hasVariant	p(HGNC:16059 ! PAK4, pmod(Ph, Ser, 474))
+HGNC:16059	increasesAmountOf	p(HGNC:10471 ! RUNX1, pmod(Ph, Thr, 207))
+HGNC:16059	partOf	complex(p(HGNC:10471 ! RUNX1), p(HGNC:16059 ! PAK4))
+HGNC:16059	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:16059 ! PAK4))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:16059 ! PAK4))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:1777 ! CDK6))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:3236 ! EGFR))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:3689 ! FGFR2))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:682 ! ARHGEF2))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:6973 ! MDM2))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:8590 ! PAK1))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:8979 ! PIK3R1))
+HGNC:16059	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:9801 ! RAC1))
+HGNC:16064	partOf	complex(p(HGNC:16064 ! GGA2), p(HGNC:3236 ! EGFR))
+HGNC:16090	partOf	complex(p(HGNC:16090 ! PGRMC1), p(HGNC:3236 ! EGFR))
+HGNC:16207	hasVariant	p(HGNC:16207 ! RALGAPA2, pmod(Ph))
+HGNC:16262	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12003
+HGNC:16262	activityPositivelyRegulatesActivityOf	FPLX:AP1
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ph))
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 127))
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 397))
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 400))
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 403))
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 61))
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 94))
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ph, Tyr, 407))
+HGNC:16262	hasVariant	p(HGNC:16262 ! YAP1, pmod(Ub))
+HGNC:16262	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(FPLX:SMAD ! SMAD), p(HGNC:11577 ! TAZ), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11195 ! SOX2), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11283 ! SRC), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11577 ! TAZ), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11714 ! TEAD1), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11717 ! TEAD4), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:13232 ! RASSF8), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:14581 ! PINK1), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:16262 ! YAP1), p(HGNC:16262 ! YAP1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:16854 ! RAPGEF2))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:17811 ! AMOTL1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:2514 ! CTNNB1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:28426 ! AKT1S1), p(HGNC:3821 ! FOXO3), p(HGNC:936 ! BAD))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:30377 ! SCRIB))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:3236 ! EGFR))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:3688 ! FGFR1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:4236 ! GFER))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:4317 ! GLI1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:6204 ! JUN))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:6407 ! KRAS))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:6840 ! MAP2K1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:7548 ! MYBL2))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:7553 ! MYC))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:8975 ! PIK3CA))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:8988 ! PIN1))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:9281 ! PPP1CA))
+HGNC:16262	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:9644 ! PTPN11))
+HGNC:16281	increasesAmountOf	p(HGNC:3072 ! DUSP6, pmod(Ub))
+HGNC:16281	partOf	complex(p(HGNC:16281 ! TRIM11), p(HGNC:3072 ! DUSP6))
+HGNC:1630	partOf	complex(p(HGNC:1630 ! CD151), p(HGNC:3236 ! EGFR))
+HGNC:16369	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:16369 ! PARK7))
+HGNC:16369	partOf	complex(p(HGNC:16369 ! PARK7), p(HGNC:9588 ! PTEN))
+HGNC:16400	activityPositivelyRegulatesActivityOf	HGNC:6407
+HGNC:16403	partOf	complex(p(HGNC:16403 ! ZNF346), p(HGNC:7553 ! MYC))
+HGNC:1653	partOf	complex(p(HGNC:1653 ! CD28), p(HGNC:4566 ! GRB2))
+HGNC:16623	activityPositivelyRegulatesActivityOf	HGNC:3796
+HGNC:16695	partOf	complex(p(HGNC:16695 ! BCAP31), p(HGNC:3236 ! EGFR))
+HGNC:16712	partOf	complex(p(HGNC:16712 ! FBXW7), p(HGNC:7553 ! MYC))
+HGNC:16712	partOf	complex(p(HGNC:16712 ! FBXW7), p(HGNC:7889 ! NOX1))
+HGNC:16743	partOf	complex(p(HGNC:16743 ! SHC4), p(HGNC:18181 ! SHC3))
+HGNC:16743	partOf	complex(p(HGNC:16743 ! SHC4), p(HGNC:3236 ! EGFR))
+HGNC:16743	partOf	complex(p(HGNC:16743 ! SHC4), p(HGNC:4566 ! GRB2))
+HGNC:1681	partOf	complex(p(HGNC:1681 ! CD44), p(HGNC:8591 ! PAK2))
+HGNC:16853	partOf	complex(p(HGNC:16853 ! IPO13), p(HGNC:6204 ! JUN))
+HGNC:16854	hasVariant	p(HGNC:16854 ! RAPGEF2, pmod(Ph, Ser, 960))
+HGNC:16854	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:16854 ! RAPGEF2))
+HGNC:16854	partOf	complex(p(HGNC:16854 ! RAPGEF2), p(HGNC:16854 ! RAPGEF2))
+HGNC:16854	partOf	complex(p(HGNC:16854 ! RAPGEF2), p(HGNC:9842 ! RALGDS))
+HGNC:16923	activityPositivelyRegulatesActivityOf	HGNC:3796
+HGNC:16923	partOf	complex(p(HGNC:16923 ! AGAP3), p(HGNC:3321 ! ELK1))
+HGNC:17142	hasVariant	p(HGNC:17142 ! OPTN, pmod(Ph))
+HGNC:17175	activityDirectlyNegativelyRegulatesActivityOf	HGNC:5173
+HGNC:17175	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:17175	decreasesAmountOf	GO:"GO:0006914"
+HGNC:17175	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:17175 ! PLCE1))
+HGNC:17175	partOf	complex(p(HGNC:17175 ! PLCE1), p(HGNC:7665 ! NCK2))
+HGNC:17175	partOf	complex(p(HGNC:17175 ! PLCE1), p(HGNC:7989 ! NRAS))
+HGNC:17192	partOf	complex(p(HGNC:17192 ! TIRAP), p(HGNC:6204 ! JUN))
+HGNC:1722	partOf	complex(p(HGNC:1722 ! CDK1), p(HGNC:1771 ! CDK2))
+HGNC:1722	partOf	complex(p(HGNC:1722 ! CDK1), p(HGNC:7553 ! MYC))
+HGNC:1725	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+HGNC:1725	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1771
+HGNC:1725	activityPositivelyRegulatesActivityOf	FPLX:"Cyclin_A"
+HGNC:1725	decreasesAmountOf	complex(p(HGNC:1582 ! CCND1, pmod(Ph)), p(HGNC:1773 ! CDK4))
+HGNC:1725	decreasesAmountOf	p(HGNC:1773 ! CDK4, pmod(Ph))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 116))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 124))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 178))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 263))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 279))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 293))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 295))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 76))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 79))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 82))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ph, Thr, 80))
+HGNC:1725	hasVariant	p(HGNC:1725 ! CDC25A, pmod(Ub))
+HGNC:1725	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:1725 ! CDC25A))
+HGNC:1725	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:1725 ! CDC25A))
+HGNC:1725	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11998 ! TP53), p(HGNC:1725 ! CDC25A))
+HGNC:1725	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1725 ! CDC25A))
+HGNC:1725	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:1725 ! CDC25A), p(HGNC:3113 ! E2F1))
+HGNC:1725	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:1725 ! CDC25A))
+HGNC:1725	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1725 ! CDC25A))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:1725 ! CDC25A))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:1744 ! CDC6))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:1771 ! CDK2))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:1777 ! CDK6))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:3113 ! E2F1))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:3114 ! E2F2))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:3236 ! EGFR))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:3430 ! ERBB2))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:7553 ! MYC))
+HGNC:1725	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:9829 ! RAF1))
+HGNC:17263	activityPositivelyRegulatesActivityOf	HGNC:6840
+HGNC:1727	partOf	complex(p(HGNC:1727 ! CDC25C), p(HGNC:8988 ! PIN1))
+HGNC:17294	activityDirectlyNegativelyRegulatesActivityOf	HGNC:5173
+HGNC:17294	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6407
+HGNC:17294	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7989
+HGNC:17294	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+HGNC:17294	hasVariant	p(HGNC:17294 ! DAB2IP, pmod(Ph, Ser, 971))
+HGNC:17294	hasVariant	p(HGNC:17294 ! DAB2IP, pmod(Ub))
+HGNC:17294	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:17294 ! DAB2IP))
+HGNC:17294	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:17294 ! DAB2IP))
+HGNC:17294	partOf	complex(p(HGNC:17294 ! DAB2IP), p(HGNC:391 ! AKT1))
+HGNC:17294	partOf	complex(p(HGNC:17294 ! DAB2IP), p(HGNC:5173 ! HRAS))
+HGNC:17294	partOf	complex(p(HGNC:17294 ! DAB2IP), p(HGNC:8979 ! PIK3R1))
+HGNC:1736	partOf	complex(p(HGNC:1736 ! CDC42), p(HGNC:9801 ! RAC1))
+HGNC:1739	partOf	complex(p(HGNC:1739 ! CDC45), p(HGNC:7553 ! MYC))
+HGNC:1744	hasVariant	p(HGNC:1744 ! CDC6, pmod(Ph))
+HGNC:1744	hasVariant	p(HGNC:1744 ! CDC6, pmod(Ph, Ser, 106))
+HGNC:1744	hasVariant	p(HGNC:1744 ! CDC6, pmod(Ph, Ser, 54))
+HGNC:1744	hasVariant	p(HGNC:1744 ! CDC6, pmod(Ph, Ser, 74))
+HGNC:1744	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1744 ! CDC6), p(HGNC:1771 ! CDK2))
+HGNC:1744	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1744 ! CDC6))
+HGNC:1744	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:1744 ! CDC6))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1744 ! CDC6))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1771 ! CDK2))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1773 ! CDK4))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1777 ! CDK6))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1784 ! CDKN1A))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:3113 ! E2F1))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:6945 ! MCM3))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:6950 ! MCM7))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:7553 ! MYC))
+HGNC:1744	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:9884 ! RB1))
+HGNC:17609	activityPositivelyRegulatesActivityOf	HGNC:11408
+HGNC:17609	activityPositivelyRegulatesActivityOf	HGNC:1784
+HGNC:17609	increasesAmountOf	p(HGNC:11998 ! TP53, pmod(Ac))
+HGNC:17609	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:17609 ! RASSF5))
+HGNC:17609	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1))
+HGNC:17609	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:17609 ! RASSF5))
+HGNC:17609	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:17609 ! RASSF5))
+HGNC:17609	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:17609 ! RASSF5), p(HGNC:20796 ! RASSF6), p(HGNC:6973 ! MDM2), p(HGNC:9882 ! RASSF1))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:17609 ! RASSF5))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:17609 ! RASSF5), p(HGNC:9883 ! RASSF2))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:17795 ! SAV1))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:5173 ! HRAS))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:6407 ! KRAS))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:6973 ! MDM2))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:7227 ! MRAS))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9281 ! PPP1CA))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1), p(HGNC:9883 ! RASSF2))
+HGNC:17609	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9883 ! RASSF2))
+HGNC:17635	partOf	complex(p(HGNC:17635 ! CD274), p(HGNC:3236 ! EGFR))
+HGNC:17635	partOf	complex(p(HGNC:17635 ! CD274), p(HGNC:6407 ! KRAS))
+HGNC:17635	partOf	complex(p(HGNC:17635 ! CD274), p(HGNC:7553 ! MYC))
+HGNC:17643	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:17643 ! GOPC))
+HGNC:1771	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11830
+HGNC:1771	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+HGNC:1771	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9281
+HGNC:1771	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+HGNC:1771	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+HGNC:1771	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6945
+HGNC:1771	activityNegativelyRegulatesActivityOf	FPLX:"Cyclin_A"
+HGNC:1771	hasVariant	p(HGNC:1771 ! CDK2, pmod(Ph))
+HGNC:1771	hasVariant	p(HGNC:1771 ! CDK2, pmod(Ph, Thr, 14))
+HGNC:1771	hasVariant	p(HGNC:1771 ! CDK2, pmod(Ph, Thr, 160))
+HGNC:1771	hasVariant	p(HGNC:1771 ! CDK2, pmod(Ph, Thr, 39))
+HGNC:1771	hasVariant	p(HGNC:1771 ! CDK2, pmod(Ph, Tyr, 15))
+HGNC:1771	increasesAmountOf	p(HGNC:952 ! BARD1, pmod(Ph))
+HGNC:1771	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1744 ! CDC6), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))
+HGNC:1771	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:3113 ! E2F1))
+HGNC:1771	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:9884 ! RB1))
+HGNC:1771	partOf	complex(p(FPLX:"Cyclin_E" ! "Cyclin_E"), p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+HGNC:1771	partOf	complex(p(FPLX:"Cyclin_E" ! "Cyclin_E"), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:11327 ! SSRP1), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))
+HGNC:1771	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+HGNC:1771	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1722 ! CDK1), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1771 ! CDK2))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A), p(HGNC:1784 ! CDKN1A))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1777 ! CDK6))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A), p(HGNC:1784 ! CDKN1A))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A), p(HGNC:8729 ! PCNA))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1785 ! CDKN1B))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1833 ! CEBPA))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:3113 ! E2F1))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:3236 ! EGFR))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:669 ! RHOC))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6871 ! MAPK1))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6877 ! MAPK3))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6945 ! MCM3))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6947 ! MCM4))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6949 ! MCM6))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6950 ! MCM7))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:7553 ! MYC))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:8988 ! PIN1))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:9281 ! PPP1CA))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:952 ! BARD1))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:9801 ! RAC1))
+HGNC:1771	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:9884 ! RB1))
+HGNC:17722	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:17722 ! SPRED2))
+HGNC:17722	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:17722 ! SPRED2))
+HGNC:17722	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:17722 ! SPRED2))
+HGNC:17722	partOf	complex(p(HGNC:17722 ! SPRED2), p(HGNC:20249 ! SPRED1))
+HGNC:17722	partOf	complex(p(HGNC:17722 ! SPRED2), p(HGNC:3236 ! EGFR))
+HGNC:17722	partOf	complex(p(HGNC:17722 ! SPRED2), p(HGNC:7765 ! NF1))
+HGNC:1773	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1100
+HGNC:1773	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9882
+HGNC:1773	hasVariant	p(HGNC:1773 ! CDK4, pmod(Ph))
+HGNC:1773	increasesAmountOf	p(HGNC:1582 ! CCND1, pmod(Ph))
+HGNC:1773	increasesAmountOf	p(HGNC:6204 ! JUN, pmod(Ph))
+HGNC:1773	partOf	complex(p(FPLX:"Cyclin_E" ! "Cyclin_E"), p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(FPLX:CDKN2 ! CDKN2), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1773 ! CDK4), p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:1773	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+HGNC:1773	partOf	complex(p(HGNC:1582 ! CCND1, pmod(Ph)), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1773	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1773	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1773	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1))
+HGNC:1773	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1773	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1773	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A), p(HGNC:1784 ! CDKN1A))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1773 ! CDK4))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1778 ! CDK7))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A, pmod(Ph)))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1785 ! CDKN1B))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:6407 ! KRAS))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:6950 ! MCM7))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:6973 ! MDM2))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:7553 ! MYC))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:9281 ! PPP1CA))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:9829 ! RAF1))
+HGNC:1773	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1))
+HGNC:1777	hasVariant	p(HGNC:1777 ! CDK6, pmod(Ph))
+HGNC:1777	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:1777	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1777	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1777	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:1777	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:1777 ! CDK6))
+HGNC:1777	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1777	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:3321 ! ELK1))
+HGNC:1777	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:7553 ! MYC))
+HGNC:1777	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:1778	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1778 ! CDK7))
+HGNC:17795	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11408
+HGNC:17795	hasVariant	p(HGNC:17795 ! SAV1, pmod(Ph))
+HGNC:17795	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:17795 ! SAV1))
+HGNC:17795	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:17795 ! SAV1))
+HGNC:17795	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:17795 ! SAV1))
+HGNC:17795	partOf	complex(p(HGNC:17795 ! SAV1), p(HGNC:20796 ! RASSF6))
+HGNC:17795	partOf	complex(p(HGNC:17795 ! SAV1), p(HGNC:391 ! AKT1))
+HGNC:17795	partOf	complex(p(HGNC:17795 ! SAV1), p(HGNC:9882 ! RASSF1))
+HGNC:17811	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:17811 ! AMOTL1))
+HGNC:1784	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+HGNC:1784	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+HGNC:1784	activityNegativelyRegulatesActivityOf	HGNC:1582
+HGNC:1784	activityNegativelyRegulatesActivityOf	HGNC:6204
+HGNC:1784	activityPositivelyRegulatesActivityOf	HGNC:11406
+HGNC:1784	activityPositivelyRegulatesActivityOf	HGNC:11805
+HGNC:1784	activityPositivelyRegulatesActivityOf	HGNC:1582
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ac))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ph))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 130))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 146))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 153))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ph, Thr, 145))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ph, Thr, 55))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ph, Thr, 57))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ph, Thr, 80))
+HGNC:1784	hasVariant	p(HGNC:1784 ! CDKN1A, pmod(Ub))
+HGNC:1784	increasesAmountOf	p(HGNC:1784 ! CDKN1A, pmod(Ac))
+HGNC:1784	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(FPLX:"RNApo_II" ! "RNApo_II"), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(FPLX:ROCK ! ROCK), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:11830 ! TK1), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1582 ! CCND1), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1784 ! CDKN1A), p(HGNC:6973 ! MDM2))
+HGNC:1784	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1784 ! CDKN1A), p(HGNC:9884 ! RB1))
+HGNC:1784	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A), p(HGNC:8729 ! PCNA))
+HGNC:1784	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A, pmod(Ph)))
+HGNC:1784	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:1784 ! CDKN1A))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:1784 ! CDKN1A), p(HGNC:9884 ! RB1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:20249 ! SPRED1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:21270 ! GRWD1), p(HGNC:6973 ! MDM2))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:28833 ! OLA1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:30281 ! RGL1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3113 ! E2F1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3288 ! EIF4EBP1, pmod(Ph)))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3290 ! EIF4EBP3))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3527 ! EZH2))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:391 ! AKT1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:392 ! AKT2))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3942 ! MTOR))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:5173 ! HRAS))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6204 ! JUN))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6407 ! KRAS))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:667 ! RHOA))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6973 ! MDM2))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:7553 ! MYC))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:7765 ! NF1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:7782 ! NFE2L2))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:7989 ! NRAS))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:8590 ! PAK1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:8607 ! PRKN))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:8729 ! PCNA))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9588 ! PTEN))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9801 ! RAC1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9829 ! RAF1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9842 ! RALGDS))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9871 ! RASA1))
+HGNC:1784	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9884 ! RB1))
+HGNC:17848	partOf	complex(p(HGNC:17848 ! STK38L), p(HGNC:682 ! ARHGEF2))
+HGNC:1785	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1785 ! CDKN1B))
+HGNC:1785	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1785 ! CDKN1B))
+HGNC:1785	partOf	complex(p(HGNC:1785 ! CDKN1B), p(HGNC:8591 ! PAK2))
+HGNC:17862	partOf	complex(p(HGNC:17862 ! SENP3), p(HGNC:3113 ! E2F1))
+HGNC:18157	partOf	complex(p(HGNC:18157 ! TAB1), p(HGNC:6973 ! MDM2))
+HGNC:18181	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:18181	hasVariant	p(HGNC:18181 ! SHC3, pmod(Ph))
+HGNC:18181	hasVariant	p(HGNC:18181 ! SHC3, pmod(Ph, Tyr))
+HGNC:18181	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:18181 ! SHC3))
+HGNC:18181	partOf	complex(p(HGNC:16743 ! SHC4), p(HGNC:18181 ! SHC3))
+HGNC:18181	partOf	complex(p(HGNC:18181 ! SHC3), p(HGNC:3236 ! EGFR))
+HGNC:18181	partOf	complex(p(HGNC:18181 ! SHC3), p(HGNC:3430 ! ERBB2))
+HGNC:18181	partOf	complex(p(HGNC:18181 ! SHC3), p(HGNC:427 ! ALK))
+HGNC:18185	hasVariant	p(HGNC:18185 ! ERRFI1, pmod(Ph))
+HGNC:18238	partOf	complex(p(HGNC:18238 ! RAB25), p(HGNC:3236 ! EGFR))
+HGNC:1833	hasVariant	p(HGNC:1833 ! CEBPA, pmod(Ph))
+HGNC:1833	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1833 ! CEBPA))
+HGNC:18547	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18547 ! CDC42SE2))
+HGNC:18610	hasVariant	p(HGNC:18610 ! KSR2, pmod(Ph, Ser, 198))
+HGNC:18610	hasVariant	p(HGNC:18610 ! KSR2, pmod(Ph, Thr, 290))
+HGNC:18610	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2))
+HGNC:18610	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2))
+HGNC:18610	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:18610	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2))
+HGNC:18610	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:18610	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:6465 ! KSR1))
+HGNC:18610	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:18683	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:18683 ! EIF4A3))
+HGNC:1874	hasVariant	p(HGNC:1874 ! CFL1, pmod(Ph))
+HGNC:18957	partOf	complex(p(HGNC:18957 ! MAGI2), p(HGNC:9588 ! PTEN))
+HGNC:18958	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:19124	partOf	complex(p(HGNC:19124 ! FIP1L1), p(HGNC:8803 ! PDGFRA))
+HGNC:195	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:195 ! ADAM17))
+HGNC:195	partOf	complex(p(HGNC:195 ! ADAM17), p(HGNC:3236 ! EGFR))
+HGNC:19680	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:19680 ! GPBAR1))
+HGNC:19700	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9882
+HGNC:19700	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:19700 ! CNKSR1))
+HGNC:19700	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:19700 ! CNKSR1))
+HGNC:19700	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:19700 ! CNKSR1))
+HGNC:19700	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:667 ! RHOA))
+HGNC:19700	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:8988 ! PIN1))
+HGNC:19700	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9502 ! CYTH2))
+HGNC:19700	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9829 ! RAF1))
+HGNC:19700	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9842 ! RALGDS))
+HGNC:19700	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9882 ! RASSF1))
+HGNC:19701	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+HGNC:19701	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2))
+HGNC:19701	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:19701	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2))
+HGNC:19701	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:19701	partOf	complex(p(HGNC:19701 ! CNKSR2), p(HGNC:9829 ! RAF1))
+HGNC:19701	partOf	complex(p(HGNC:19701 ! CNKSR2), p(HGNC:9839 ! RALA))
+HGNC:1984	partOf	complex(p(HGNC:1984 ! CISH), p(HGNC:882 ! ATR), p(HGNC:8988 ! PIN1))
+HGNC:19950	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:19950 ! RDM1))
+HGNC:19986	partOf	complex(p(HGNC:19986 ! CYCS), p(HGNC:576 ! APAF1))
+HGNC:2001	partOf	complex(p(HGNC:2001 ! GREM1), p(HGNC:3236 ! EGFR))
+HGNC:20249	partOf	complex(p(HGNC:17722 ! SPRED2), p(HGNC:20249 ! SPRED1))
+HGNC:20249	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:20249 ! SPRED1))
+HGNC:20249	partOf	complex(p(HGNC:20249 ! SPRED1), p(HGNC:7765 ! NF1))
+HGNC:20249	partOf	complex(p(HGNC:20249 ! SPRED1), p(HGNC:9281 ! PPP1CA))
+HGNC:20331	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:20331	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+HGNC:20473	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:20473 ! BRIP1))
+HGNC:20473	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:20473 ! BRIP1), p(HGNC:20473 ! BRIP1))
+HGNC:20473	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:20473 ! BRIP1), p(HGNC:952 ! BARD1))
+HGNC:20473	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:20473 ! BRIP1))
+HGNC:20473	partOf	complex(p(HGNC:20473 ! BRIP1), p(HGNC:20473 ! BRIP1))
+HGNC:20473	partOf	complex(p(HGNC:20473 ! BRIP1), p(HGNC:952 ! BARD1))
+HGNC:20609	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:20609 ! AIMP2))
+HGNC:20610	partOf	complex(p(HGNC:20610 ! PHLPP1), p(HGNC:391 ! AKT1))
+HGNC:20696	hasVariant	p(HGNC:20696 ! ELP3, pmod(Ph))
+HGNC:20772	partOf	complex(p(HGNC:20772 ! TUBB3), p(HGNC:9588 ! PTEN))
+HGNC:20793	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:20793 ! RASSF4))
+HGNC:20793	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:20793 ! RASSF4))
+HGNC:20796	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:20796 ! RASSF6))
+HGNC:20796	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:20796 ! RASSF6))
+HGNC:20796	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:20796 ! RASSF6))
+HGNC:20796	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:17609 ! RASSF5), p(HGNC:20796 ! RASSF6), p(HGNC:6973 ! MDM2), p(HGNC:9882 ! RASSF1))
+HGNC:20796	partOf	complex(p(HGNC:17795 ! SAV1), p(HGNC:20796 ! RASSF6))
+HGNC:20796	partOf	complex(p(HGNC:20796 ! RASSF6), p(HGNC:6407 ! KRAS))
+HGNC:20796	partOf	complex(p(HGNC:20796 ! RASSF6), p(HGNC:6973 ! MDM2))
+HGNC:20967	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:20967 ! NACC1))
+HGNC:21166	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:21166 ! RHEBL1))
+HGNC:21270	partOf	complex(p(FPLX:"p53_family" ! "p53_family"), p(HGNC:11998 ! TP53), p(HGNC:21270 ! GRWD1))
+HGNC:21270	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:21270 ! GRWD1))
+HGNC:21270	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:21270 ! GRWD1), p(HGNC:6973 ! MDM2))
+HGNC:21399	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:21399 ! FOXN4))
+HGNC:21578	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:21578 ! RNF144B))
+HGNC:21869	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:21869 ! AGK))
+HGNC:22219	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:22219 ! KIAA1549))
+HGNC:22265	partOf	complex(p(HGNC:22265 ! BHLHA15), p(HGNC:6407 ! KRAS))
+HGNC:22950	partOf	complex(p(HGNC:22950 ! PREX2), p(HGNC:2550 ! CELF2))
+HGNC:22950	partOf	complex(p(HGNC:22950 ! PREX2), p(HGNC:3942 ! MTOR))
+HGNC:22950	partOf	complex(p(HGNC:22950 ! PREX2), p(HGNC:9588 ! PTEN))
+HGNC:22953	partOf	complex(p(HGNC:22953 ! DEPTOR), p(HGNC:24825 ! MLST8), p(HGNC:28426 ! AKT1S1), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:22953	partOf	complex(p(HGNC:22953 ! DEPTOR), p(HGNC:3942 ! MTOR))
+HGNC:23133	partOf	complex(p(HGNC:23133 ! NAT9), p(HGNC:3489 ! ETS2))
+HGNC:23177	activityPositivelyRegulatesActivityOf	HGNC:7782
+HGNC:23177	increasesAmountOf	p(HGNC:7782 ! NFE2L2, pmod(Ub))
+HGNC:23177	partOf	complex(p(HGNC:23177 ! KEAP1), p(HGNC:7782 ! NFE2L2))
+HGNC:2319	partOf	complex(p(HGNC:2319 ! CPNE6), p(HGNC:9801 ! RAC1))
+HGNC:23196	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:23196 ! EXOC6))
+HGNC:23196	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:23196 ! EXOC6))
+HGNC:23196	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:23214 ! EXOC7))
+HGNC:23196	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:24659 ! EXOC8))
+HGNC:23196	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:24968 ! EXOC2))
+HGNC:23196	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:30378 ! EXOC3))
+HGNC:23196	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:30380 ! EXOC1))
+HGNC:23196	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:30389 ! EXOC4))
+HGNC:23196	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:3236 ! EGFR))
+HGNC:23200	hasVariant	p(HGNC:23200 ! HBP1, pmod(Ub))
+HGNC:23214	hasVariant	p(HGNC:23214 ! EXOC7, pmod(Ph))
+HGNC:23214	hasVariant	p(HGNC:23214 ! EXOC7, pmod(Ph, Ser, 250))
+HGNC:23214	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:23214 ! EXOC7))
+HGNC:23214	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:23214 ! EXOC7))
+HGNC:23214	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:24659 ! EXOC8))
+HGNC:23214	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:24968 ! EXOC2))
+HGNC:23214	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:30378 ! EXOC3))
+HGNC:23214	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:30380 ! EXOC1))
+HGNC:23214	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:30389 ! EXOC4))
+HGNC:23214	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:3236 ! EGFR))
+HGNC:23214	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:9839 ! RALA))
+HGNC:23217	partOf	complex(p(HGNC:23217 ! GKN1), p(HGNC:5173 ! HRAS))
+HGNC:23251	partOf	complex(p(HGNC:23251 ! AWAT2), p(HGNC:7765 ! NF1))
+HGNC:23393	partOf	complex(p(HGNC:23393 ! CARM1), p(HGNC:7553 ! MYC))
+HGNC:23664	activityPositivelyRegulatesActivityOf	HGNC:6973
+HGNC:23692	partOf	complex(p(HGNC:23692 ! ACKR3), p(HGNC:3236 ! EGFR))
+HGNC:23820	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:23820 ! E2F7))
+HGNC:23820	partOf	complex(p(HGNC:23820 ! E2F7), p(HGNC:23820 ! E2F7))
+HGNC:23820	partOf	complex(p(HGNC:23820 ! E2F7), p(HGNC:3113 ! E2F1))
+HGNC:23820	partOf	complex(p(HGNC:23820 ! E2F7), p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1))
+HGNC:23820	partOf	complex(p(HGNC:23820 ! E2F7), p(HGNC:9884 ! RB1))
+HGNC:23927	hasVariant	p(HGNC:23927 ! ITGB1BP1, pmod(Ph, Ser, 10))
+HGNC:2394	partOf	complex(p(HGNC:2394 ! CRYBA1), p(HGNC:3236 ! EGFR))
+HGNC:24224	partOf	complex(p(HGNC:24224 ! CDK12), p(HGNC:8591 ! PAK2))
+HGNC:24615	hasVariant	p(HGNC:24615 ! EEF2K, pmod(Ph))
+HGNC:24627	hasVariant	p(HGNC:24627 ! DCBLD2, pmod(Ph))
+HGNC:24659	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:24659 ! EXOC8))
+HGNC:24659	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:24659 ! EXOC8))
+HGNC:24659	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:24659 ! EXOC8))
+HGNC:24659	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:24968 ! EXOC2))
+HGNC:24659	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:30378 ! EXOC3))
+HGNC:24659	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:30380 ! EXOC1))
+HGNC:24659	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:30389 ! EXOC4))
+HGNC:24659	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:3236 ! EGFR))
+HGNC:24659	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:9839 ! RALA))
+HGNC:24659	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:9840 ! RALB))
+HGNC:24679	partOf	complex(p(HGNC:24679 ! FBXL20), p(HGNC:6005 ! IL21), p(HGNC:9588 ! PTEN))
+HGNC:24825	partOf	complex(p(HGNC:22953 ! DEPTOR), p(HGNC:24825 ! MLST8), p(HGNC:28426 ! AKT1S1), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:24825	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:30287 ! RPTOR))
+HGNC:24825	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:24825	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:24825	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:3288 ! EIF4EBP1))
+HGNC:24825	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:3942 ! MTOR))
+HGNC:24825	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:3942 ! MTOR), p(HGNC:7553 ! MYC))
+HGNC:24948	partOf	complex(p(HGNC:24948 ! DOT1L), p(HGNC:3373 ! EP300), p(HGNC:7553 ! MYC))
+HGNC:24968	hasVariant	p(HGNC:24968 ! EXOC2, pmod(Ph))
+HGNC:24968	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:24968 ! EXOC2))
+HGNC:24968	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:24968 ! EXOC2), p(HGNC:30389 ! EXOC4))
+HGNC:24968	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:24968 ! EXOC2))
+HGNC:24968	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:24968 ! EXOC2))
+HGNC:24968	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:24968 ! EXOC2))
+HGNC:24968	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:24968 ! EXOC2))
+HGNC:24968	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:30378 ! EXOC3))
+HGNC:24968	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:30380 ! EXOC1))
+HGNC:24968	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:30389 ! EXOC4))
+HGNC:24968	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:3236 ! EGFR))
+HGNC:24968	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:682 ! ARHGEF2))
+HGNC:24968	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:9839 ! RALA))
+HGNC:24968	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:9840 ! RALB))
+HGNC:2500	partOf	complex(p(HGNC:2500 ! CCN2), p(HGNC:3236 ! EGFR))
+HGNC:2514	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:2514 ! CTNNB1))
+HGNC:2514	partOf	complex(p(HGNC:2514 ! CTNNB1), p(HGNC:6886 ! MAPK9), p(HGNC:9801 ! RAC1))
+HGNC:2550	partOf	complex(p(HGNC:22950 ! PREX2), p(HGNC:2550 ! CELF2))
+HGNC:25521	partOf	complex(p(HGNC:25521 ! SRBD1), p(HGNC:427 ! ALK))
+HGNC:25550	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:25550 ! RMDN3), p(HGNC:9829 ! RAF1))
+HGNC:25550	partOf	complex(p(HGNC:25550 ! RMDN3), p(HGNC:3430 ! ERBB2))
+HGNC:25550	partOf	complex(p(HGNC:25550 ! RMDN3), p(HGNC:9829 ! RAF1))
+HGNC:25717	partOf	complex(p(HGNC:25717 ! NT5DC2), p(HGNC:3236 ! EGFR))
+HGNC:2578	partOf	complex(p(HGNC:2578 ! CYBB), p(HGNC:7889 ! NOX1))
+HGNC:26144	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:26144 ! PALB2))
+HGNC:2672	activityPositivelyRegulatesActivityOf	HGNC:11998
+HGNC:2672	activityPositivelyRegulatesActivityOf	HGNC:1784
+HGNC:2674	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:2674 ! DAPK1))
+HGNC:2681	partOf	complex(p(HGNC:12630 ! USP7), p(HGNC:2681 ! DAXX), p(HGNC:6973 ! MDM2))
+HGNC:270	hasVariant	p(HGNC:270 ! PARP1, pmod(Ph, Tyr))
+HGNC:270	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:270 ! PARP1), p(HGNC:3433 ! ERCC1))
+HGNC:270	partOf	complex(p(HGNC:14929 ! SIRT1), p(HGNC:270 ! PARP1), p(HGNC:3942 ! MTOR))
+HGNC:270	partOf	complex(p(HGNC:270 ! PARP1), p(HGNC:3942 ! MTOR))
+HGNC:27949	partOf	complex(p(HGNC:27949 ! GADL1), p(HGNC:3236 ! EGFR))
+HGNC:27962	hasVariant	p(HGNC:27962 ! STING1, pmod(Ph))
+HGNC:27962	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:27962 ! STING1))
+HGNC:28115	partOf	complex(p(HGNC:28115 ! TBCEL), p(HGNC:6407 ! KRAS))
+HGNC:28426	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:28426 ! AKT1S1), p(HGNC:3821 ! FOXO3), p(HGNC:936 ! BAD))
+HGNC:28426	partOf	complex(p(HGNC:22953 ! DEPTOR), p(HGNC:24825 ! MLST8), p(HGNC:28426 ! AKT1S1), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:2861	partOf	complex(a(CHEBI:44185 ! methotrexate), p(HGNC:2861 ! DHFR))
+HGNC:2861	partOf	complex(a(PUBCHEM:35595 ! 35595), p(HGNC:2861 ! DHFR))
+HGNC:2861	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:2861 ! DHFR))
+HGNC:2861	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:2861 ! DHFR))
+HGNC:2861	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:12441 ! TYMS), p(HGNC:2861 ! DHFR), p(HGNC:2861 ! DHFR))
+HGNC:2861	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:2861 ! DHFR))
+HGNC:2861	partOf	complex(p(HGNC:2861 ! DHFR), p(HGNC:2861 ! DHFR))
+HGNC:2861	partOf	complex(p(HGNC:2861 ! DHFR), p(HGNC:3236 ! EGFR))
+HGNC:2861	partOf	complex(p(HGNC:2861 ! DHFR), p(HGNC:6973 ! MDM2))
+HGNC:28611	partOf	complex(p(HGNC:28611 ! RICTOR), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:28611	partOf	complex(p(HGNC:28611 ! RICTOR), p(HGNC:3942 ! MTOR))
+HGNC:28719	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:28719 ! HAUS3))
+HGNC:28719	partOf	complex(p(HGNC:15533 ! SPRY4), p(HGNC:28719 ! HAUS3))
+HGNC:28833	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:28833 ! OLA1))
+HGNC:28833	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:28833 ! OLA1))
+HGNC:28866	partOf	complex(p(HGNC:28866 ! IGF2BP1), p(HGNC:6407 ! KRAS))
+HGNC:28866	partOf	complex(p(HGNC:28866 ! IGF2BP1), p(HGNC:7553 ! MYC))
+HGNC:28958	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:28958 ! NUP93))
+HGNC:2903	partOf	complex(p(HGNC:2903 ! DLG4), p(HGNC:8988 ! PIN1))
+HGNC:29038	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:29038 ! OTUD3))
+HGNC:29038	partOf	complex(p(HGNC:29038 ! OTUD3), p(HGNC:9588 ! PTEN))
+HGNC:29091	hasVariant	p(HGNC:29091 ! ATG13, pmod(Ph))
+HGNC:2916	hasVariant	p(HGNC:2916 ! DLX3, pmod(Ub))
+HGNC:29233	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:29233 ! MAVS))
+HGNC:29233	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:29233 ! MAVS))
+HGNC:29318	increasesAmountOf	p(HGNC:11408 ! STK4, pmod(Me))
+HGNC:29480	partOf	complex(p(HGNC:29480 ! LRG1), p(HGNC:3321 ! ELK1))
+HGNC:29573	partOf	complex(p(HGNC:29573 ! PHLDB2), p(HGNC:6973 ! MDM2))
+HGNC:29608	partOf	complex(p(HGNC:29608 ! MTDH), p(HGNC:9588 ! PTEN))
+HGNC:2976	partOf	complex(p(HGNC:2976 ! DNMT1), p(HGNC:7553 ! MYC))
+HGNC:2976	partOf	complex(p(HGNC:2976 ! DNMT1), p(HGNC:9884 ! RB1))
+HGNC:2978	partOf	complex(p(HGNC:2978 ! DNMT3A), p(HGNC:3765 ! FLT3), p(HGNC:7910 ! NPM1))
+HGNC:29869	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:29869 ! SHC2))
+HGNC:29869	partOf	complex(p(HGNC:29869 ! SHC2), p(HGNC:3236 ! EGFR))
+HGNC:29869	partOf	complex(p(HGNC:29869 ! SHC2), p(HGNC:3430 ! ERBB2))
+HGNC:29869	partOf	complex(p(HGNC:29869 ! SHC2), p(HGNC:4566 ! GRB2))
+HGNC:29913	hasVariant	p(HGNC:29913 ! ZC3HC1, pmod(Ph))
+HGNC:30035	partOf	complex(p(HGNC:30035 ! PIK3R5), p(HGNC:8978 ! PIK3CG))
+HGNC:30064	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:30064 ! PBRM1))
+HGNC:30281	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:30281 ! RGL1))
+HGNC:30281	partOf	complex(p(HGNC:30281 ! RGL1), p(HGNC:5173 ! HRAS))
+HGNC:30281	partOf	complex(p(HGNC:30281 ! RGL1), p(HGNC:8816 ! PDPK1))
+HGNC:30281	partOf	complex(p(HGNC:30281 ! RGL1), p(HGNC:9842 ! RALGDS))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 696))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 721))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 722))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 792))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 8))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 855))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 859))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 863))
+HGNC:30287	hasVariant	p(HGNC:30287 ! RPTOR, pmod(Ph, Thr, 908))
+HGNC:30287	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:30287 ! RPTOR))
+HGNC:30287	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:30287 ! RPTOR))
+HGNC:30287	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:30287 ! RPTOR))
+HGNC:30287	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1))
+HGNC:30287	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:30287 ! RPTOR))
+HGNC:30287	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:30287 ! RPTOR))
+HGNC:30287	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:30287 ! RPTOR))
+HGNC:30287	partOf	complex(p(HGNC:22953 ! DEPTOR), p(HGNC:24825 ! MLST8), p(HGNC:28426 ! AKT1S1), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:30287 ! RPTOR))
+HGNC:30287	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:28611 ! RICTOR), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:30287 ! RPTOR))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3289 ! EIF4EBP2))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:391 ! AKT1))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR, pmod(Ph)))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:4564 ! GRB10))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:4564 ! GRB10), p(HGNC:6091 ! INSR))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6125 ! IRS1))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6126 ! IRS2))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6465 ! KSR1))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6871 ! MAPK1))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6877 ! MAPK3))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:7553 ! MYC))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:9376 ! PRKAA1))
+HGNC:30287	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:9377 ! PRKAA2))
+HGNC:30297	partOf	complex(p(HGNC:30297 ! RCC2), p(HGNC:9839 ! RALA))
+HGNC:30298	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:30298 ! UIMC1))
+HGNC:30377	hasVariant	p(HGNC:30377 ! SCRIB, pmod(Ph))
+HGNC:30377	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:30377 ! SCRIB))
+HGNC:30377	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:30377 ! SCRIB))
+HGNC:30377	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:30377 ! SCRIB))
+HGNC:30377	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:6877 ! MAPK3))
+HGNC:30377	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:7553 ! MYC))
+HGNC:30377	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:8592 ! PAK3))
+HGNC:30377	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:9281 ! PPP1CA))
+HGNC:30377	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:9588 ! PTEN))
+HGNC:30377	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:9801 ! RAC1))
+HGNC:30378	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:30378 ! EXOC3))
+HGNC:30378	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:30378 ! EXOC3))
+HGNC:30378	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:30378 ! EXOC3))
+HGNC:30378	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:30378 ! EXOC3))
+HGNC:30378	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:30378 ! EXOC3))
+HGNC:30378	partOf	complex(p(HGNC:30378 ! EXOC3), p(HGNC:30380 ! EXOC1))
+HGNC:30378	partOf	complex(p(HGNC:30378 ! EXOC3), p(HGNC:30389 ! EXOC4))
+HGNC:30378	partOf	complex(p(HGNC:30378 ! EXOC3), p(HGNC:3236 ! EGFR))
+HGNC:30378	partOf	complex(p(HGNC:30378 ! EXOC3), p(HGNC:9840 ! RALB))
+HGNC:30380	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:30380 ! EXOC1))
+HGNC:30380	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:30380 ! EXOC1))
+HGNC:30380	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:30380 ! EXOC1))
+HGNC:30380	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:30380 ! EXOC1))
+HGNC:30380	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:30380 ! EXOC1))
+HGNC:30380	partOf	complex(p(HGNC:30378 ! EXOC3), p(HGNC:30380 ! EXOC1))
+HGNC:30380	partOf	complex(p(HGNC:30380 ! EXOC1), p(HGNC:30389 ! EXOC4))
+HGNC:30380	partOf	complex(p(HGNC:30380 ! EXOC1), p(HGNC:6204 ! JUN))
+HGNC:30380	partOf	complex(p(HGNC:30380 ! EXOC1), p(HGNC:682 ! ARHGEF2))
+HGNC:30380	partOf	complex(p(HGNC:30380 ! EXOC1), p(HGNC:9840 ! RALB))
+HGNC:30389	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:24968 ! EXOC2), p(HGNC:30389 ! EXOC4))
+HGNC:30389	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:30389 ! EXOC4))
+HGNC:30389	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:30389 ! EXOC4))
+HGNC:30389	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:30389 ! EXOC4))
+HGNC:30389	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:30389 ! EXOC4))
+HGNC:30389	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:30389 ! EXOC4))
+HGNC:30389	partOf	complex(p(HGNC:30378 ! EXOC3), p(HGNC:30389 ! EXOC4))
+HGNC:30389	partOf	complex(p(HGNC:30380 ! EXOC1), p(HGNC:30389 ! EXOC4))
+HGNC:30389	partOf	complex(p(HGNC:30389 ! EXOC4), p(HGNC:3236 ! EGFR))
+HGNC:30389	partOf	complex(p(HGNC:30389 ! EXOC4), p(HGNC:7553 ! MYC))
+HGNC:30389	partOf	complex(p(HGNC:30389 ! EXOC4), p(HGNC:9840 ! RALB))
+HGNC:3049	partOf	complex(p(HGNC:3049 ! DSG2), p(HGNC:3236 ! EGFR))
+HGNC:3064	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+HGNC:3064	decreasesAmountOf	p(FPLX:AKT ! AKT, pmod(Ph))
+HGNC:3064	decreasesAmountOf	p(HGNC:11998 ! TP53, pmod(Ph))
+HGNC:3064	decreasesAmountOf	p(HGNC:3236 ! EGFR, pmod(Ph))
+HGNC:3064	decreasesAmountOf	p(HGNC:6091 ! INSR, pmod(Ph))
+HGNC:3064	decreasesAmountOf	p(HGNC:9884 ! RB1, pmod(Ph))
+HGNC:3064	hasVariant	p(HGNC:3064 ! DUSP1, pmod(Ac))
+HGNC:3064	hasVariant	p(HGNC:3064 ! DUSP1, pmod(Ac, Lys, 57))
+HGNC:3064	hasVariant	p(HGNC:3064 ! DUSP1, pmod(Ph))
+HGNC:3064	hasVariant	p(HGNC:3064 ! DUSP1, pmod(Ph, Ser, 296))
+HGNC:3064	hasVariant	p(HGNC:3064 ! DUSP1, pmod(Ph, Ser, 323))
+HGNC:3064	hasVariant	p(HGNC:3064 ! DUSP1, pmod(Ph, Ser, 334))
+HGNC:3064	hasVariant	p(HGNC:3064 ! DUSP1, pmod(Ph, Ser, 359))
+HGNC:3064	hasVariant	p(HGNC:3064 ! DUSP1, pmod(Ph, Ser, 364))
+HGNC:3064	partOf	complex(p(FPLX:"JUN_family" ! "JUN_family"), p(HGNC:3064 ! DUSP1))
+HGNC:3064	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3064 ! DUSP1))
+HGNC:3064	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:3064 ! DUSP1))
+HGNC:3064	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:3069 ! DUSP3))
+HGNC:3064	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:3072 ! DUSP6))
+HGNC:3064	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:3796 ! FOS))
+HGNC:3064	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:5350 ! ICMT))
+HGNC:3064	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:6871 ! MAPK1))
+HGNC:3064	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:6877 ! MAPK3))
+HGNC:3068	partOf	complex(p(HGNC:3068 ! DUSP2), p(HGNC:3068 ! DUSP2))
+HGNC:3068	partOf	complex(p(HGNC:3068 ! DUSP2), p(HGNC:3069 ! DUSP3))
+HGNC:3068	partOf	complex(p(HGNC:3068 ! DUSP2), p(HGNC:3072 ! DUSP6))
+HGNC:3068	partOf	complex(p(HGNC:3068 ! DUSP2), p(HGNC:6871 ! MAPK1))
+HGNC:3069	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+HGNC:3069	hasVariant	p(HGNC:3069 ! DUSP3, pmod(Ph, Tyr, 138))
+HGNC:3069	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:3069 ! DUSP3))
+HGNC:3069	partOf	complex(p(HGNC:3068 ! DUSP2), p(HGNC:3069 ! DUSP3))
+HGNC:3069	partOf	complex(p(HGNC:3069 ! DUSP3), p(HGNC:3069 ! DUSP3))
+HGNC:3069	partOf	complex(p(HGNC:3069 ! DUSP3), p(HGNC:3236 ! EGFR))
+HGNC:3069	partOf	complex(p(HGNC:3069 ! DUSP3), p(HGNC:6871 ! MAPK1))
+HGNC:3069	partOf	complex(p(HGNC:3069 ! DUSP3), p(HGNC:6877 ! MAPK3))
+HGNC:3070	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+HGNC:3070	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+HGNC:3070	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:3070 ! DUSP4))
+HGNC:3070	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:3236 ! EGFR))
+HGNC:3070	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:6871 ! MAPK1))
+HGNC:3070	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:6877 ! MAPK3))
+HGNC:3070	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:7553 ! MYC))
+HGNC:3071	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+HGNC:3071	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+HGNC:3071	hasVariant	p(HGNC:3071 ! DUSP5, pmod(Ph))
+HGNC:3071	partOf	complex(p(HGNC:3071 ! DUSP5), p(HGNC:3071 ! DUSP5))
+HGNC:3071	partOf	complex(p(HGNC:3071 ! DUSP5), p(HGNC:6871 ! MAPK1))
+HGNC:3071	partOf	complex(p(HGNC:3071 ! DUSP5), p(HGNC:6877 ! MAPK3))
+HGNC:3072	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+HGNC:3072	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+HGNC:3072	hasVariant	p(HGNC:3072 ! DUSP6, pmod(Ph))
+HGNC:3072	hasVariant	p(HGNC:3072 ! DUSP6, pmod(Ph, Ser, 159))
+HGNC:3072	hasVariant	p(HGNC:3072 ! DUSP6, pmod(Ph, Ser, 197))
+HGNC:3072	hasVariant	p(HGNC:3072 ! DUSP6, pmod(Ub))
+HGNC:3072	partOf	complex(p(HGNC:16281 ! TRIM11), p(HGNC:3072 ! DUSP6))
+HGNC:3072	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:3072 ! DUSP6))
+HGNC:3072	partOf	complex(p(HGNC:3068 ! DUSP2), p(HGNC:3072 ! DUSP6))
+HGNC:3072	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:3072 ! DUSP6))
+HGNC:3072	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:3488 ! ETS1))
+HGNC:3072	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:3489 ! ETS2))
+HGNC:3072	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:6871 ! MAPK1, pmod(Ph)))
+HGNC:3072	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:6877 ! MAPK3))
+HGNC:3072	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:8988 ! PIN1))
+HGNC:3072	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:9884 ! RB1))
+HGNC:30766	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:12033 ! TRAF3), p(HGNC:30766 ! TRAF3IP3))
+HGNC:30766	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:30766 ! TRAF3IP3))
+HGNC:30833	partOf	complex(p(HGNC:30833 ! CDK2AP2), p(HGNC:6973 ! MDM2))
+HGNC:3091	partOf	complex(p(HGNC:3091 ! DYRK1A), p(HGNC:6126 ! IRS2))
+HGNC:3091	partOf	complex(p(HGNC:3091 ! DYRK1A), p(HGNC:6973 ! MDM2))
+HGNC:3113	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11749
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ac))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ac, Lys, 117))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ac, Lys, 117), pmod(Ac, Lys, 120), pmod(Ac, Lys, 125))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ac, Lys, 120))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ac, Lys, 125))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ph))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 31))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 332))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 337))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 375))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 403))
+HGNC:3113	hasVariant	p(HGNC:3113 ! E2F1, pmod(Ph, Thr, 433))
+HGNC:3113	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:3113 ! E2F1), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:11205 ! SP1), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:11751 ! TFDP2), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1773 ! CDK4), p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:1725 ! CDC25A), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:17862 ! SENP3), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:23820 ! E2F7), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:23820 ! E2F7), p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3113 ! E2F1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:7553 ! MYC))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3115 ! E2F3))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3236 ! EGFR))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3689 ! FGFR2))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3942 ! MTOR))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:576 ! APAF1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6037 ! ILF2))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6120 ! IRF5))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:7553 ! MYC))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:7794 ! NFKB1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:8550 ! PA2G4))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:8988 ! PIN1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9236 ! PPARG))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9588 ! PTEN))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9829 ! RAF1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9882 ! RASSF1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1))
+HGNC:3113	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1, pmod(Ph)))
+HGNC:3114	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11749
+HGNC:3114	hasVariant	p(HGNC:3114 ! E2F2, pmod(Ph))
+HGNC:3114	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:3114	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:3114 ! E2F2))
+HGNC:3114	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:3114 ! E2F2))
+HGNC:3114	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2))
+HGNC:3114	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3))
+HGNC:3114	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:3114	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:7553 ! MYC))
+HGNC:3114	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:9884 ! RB1))
+HGNC:3114	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:3114 ! E2F2))
+HGNC:3114	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3))
+HGNC:3114	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:4566 ! GRB2))
+HGNC:3114	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:7545 ! MYB))
+HGNC:3114	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:7553 ! MYC))
+HGNC:3114	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:9884 ! RB1))
+HGNC:3115	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11749
+HGNC:3115	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:3115	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:3115 ! E2F3))
+HGNC:3115	partOf	complex(p(HGNC:11751 ! TFDP2), p(HGNC:3115 ! E2F3))
+HGNC:3115	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3))
+HGNC:3115	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:3115	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3115 ! E2F3))
+HGNC:3115	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:3115	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3))
+HGNC:3115	partOf	complex(p(HGNC:3115 ! E2F3), p(HGNC:3797 ! FOSB))
+HGNC:3115	partOf	complex(p(HGNC:3115 ! E2F3), p(HGNC:6947 ! MCM4))
+HGNC:3115	partOf	complex(p(HGNC:3115 ! E2F3), p(HGNC:7553 ! MYC))
+HGNC:3115	partOf	complex(p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1, pmod(Ph)))
+HGNC:3155	activityDirectlyPositivelyRegulatesActivityOf	HGNC:667
+HGNC:3155	activityPositivelyRegulatesActivityOf	HGNC:668
+HGNC:3155	hasVariant	p(HGNC:3155 ! ECT2, pmod(Ph, Thr, 359))
+HGNC:3155	hasVariant	p(HGNC:3155 ! ECT2, pmod(Ph, Thr, 373))
+HGNC:3155	hasVariant	p(HGNC:3155 ! ECT2, pmod(Ph, Thr, 846))
+HGNC:3155	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3155 ! ECT2))
+HGNC:3155	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:3155 ! ECT2))
+HGNC:3155	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:667 ! RHOA))
+HGNC:3155	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:6871 ! MAPK1))
+HGNC:3155	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:6949 ! MCM6))
+HGNC:3155	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:9281 ! PPP1CA))
+HGNC:3155	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:9801 ! RAC1))
+HGNC:3155	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:9874 ! RASAL2))
+HGNC:31586	partOf	complex(p(HGNC:31586 ! MIR21), p(HGNC:9588 ! PTEN))
+HGNC:31601	activityNegativelyRegulatesActivityOf	HGNC:9588
+HGNC:31859	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:31859 ! TRIM67))
+HGNC:3229	partOf	complex(p(HGNC:3229 ! EGF), p(HGNC:3236 ! EGFR))
+HGNC:3236	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+HGNC:3236	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12657
+HGNC:3236	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1541
+HGNC:3236	activityDirectlyPositivelyRegulatesActivityOf	HGNC:29869
+HGNC:3236	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:3236	activityNegativelyRegulatesActivityOf	CHEBI:25107
+HGNC:3236	activityPositivelyRegulatesActivityOf	CHEBI:26216
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Met))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Ser))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 1026))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 1071))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 1081))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 1120))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 768))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Thr, 678))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Thr, 693))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1016))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1016), pmod(Ph, Tyr, 1069), pmod(Ph, Tyr, 1092), pmod(Ph, Tyr, 1110), pmod(Ph, Tyr, 1172), pmod(Ph, Tyr, 1197))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1016), pmod(Ph, Tyr, 1069), pmod(Ph, Tyr, 1092), pmod(Ph, Tyr, 1110), pmod(Ph, Tyr, 1172), pmod(Ph, Tyr, 1197), pmod(Ub, Lys), pmod(Ub, Lys, 716), pmod(Ub, Lys, 737), pmod(Ub, Lys, 754), pmod(Ub, Lys, 867), pmod(Ub, Lys, 929), pmod(Ub, Lys, 970))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1069))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1092))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1110))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1125))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1172))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1197))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 869))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ub))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, pmod(Ub, Lys))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, var("p.Leu858Arg"))
+HGNC:3236	hasVariant	p(HGNC:3236 ! EGFR, var("p.Pro753Ser"))
+HGNC:3236	increasesAmountOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))
+HGNC:3236	increasesAmountOf	p(HGNC:6204 ! JUN, pmod(Ph))
+HGNC:3236	increasesAmountOf	p(HGNC:8729 ! PCNA, pmod(Ph))
+HGNC:3236	partOf	complex(a(CHEBI:114785 ! erlotinib), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(a(CHEBI:16243 ! quercetin), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(a(CHEBI:49603 ! lapatinib), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(a(CHEBI:49668 ! gefitinib), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(a(CHEBI:61390 ! afatinib), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(a(CHEBI:61400 ! WZ4002), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(a(PUBCHEM:57519532 ! 57519532), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(a(TEXT:"protein tyrosine kinase"), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(bp(MESH:D011839 ! "Radiation, Ionizing"), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1)), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:3236	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(FPLX:Integrins ! Integrins), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET))
+HGNC:3236	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:3236	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+HGNC:3236	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:10905 ! SLC10A1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11389 ! STK11), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:3236	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:3236	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:3236	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11036 ! SLC5A1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:3236	partOf	complex(p(HGNC:11188 ! SOS2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11205 ! SP1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11280 ! SQSTM1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11283 ! SRC), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11834 ! TKT), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11908 ! TNFRSF11A), p(HGNC:1527 ! CAV1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:3236	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3236 ! EGFR), p(HGNC:6973 ! MDM2))
+HGNC:3236	partOf	complex(p(HGNC:12307 ! TRIP13), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:12513 ! UCHL1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:13646 ! LAPTM4B), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:14969 ! SNX5), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))
+HGNC:3236	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:3236	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET))
+HGNC:3236	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:16064 ! GGA2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:16090 ! PGRMC1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1630 ! CD151), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:16695 ! BCAP31), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:16743 ! SHC4), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:17635 ! CD274), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:17722 ! SPRED2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:18181 ! SHC3), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:18238 ! RAB25), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:195 ! ADAM17), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:2001 ! GREM1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:23196 ! EXOC6), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:23692 ! ACKR3), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:2394 ! CRYBA1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:2500 ! CCN2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:25717 ! NT5DC2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:27949 ! GADL1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:2861 ! DHFR), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:29869 ! SHC2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:30378 ! EXOC3), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:30389 ! EXOC4), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:3049 ! DSG2), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:3069 ! DUSP3), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:3229 ! EGF), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:3430 ! ERBB2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3380 ! EPB41L3))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3420 ! EPS8))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:3430 ! ERBB2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:3431 ! ERBB3))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:7029 ! MET))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3431 ! ERBB3), p(HGNC:3432 ! ERBB4))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3466 ! ESM1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:348 ! AHR))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3688 ! FGFR1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3689 ! FGFR2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3691 ! FGFR4))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3796 ! FOS))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:391 ! AKT1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:392 ! AKT2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3942 ! MTOR, pmod(Ph)))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:427 ! ALK))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4392 ! GNAS))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4564 ! GRB10))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4568 ! RAPGEF1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4983 ! HMGB1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:5173 ! HRAS))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6036 ! FOXK2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6091 ! INSR))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6125 ! IRS1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6126 ! IRS2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6204 ! JUN))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6307 ! KDR))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6348 ! KLF4))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:644 ! AR))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:646 ! ARAF))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:682 ! ARHGEF2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6842 ! MAP2K2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6871 ! MAPK1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6945 ! MCM3))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6947 ! MCM4))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6949 ! MCM6))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6973 ! MDM2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET), p(HGNC:7782 ! NFE2L2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7511 ! MUC13))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7553 ! MYC))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7765 ! NF1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8127 ! OGT))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8590 ! PAK1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8803 ! PDGFRA))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8804 ! PDGFRB))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8816 ! PDPK1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8975 ! PIK3CA))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8979 ! PIK3R1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8980 ! PIK3R2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8981 ! PIK3R3))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9103 ! PLXNB1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9376 ! PRKAA1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9385 ! PRKAG1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9588 ! PTEN))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9605 ! PTGS2))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9644 ! PTPN11))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9829 ! RAF1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9871 ! RASA1))
+HGNC:3236	partOf	complex(p(HGNC:3236 ! EGFR, pmod(Ph)), p(HGNC:4566 ! GRB2))
+HGNC:3263	partOf	complex(p(HGNC:3263 ! AGO2), p(HGNC:6407 ! KRAS))
+HGNC:3285	hasVariant	p(HGNC:3285 ! EIF4B, pmod(Ph))
+HGNC:3287	partOf	complex(p(HGNC:3287 ! EIF4E), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser, 101))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser, 112))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser, 65))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser, 83))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 36))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 37))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 41))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 45))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 46))
+HGNC:3288	hasVariant	p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 70))
+HGNC:3288	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR))
+HGNC:3288	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	partOf	complex(p(HGNC:1148 ! BUB1), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3288 ! EIF4EBP1, pmod(Ph)))
+HGNC:3288	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR))
+HGNC:3288	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:3288	partOf	complex(p(HGNC:3287 ! EIF4E), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:3288 ! EIF4EBP1))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:3289 ! EIF4EBP2))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:391 ! AKT1))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:392 ! AKT2))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:393 ! AKT3))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:576 ! APAF1))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:6871 ! MAPK1))
+HGNC:3288	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:9236 ! PPARG))
+HGNC:3289	hasVariant	p(HGNC:3289 ! EIF4EBP2, pmod(Ph))
+HGNC:3289	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3289 ! EIF4EBP2))
+HGNC:3289	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:3289 ! EIF4EBP2))
+HGNC:3289	partOf	complex(p(HGNC:3289 ! EIF4EBP2), p(HGNC:3942 ! MTOR))
+HGNC:32897	activityPositivelyRegulatesActivityOf	HGNC:16262
+HGNC:3290	hasVariant	p(HGNC:3290 ! EIF4EBP3, pmod(Ph))
+HGNC:3290	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3290 ! EIF4EBP3))
+HGNC:3321	activityPositivelyRegulatesActivityOf	HGNC:11291
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph, 383))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 324))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 324), pmod(Ph, Ser, 383), pmod(Ph, Ser, 389), pmod(Ph, Ser, 422), pmod(Ph, Thr, 336))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 383))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 383), pmod(Ph, Ser, 389))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 389))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 422))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, pmod(Ph, Thr, 336))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, var("p.Ser383Ala"))
+HGNC:3321	hasVariant	p(HGNC:3321 ! ELK1, var("p.Trp379Ala"))
+HGNC:3321	partOf	complex(p(FPLX:"FOS_family" ! "FOS_family"), p(HGNC:3321 ! ELK1), p(HGNC:3321 ! ELK1))
+HGNC:3321	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:3321 ! ELK1))
+HGNC:3321	partOf	complex(p(HGNC:16923 ! AGAP3), p(HGNC:3321 ! ELK1))
+HGNC:3321	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:3321 ! ELK1))
+HGNC:3321	partOf	complex(p(HGNC:29480 ! LRG1), p(HGNC:3321 ! ELK1))
+HGNC:3321	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:3321 ! ELK1))
+HGNC:3321	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:3488 ! ETS1))
+HGNC:3321	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:3796 ! FOS))
+HGNC:3321	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:6204 ! JUN))
+HGNC:3321	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:6871 ! MAPK1))
+HGNC:3321	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:6877 ! MAPK3))
+HGNC:333	activityPositivelyRegulatesActivityOf	HGNC:16262
+HGNC:3373	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3373 ! EP300))
+HGNC:3373	partOf	complex(p(HGNC:24948 ! DOT1L), p(HGNC:3373 ! EP300), p(HGNC:7553 ! MYC))
+HGNC:3374	partOf	complex(p(HGNC:3374 ! EPAS1), p(HGNC:7553 ! MYC))
+HGNC:3380	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3380 ! EPB41L3))
+HGNC:3388	partOf	complex(p(HGNC:3388 ! EPHA4), p(HGNC:8804 ! PDGFRB))
+HGNC:33904	partOf	complex(p(HGNC:33904 ! ACOD1), p(HGNC:3430 ! ERBB2))
+HGNC:33984	partOf	complex(p(HGNC:1166 ! RASSF7), p(HGNC:33984 ! RASSF10))
+HGNC:33984	partOf	complex(p(HGNC:33984 ! RASSF10), p(HGNC:6950 ! MCM7))
+HGNC:33984	partOf	complex(p(HGNC:33984 ! RASSF10), p(HGNC:9281 ! PPP1CA))
+HGNC:3420	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11320 ! ABI1), p(HGNC:3420 ! EPS8))
+HGNC:3420	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3420 ! EPS8))
+HGNC:3420	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3420 ! EPS8))
+HGNC:3430	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+HGNC:3430	activityDirectlyPositivelyRegulatesActivityOf	HGNC:18181
+HGNC:3430	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:3430	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:3430	activityPositivelyRegulatesActivityOf	FPLX:E2F
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1023))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1112))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1196))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1221))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1222))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1248))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 877))
+HGNC:3430	hasVariant	p(HGNC:3430 ! ERBB2, pmod(Ub))
+HGNC:3430	partOf	complex(a(CHEBI:28748 ! doxorubicin), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(a(CHEBI:49603 ! lapatinib), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(a(CHEBI:61390 ! afatinib), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(a(PUBCHEM:57519532 ! 57519532), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(FPLX:AKT ! AKT), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3430 ! ERBB2), p(HGNC:4566 ! GRB2))
+HGNC:3430	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:11036 ! SLC5A1), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3430 ! ERBB2), p(HGNC:4566 ! GRB2))
+HGNC:3430	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3430 ! ERBB2), p(HGNC:9588 ! PTEN))
+HGNC:3430	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:18181 ! SHC3), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:25550 ! RMDN3), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:29869 ! SHC2), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:3431 ! ERBB3))
+HGNC:3430	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:7029 ! MET))
+HGNC:3430	partOf	complex(p(HGNC:33904 ! ACOD1), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:3430 ! ERBB2), p(HGNC:3430 ! ERBB2))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:3431 ! ERBB3))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:3488 ! ETS1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:4566 ! GRB2))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:5118 ! HOXB7))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:5173 ! HRAS))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:6091 ! INSR))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:6125 ! IRS1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:6407 ! KRAS))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:6973 ! MDM2))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:7029 ! MET))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:7514 ! MUC4))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:7553 ! MYC))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:7782 ! NFE2L2))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8004 ! NRP1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8550 ! PA2G4))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8590 ! PAK1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8975 ! PIK3CA))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8979 ! PIK3R1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8980 ! PIK3R2))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8981 ! PIK3R3))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8988 ! PIN1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9103 ! PLXNB1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9588 ! PTEN))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9644 ! PTPN11))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9871 ! RASA1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9884 ! RB1))
+HGNC:3430	partOf	complex(p(HGNC:3430 ! ERBB2), p(UP:A0FKN4 ! A0FKN4))
+HGNC:3431	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:3431 ! ERBB3))
+HGNC:3431	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3431 ! ERBB3), p(HGNC:3432 ! ERBB4))
+HGNC:3431	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:3431 ! ERBB3))
+HGNC:3432	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3431 ! ERBB3), p(HGNC:3432 ! ERBB4))
+HGNC:3433	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:270 ! PARP1), p(HGNC:3433 ! ERCC1))
+HGNC:3438	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3438 ! ERCC6))
+HGNC:34410	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:34410 ! NEURL4), p(HGNC:4868 ! HERC2))
+HGNC:3444	hasVariant	p(HGNC:3444 ! ERF, pmod(Ph))
+HGNC:3444	hasVariant	p(HGNC:3444 ! ERF, pmod(Ph, Ser, 161))
+HGNC:3444	hasVariant	p(HGNC:3444 ! ERF, pmod(Ph, Ser, 251))
+HGNC:3444	partOf	complex(p(HGNC:3444 ! ERF), p(HGNC:3444 ! ERF))
+HGNC:3444	partOf	complex(p(HGNC:3444 ! ERF), p(HGNC:6871 ! MAPK1))
+HGNC:3446	partOf	complex(p(HGNC:3446 ! ERG), p(HGNC:9588 ! PTEN))
+HGNC:3466	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3466 ! ESM1))
+HGNC:3467	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3467 ! ESR1), p(HGNC:370 ! AKAP12), p(HGNC:7112 ! MKRN1))
+HGNC:3467	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3467 ! ESR1))
+HGNC:3467	partOf	complex(p(HGNC:3467 ! ESR1), p(HGNC:7782 ! NFE2L2))
+HGNC:3468	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3468 ! ESR2))
+HGNC:348	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:348 ! AHR))
+HGNC:3488	activityPositivelyRegulatesActivityOf	HGNC:7029
+HGNC:3488	hasVariant	p(HGNC:3488 ! ETS1, pmod(Ph))
+HGNC:3488	hasVariant	p(HGNC:3488 ! ETS1, pmod(Ph, Ser))
+HGNC:3488	hasVariant	p(HGNC:3488 ! ETS1, pmod(Ph, Ser, 251))
+HGNC:3488	hasVariant	p(HGNC:3488 ! ETS1, pmod(Ph, Ser, 282))
+HGNC:3488	hasVariant	p(HGNC:3488 ! ETS1, pmod(Ph, Ser, 285))
+HGNC:3488	hasVariant	p(HGNC:3488 ! ETS1, pmod(Ph, Thr, 38))
+HGNC:3488	increasesAmountOf	MESH:D009369
+HGNC:3488	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3488 ! ETS1))
+HGNC:3488	partOf	complex(p(HGNC:11998 ! TP53, var("p.Arg273His")), p(HGNC:3488 ! ETS1))
+HGNC:3488	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:3488 ! ETS1))
+HGNC:3488	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:3488 ! ETS1))
+HGNC:3488	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:3488 ! ETS1))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:3488 ! ETS1))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:3489 ! ETS2))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:5960 ! IKBKB))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:6204 ! JUN))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:6871 ! MAPK1))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:7545 ! MYB))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:7794 ! NFKB1))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:7989 ! NRAS))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:9588 ! PTEN))
+HGNC:3488	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:9884 ! RB1))
+HGNC:3489	activityNegativelyRegulatesActivityOf	FPLX:E2F
+HGNC:3489	activityPositivelyRegulatesActivityOf	HGNC:1582
+HGNC:3489	activityPositivelyRegulatesActivityOf	HGNC:3064
+HGNC:3489	activityPositivelyRegulatesActivityOf	HGNC:3489
+HGNC:3489	activityPositivelyRegulatesActivityOf	HGNC:3796
+HGNC:3489	activityPositivelyRegulatesActivityOf	HGNC:6204
+HGNC:3489	activityPositivelyRegulatesActivityOf	HGNC:6973
+HGNC:3489	hasVariant	p(HGNC:3489 ! ETS2, pmod(Ph))
+HGNC:3489	hasVariant	p(HGNC:3489 ! ETS2, pmod(Ph, Ser))
+HGNC:3489	hasVariant	p(HGNC:3489 ! ETS2, pmod(Ph, Ser, 246))
+HGNC:3489	hasVariant	p(HGNC:3489 ! ETS2, pmod(Ph, Ser, 310))
+HGNC:3489	hasVariant	p(HGNC:3489 ! ETS2, pmod(Ph, Thr, 72))
+HGNC:3489	partOf	complex(p(HGNC:23133 ! NAT9), p(HGNC:3489 ! ETS2))
+HGNC:3489	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:3489 ! ETS2))
+HGNC:3489	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:3489 ! ETS2))
+HGNC:3489	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:3489 ! ETS2))
+HGNC:3489	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:3796 ! FOS))
+HGNC:3489	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:6204 ! JUN))
+HGNC:3489	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:7553 ! MYC))
+HGNC:3489	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:9588 ! PTEN))
+HGNC:3501	partOf	complex(p(HGNC:3501 ! EVI5), p(HGNC:7553 ! MYC))
+HGNC:3527	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3527 ! EZH2))
+HGNC:3527	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3527 ! EZH2))
+HGNC:3527	partOf	complex(p(HGNC:3527 ! EZH2), p(HGNC:7545 ! MYB))
+HGNC:3527	partOf	complex(p(HGNC:3527 ! EZH2), p(HGNC:9588 ! PTEN))
+HGNC:3582	hasVariant	p(HGNC:3582 ! FANCA, pmod(Ph, Ser, 1149))
+HGNC:3582	hasVariant	p(HGNC:3582 ! FANCA, pmod(Ph, Ser, 1449))
+HGNC:3582	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3582 ! FANCA))
+HGNC:3582	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:3582 ! FANCA))
+HGNC:3582	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:3584 ! FANCC))
+HGNC:3582	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:3588 ! FANCG))
+HGNC:3582	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:391 ! AKT1))
+HGNC:3582	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:6948 ! MCM5))
+HGNC:3582	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:6950 ! MCM7))
+HGNC:3582	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:9376 ! PRKAA1))
+HGNC:3584	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:3584 ! FANCC))
+HGNC:3584	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:3584 ! FANCC))
+HGNC:3584	partOf	complex(p(HGNC:3584 ! FANCC), p(HGNC:3584 ! FANCC))
+HGNC:3588	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:3588 ! FANCG))
+HGNC:3613	activityPositivelyRegulatesActivityOf	HGNC:3236
+HGNC:3618	activityPositivelyRegulatesActivityOf	HGNC:3236
+HGNC:3621	activityPositivelyRegulatesActivityOf	HGNC:3236
+HGNC:3663	partOf	complex(p(HGNC:3663 ! FGD1), p(HGNC:9588 ! PTEN))
+HGNC:3675	partOf	complex(p(HGNC:3675 ! FGF19), p(HGNC:3691 ! FGFR4))
+HGNC:3676	partOf	complex(p(HGNC:3676 ! FGF2), p(HGNC:3688 ! FGFR1))
+HGNC:3678	partOf	complex(p(HGNC:3678 ! FGF21), p(HGNC:3688 ! FGFR1), p(HGNC:6344 ! KL))
+HGNC:3686	partOf	complex(p(HGNC:3686 ! FGF8), p(HGNC:3688 ! FGFR1))
+HGNC:3688	activityPositivelyRegulatesActivityOf	HGNC:1504
+HGNC:3688	activityPositivelyRegulatesActivityOf	HGNC:8816
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Ser, 777))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 154))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 280))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 307))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 463))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 583))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 585))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 605))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 653))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 654))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 730))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 766))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, var("p.?"))
+HGNC:3688	hasVariant	p(HGNC:3688 ! FGFR1, var("p.Val561Met"))
+HGNC:3688	increasesAmountOf	p(FPLX:ERK ! ERK, pmod(Ph))
+HGNC:3688	increasesAmountOf	p(HGNC:3236 ! EGFR, pmod(Ph))
+HGNC:3688	increasesAmountOf	p(HGNC:8816 ! PDPK1, pmod(Ph))
+HGNC:3688	partOf	complex(a(CHEBI:63453 ! AZD4547), p(HGNC:3688 ! FGFR1, var("p.Val561Met")))
+HGNC:3688	partOf	complex(a(CHEBI:78543 ! ponatinib), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:3676 ! FGF2), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:3678 ! FGF21), p(HGNC:3688 ! FGFR1), p(HGNC:6344 ! KL))
+HGNC:3688	partOf	complex(p(HGNC:3686 ! FGF8), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3688 ! FGFR1))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3), p(HGNC:3691 ! FGFR4))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3691 ! FGFR4))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3690 ! FGFR3))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3691 ! FGFR4))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3765 ! FLT3))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3778 ! FN1))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:391 ! AKT1))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3942 ! MTOR))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:4566 ! GRB2))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:6307 ! KDR))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:7553 ! MYC))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:8804 ! PDGFRB))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:8979 ! PIK3R1))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:8980 ! PIK3R2))
+HGNC:3688	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:9618 ! PTK7))
+HGNC:3689	hasVariant	p(HGNC:3689 ! FGFR2, pmod(Ph))
+HGNC:3689	hasVariant	p(HGNC:3689 ! FGFR2, pmod(Ph, Ser, 782))
+HGNC:3689	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3))
+HGNC:3689	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3), p(HGNC:3691 ! FGFR4))
+HGNC:3689	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3691 ! FGFR4))
+HGNC:3689	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:3689 ! FGFR2))
+HGNC:3689	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3))
+HGNC:3689	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:3691 ! FGFR4))
+HGNC:3689	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:4566 ! GRB2))
+HGNC:3689	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:8979 ! PIK3R1))
+HGNC:3689	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:9644 ! PTPN11))
+HGNC:3689	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:9967 ! RET))
+HGNC:3690	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3690
+HGNC:3690	activityPositivelyRegulatesActivityOf	HGNC:667
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, pmod(Ph))
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr))
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 577))
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 647))
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 648))
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 724))
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 760))
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 770))
+HGNC:3690	hasVariant	p(HGNC:3690 ! FGFR3, var("p.?"))
+HGNC:3690	partOf	complex(a(CHEBI:63448 ! PD173074), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(a(CHEBI:63453 ! AZD4547), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(p(HGNC:11524 ! TACC3), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3), p(HGNC:3691 ! FGFR4))
+HGNC:3690	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:3690 ! FGFR3))
+HGNC:3690	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:3691 ! FGFR4))
+HGNC:3690	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:4566 ! GRB2))
+HGNC:3690	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:7553 ! MYC))
+HGNC:3690	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:8975 ! PIK3CA))
+HGNC:3691	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3691
+HGNC:3691	hasVariant	p(HGNC:3691 ! FGFR4, pmod(Ph))
+HGNC:3691	hasVariant	p(HGNC:3691 ! FGFR4, pmod(Ph, Tyr, 642))
+HGNC:3691	hasVariant	p(HGNC:3691 ! FGFR4, pmod(Ph, Tyr, 643))
+HGNC:3691	partOf	complex(a(CHEBI:78543 ! ponatinib), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(a(PUBCHEM:46944259 ! 46944259), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3675 ! FGF19), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3690 ! FGFR3), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3689 ! FGFR2), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3691 ! FGFR4), p(HGNC:3691 ! FGFR4))
+HGNC:3691	partOf	complex(p(HGNC:3691 ! FGFR4), p(HGNC:8800 ! PDGFB))
+HGNC:3691	partOf	complex(p(HGNC:3691 ! FGFR4), p(HGNC:9644 ! PTPN11))
+HGNC:370	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3467 ! ESR1), p(HGNC:370 ! AKAP12), p(HGNC:7112 ! MKRN1))
+HGNC:37126	activityNegativelyRegulatesActivityOf	HGNC:1784
+HGNC:3754	partOf	complex(p(HGNC:3754 ! FLNA), p(HGNC:8590 ! PAK1))
+HGNC:3765	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9644
+HGNC:3765	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+HGNC:3765	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3765
+HGNC:3765	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4564
+HGNC:3765	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:3765	hasVariant	p(HGNC:3765 ! FLT3, pmod(Ph))
+HGNC:3765	hasVariant	p(HGNC:3765 ! FLT3, pmod(Ph, Tyr, 589))
+HGNC:3765	hasVariant	p(HGNC:3765 ! FLT3, pmod(Ph, Tyr, 591))
+HGNC:3765	hasVariant	p(HGNC:3765 ! FLT3, pmod(Ph, Tyr, 597))
+HGNC:3765	hasVariant	p(HGNC:3765 ! FLT3, pmod(Ub))
+HGNC:3765	hasVariant	p(HGNC:3765 ! FLT3, var("p.Asn841His"))
+HGNC:3765	partOf	complex(a(CHEBI:90217 ! quizartinib), p(HGNC:3765 ! FLT3))
+HGNC:3765	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:3765 ! FLT3))
+HGNC:3765	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3765 ! FLT3))
+HGNC:3765	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3765 ! FLT3))
+HGNC:3765	partOf	complex(p(HGNC:2978 ! DNMT3A), p(HGNC:3765 ! FLT3), p(HGNC:7910 ! NPM1))
+HGNC:3765	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3765 ! FLT3))
+HGNC:3765	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:3765 ! FLT3))
+HGNC:3765	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:3766 ! FLT3LG))
+HGNC:3765	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:4564 ! GRB10))
+HGNC:3765	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:4566 ! GRB2))
+HGNC:3765	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:8979 ! PIK3R1))
+HGNC:3765	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:9583 ! PTBP1))
+HGNC:3765	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:9644 ! PTPN11))
+HGNC:3766	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:3766 ! FLT3LG))
+HGNC:3778	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3778 ! FN1))
+HGNC:3782	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+HGNC:3782	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7227
+HGNC:3782	partOf	complex(p(HGNC:3782 ! FNTA), p(HGNC:3785 ! FNTB))
+HGNC:3785	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+HGNC:3785	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7227
+HGNC:3785	partOf	complex(p(HGNC:3782 ! FNTA), p(HGNC:3785 ! FNTB))
+HGNC:3796	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+HGNC:3796	hasVariant	p(HGNC:3796 ! FOS, pmod(Ph))
+HGNC:3796	hasVariant	p(HGNC:3796 ! FOS, pmod(Ph, Ser, 362))
+HGNC:3796	hasVariant	p(HGNC:3796 ! FOS, pmod(Ph, Ser, 362), pmod(Ph, Ser, 374), pmod(Ph, Thr, 232), pmod(Ph, Thr, 325), pmod(Ph, Thr, 331))
+HGNC:3796	hasVariant	p(HGNC:3796 ! FOS, pmod(Ph, Ser, 374))
+HGNC:3796	hasVariant	p(HGNC:3796 ! FOS, pmod(Ph, Thr, 232))
+HGNC:3796	hasVariant	p(HGNC:3796 ! FOS, pmod(Ph, Thr, 325))
+HGNC:3796	hasVariant	p(HGNC:3796 ! FOS, pmod(Ph, Thr, 331))
+HGNC:3796	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN), p(HGNC:6204 ! JUN))
+HGNC:3796	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:10471 ! RUNX1), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:3796 ! FOS))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:5173 ! HRAS), p(HGNC:7553 ! MYC))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN), p(HGNC:6204 ! JUN))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN), p(HGNC:7553 ! MYC))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6840 ! MAP2K1))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6871 ! MAPK1))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:7545 ! MYB))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:7553 ! MYC))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:9377 ! PRKAA2))
+HGNC:3796	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:9884 ! RB1))
+HGNC:3797	partOf	complex(p(HGNC:3115 ! E2F3), p(HGNC:3797 ! FOSB))
+HGNC:3818	increasesAmountOf	HGNC:11998
+HGNC:3821	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:28426 ! AKT1S1), p(HGNC:3821 ! FOXO3), p(HGNC:936 ! BAD))
+HGNC:391	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+HGNC:391	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+HGNC:391	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+HGNC:391	activityDirectlyNegativelyRegulatesActivityOf	HGNC:17294
+HGNC:391	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+HGNC:391	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9281
+HGNC:391	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9801
+HGNC:391	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+HGNC:391	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1771
+HGNC:391	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+HGNC:391	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6973
+HGNC:391	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8822
+HGNC:391	activityPositivelyRegulatesActivityOf	HGNC:3796
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ac, Lys, 14))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, 308))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, 473))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Ser, 129))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Ser, 473))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Ser, 473), pmod(Ph, Thr, 308))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Ser, 473), pmod(Ph, Thr, 308), pmod(Ph, Tyr, 474))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Ser, 475))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Ser, 477))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Thr))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Thr, 308))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Thr, 34))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Thr, 450))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Thr, 479))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Tyr, 315))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Tyr, 326))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ph, Tyr, 474))
+HGNC:391	hasVariant	p(HGNC:391 ! AKT1, pmod(Ub, Lys, 284))
+HGNC:391	increasesAmountOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2, pmod(Ph)))
+HGNC:391	increasesAmountOf	p(HGNC:3489 ! ETS2, pmod(Ph))
+HGNC:391	increasesAmountOf	p(HGNC:4617 ! GSK3B, pmod(Ph))
+HGNC:391	increasesAmountOf	p(HGNC:6871 ! MAPK1, pmod(Ph))
+HGNC:391	increasesAmountOf	p(HGNC:989 ! BCL10, pmod(Ph))
+HGNC:391	partOf	complex(bp(GO:"GO:0120200" ! "rod photoreceptor outer segment"), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(FPLX:HSPA ! HSPA), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:13315 ! HDAC8), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:17294 ! DAB2IP), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:17795 ! SAV1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:20610 ! PHLPP1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:391 ! AKT1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:392 ! AKT2))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:392 ! AKT2), p(HGNC:393 ! AKT3))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:392 ! AKT2), p(HGNC:8590 ! PAK1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:393 ! AKT3))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:3942 ! MTOR))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:4564 ! GRB10))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:6125 ! IRS1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:6407 ! KRAS))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:6840 ! MAP2K1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:6973 ! MDM2))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:7782 ! NFE2L2))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:812 ! ATP2A2))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8590 ! PAK1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8630 ! PEBP1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8816 ! PDPK1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8975 ! PIK3CA))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8979 ! PIK3R1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9103 ! PLXNB1))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9281 ! PPP1CA))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9377 ! PRKAA2))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9588 ! PTEN))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9611 ! PTK2))
+HGNC:391	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9829 ! RAF1))
+HGNC:392	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+HGNC:392	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+HGNC:392	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1784
+HGNC:392	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+HGNC:392	activityNegativelyRegulatesActivityOf	HGNC:1771
+HGNC:392	activityPositivelyRegulatesActivityOf	HGNC:9839
+HGNC:392	decreasesAmountOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2))
+HGNC:392	hasVariant	p(HGNC:392 ! AKT2, pmod(Ph))
+HGNC:392	hasVariant	p(HGNC:392 ! AKT2, pmod(Ph, 308))
+HGNC:392	hasVariant	p(HGNC:392 ! AKT2, pmod(Ph, 473))
+HGNC:392	hasVariant	p(HGNC:392 ! AKT2, pmod(Ph, Ser, 474))
+HGNC:392	hasVariant	p(HGNC:392 ! AKT2, pmod(Ph, Thr, 309))
+HGNC:392	increasesAmountOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2, pmod(Ph)))
+HGNC:392	increasesAmountOf	p(HGNC:16207 ! RALGAPA2, pmod(Ph))
+HGNC:392	increasesAmountOf	p(HGNC:8816 ! PDPK1, pmod(Ph))
+HGNC:392	partOf	complex(p(FPLX:AMPK ! AMPK), p(HGNC:392 ! AKT2))
+HGNC:392	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:392 ! AKT2))
+HGNC:392	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:392 ! AKT2))
+HGNC:392	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:392 ! AKT2))
+HGNC:392	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:392 ! AKT2))
+HGNC:392	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:392 ! AKT2))
+HGNC:392	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:392 ! AKT2))
+HGNC:392	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:392 ! AKT2), p(HGNC:393 ! AKT3))
+HGNC:392	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:392 ! AKT2), p(HGNC:8590 ! PAK1))
+HGNC:392	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:392 ! AKT2))
+HGNC:392	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:393 ! AKT3))
+HGNC:392	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:3942 ! MTOR))
+HGNC:392	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:6081 ! INS))
+HGNC:392	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:8590 ! PAK1))
+HGNC:392	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:8816 ! PDPK1))
+HGNC:392	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:8977 ! PIK3CD))
+HGNC:392	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:9588 ! PTEN))
+HGNC:393	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+HGNC:393	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+HGNC:393	hasVariant	p(HGNC:393 ! AKT3, pmod(Ph, 308))
+HGNC:393	hasVariant	p(HGNC:393 ! AKT3, pmod(Ph, 473))
+HGNC:393	hasVariant	p(HGNC:393 ! AKT3, pmod(Ph, Ser, 472))
+HGNC:393	hasVariant	p(HGNC:393 ! AKT3, pmod(Ph, Ser, 474))
+HGNC:393	hasVariant	p(HGNC:393 ! AKT3, pmod(Ph, Thr, 305))
+HGNC:393	increasesAmountOf	p(HGNC:6118 ! IRF3, pmod(Ph))
+HGNC:393	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:393 ! AKT3))
+HGNC:393	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:393 ! AKT3))
+HGNC:393	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:392 ! AKT2), p(HGNC:393 ! AKT3))
+HGNC:393	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:393 ! AKT3))
+HGNC:393	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:393 ! AKT3))
+HGNC:393	partOf	complex(p(HGNC:393 ! AKT3), p(HGNC:393 ! AKT3))
+HGNC:393	partOf	complex(p(HGNC:393 ! AKT3), p(HGNC:8979 ! PIK3R1))
+HGNC:3942	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+HGNC:3942	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3289
+HGNC:3942	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10437
+HGNC:3942	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+HGNC:3942	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3290
+HGNC:3942	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+HGNC:3942	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4564
+HGNC:3942	activityNegativelyRegulatesActivityOf	HGNC:9829
+HGNC:3942	activityPositivelyRegulatesActivityOf	HGNC:10431
+HGNC:3942	hasVariant	p(HGNC:3942 ! MTOR, pmod(Ph))
+HGNC:3942	hasVariant	p(HGNC:3942 ! MTOR, pmod(Ph), pmod(Ph))
+HGNC:3942	hasVariant	p(HGNC:3942 ! MTOR, pmod(Ph, Ser, 2159))
+HGNC:3942	hasVariant	p(HGNC:3942 ! MTOR, pmod(Ph, Ser, 2448))
+HGNC:3942	hasVariant	p(HGNC:3942 ! MTOR, pmod(Ph, Ser, 2481))
+HGNC:3942	hasVariant	p(HGNC:3942 ! MTOR, pmod(Ph, Thr, 2446))
+HGNC:3942	increasesAmountOf	CHEBI:9168
+HGNC:3942	increasesAmountOf	p(FPLX:"AMPK_alpha" ! "AMPK_alpha", pmod(Ph))
+HGNC:3942	increasesAmountOf	p(HGNC:10431 ! RPS6KA2, pmod(Ph))
+HGNC:3942	increasesAmountOf	p(HGNC:11805 ! TIAM1, pmod(Ph))
+HGNC:3942	increasesAmountOf	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 15))
+HGNC:3942	increasesAmountOf	p(HGNC:6204 ! JUN, pmod(Ph))
+HGNC:3942	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(a(CHEBI:9168 ! sirolimus), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(a(PUBCHEM:148191 ! 148191), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(FPLX:AKT ! AKT), p(FPLX:PI3K ! PI3K), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(FPLX:C1 ! C1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(FPLX:KSR ! KSR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(FPLX:MAPK ! MAPK), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(FPLX:Notch ! Notch), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(FPLX:Wnt ! Wnt), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:10011 ! RHEB), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:3942 ! MTOR, pmod(Ph)))
+HGNC:3942	partOf	complex(p(HGNC:10437 ! RPS6KB2), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:11364 ! STAT3), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:11753 ! TFEB), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:14929 ! SIRT1), p(HGNC:270 ! PARP1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:14929 ! SIRT1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:22950 ! PREX2), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:22953 ! DEPTOR), p(HGNC:24825 ! MLST8), p(HGNC:28426 ! AKT1S1), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:22953 ! DEPTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:3942 ! MTOR), p(HGNC:7553 ! MYC))
+HGNC:3942	partOf	complex(p(HGNC:270 ! PARP1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:28611 ! RICTOR), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:28611 ! RICTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:3942 ! MTOR, pmod(Ph)))
+HGNC:3942	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3942 ! MTOR, pmod(Ph)))
+HGNC:3942	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:3289 ! EIF4EBP2), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:3942 ! MTOR, pmod(Ph)))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:4923 ! HK2))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:6125 ! IRS1))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:6407 ! KRAS))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:667 ! RHOA))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:6973 ! MDM2))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:7553 ! MYC))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:7873 ! NOS2))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:7939 ! NPPA))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:8816 ! PDPK1))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:8975 ! PIK3CA))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:9376 ! PRKAA1))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:9413 ! PRKDC))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:9801 ! RAC1))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:9884 ! RB1))
+HGNC:3942	partOf	complex(p(HGNC:3942 ! MTOR, pmod(Ph)), p(HGNC:9588 ! PTEN))
+HGNC:39755	partOf	complex(p(HGNC:39755 ! MUC22), p(HGNC:7553 ! MYC))
+HGNC:4037	partOf	complex(p(HGNC:4037 ! FYN), p(HGNC:667 ! RHOA))
+HGNC:4066	partOf	complex(p(HGNC:4066 ! GAB1), p(HGNC:9644 ! PTPN11))
+HGNC:4095	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:4095 ! GADD45A))
+HGNC:4170	partOf	complex(p(HGNC:4170 ! GATA1), p(HGNC:8979 ! PIK3R1))
+HGNC:4236	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:4236 ! GFER))
+HGNC:4236	partOf	complex(p(HGNC:4236 ! GFER), p(HGNC:8988 ! PIN1))
+HGNC:427	activityNegativelyRegulatesActivityOf	HGNC:427
+HGNC:427	activityNegativelyRegulatesActivityOf	HGNC:7029
+HGNC:427	hasVariant	p(HGNC:427 ! ALK, pmod(Ph))
+HGNC:427	hasVariant	p(HGNC:427 ! ALK, pmod(Ph, Tyr, 1278))
+HGNC:427	hasVariant	p(HGNC:427 ! ALK, pmod(Ph, Tyr, 1282))
+HGNC:427	hasVariant	p(HGNC:427 ! ALK, pmod(Ph, Tyr, 1283))
+HGNC:427	increasesAmountOf	p(HGNC:29913 ! ZC3HC1, pmod(Ph))
+HGNC:427	increasesAmountOf	p(HGNC:6871 ! MAPK1, pmod(Ph))
+HGNC:427	increasesAmountOf	p(HGNC:6877 ! MAPK3, pmod(Ph))
+HGNC:427	partOf	complex(a(CHEBI:64310 ! crizotinib), p(HGNC:427 ! ALK))
+HGNC:427	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:427 ! ALK))
+HGNC:427	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:427 ! ALK))
+HGNC:427	partOf	complex(p(HGNC:1316 ! EML4), p(HGNC:427 ! ALK))
+HGNC:427	partOf	complex(p(HGNC:18181 ! SHC3), p(HGNC:427 ! ALK))
+HGNC:427	partOf	complex(p(HGNC:25521 ! SRBD1), p(HGNC:427 ! ALK))
+HGNC:427	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:427 ! ALK))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:427 ! ALK))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:4566 ! GRB2))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:5145 ! HPCAL1))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:6125 ! IRS1))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:6871 ! MAPK1))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:7029 ! MET))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:7553 ! MYC))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:7765 ! NF1))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:7910 ! NPM1))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:8979 ! PIK3R1))
+HGNC:427	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:9391 ! PRKAR2A))
+HGNC:4274	partOf	complex(p(HGNC:4274 ! GJA1), p(HGNC:667 ! RHOA))
+HGNC:4281	activityPositivelyRegulatesActivityOf	HGNC:7782
+HGNC:4317	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:4317 ! GLI1))
+HGNC:4370	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:4370 ! GMEB1))
+HGNC:4392	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4392 ! GNAS))
+HGNC:4392	partOf	complex(p(HGNC:4392 ! GNAS), p(HGNC:8975 ! PIK3CA))
+HGNC:4446	partOf	complex(p(HGNC:4446 ! GPAA1), p(HGNC:7553 ! MYC))
+HGNC:4564	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+HGNC:4564	hasVariant	p(HGNC:4564 ! GRB10, pmod(Ph, Ser, 150))
+HGNC:4564	hasVariant	p(HGNC:4564 ! GRB10, pmod(Ph, Ser, 418))
+HGNC:4564	hasVariant	p(HGNC:4564 ! GRB10, pmod(Ph, Ser, 476))
+HGNC:4564	hasVariant	p(HGNC:4564 ! GRB10, pmod(Ph, Ser, 503))
+HGNC:4564	hasVariant	p(HGNC:4564 ! GRB10, pmod(Ph, Tyr))
+HGNC:4564	hasVariant	p(HGNC:4564 ! GRB10, pmod(Ph, Tyr, 67))
+HGNC:4564	partOf	complex(complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1)), p(HGNC:4564 ! GRB10))
+HGNC:4564	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:4564 ! GRB10))
+HGNC:4564	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:4564 ! GRB10), p(HGNC:6091 ! INSR))
+HGNC:4564	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4564 ! GRB10))
+HGNC:4564	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:4564 ! GRB10))
+HGNC:4564	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:4564 ! GRB10))
+HGNC:4564	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:4564 ! GRB10))
+HGNC:4564	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:4566 ! GRB2))
+HGNC:4564	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:6091 ! INSR))
+HGNC:4564	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:6125 ! IRS1))
+HGNC:4564	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:6126 ! IRS2))
+HGNC:4564	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:6840 ! MAP2K1))
+HGNC:4564	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:8979 ! PIK3R1))
+HGNC:4564	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:9829 ! RAF1))
+HGNC:4566	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11187
+HGNC:4566	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11188
+HGNC:4566	hasVariant	p(HGNC:4566 ! GRB2, pmod(Ph))
+HGNC:4566	hasVariant	p(HGNC:4566 ! GRB2, pmod(Ph, Tyr))
+HGNC:4566	hasVariant	p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 160))
+HGNC:4566	hasVariant	p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 209))
+HGNC:4566	hasVariant	p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 37))
+HGNC:4566	hasVariant	p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 52))
+HGNC:4566	hasVariant	p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 7))
+HGNC:4566	hasVariant	p(HGNC:4566 ! GRB2, pmod(Ub))
+HGNC:4566	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+HGNC:4566	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3430 ! ERBB2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:4566 ! GRB2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+HGNC:4566	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:4566 ! GRB2), p(HGNC:9644 ! PTPN11))
+HGNC:4566	partOf	complex(p(FPLX:SHC ! SHC, pmod(Ph, Tyr)), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:10840 ! SHC1, pmod(Ph)), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:11188 ! SOS2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:4566 ! GRB2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:11188 ! SOS2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:11269 ! SPRY1), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3430 ! ERBB2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2), p(HGNC:7029 ! MET))
+HGNC:4566	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:15533 ! SPRY4), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:1653 ! CD28), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:16743 ! SHC4), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:29869 ! SHC2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3236 ! EGFR, pmod(Ph)), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:4566 ! GRB2))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:4568 ! RAPGEF1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:4591 ! ARHGAP35))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6091 ! INSR))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1, pmod(Ph)))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6126 ! IRS2))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6407 ! KRAS))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6840 ! MAP2K1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8590 ! PAK1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8803 ! PDGFRA))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8804 ! PDGFRB))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8975 ! PIK3CA))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8979 ! PIK3R1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8980 ! PIK3R2))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8981 ! PIK3R3))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9103 ! PLXNB1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9281 ! PPP1CA))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9378 ! PRKAB1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9644 ! PTPN11, pmod(Ph)))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9801 ! RAC1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9829 ! RAF1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9871 ! RASA1))
+HGNC:4566	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9884 ! RB1))
+HGNC:4568	hasVariant	p(HGNC:4568 ! RAPGEF1, pmod(Ph, Tyr, 504))
+HGNC:4568	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:4568 ! RAPGEF1))
+HGNC:4568	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:4568 ! RAPGEF1))
+HGNC:4568	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4568 ! RAPGEF1))
+HGNC:4568	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4568 ! RAPGEF1))
+HGNC:4568	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:4568 ! RAPGEF1))
+HGNC:4568	partOf	complex(p(HGNC:4568 ! RAPGEF1), p(HGNC:9876 ! RASGRF2))
+HGNC:4591	activityDirectlyNegativelyRegulatesActivityOf	HGNC:667
+HGNC:4591	hasVariant	p(HGNC:4591 ! ARHGAP35, pmod(Ph, Ser, 1150))
+HGNC:4591	hasVariant	p(HGNC:4591 ! ARHGAP35, pmod(Ph, Ser, 1236))
+HGNC:4591	hasVariant	p(HGNC:4591 ! ARHGAP35, pmod(Ph, Tyr))
+HGNC:4591	hasVariant	p(HGNC:4591 ! ARHGAP35, pmod(Ph, Tyr, 1105))
+HGNC:4591	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:4591 ! ARHGAP35))
+HGNC:4591	partOf	complex(p(HGNC:4591 ! ARHGAP35), p(HGNC:667 ! RHOA))
+HGNC:4591	partOf	complex(p(HGNC:4591 ! ARHGAP35), p(HGNC:9644 ! PTPN11))
+HGNC:4591	partOf	complex(p(HGNC:4591 ! ARHGAP35), p(HGNC:9801 ! RAC1))
+HGNC:4617	hasVariant	p(HGNC:4617 ! GSK3B, pmod(Ph))
+HGNC:4623	partOf	complex(p(HGNC:4623 ! GSR), p(HGNC:8979 ! PIK3R1))
+HGNC:4834	partOf	complex(p(HGNC:4834 ! HBS1L), p(HGNC:7545 ! MYB))
+HGNC:4839	partOf	complex(p(HGNC:4839 ! HCFC1), p(HGNC:7553 ! MYC))
+HGNC:4854	partOf	complex(p(HGNC:4854 ! HDAC3), p(HGNC:6973 ! MDM2))
+HGNC:4868	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:34410 ! NEURL4), p(HGNC:4868 ! HERC2))
+HGNC:4893	partOf	complex(p(HGNC:4893 ! HGF), p(HGNC:7029 ! MET))
+HGNC:4910	partOf	complex(p(HGNC:4910 ! HIF1A), p(HGNC:7553 ! MYC))
+HGNC:4922	partOf	complex(p(HGNC:4922 ! HK1), p(HGNC:6407 ! KRAS))
+HGNC:4923	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:4923 ! HK2))
+HGNC:4983	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:4983 ! HMGB1))
+HGNC:5009	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:5009 ! HMGA2))
+HGNC:5013	partOf	complex(p(HGNC:5013 ! HMOX1), p(HGNC:7782 ! NFE2L2))
+HGNC:5100	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:5100 ! HOXA10))
+HGNC:5118	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:5118 ! HOXB7))
+HGNC:5145	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:5145 ! HPCAL1))
+HGNC:5147	partOf	complex(p(HGNC:5147 ! HPD), p(HGNC:7553 ! MYC), p(PFAM:PF02172 ! KIX))
+HGNC:5173	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+HGNC:5173	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11805
+HGNC:5173	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+HGNC:5173	activityDirectlyPositivelyRegulatesActivityOf	HGNC:646
+HGNC:5173	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+HGNC:5173	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+HGNC:5173	activityPositivelyRegulatesActivityOf	HGNC:9884
+HGNC:5173	hasVariant	p(HGNC:5173 ! HRAS, pmod(Ph))
+HGNC:5173	hasVariant	p(HGNC:5173 ! HRAS, var("p.Gly12Val"))
+HGNC:5173	increasesAmountOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))
+HGNC:5173	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:5173 ! HRAS), p(HGNC:9829 ! RAF1))
+HGNC:5173	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:17294 ! DAB2IP), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:23217 ! GKN1), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:30281 ! RGL1), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:5173 ! HRAS), p(HGNC:7553 ! MYC))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:5173 ! HRAS))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6091 ! INSR))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6204 ! JUN))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6407 ! KRAS))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:646 ! ARAF))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6840 ! MAP2K1))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:7553 ! MYC))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:7765 ! NF1))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:7989 ! NRAS))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:8977 ! PIK3CD))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:8978 ! PIK3CG))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:8979 ! PIK3R1))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9753 ! QPCT))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9769 ! RGL2))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9829 ! RAF1))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9842 ! RALGDS))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9871 ! RASA1))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9875 ! RASGRF1))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9882 ! RASSF1))
+HGNC:5173	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9883 ! RASSF2))
+HGNC:5329	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:5329 ! IAPP))
+HGNC:533	partOf	complex(p(HGNC:533 ! ANXA1), p(HGNC:667 ! RHOA))
+HGNC:53304	activityPositivelyRegulatesActivityOf	HGNC:667
+HGNC:5350	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:5350 ! ICMT))
+HGNC:5350	partOf	complex(p(HGNC:5350 ! ICMT), p(HGNC:667 ! RHOA))
+HGNC:5350	partOf	complex(p(HGNC:5350 ! ICMT), p(HGNC:9802 ! RAC2))
+HGNC:5358	hasVariant	p(HGNC:5358 ! IRF8, pmod(Ph))
+HGNC:5360	partOf	complex(p(HGNC:5360 ! ID1), p(HGNC:7553 ! MYC))
+HGNC:5394	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:5394 ! CFI))
+HGNC:576	activityPositivelyRegulatesActivityOf	HGNC:576
+HGNC:576	hasVariant	p(HGNC:576 ! APAF1, pmod(Ph, Ser, 268))
+HGNC:576	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:576 ! APAF1))
+HGNC:576	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:576 ! APAF1))
+HGNC:576	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:576 ! APAF1))
+HGNC:576	partOf	complex(p(HGNC:1511 ! CASP9), p(HGNC:576 ! APAF1))
+HGNC:576	partOf	complex(p(HGNC:19986 ! CYCS), p(HGNC:576 ! APAF1))
+HGNC:576	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:576 ! APAF1))
+HGNC:576	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:576 ! APAF1))
+HGNC:576	partOf	complex(p(HGNC:576 ! APAF1), p(HGNC:576 ! APAF1))
+HGNC:576	partOf	complex(p(HGNC:576 ! APAF1), p(HGNC:9281 ! PPP1CA))
+HGNC:5960	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:5960 ! IKBKB))
+HGNC:6005	partOf	complex(p(HGNC:24679 ! FBXL20), p(HGNC:6005 ! IL21), p(HGNC:9588 ! PTEN))
+HGNC:6036	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6036 ! FOXK2))
+HGNC:6037	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6037 ! ILF2))
+HGNC:6075	partOf	complex(p(HGNC:6075 ! INPP4B), p(HGNC:6075 ! INPP4B))
+HGNC:6075	partOf	complex(p(HGNC:6075 ! INPP4B), p(HGNC:6075 ! INPP4B), p(HGNC:9588 ! PTEN))
+HGNC:6075	partOf	complex(p(HGNC:6075 ! INPP4B), p(HGNC:9816 ! RAD50))
+HGNC:6081	activityPositivelyRegulatesActivityOf	HGNC:9839
+HGNC:6081	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:6081 ! INS))
+HGNC:6081	partOf	complex(p(HGNC:6081 ! INS), p(HGNC:6091 ! INSR))
+HGNC:6091	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6126
+HGNC:6091	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+HGNC:6091	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1541
+HGNC:6091	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6091
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph, Ser))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 1185))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 1189))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 1190))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 1355))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 1361))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 992))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 999))
+HGNC:6091	hasVariant	p(HGNC:6091 ! INSR, pmod(Ub))
+HGNC:6091	increasesAmountOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))
+HGNC:6091	increasesAmountOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 368)))
+HGNC:6091	increasesAmountOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 580)))
+HGNC:6091	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(FPLX:PI3K ! PI3K), p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+HGNC:6091	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+HGNC:6091	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:12669 ! VDAC1), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:4564 ! GRB10), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:6081 ! INS), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6091 ! INSR), p(HGNC:6091 ! INSR))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6093 ! INSRR))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1), p(HGNC:6126 ! IRS2))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1), p(HGNC:9644 ! PTPN11))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6126 ! IRS2))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6563 ! LGALS3))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6871 ! MAPK1))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6877 ! MAPK3))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:7029 ! MET))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:8981 ! PIK3R3))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9376 ! PRKAA1))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9377 ! PRKAA2))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9502 ! CYTH2))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9644 ! PTPN11))
+HGNC:6091	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9871 ! RASA1))
+HGNC:6093	hasVariant	p(HGNC:6093 ! INSRR, pmod(Ph))
+HGNC:6093	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6093 ! INSRR))
+HGNC:6093	partOf	complex(p(HGNC:6093 ! INSRR), p(HGNC:6093 ! INSRR))
+HGNC:6093	partOf	complex(p(HGNC:6093 ! INSRR), p(HGNC:6093 ! INSRR), p(HGNC:6093 ! INSRR), p(HGNC:6093 ! INSRR))
+HGNC:6110	partOf	complex(p(HGNC:6110 ! IQGAP1), p(HGNC:667 ! RHOA))
+HGNC:6118	hasVariant	p(HGNC:6118 ! IRF3, pmod(Ph))
+HGNC:6118	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:6118 ! IRF3))
+HGNC:6120	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6120 ! IRF5))
+HGNC:6125	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:6125	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 1101))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 1101), pmod(Ph, Ser, 270))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 1222))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 1223))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 24))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 270))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 270), pmod(Ph, Ser, 307))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 270), pmod(Ph, Ser, 636))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 272))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 274))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 307))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 312))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 315))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 323))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 527))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 531))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 616))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 636))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 639))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 1179))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 1229))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 465))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 612))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 632))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 896))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 941))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 989))
+HGNC:6125	hasVariant	p(HGNC:6125 ! IRS1, pmod(Ub))
+HGNC:6125	partOf	complex(p(FPLX:PI3K ! PI3K), p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(FPLX:ROCK ! ROCK), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1, pmod(Ph)))
+HGNC:6125	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1), p(HGNC:6126 ! IRS2))
+HGNC:6125	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1), p(HGNC:9644 ! PTPN11))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:6125 ! IRS1))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:6126 ! IRS2))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:6877 ! MAPK3))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:6973 ! MDM2))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8975 ! PIK3CA, var("p.Glu545Lys")))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8979 ! PIK3R1))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8980 ! PIK3R2))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8981 ! PIK3R3))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8988 ! PIN1))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:9588 ! PTEN))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:9644 ! PTPN11))
+HGNC:6125	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:9783 ! RAB5A))
+HGNC:6126	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+HGNC:6126	hasVariant	p(HGNC:6126 ! IRS2, pmod(Ph))
+HGNC:6126	hasVariant	p(HGNC:6126 ! IRS2, pmod(Ph, Tyr, 628))
+HGNC:6126	hasVariant	p(HGNC:6126 ! IRS2, pmod(Ph, Tyr, 632))
+HGNC:6126	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6126 ! IRS2))
+HGNC:6126	partOf	complex(p(HGNC:3091 ! DYRK1A), p(HGNC:6126 ! IRS2))
+HGNC:6126	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6126 ! IRS2))
+HGNC:6126	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:6126 ! IRS2))
+HGNC:6126	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6126 ! IRS2))
+HGNC:6126	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1), p(HGNC:6126 ! IRS2))
+HGNC:6126	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6126 ! IRS2))
+HGNC:6126	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:6126 ! IRS2))
+HGNC:6126	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8975 ! PIK3CA))
+HGNC:6126	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8978 ! PIK3CG))
+HGNC:6126	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8979 ! PIK3R1))
+HGNC:6126	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8981 ! PIK3R3))
+HGNC:6126	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8988 ! PIN1))
+HGNC:6126	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:9644 ! PTPN11))
+HGNC:620	partOf	complex(p(HGNC:620 ! APP), p(HGNC:8988 ! PIN1))
+HGNC:6204	activityPositivelyRegulatesActivityOf	HGNC:1582
+HGNC:6204	activityPositivelyRegulatesActivityOf	HGNC:3489
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Ser, 243))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Ser, 249))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Ser, 63))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Ser, 63), pmod(Ph, Ser, 73))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Ser, 63), pmod(Ph, Ser, 73), pmod(Ph, Thr, 91), pmod(Ph, Thr, 93))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Ser, 73))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Thr, 2))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Thr, 239))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Thr, 286))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Thr, 8))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Thr, 89))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Thr, 91))
+HGNC:6204	hasVariant	p(HGNC:6204 ! JUN, pmod(Ph, Thr, 93))
+HGNC:6204	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:11998 ! TP53), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:11205 ! SP1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:16853 ! IPO13), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:17192 ! TIRAP), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:30380 ! EXOC1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN), p(HGNC:7553 ! MYC))
+HGNC:6204	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6204 ! JUN))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6204 ! JUN), p(HGNC:7782 ! NFE2L2))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6871 ! MAPK1))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6877 ! MAPK3))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6973 ! MDM2))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7176 ! MMP9))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7553 ! MYC))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7553 ! MYC), p(HGNC:7782 ! NFE2L2))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7782 ! NFE2L2))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:8816 ! PDPK1))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:8988 ! PIN1))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:9841 ! RALBP1))
+HGNC:6204	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:9955 ! RELA))
+HGNC:6205	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:6205 ! JUNB))
+HGNC:6307	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6307 ! KDR))
+HGNC:6307	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:6307 ! KDR))
+HGNC:6344	partOf	complex(p(HGNC:3678 ! FGF21), p(HGNC:3688 ! FGFR1), p(HGNC:6344 ! KL))
+HGNC:6348	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6348 ! KLF4))
+HGNC:6407	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+HGNC:6407	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8977
+HGNC:6407	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+HGNC:6407	activityNegativelyRegulatesActivityOf	CHEBI:26523
+HGNC:6407	activityNegativelyRegulatesActivityOf	HGNC:9884
+HGNC:6407	activityPositivelyRegulatesActivityOf	HGNC:10430
+HGNC:6407	activityPositivelyRegulatesActivityOf	HGNC:3796
+HGNC:6407	hasVariant	p(HGNC:6407 ! KRAS, pmod(Me))
+HGNC:6407	hasVariant	p(HGNC:6407 ! KRAS, pmod(Ph))
+HGNC:6407	hasVariant	p(HGNC:6407 ! KRAS, pmod(Ph, Tyr, 32))
+HGNC:6407	hasVariant	p(HGNC:6407 ! KRAS, var("p.Gln61His"))
+HGNC:6407	hasVariant	p(HGNC:6407 ! KRAS, var("p.Gln61Leu"))
+HGNC:6407	hasVariant	p(HGNC:6407 ! KRAS, var("p.Gly12Cys"))
+HGNC:6407	hasVariant	p(HGNC:6407 ! KRAS, var("p.Gly12Val"))
+HGNC:6407	hasVariant	p(HGNC:6407 ! KRAS, var("p.Gly13Asp"))
+HGNC:6407	increasesAmountOf	p(HGNC:11998 ! TP53, pmod(Me))
+HGNC:6407	increasesAmountOf	p(HGNC:9882 ! RASSF1, pmod(Me))
+HGNC:6407	partOf	complex(a(CHEBI:15996 ! GTP), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(a(CHEBI:17552 ! GDP), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1)), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11389 ! STK11), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:11998 ! TP53), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:6407	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:9829 ! RAF1))
+HGNC:6407	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:11188 ! SOS2), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:14900 ! IL22), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:6407	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:17635 ! CD274), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:20796 ! RASSF6), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:22265 ! BHLHA15), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:28115 ! TBCEL), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:28866 ! IGF2BP1), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:3263 ! AGO2), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:4922 ! HK1), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:6407 ! KRAS), p(HGNC:6407 ! KRAS))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:646 ! ARAF))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:6563 ! LGALS3))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:667 ! RHOA))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:6871 ! MAPK1))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7029 ! MET))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7029 ! MET), p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7553 ! MYC))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7765 ! NF1))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7782 ! NFE2L2))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8977 ! PIK3CD))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8978 ! PIK3CG))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8979 ! PIK3R1))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8980 ! PIK3R2))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9155 ! PNLIP))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9588 ! PTEN))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9769 ! RGL2))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9801 ! RAC1))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9829 ! RAF1))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9842 ! RALGDS))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9876 ! RASGRF2))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9882 ! RASSF1))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9883 ! RASSF2))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9884 ! RB1))
+HGNC:6407	partOf	complex(p(HGNC:6407 ! KRAS), p(UP:P62158 ! P62158))
+HGNC:644	increasesAmountOf	HGNC:3236
+HGNC:644	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:644 ! AR))
+HGNC:646	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+HGNC:646	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6842
+HGNC:646	hasVariant	p(HGNC:646 ! ARAF, pmod(Ph))
+HGNC:646	hasVariant	p(HGNC:646 ! ARAF, pmod(Ph, Ser, 299))
+HGNC:646	hasVariant	p(HGNC:646 ! ARAF, pmod(Ph, Tyr, 302))
+HGNC:646	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:646 ! ARAF))
+HGNC:646	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:646 ! ARAF))
+HGNC:646	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:646 ! ARAF), p(HGNC:9829 ! RAF1))
+HGNC:646	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:646 ! ARAF))
+HGNC:646	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:646 ! ARAF))
+HGNC:646	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:646 ! ARAF))
+HGNC:646	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:646 ! ARAF))
+HGNC:646	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:646 ! ARAF))
+HGNC:646	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:646 ! ARAF), p(HGNC:646 ! ARAF))
+HGNC:646	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:6840 ! MAP2K1))
+HGNC:646	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:6842 ! MAP2K2))
+HGNC:646	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:7227 ! MRAS))
+HGNC:646	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:7989 ! NRAS))
+HGNC:646	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:8979 ! PIK3R1))
+HGNC:646	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:9829 ! RAF1))
+HGNC:6465	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+HGNC:6465	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+HGNC:6465	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+HGNC:6465	hasVariant	p(HGNC:6465 ! KSR1, pmod(Ph))
+HGNC:6465	hasVariant	p(HGNC:6465 ! KSR1, pmod(Ph, Ser, 334))
+HGNC:6465	hasVariant	p(HGNC:6465 ! KSR1, pmod(Ph, Ser, 406))
+HGNC:6465	hasVariant	p(HGNC:6465 ! KSR1, pmod(Ph, Ser, 458))
+HGNC:6465	hasVariant	p(HGNC:6465 ! KSR1, pmod(Ph, Thr, 274))
+HGNC:6465	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6465 ! KSR1))
+HGNC:6465	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:6465 ! KSR1))
+HGNC:6465	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:6465 ! KSR1))
+HGNC:6465	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6465 ! KSR1))
+HGNC:6465	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:6465 ! KSR1))
+HGNC:6465	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:682 ! ARHGEF2))
+HGNC:6465	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:6840 ! MAP2K1))
+HGNC:6465	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:7765 ! NF1))
+HGNC:6465	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:9829 ! RAF1))
+HGNC:6465	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:9874 ! RASAL2))
+HGNC:6499	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:6499 ! LAMP1))
+HGNC:6514	increasesAmountOf	p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 127))
+HGNC:6514	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:6514 ! LATS1))
+HGNC:6515	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6515 ! LATS2))
+HGNC:6563	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6563 ! LGALS3))
+HGNC:6563	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:6563 ! LGALS3))
+HGNC:659	partOf	complex(p(HGNC:659 ! ARF6), p(HGNC:668 ! RHOB))
+HGNC:667	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10251
+HGNC:667	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+HGNC:667	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:667	hasVariant	p(HGNC:667 ! RHOA, pmod(Glyco))
+HGNC:667	hasVariant	p(HGNC:667 ! RHOA, pmod(Ph))
+HGNC:667	hasVariant	p(HGNC:667 ! RHOA, pmod(Ph, Ser, 188))
+HGNC:667	hasVariant	p(HGNC:667 ! RHOA, pmod(Ub))
+HGNC:667	hasVariant	p(HGNC:667 ! RHOA, var("p.Gly17Val"))
+HGNC:667	partOf	complex(a(CHEBI:15996 ! GTP), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(FPLX:ROCK ! ROCK), p(HGNC:667 ! RHOA), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:10252 ! ROCK2), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:667 ! RHOA, var("p.Gly17Val")))
+HGNC:667	partOf	complex(p(HGNC:13518 ! CLIC4), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:1603 ! CCR2), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:4037 ! FYN), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:4274 ! GJA1), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:4591 ! ARHGAP35), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:533 ! ANXA1), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:5350 ! ICMT), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:6110 ! IQGAP1), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:667 ! RHOA))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:667 ! RHOA), p(HGNC:9801 ! RAC1))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:668 ! RHOB))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:668 ! RHOB), p(HGNC:669 ! RHOC))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:669 ! RHOC))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:669 ! RHOC), p(HGNC:9801 ! RAC1))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:682 ! ARHGEF2))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:682 ! ARHGEF2), p(HGNC:9801 ! RAC1))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:6973 ! MDM2))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:7029 ! MET))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:7553 ! MYC))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9103 ! PLXNB1))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9588 ! PTEN))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9644 ! PTPN11))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9774 ! RAB35))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9802 ! RAC2))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9839 ! RALA))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9882 ! RASSF1))
+HGNC:667	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9884 ! RB1))
+HGNC:668	decreasesAmountOf	p(HGNC:391 ! AKT1, pmod(Ph))
+HGNC:668	partOf	complex(p(HGNC:659 ! ARF6), p(HGNC:668 ! RHOB))
+HGNC:668	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:668 ! RHOB))
+HGNC:668	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:668 ! RHOB), p(HGNC:669 ! RHOC))
+HGNC:668	partOf	complex(p(HGNC:668 ! RHOB), p(HGNC:668 ! RHOB))
+HGNC:668	partOf	complex(p(HGNC:668 ! RHOB), p(HGNC:669 ! RHOC))
+HGNC:668	partOf	complex(p(HGNC:668 ! RHOB), p(HGNC:9801 ! RAC1))
+HGNC:669	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:669 ! RHOC))
+HGNC:669	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:669 ! RHOC))
+HGNC:669	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:668 ! RHOB), p(HGNC:669 ! RHOC))
+HGNC:669	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:669 ! RHOC))
+HGNC:669	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:669 ! RHOC), p(HGNC:9801 ! RAC1))
+HGNC:669	partOf	complex(p(HGNC:668 ! RHOB), p(HGNC:669 ! RHOC))
+HGNC:669	partOf	complex(p(HGNC:669 ! RHOC), p(HGNC:9801 ! RAC1))
+HGNC:669	partOf	complex(p(HGNC:669 ! RHOC), p(HGNC:9803 ! RAC3))
+HGNC:6735	partOf	complex(p(HGNC:6735 ! LYN), p(HGNC:9884 ! RB1))
+HGNC:6763	partOf	complex(a(PUBCHEM:50909854 ! 50909854), p(HGNC:6763 ! MAD2L1))
+HGNC:6773	partOf	complex(p(HGNC:6773 ! SMAD7), p(HGNC:7166 ! MMP2), p(HGNC:9588 ! PTEN))
+HGNC:682	activityDirectlyPositivelyRegulatesActivityOf	HGNC:667
+HGNC:682	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:682	hasVariant	p(HGNC:682 ! ARHGEF2, pmod(Ph))
+HGNC:682	hasVariant	p(HGNC:682 ! ARHGEF2, pmod(Ph, Ser, 886))
+HGNC:682	hasVariant	p(HGNC:682 ! ARHGEF2, pmod(Ph, Ser, 960))
+HGNC:682	hasVariant	p(HGNC:682 ! ARHGEF2, pmod(Ph, Thr, 679))
+HGNC:682	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:17848 ! STK38L), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:30380 ! EXOC1), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:682 ! ARHGEF2), p(HGNC:9801 ! RAC1))
+HGNC:682	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:682 ! ARHGEF2))
+HGNC:682	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:6871 ! MAPK1))
+HGNC:682	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:7553 ! MYC))
+HGNC:682	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:8590 ! PAK1))
+HGNC:682	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:9801 ! RAC1))
+HGNC:6840	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6871
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph))
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 218))
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 218), pmod(Ph, Ser, 222))
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 222))
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 248))
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 304))
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph, Thr, 286))
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph, Thr, 292))
+HGNC:6840	hasVariant	p(HGNC:6840 ! MAP2K1, pmod(Ph, Thr, 386))
+HGNC:6840	increasesAmountOf	p(HGNC:12363 ! TSC2, pmod(Ph))
+HGNC:6840	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:1097 ! BRAF, var("p.Val600Glu")), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:19701 ! CNKSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:18610 ! KSR2), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6840 ! MAP2K1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6842 ! MAP2K2))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6842 ! MAP2K2), p(HGNC:6871 ! MAPK1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1), p(HGNC:6871 ! MAPK1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1), p(HGNC:6877 ! MAPK3))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1), p(HGNC:9829 ! RAF1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6877 ! MAPK3))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:7553 ! MYC))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:7782 ! NFE2L2))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:8590 ! PAK1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:8630 ! PEBP1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:8630 ! PEBP1), p(HGNC:9829 ! RAF1))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:9588 ! PTEN))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:9644 ! PTPN11))
+HGNC:6840	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:9829 ! RAF1))
+HGNC:6842	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6871
+HGNC:6842	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+HGNC:6842	hasVariant	p(HGNC:6842 ! MAP2K2, pmod(Ph))
+HGNC:6842	hasVariant	p(HGNC:6842 ! MAP2K2, pmod(Ph, Ser, 222))
+HGNC:6842	hasVariant	p(HGNC:6842 ! MAP2K2, pmod(Ph, Ser, 222), pmod(Ph, Ser, 226))
+HGNC:6842	hasVariant	p(HGNC:6842 ! MAP2K2, pmod(Ph, Ser, 226))
+HGNC:6842	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6842 ! MAP2K2))
+HGNC:6842	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6842 ! MAP2K2))
+HGNC:6842	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:6842 ! MAP2K2))
+HGNC:6842	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6842 ! MAP2K2))
+HGNC:6842	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6842 ! MAP2K2), p(HGNC:6871 ! MAPK1))
+HGNC:6842	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:6842 ! MAP2K2))
+HGNC:6842	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:6871 ! MAPK1))
+HGNC:6842	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:6877 ! MAPK3))
+HGNC:6842	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:7782 ! NFE2L2))
+HGNC:6842	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:9829 ! RAF1))
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12362
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12363
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1784
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3064
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+HGNC:6871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3064
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3321
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3444
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4564
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+HGNC:6871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6871
+HGNC:6871	activityPositivelyRegulatesActivityOf	HGNC:7794
+HGNC:6871	hasVariant	p(HGNC:6871 ! MAPK1, pmod(Ph))
+HGNC:6871	hasVariant	p(HGNC:6871 ! MAPK1, pmod(Ph, Ser))
+HGNC:6871	hasVariant	p(HGNC:6871 ! MAPK1, pmod(Ph, Thr, 185))
+HGNC:6871	hasVariant	p(HGNC:6871 ! MAPK1, pmod(Ph, Thr, 185), pmod(Ph, Tyr, 187))
+HGNC:6871	hasVariant	p(HGNC:6871 ! MAPK1, pmod(Ph, Thr, 190))
+HGNC:6871	hasVariant	p(HGNC:6871 ! MAPK1, pmod(Ph, Tyr, 187))
+HGNC:6871	hasVariant	p(HGNC:6871 ! MAPK1, pmod(Ph, Tyr, 205))
+HGNC:6871	increasesAmountOf	p(HGNC:11728 ! TERF1, pmod(Ph))
+HGNC:6871	partOf	complex(p(FPLX:KSR ! KSR), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3068 ! DUSP2), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3069 ! DUSP3), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3071 ! DUSP5), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:6871 ! MAPK1, pmod(Ph)))
+HGNC:6871	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3444 ! ERF), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6842 ! MAP2K2), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1), p(HGNC:6877 ! MAPK3))
+HGNC:6871	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1), p(HGNC:9829 ! RAF1))
+HGNC:6871	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:6871 ! MAPK1))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:6877 ! MAPK3))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:7553 ! MYC))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:7794 ! NFKB1))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:8590 ! PAK1))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:8630 ! PEBP1))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:8822 ! PEA15))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:952 ! BARD1))
+HGNC:6871	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:9829 ! RAF1))
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11187
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3064
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7545
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+HGNC:6877	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3064
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3321
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3489
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4564
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:682
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+HGNC:6877	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+HGNC:6877	hasVariant	p(HGNC:6877 ! MAPK3, pmod(Ph))
+HGNC:6877	hasVariant	p(HGNC:6877 ! MAPK3, pmod(Ph, Thr, 202))
+HGNC:6877	hasVariant	p(HGNC:6877 ! MAPK3, pmod(Ph, Thr, 202), pmod(Ph, Tyr, 204))
+HGNC:6877	hasVariant	p(HGNC:6877 ! MAPK3, pmod(Ph, Thr, 207))
+HGNC:6877	hasVariant	p(HGNC:6877 ! MAPK3, pmod(Ph, Tyr, 204))
+HGNC:6877	increasesAmountOf	p(HGNC:1784 ! CDKN1A, pmod(Ph))
+HGNC:6877	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:10431 ! RPS6KA2), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:10435 ! RPS6KA6), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:3064 ! DUSP1), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:3069 ! DUSP3), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:3071 ! DUSP5), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:3321 ! ELK1), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:6877 ! MAPK3))
+HGNC:6877	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:7553 ! MYC))
+HGNC:6877	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:8591 ! PAK2))
+HGNC:6877	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:8822 ! PEA15))
+HGNC:6877	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:9829 ! RAF1))
+HGNC:6877	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:9842 ! RALGDS))
+HGNC:6886	partOf	complex(p(HGNC:2514 ! CTNNB1), p(HGNC:6886 ! MAPK9), p(HGNC:9801 ! RAC1))
+HGNC:6913	partOf	complex(p(HGNC:6913 ! MAX), p(HGNC:7553 ! MYC))
+HGNC:6945	hasVariant	p(HGNC:6945 ! MCM3, pmod(Ph, Thr, 722))
+HGNC:6945	partOf	complex(p(HGNC:10437 ! RPS6KB2), p(HGNC:6945 ! MCM3))
+HGNC:6945	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6945 ! MCM3))
+HGNC:6945	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6945 ! MCM3))
+HGNC:6945	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:6945 ! MCM3))
+HGNC:6945	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6945 ! MCM3))
+HGNC:6945	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6945 ! MCM3))
+HGNC:6945	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6947 ! MCM4))
+HGNC:6945	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6948 ! MCM5))
+HGNC:6945	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6948 ! MCM5), p(HGNC:6950 ! MCM7))
+HGNC:6945	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6949 ! MCM6))
+HGNC:6945	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6950 ! MCM7))
+HGNC:6945	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:7782 ! NFE2L2))
+HGNC:6945	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:8591 ! PAK2))
+HGNC:6947	hasVariant	p(HGNC:6947 ! MCM4, pmod(Ph))
+HGNC:6947	hasVariant	p(HGNC:6947 ! MCM4, pmod(Ph, Ser, 32))
+HGNC:6947	hasVariant	p(HGNC:6947 ! MCM4, pmod(Ph, Ser, 54))
+HGNC:6947	hasVariant	p(HGNC:6947 ! MCM4, pmod(Ph, Thr, 110))
+HGNC:6947	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6947 ! MCM4))
+HGNC:6947	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:6947 ! MCM4))
+HGNC:6947	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6947 ! MCM4))
+HGNC:6947	partOf	complex(p(HGNC:3115 ! E2F3), p(HGNC:6947 ! MCM4))
+HGNC:6947	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6947 ! MCM4))
+HGNC:6947	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6947 ! MCM4))
+HGNC:6947	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6947 ! MCM4))
+HGNC:6947	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6948 ! MCM5))
+HGNC:6947	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6949 ! MCM6))
+HGNC:6947	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6949 ! MCM6), p(HGNC:6950 ! MCM7))
+HGNC:6947	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6950 ! MCM7))
+HGNC:6947	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:9884 ! RB1))
+HGNC:6948	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6948 ! MCM5))
+HGNC:6948	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:6948 ! MCM5))
+HGNC:6948	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6948 ! MCM5))
+HGNC:6948	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6948 ! MCM5), p(HGNC:6950 ! MCM7))
+HGNC:6948	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6948 ! MCM5))
+HGNC:6948	partOf	complex(p(HGNC:6948 ! MCM5), p(HGNC:6949 ! MCM6))
+HGNC:6948	partOf	complex(p(HGNC:6948 ! MCM5), p(HGNC:6950 ! MCM7))
+HGNC:6948	partOf	complex(p(HGNC:6948 ! MCM5), p(HGNC:9839 ! RALA))
+HGNC:6949	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6949 ! MCM6), p(HGNC:6950 ! MCM7))
+HGNC:6949	partOf	complex(p(HGNC:6948 ! MCM5), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:6949 ! MCM6), p(HGNC:6949 ! MCM6))
+HGNC:6949	partOf	complex(p(HGNC:6949 ! MCM6), p(HGNC:6950 ! MCM7))
+HGNC:6949	partOf	complex(p(HGNC:6949 ! MCM6), p(HGNC:952 ! BARD1))
+HGNC:695	partOf	complex(p(HGNC:695 ! ARL4A), p(HGNC:8590 ! PAK1))
+HGNC:6950	hasVariant	p(HGNC:6950 ! MCM7, pmod(Ph))
+HGNC:6950	hasVariant	p(HGNC:6950 ! MCM7, pmod(Ph, Ser, 121))
+HGNC:6950	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:11291 ! SRF), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:33984 ! RASSF10), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6948 ! MCM5), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6949 ! MCM6), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:6948 ! MCM5), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:6949 ! MCM6), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:6950 ! MCM7), p(HGNC:6950 ! MCM7))
+HGNC:6950	partOf	complex(p(HGNC:6950 ! MCM7), p(HGNC:7553 ! MYC))
+HGNC:6950	partOf	complex(p(HGNC:6950 ! MCM7), p(HGNC:9588 ! PTEN))
+HGNC:6950	partOf	complex(p(HGNC:6950 ! MCM7), p(HGNC:9884 ! RB1))
+HGNC:6973	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+HGNC:6973	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ac))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 166))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 186))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 188))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 253))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 370))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 395))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 407))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Thr, 216))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Tyr, 276))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Tyr, 394))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ph, Tyr, 405))
+HGNC:6973	hasVariant	p(HGNC:6973 ! MDM2, pmod(Ub))
+HGNC:6973	partOf	complex(a(CHEBI:27899 ! cisplatin), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:10316 ! RPL23), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:10404 ! RPS2), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:10486 ! S100A1), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11764 ! TG), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12003 ! TP73), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1773 ! CDK4), p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1784 ! CDKN1A), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:3236 ! EGFR), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6974 ! MDM4))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:7553 ! MYC))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:8846 ! PER2))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:6973	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2, pmod(Ph)))
+HGNC:6973	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:12630 ! USP7), p(HGNC:2681 ! DAXX), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:12687 ! VHL), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:13787 ! BCL2L12), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:17609 ! RASSF5), p(HGNC:20796 ! RASSF6), p(HGNC:6973 ! MDM2), p(HGNC:9882 ! RASSF1))
+HGNC:6973	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:21270 ! GRWD1), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:6973	partOf	complex(p(HGNC:18157 ! TAB1), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:20796 ! RASSF6), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:2861 ! DHFR), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:29573 ! PHLDB2), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:30833 ! CDK2AP2), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:3091 ! DYRK1A), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:6973	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:4854 ! HDAC3), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:6973 ! MDM2))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:6974 ! MDM4))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:7417 ! MTBP))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:7652 ! NBN))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:7707 ! NDUFS1))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:7776 ! NFATC2))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:8607 ! PRKN))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:8846 ! PER2))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:9281 ! PPP1CA))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:9882 ! RASSF1))
+HGNC:6973	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:6974	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:6974 ! MDM4))
+HGNC:6974	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6974 ! MDM4))
+HGNC:6974	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:6974 ! MDM4))
+HGNC:6974	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:6974 ! MDM4))
+HGNC:701	partOf	complex(p(HGNC:701 ! ARNTL), p(HGNC:7553 ! MYC))
+HGNC:7029	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:7029	activityNegativelyRegulatesActivityOf	HGNC:1097
+HGNC:7029	activityNegativelyRegulatesActivityOf	HGNC:3236
+HGNC:7029	activityNegativelyRegulatesActivityOf	HGNC:7029
+HGNC:7029	activityPositivelyRegulatesActivityOf	FPLX:SHC
+HGNC:7029	activityPositivelyRegulatesActivityOf	HGNC:11998
+HGNC:7029	activityPositivelyRegulatesActivityOf	HGNC:1784
+HGNC:7029	activityPositivelyRegulatesActivityOf	HGNC:6871
+HGNC:7029	activityPositivelyRegulatesActivityOf	HGNC:6877
+HGNC:7029	decreasesAmountOf	GO:"GO:0006914"
+HGNC:7029	decreasesAmountOf	GO:"GO:0016049"
+HGNC:7029	decreasesAmountOf	MESH:D002470
+HGNC:7029	hasVariant	p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1003))
+HGNC:7029	hasVariant	p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1230))
+HGNC:7029	hasVariant	p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1234))
+HGNC:7029	hasVariant	p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1235))
+HGNC:7029	hasVariant	p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1349))
+HGNC:7029	hasVariant	p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1356))
+HGNC:7029	hasVariant	p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1365))
+HGNC:7029	hasVariant	p(HGNC:7029 ! MET, pmod(Ub))
+HGNC:7029	increasesAmountOf	GO:"GO:0006915"
+HGNC:7029	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(a(TEXT:"NCIT:C63927"), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(FPLX:AKT ! AKT), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(FPLX:GST ! GST), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(FPLX:PDGFR ! PDGFR), p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:4566 ! GRB2), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET), p(HGNC:7782 ! NFE2L2))
+HGNC:7029	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:4893 ! HGF), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7029 ! MET), p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:7029	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:7029 ! MET), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:7029 ! MET), p(HGNC:7029 ! MET), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:7029 ! MET), p(HGNC:7029 ! MET), p(HGNC:7029 ! MET), p(HGNC:7029 ! MET))
+HGNC:7029	partOf	complex(p(HGNC:7029 ! MET), p(HGNC:7381 ! MST1R))
+HGNC:7029	partOf	complex(p(HGNC:7029 ! MET), p(HGNC:9103 ! PLXNB1))
+HGNC:7095	hasVariant	p(HGNC:7095 ! MID1, pmod(Ph))
+HGNC:7112	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3467 ! ESR1), p(HGNC:370 ! AKAP12), p(HGNC:7112 ! MKRN1))
+HGNC:7112	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:7112 ! MKRN1))
+HGNC:7132	partOf	complex(p(HGNC:7132 ! KMT2A), p(HGNC:7136 ! MLLT3), p(HGNC:7545 ! MYB))
+HGNC:7136	partOf	complex(p(HGNC:7132 ! KMT2A), p(HGNC:7136 ! MLLT3), p(HGNC:7545 ! MYB))
+HGNC:7137	hasVariant	p(HGNC:7137 ! AFDN, pmod(Ph))
+HGNC:7166	partOf	complex(p(HGNC:6773 ! SMAD7), p(HGNC:7166 ! MMP2), p(HGNC:9588 ! PTEN))
+HGNC:717	partOf	complex(p(HGNC:717 ! ARSD), p(HGNC:9588 ! PTEN))
+HGNC:7176	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7176 ! MMP9))
+HGNC:7227	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:7227 ! MRAS))
+HGNC:7227	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:7227 ! MRAS))
+HGNC:7227	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:7227 ! MRAS), p(HGNC:9829 ! RAF1))
+HGNC:7227	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:7227 ! MRAS))
+HGNC:7227	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:7227 ! MRAS))
+HGNC:7227	partOf	complex(p(HGNC:7227 ! MRAS), p(HGNC:9829 ! RAF1))
+HGNC:7227	partOf	complex(p(HGNC:7227 ! MRAS), p(HGNC:9842 ! RALGDS))
+HGNC:7381	partOf	complex(p(HGNC:7029 ! MET), p(HGNC:7381 ! MST1R))
+HGNC:7399	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7399 ! MT1G))
+HGNC:7417	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:7417 ! MTBP))
+HGNC:7417	partOf	complex(p(HGNC:7417 ! MTBP), p(HGNC:7553 ! MYC))
+HGNC:7508	activityPositivelyRegulatesActivityOf	HGNC:3236
+HGNC:7511	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7511 ! MUC13))
+HGNC:7514	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:7514 ! MUC4))
+HGNC:7526	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7526 ! MMUT))
+HGNC:7545	hasVariant	p(HGNC:7545 ! MYB, pmod(Ph, Ser, 532))
+HGNC:7545	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:3527 ! EZH2), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:4834 ! HBS1L), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:7132 ! KMT2A), p(HGNC:7136 ! MLLT3), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:7545 ! MYB), p(HGNC:7545 ! MYB))
+HGNC:7545	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:7553 ! MYC))
+HGNC:7545	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:8988 ! PIN1))
+HGNC:7545	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:9605 ! PTGS2))
+HGNC:7545	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:9841 ! RALBP1))
+HGNC:7548	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:7548 ! MYBL2))
+HGNC:7553	activityNegativelyRegulatesActivityOf	CHEBI:26523
+HGNC:7553	activityPositivelyRegulatesActivityOf	HGNC:22933
+HGNC:7553	activityPositivelyRegulatesActivityOf	HGNC:26539
+HGNC:7553	activityPositivelyRegulatesActivityOf	HGNC:7029
+HGNC:7553	activityPositivelyRegulatesActivityOf	HGNC:8816
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, 58))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, 67))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, Ser))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, Ser, 373))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, Ser, 62))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, Ser, 71))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, Thr))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, Thr, 358))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ph, Thr, 58))
+HGNC:7553	hasVariant	p(HGNC:7553 ! MYC, pmod(Ub))
+HGNC:7553	increasesAmountOf	HGNC:2514
+HGNC:7553	increasesAmountOf	HGNC:959
+HGNC:7553	increasesAmountOf	HGNC:990
+HGNC:7553	partOf	complex(p(FPLX:AKT ! AKT), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(FPLX:ETS ! ETS), p(FPLX:ETS ! ETS), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(FPLX:NFkappaB ! NFkappaB), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(FPLX:VAV ! VAV), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1052 ! BIN1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:10894 ! PRMT5), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:11205 ! SP1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:11588 ! TBP), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:11641 ! TCF7L2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:11730 ! TERT), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:11760 ! TFPI), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:12441 ! TYMS), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:12347 ! TRRAP), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:12441 ! TYMS), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:12757 ! WDR5), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:12936 ! ZBTB17), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:13575 ! BRD4), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:13718 ! FOSL1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:13748 ! DLEU2), p(HGNC:14013 ! SMC4), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:13759 ! CYFIP1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:14067 ! HDAC7), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:16403 ! ZNF346), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:16712 ! FBXW7), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1722 ! CDK1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1739 ! CDC45), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:17635 ! CD274), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:23393 ! CARM1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:24825 ! MLST8), p(HGNC:3942 ! MTOR), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:24948 ! DOT1L), p(HGNC:3373 ! EP300), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:28866 ! IGF2BP1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:2976 ! DNMT1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:30389 ! EXOC4), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3070 ! DUSP4), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3115 ! E2F3), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3374 ! EPAS1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3501 ! EVI5), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:5173 ! HRAS), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:39755 ! MUC22), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:4446 ! GPAA1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:4839 ! HCFC1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:4910 ! HIF1A), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:5147 ! HPD), p(HGNC:7553 ! MYC), p(PFAM:PF02172 ! KIX))
+HGNC:7553	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:5360 ! ID1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7553 ! MYC), p(HGNC:7782 ! NFE2L2))
+HGNC:7553	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:6913 ! MAX), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:6950 ! MCM7), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:701 ! ARNTL), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:7417 ! MTBP), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7553 ! MYC), p(HGNC:7553 ! MYC))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7672 ! NCOR1))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7673 ! NCOR2))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7782 ! NFE2L2))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7989 ! NRAS))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8591 ! PAK2))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8638 ! KAT2B))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8804 ! PDGFRB))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8988 ! PIN1))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8988 ! PIN1), p(HGNC:8988 ! PIN1))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9221 ! POU5F1))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9281 ! PPP1CA))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9588 ! PTEN))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9709 ! PVT1))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9801 ! RAC1))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9829 ! RAF1))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9884 ! RB1))
+HGNC:7553	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:990 ! BCL2))
+HGNC:7596	partOf	complex(p(HGNC:7596 ! MYO1B), p(HGNC:9588 ! PTEN))
+HGNC:76	increasesAmountOf	p(HGNC:16262 ! YAP1, pmod(Ph, Tyr, 407))
+HGNC:7652	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:7652 ! NBN))
+HGNC:7665	partOf	complex(p(HGNC:17175 ! PLCE1), p(HGNC:7665 ! NCK2))
+HGNC:7672	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7672 ! NCOR1))
+HGNC:7673	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7673 ! NCOR2))
+HGNC:7707	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:7707 ! NDUFS1))
+HGNC:7765	activityDirectlyNegativelyRegulatesActivityOf	HGNC:5173
+HGNC:7765	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:7765	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:11909 ! TNFRSF11B), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:17722 ! SPRED2), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:20249 ! SPRED1), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:23251 ! AWAT2), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:7765 ! NF1))
+HGNC:7765	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:7989 ! NRAS))
+HGNC:7765	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:8803 ! PDGFRA))
+HGNC:7765	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:9871 ! RASA1))
+HGNC:7765	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:9874 ! RASAL2))
+HGNC:7776	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:7776 ! NFATC2))
+HGNC:7782	activityNegativelyRegulatesActivityOf	CHEBI:26523
+HGNC:7782	activityPositivelyRegulatesActivityOf	HGNC:3489
+HGNC:7782	decreasesAmountOf	MESH:D010190
+HGNC:7782	hasVariant	p(HGNC:7782 ! NFE2L2, pmod(Ac))
+HGNC:7782	hasVariant	p(HGNC:7782 ! NFE2L2, pmod(Ph))
+HGNC:7782	hasVariant	p(HGNC:7782 ! NFE2L2, pmod(Ph, Ser, 40))
+HGNC:7782	hasVariant	p(HGNC:7782 ! NFE2L2, pmod(Ub))
+HGNC:7782	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(a(CHEBI:28748 ! doxorubicin), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(FPLX:AMPK ! AMPK), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(FPLX:NFkappaB ! NFkappaB), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:23177 ! KEAP1), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:7029 ! MET), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:3467 ! ESR1), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:5013 ! HMOX1), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:6204 ! JUN), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7553 ! MYC), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:7782 ! NFE2L2), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:7782 ! NFE2L2), p(HGNC:7782 ! NFE2L2), p(HGNC:7782 ! NFE2L2))
+HGNC:7782	partOf	complex(p(HGNC:7782 ! NFE2L2), p(HGNC:9803 ! RAC3))
+HGNC:7794	hasVariant	p(HGNC:7794 ! NFKB1, pmod(Ph, Ser, 337))
+HGNC:7794	hasVariant	p(HGNC:7794 ! NFKB1, pmod(Ph, Ser, 923))
+HGNC:7794	hasVariant	p(HGNC:7794 ! NFKB1, pmod(Ph, Ser, 927))
+HGNC:7794	hasVariant	p(HGNC:7794 ! NFKB1, pmod(Ph, Ser, 932))
+HGNC:7794	hasVariant	p(HGNC:7794 ! NFKB1, pmod(Ph, Thr, 931))
+HGNC:7794	hasVariant	p(HGNC:7794 ! NFKB1, pmod(Ub))
+HGNC:7794	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:7794 ! NFKB1))
+HGNC:7794	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:7794 ! NFKB1))
+HGNC:7794	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7794 ! NFKB1))
+HGNC:7794	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:7794 ! NFKB1))
+HGNC:7794	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:7794 ! NFKB1))
+HGNC:7794	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:7794 ! NFKB1))
+HGNC:7794	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:7794 ! NFKB1))
+HGNC:7794	partOf	complex(p(HGNC:7794 ! NFKB1), p(HGNC:998 ! BCL3))
+HGNC:7838	partOf	complex(p(HGNC:7838 ! "NKX3-1"), p(HGNC:9588 ! PTEN))
+HGNC:786	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:786 ! ATF4), p(HGNC:9967 ! RET))
+HGNC:7873	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:7873 ! NOS2))
+HGNC:7881	hasVariant	p(HGNC:7881 ! NOTCH1, pmod(Ph))
+HGNC:7889	activityNegativelyRegulatesActivityOf	CHEBI:26523
+HGNC:7889	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:7889 ! NOX1))
+HGNC:7889	partOf	complex(p(HGNC:16712 ! FBXW7), p(HGNC:7889 ! NOX1))
+HGNC:7889	partOf	complex(p(HGNC:2578 ! CYBB), p(HGNC:7889 ! NOX1))
+HGNC:7889	partOf	complex(p(HGNC:7889 ! NOX1), p(HGNC:7889 ! NOX1))
+HGNC:7889	partOf	complex(p(HGNC:7889 ! NOX1), p(HGNC:9801 ! RAC1))
+HGNC:7910	partOf	complex(p(HGNC:2978 ! DNMT3A), p(HGNC:3765 ! FLT3), p(HGNC:7910 ! NPM1))
+HGNC:7910	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:7910 ! NPM1))
+HGNC:7939	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:7939 ! NPPA))
+HGNC:7989	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+HGNC:7989	activityDirectlyPositivelyRegulatesActivityOf	HGNC:646
+HGNC:7989	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+HGNC:7989	activityPositivelyRegulatesActivityOf	HGNC:6204
+HGNC:7989	hasVariant	p(HGNC:7989 ! NRAS, pmod(Ph, Tyr, 32))
+HGNC:7989	hasVariant	p(HGNC:7989 ! NRAS, var("p.Gln61Leu"))
+HGNC:7989	hasVariant	p(HGNC:7989 ! NRAS, var("p.Gln61Lys"))
+HGNC:7989	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:7989	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:17175 ! PLCE1), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7029 ! MET), p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:7989	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:7989 ! NRAS))
+HGNC:7989	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:7989	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:8978 ! PIK3CG))
+HGNC:7989	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:8979 ! PIK3R1))
+HGNC:7989	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:9588 ! PTEN))
+HGNC:7989	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:9769 ! RGL2))
+HGNC:7989	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:9829 ! RAF1))
+HGNC:8004	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8004 ! NRP1))
+HGNC:8100	hasVariant	p(HGNC:8100 ! OC90, pmod(Me))
+HGNC:812	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:812 ! ATP2A2))
+HGNC:8127	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8127 ! OGT))
+HGNC:8550	hasVariant	p(HGNC:8550 ! PA2G4, pmod(Ph), var("p.Thr261Ala"))
+HGNC:8550	hasVariant	p(HGNC:8550 ! PA2G4, pmod(Ph, Thr, 261))
+HGNC:8550	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:8550 ! PA2G4))
+HGNC:8550	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8550 ! PA2G4))
+HGNC:8550	partOf	complex(p(HGNC:8550 ! PA2G4), p(HGNC:8590 ! PAK1))
+HGNC:8550	partOf	complex(p(HGNC:8550 ! PA2G4), p(HGNC:9884 ! RB1))
+HGNC:8590	activityDirectlyPositivelyRegulatesActivityOf	HGNC:646
+HGNC:8590	activityNegativelyRegulatesActivityOf	HGNC:7968
+HGNC:8590	activityPositivelyRegulatesActivityOf	HGNC:1582
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph))
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph, Ser, 144))
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph, Ser, 199))
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph, Ser, 204))
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph, Ser, 57))
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph, Thr, 109))
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph, Thr, 212))
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph, Thr, 423))
+HGNC:8590	hasVariant	p(HGNC:8590 ! PAK1, pmod(Ph, Thr, 84))
+HGNC:8590	partOf	complex(a(CHEBI:101355 ! "IPA-3"), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:11128 ! SNAI1), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:11364 ! STAT3), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:15607 ! ARHGEF7), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:3754 ! FLNA), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:392 ! AKT2), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:695 ! ARL4A), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:8550 ! PA2G4), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8590 ! PAK1))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8590 ! PAK1), p(HGNC:9801 ! RAC1))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8591 ! PAK2))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8592 ! PAK3))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8816 ! PDPK1))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9281 ! PPP1CA))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9718 ! PXN))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9801 ! RAC1))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9829 ! RAF1))
+HGNC:8590	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9884 ! RB1))
+HGNC:8591	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1508
+HGNC:8591	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7553
+HGNC:8591	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+HGNC:8591	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8591
+HGNC:8591	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 141))
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 19))
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 192))
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 197))
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 20))
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Thr, 134))
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Thr, 169))
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Thr, 402))
+HGNC:8591	hasVariant	p(HGNC:8591 ! PAK2, pmod(Ph, Tyr, 130))
+HGNC:8591	increasesAmountOf	p(HGNC:8590 ! PAK1, pmod(Ph))
+HGNC:8591	increasesAmountOf	p(HGNC:9884 ! RB1, pmod(Ph))
+HGNC:8591	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:1681 ! CD44), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:1785 ! CDKN1B), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:24224 ! CDK12), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:6945 ! MCM3), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:8591 ! PAK2), p(HGNC:8591 ! PAK2))
+HGNC:8591	partOf	complex(p(HGNC:8591 ! PAK2), p(HGNC:8592 ! PAK3))
+HGNC:8591	partOf	complex(p(HGNC:8591 ! PAK2), p(HGNC:9801 ! RAC1))
+HGNC:8591	partOf	complex(p(HGNC:8591 ! PAK2), p(HGNC:9802 ! RAC2))
+HGNC:8592	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8592
+HGNC:8592	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+HGNC:8592	hasVariant	p(HGNC:8592 ! PAK3, pmod(Ph))
+HGNC:8592	hasVariant	p(HGNC:8592 ! PAK3, pmod(Ph, Ser, 154))
+HGNC:8592	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:8592 ! PAK3))
+HGNC:8592	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8592 ! PAK3))
+HGNC:8592	partOf	complex(p(HGNC:8591 ! PAK2), p(HGNC:8592 ! PAK3))
+HGNC:8592	partOf	complex(p(HGNC:8592 ! PAK3), p(HGNC:8592 ! PAK3))
+HGNC:8592	partOf	complex(p(HGNC:8592 ! PAK3), p(HGNC:9801 ! RAC1))
+HGNC:8607	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:8607 ! PRKN))
+HGNC:8607	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:8607 ! PRKN))
+HGNC:8630	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+HGNC:8630	hasVariant	p(HGNC:8630 ! PEBP1, pmod(Ph, Ser, 109))
+HGNC:8630	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:8630 ! PEBP1))
+HGNC:8630	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:8630 ! PEBP1))
+HGNC:8630	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8630 ! PEBP1))
+HGNC:8630	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:8630 ! PEBP1))
+HGNC:8630	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:8630 ! PEBP1), p(HGNC:9829 ! RAF1))
+HGNC:8630	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:8630 ! PEBP1))
+HGNC:8630	partOf	complex(p(HGNC:8630 ! PEBP1), p(HGNC:8630 ! PEBP1))
+HGNC:8630	partOf	complex(p(HGNC:8630 ! PEBP1), p(HGNC:9829 ! RAF1))
+HGNC:8638	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8638 ! KAT2B))
+HGNC:8729	hasVariant	p(HGNC:8729 ! PCNA, pmod(Ph))
+HGNC:8729	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A), p(HGNC:8729 ! PCNA))
+HGNC:8729	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:8729 ! PCNA))
+HGNC:8760	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8760 ! PDCD1))
+HGNC:8799	partOf	complex(p(HGNC:8799 ! PDGFA), p(HGNC:8803 ! PDGFRA))
+HGNC:8800	partOf	complex(p(HGNC:3691 ! FGFR4), p(HGNC:8800 ! PDGFB))
+HGNC:8800	partOf	complex(p(HGNC:8800 ! PDGFB), p(HGNC:8804 ! PDGFRB))
+HGNC:8803	activityPositivelyRegulatesActivityOf	FPLX:SHC
+HGNC:8803	activityPositivelyRegulatesActivityOf	HGNC:6871
+HGNC:8803	hasVariant	p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr))
+HGNC:8803	hasVariant	p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr, 1018))
+HGNC:8803	hasVariant	p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr, 742))
+HGNC:8803	hasVariant	p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr, 754))
+HGNC:8803	hasVariant	p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr, 762))
+HGNC:8803	hasVariant	p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr, 988))
+HGNC:8803	hasVariant	p(HGNC:8803 ! PDGFRA, pmod(Ub))
+HGNC:8803	increasesAmountOf	p(HGNC:11805 ! TIAM1, pmod(Ph))
+HGNC:8803	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8803 ! PDGFRA))
+HGNC:8803	partOf	complex(p(HGNC:19124 ! FIP1L1), p(HGNC:8803 ! PDGFRA))
+HGNC:8803	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8803 ! PDGFRA))
+HGNC:8803	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8803 ! PDGFRA))
+HGNC:8803	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:8803 ! PDGFRA))
+HGNC:8803	partOf	complex(p(HGNC:8799 ! PDGFA), p(HGNC:8803 ! PDGFRA))
+HGNC:8803	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8803 ! PDGFRA), p(HGNC:9644 ! PTPN11))
+HGNC:8803	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8804 ! PDGFRB))
+HGNC:8803	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8975 ! PIK3CA))
+HGNC:8803	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8979 ! PIK3R1))
+HGNC:8803	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:9588 ! PTEN))
+HGNC:8803	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:9644 ! PTPN11))
+HGNC:8803	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:9871 ! RASA1))
+HGNC:8804	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+HGNC:8804	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+HGNC:8804	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 1009))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 1021))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 562))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 581))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 716))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 740))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 751))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 763))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 771))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 775))
+HGNC:8804	hasVariant	p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 857))
+HGNC:8804	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:3388 ! EPHA4), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:8800 ! PDGFB), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:8804 ! PDGFRB))
+HGNC:8804	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:8804 ! PDGFRB), p(HGNC:9644 ! PTPN11))
+HGNC:8804	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:8979 ! PIK3R1))
+HGNC:8804	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:8981 ! PIK3R3))
+HGNC:8804	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:9588 ! PTEN))
+HGNC:8804	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:9644 ! PTPN11))
+HGNC:8804	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:9829 ! RAF1))
+HGNC:8804	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:9871 ! RASA1))
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10432
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10437
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:392
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:393
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8590
+HGNC:8816	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8816
+HGNC:8816	activityNegativelyRegulatesActivityOf	HGNC:8816
+HGNC:8816	activityPositivelyRegulatesActivityOf	HGNC:10251
+HGNC:8816	activityPositivelyRegulatesActivityOf	HGNC:10430
+HGNC:8816	activityPositivelyRegulatesActivityOf	HGNC:3942
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph))
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph, Ser, 241))
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph, Ser, 25))
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph, Ser, 393))
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph, Ser, 396))
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph, Thr, 513))
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph, Tyr, 373))
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph, Tyr, 376))
+HGNC:8816	hasVariant	p(HGNC:8816 ! PDPK1, pmod(Ph, Tyr, 9))
+HGNC:8816	increasesAmountOf	p(HGNC:10431 ! RPS6KA2, pmod(Ph))
+HGNC:8816	increasesAmountOf	p(HGNC:7553 ! MYC, pmod(Ph))
+HGNC:8816	increasesAmountOf	p(HGNC:9588 ! PTEN, pmod(Ph))
+HGNC:8816	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:30281 ! RGL1), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8816 ! PDPK1))
+HGNC:8816	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8822 ! PEA15))
+HGNC:8816	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8974 ! PIK3C3))
+HGNC:8816	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8975 ! PIK3CA))
+HGNC:8816	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8978 ! PIK3CG))
+HGNC:8816	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:9588 ! PTEN))
+HGNC:8816	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:9842 ! RALGDS))
+HGNC:882	partOf	complex(p(HGNC:1984 ! CISH), p(HGNC:882 ! ATR), p(HGNC:8988 ! PIN1))
+HGNC:8822	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+HGNC:8822	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+HGNC:8822	hasVariant	p(HGNC:8822 ! PEA15, pmod(Ph, Ser, 104))
+HGNC:8822	hasVariant	p(HGNC:8822 ! PEA15, pmod(Ph, Ser, 116))
+HGNC:8822	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:8822 ! PEA15))
+HGNC:8822	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:8822 ! PEA15))
+HGNC:8822	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:8822 ! PEA15))
+HGNC:8822	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:8822 ! PEA15))
+HGNC:8822	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8822 ! PEA15))
+HGNC:8822	partOf	complex(p(HGNC:8822 ! PEA15), p(HGNC:8822 ! PEA15))
+HGNC:8822	partOf	complex(p(HGNC:8822 ! PEA15), p(HGNC:9801 ! RAC1))
+HGNC:8846	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:8846 ! PER2))
+HGNC:8846	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8846 ! PER2))
+HGNC:8846	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:8846 ! PER2))
+HGNC:8846	partOf	complex(p(HGNC:8846 ! PER2), p(HGNC:9588 ! PTEN))
+HGNC:8896	partOf	complex(p(HGNC:8896 ! PGK1), p(HGNC:9588 ! PTEN))
+HGNC:8974	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8974 ! PIK3C3))
+HGNC:8975	activityPositivelyRegulatesActivityOf	HGNC:10432
+HGNC:8975	hasVariant	p(HGNC:8975 ! PIK3CA, pmod(Ph))
+HGNC:8975	hasVariant	p(HGNC:8975 ! PIK3CA, var("p.Glu545Lys"))
+HGNC:8975	increasesAmountOf	p(HGNC:5173 ! HRAS, pmod(Ph))
+HGNC:8975	partOf	complex(a(CHEBI:90524 ! "PI-103"), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:3236 ! EGFR), p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8975 ! PIK3CA), p(HGNC:9588 ! PTEN))
+HGNC:8975	partOf	complex(p(HGNC:14545 ! RASGRP3), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:3690 ! FGFR3), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:4392 ! GNAS), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8975 ! PIK3CA, var("p.Glu545Lys")))
+HGNC:8975	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:7029 ! MET), p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8975 ! PIK3CA))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8977 ! PIK3CD))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8978 ! PIK3CG))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 368)))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 580)))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ub)))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8980 ! PIK3R2))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8980 ! PIK3R2), p(HGNC:8980 ! PIK3R2))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8981 ! PIK3R3))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:9502 ! CYTH2))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:9588 ! PTEN))
+HGNC:8975	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:9801 ! RAC1))
+HGNC:8977	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+HGNC:8977	hasVariant	p(HGNC:8977 ! PIK3CD, pmod(Ph))
+HGNC:8977	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:8977 ! PIK3CD))
+HGNC:8977	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:8977 ! PIK3CD))
+HGNC:8977	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8977 ! PIK3CD))
+HGNC:8977	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8977 ! PIK3CD))
+HGNC:8977	partOf	complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8978 ! PIK3CG))
+HGNC:8977	partOf	complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8979 ! PIK3R1))
+HGNC:8977	partOf	complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8980 ! PIK3R2))
+HGNC:8977	partOf	complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8981 ! PIK3R3))
+HGNC:8978	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8816
+HGNC:8978	hasVariant	p(HGNC:8978 ! PIK3CG, pmod(Ph))
+HGNC:8978	increasesAmountOf	p(HGNC:3288 ! EIF4EBP1, pmod(Ph))
+HGNC:8978	increasesAmountOf	p(HGNC:5173 ! HRAS, pmod(Ph))
+HGNC:8978	partOf	complex(complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1)), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:30035 ! PIK3R5), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8978 ! PIK3CG))
+HGNC:8978	partOf	complex(p(HGNC:8978 ! PIK3CG), p(HGNC:9377 ! PRKAA2))
+HGNC:8979	hasVariant	p(HGNC:8979 ! PIK3R1, pmod(Ph))
+HGNC:8979	hasVariant	p(HGNC:8979 ! PIK3R1, pmod(Ph, Ser, 608))
+HGNC:8979	hasVariant	p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 368))
+HGNC:8979	hasVariant	p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 580))
+HGNC:8979	hasVariant	p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 607))
+HGNC:8979	hasVariant	p(HGNC:8979 ! PIK3R1, pmod(Ub))
+HGNC:8979	partOf	complex(complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1)), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:17294 ! DAB2IP), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:393 ! AKT3), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:4170 ! GATA1), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:4623 ! GSR), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 368)))
+HGNC:8979	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 580)))
+HGNC:8979	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1, pmod(Ub)))
+HGNC:8979	partOf	complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8979 ! PIK3R1))
+HGNC:8979	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:8980 ! PIK3R2))
+HGNC:8979	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:8981 ! PIK3R3))
+HGNC:8979	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:9588 ! PTEN))
+HGNC:8979	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:9644 ! PTPN11))
+HGNC:8979	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:9801 ! RAC1))
+HGNC:8980	activityPositivelyRegulatesActivityOf	CHEBI:36080
+HGNC:8980	increasesAmountOf	MESH:D055550
+HGNC:8980	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8980 ! PIK3R2), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:8980 ! PIK3R2))
+HGNC:8980	partOf	complex(p(HGNC:8980 ! PIK3R2), p(HGNC:8981 ! PIK3R3))
+HGNC:8980	partOf	complex(p(HGNC:8980 ! PIK3R2), p(HGNC:905 ! AXL))
+HGNC:8980	partOf	complex(p(HGNC:8980 ! PIK3R2), p(HGNC:9588 ! PTEN))
+HGNC:8980	partOf	complex(p(HGNC:8980 ! PIK3R2), p(HGNC:9644 ! PTPN11))
+HGNC:8981	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+HGNC:8981	hasVariant	p(HGNC:8981 ! PIK3R3, pmod(Ph))
+HGNC:8981	hasVariant	p(HGNC:8981 ! PIK3R3, pmod(Ph, Tyr, 341))
+HGNC:8981	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:8980 ! PIK3R2), p(HGNC:8981 ! PIK3R3))
+HGNC:8981	partOf	complex(p(HGNC:8981 ! PIK3R3), p(HGNC:9884 ! RB1))
+HGNC:8988	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7553
+HGNC:8988	increasesAmountOf	GO:"GO:0016311"
+HGNC:8988	increasesAmountOf	MESH:D009857
+HGNC:8988	partOf	complex(p(FPLX:"CAMK2_complex" ! "CAMK2_complex"), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:12761 ! WEE1), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:14000 ! PRDM16), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:1727 ! CDC25C), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:1984 ! CISH), p(HGNC:882 ! ATR), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:2903 ! DLG4), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:4236 ! GFER), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:620 ! APP), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:8988 ! PIN1), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:8988 ! PIN1), p(HGNC:8988 ! PIN1))
+HGNC:8988	partOf	complex(p(HGNC:8988 ! PIN1), p(HGNC:9829 ! RAF1))
+HGNC:8988	partOf	complex(p(HGNC:8988 ! PIN1), p(HGNC:9884 ! RB1))
+HGNC:8988	partOf	complex(p(HGNC:8988 ! PIN1), p(HGNC:9955 ! RELA))
+HGNC:905	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:905 ! AXL))
+HGNC:905	partOf	complex(p(HGNC:8980 ! PIK3R2), p(HGNC:905 ! AXL))
+HGNC:9077	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:9077 ! PLK1))
+HGNC:9077	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9077 ! PLK1))
+HGNC:9103	activityPositivelyRegulatesActivityOf	HGNC:7029
+HGNC:9103	decreasesAmountOf	p(HGNC:9588 ! PTEN, pmod(Ph))
+HGNC:9103	hasVariant	p(HGNC:9103 ! PLXNB1, pmod(Ph, Tyr, 1708))
+HGNC:9103	hasVariant	p(HGNC:9103 ! PLXNB1, pmod(Ph, Tyr, 1732))
+HGNC:9103	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9103 ! PLXNB1))
+HGNC:9103	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9103 ! PLXNB1))
+HGNC:9103	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9103 ! PLXNB1))
+HGNC:9103	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9103 ! PLXNB1))
+HGNC:9103	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9103 ! PLXNB1))
+HGNC:9103	partOf	complex(p(HGNC:7029 ! MET), p(HGNC:9103 ! PLXNB1))
+HGNC:9103	partOf	complex(p(HGNC:9103 ! PLXNB1), p(HGNC:9801 ! RAC1))
+HGNC:9108	activityPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:9142	partOf	complex(p(HGNC:9142 ! PRRX1), p(HGNC:9588 ! PTEN))
+HGNC:9155	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9155 ! PNLIP))
+HGNC:9221	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9221 ! POU5F1))
+HGNC:9236	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9236 ! PPARG))
+HGNC:9236	partOf	complex(p(HGNC:3288 ! EIF4EBP1), p(HGNC:9236 ! PPARG))
+HGNC:9281	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1100
+HGNC:9281	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+HGNC:9281	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+HGNC:9281	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+HGNC:9281	decreasesAmountOf	p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 127))
+HGNC:9281	decreasesAmountOf	p(HGNC:3236 ! EGFR, pmod(Ph))
+HGNC:9281	decreasesAmountOf	p(HGNC:6091 ! INSR, pmod(Ph))
+HGNC:9281	decreasesAmountOf	p(HGNC:6204 ! JUN, pmod(Ph))
+HGNC:9281	decreasesAmountOf	p(HGNC:8592 ! PAK3, pmod(Ph))
+HGNC:9281	hasVariant	p(HGNC:9281 ! PPP1CA, pmod(Ph))
+HGNC:9281	hasVariant	p(HGNC:9281 ! PPP1CA, pmod(Ph, Thr, 320))
+HGNC:9281	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:1166 ! RASSF7), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:13232 ! RASSF8), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:15739 ! RASSF9), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:20249 ! SPRED1), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:33984 ! RASSF10), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:576 ! APAF1), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9281 ! PPP1CA))
+HGNC:9281	partOf	complex(p(HGNC:9281 ! PPP1CA), p(HGNC:9588 ! PTEN))
+HGNC:9281	partOf	complex(p(HGNC:9281 ! PPP1CA), p(HGNC:9884 ! RB1))
+HGNC:9284	partOf	complex(p(HGNC:9284 ! PPP1R10), p(HGNC:9588 ! PTEN))
+HGNC:936	hasVariant	p(HGNC:936 ! BAD, pmod(Ph, Ser, 75))
+HGNC:936	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:28426 ! AKT1S1), p(HGNC:3821 ! FOXO3), p(HGNC:936 ! BAD))
+HGNC:9376	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+HGNC:9376	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+HGNC:9376	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+HGNC:9376	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9378
+HGNC:9376	activityPositivelyRegulatesActivityOf	HGNC:11998
+HGNC:9376	activityPositivelyRegulatesActivityOf	HGNC:12363
+HGNC:9376	hasVariant	p(HGNC:9376 ! PRKAA1, pmod(Ph))
+HGNC:9376	hasVariant	p(HGNC:9376 ! PRKAA1, pmod(Ph, Ser, 486))
+HGNC:9376	hasVariant	p(HGNC:9376 ! PRKAA1, pmod(Ph, Ser, 496))
+HGNC:9376	hasVariant	p(HGNC:9376 ! PRKAA1, pmod(Ph, Thr, 183))
+HGNC:9376	increasesAmountOf	p(HGNC:11998 ! TP53, pmod(Ph, Ser, 15))
+HGNC:9376	increasesAmountOf	p(HGNC:3489 ! ETS2, pmod(Ph))
+HGNC:9376	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:9376 ! PRKAA1))
+HGNC:9376	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9376 ! PRKAA1))
+HGNC:9376	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:9376 ! PRKAA1))
+HGNC:9376	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:9376 ! PRKAA1))
+HGNC:9376	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9376 ! PRKAA1))
+HGNC:9376	partOf	complex(p(HGNC:3582 ! FANCA), p(HGNC:9376 ! PRKAA1))
+HGNC:9376	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:9376 ! PRKAA1))
+HGNC:9376	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9376 ! PRKAA1))
+HGNC:9376	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2))
+HGNC:9376	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9376	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2, pmod(Ph)), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9376	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9378 ! PRKAB1))
+HGNC:9376	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9379 ! PRKAB2))
+HGNC:9376	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9385 ! PRKAG1))
+HGNC:9376	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9386 ! PRKAG2))
+HGNC:9376	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9387 ! PRKAG3))
+HGNC:9377	hasVariant	p(HGNC:9377 ! PRKAA2, pmod(Ph, Ser, 173))
+HGNC:9377	hasVariant	p(HGNC:9377 ! PRKAA2, pmod(Ph, Thr, 172))
+HGNC:9377	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:30287 ! RPTOR), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:8978 ! PIK3CG), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9377	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2, pmod(Ph)), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9377	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9377 ! PRKAA2))
+HGNC:9377	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1))
+HGNC:9377	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9379 ! PRKAB2))
+HGNC:9377	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9385 ! PRKAG1))
+HGNC:9377	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9386 ! PRKAG2))
+HGNC:9377	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9387 ! PRKAG3))
+HGNC:9378	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9378 ! PRKAB1))
+HGNC:9378	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9378	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2, pmod(Ph)), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9378	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9378 ! PRKAB1))
+HGNC:9378	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1))
+HGNC:9378	partOf	complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2))
+HGNC:9378	partOf	complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9385 ! PRKAG1))
+HGNC:9378	partOf	complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9386 ! PRKAG2))
+HGNC:9378	partOf	complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9387 ! PRKAG3))
+HGNC:9379	hasVariant	p(HGNC:9379 ! PRKAB2, pmod(Ph))
+HGNC:9379	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:9379 ! PRKAB2))
+HGNC:9379	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9379	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2, pmod(Ph)), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9379	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9379 ! PRKAB2))
+HGNC:9379	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9379 ! PRKAB2))
+HGNC:9379	partOf	complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2))
+HGNC:9379	partOf	complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9379 ! PRKAB2))
+HGNC:9379	partOf	complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1))
+HGNC:9379	partOf	complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9386 ! PRKAG2))
+HGNC:9379	partOf	complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9387 ! PRKAG3))
+HGNC:9385	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9385 ! PRKAG1))
+HGNC:9385	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9385	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2, pmod(Ph)), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9385	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9385 ! PRKAG1))
+HGNC:9385	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9385 ! PRKAG1))
+HGNC:9385	partOf	complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9385 ! PRKAG1))
+HGNC:9385	partOf	complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1))
+HGNC:9385	partOf	complex(p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2))
+HGNC:9386	partOf	complex(complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3)), p(HGNC:9386 ! PRKAG2))
+HGNC:9386	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9386	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2, pmod(Ph)), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9386	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9386 ! PRKAG2))
+HGNC:9386	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9386 ! PRKAG2))
+HGNC:9386	partOf	complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9386 ! PRKAG2))
+HGNC:9386	partOf	complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9386 ! PRKAG2))
+HGNC:9386	partOf	complex(p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2))
+HGNC:9387	hasVariant	p(HGNC:9387 ! PRKAG3, pmod(Ph))
+HGNC:9387	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9387 ! PRKAG3))
+HGNC:9387	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9387	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2, pmod(Ph)), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))
+HGNC:9387	partOf	complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9387 ! PRKAG3))
+HGNC:9387	partOf	complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9387 ! PRKAG3))
+HGNC:9387	partOf	complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9387 ! PRKAG3))
+HGNC:9387	partOf	complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9387 ! PRKAG3))
+HGNC:9387	partOf	complex(p(HGNC:9387 ! PRKAG3), p(HGNC:9387 ! PRKAG3))
+HGNC:9391	partOf	complex(p(HGNC:427 ! ALK), p(HGNC:9391 ! PRKAR2A))
+HGNC:9413	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:9413 ! PRKDC))
+HGNC:9502	hasVariant	p(HGNC:9502 ! CYTH2, pmod(Ph, Ser, 392))
+HGNC:9502	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9502 ! CYTH2))
+HGNC:9502	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9502 ! CYTH2))
+HGNC:9502	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:9502 ! CYTH2))
+HGNC:9502	partOf	complex(p(HGNC:9502 ! CYTH2), p(HGNC:9502 ! CYTH2))
+HGNC:9502	partOf	complex(p(HGNC:9502 ! CYTH2), p(HGNC:9841 ! RALBP1))
+HGNC:952	hasVariant	p(HGNC:952 ! BARD1, pmod(Ph))
+HGNC:952	partOf	complex(p(HGNC:10696 ! EXOC5), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:20473 ! BRIP1), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:20473 ! BRIP1), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:6949 ! MCM6), p(HGNC:952 ! BARD1))
+HGNC:952	partOf	complex(p(HGNC:952 ! BARD1), p(HGNC:952 ! BARD1))
+HGNC:9583	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:9583 ! PTBP1))
+HGNC:9588	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9588
+HGNC:9588	activityNegativelyRegulatesActivityOf	HGNC:1744
+HGNC:9588	activityPositivelyRegulatesActivityOf	HGNC:6407
+HGNC:9588	decreasesAmountOf	p(HGNC:16262 ! YAP1, pmod(Ph))
+HGNC:9588	decreasesAmountOf	p(HGNC:6950 ! MCM7, pmod(Ph))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Me))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Ser))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Ser, 370))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Ser, 380))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Ser, 385))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Thr, 366))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Thr, 382))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Thr, 383))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Tyr))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Tyr, 240))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ph, Tyr, 315))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, pmod(Ub))
+HGNC:9588	hasVariant	p(HGNC:9588 ! PTEN, var("p.Gly251Cys"))
+HGNC:9588	increasesAmountOf	p(HGNC:9588 ! PTEN, pmod(Ub))
+HGNC:9588	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(FPLX:AKT ! AKT), p(FPLX:PI3K ! PI3K), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(FPLX:AMPK ! AMPK), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(FPLX:HDAC ! HDAC), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:10436 ! RPS6KB1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11254 ! SPOP), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11364 ! STAT3), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11389 ! STK11), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11554 ! TAGLN2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:8975 ! PIK3CA), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN), p(HGNC:9884 ! RB1))
+HGNC:9588	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:12932 ! TRIM25), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:14289 ! NLGN3), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:3430 ! ERBB2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:16369 ! PARK7), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:18957 ! MAGI2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:20772 ! TUBB3), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:22950 ! PREX2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:24679 ! FBXL20), p(HGNC:6005 ! IL21), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:29038 ! OTUD3), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:29608 ! MTDH), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:31586 ! MIR21), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3446 ! ERG), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3489 ! ETS2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3527 ! EZH2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3663 ! FGD1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:392 ! AKT2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:3942 ! MTOR, pmod(Ph)), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:6075 ! INPP4B), p(HGNC:6075 ! INPP4B), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:6773 ! SMAD7), p(HGNC:7166 ! MMP2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:6950 ! MCM7), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:717 ! ARSD), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:7596 ! MYO1B), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:7838 ! "NKX3-1"), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:8846 ! PER2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:8896 ! PGK1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:8980 ! PIK3R2), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:9142 ! PRRX1), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:9281 ! PPP1CA), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:9284 ! PPP1R10), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:9588 ! PTEN), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:9588 ! PTEN), p(HGNC:9588 ! PTEN), p(HGNC:9588 ! PTEN))
+HGNC:9588	partOf	complex(p(HGNC:9588 ! PTEN), p(HGNC:9824 ! RAD52))
+HGNC:9588	partOf	complex(p(HGNC:9588 ! PTEN), p(HGNC:9884 ! RB1))
+HGNC:9588	partOf	complex(p(HGNC:9588 ! PTEN), p(HGNC:9975 ! TRIM27))
+HGNC:9588	partOf	complex(p(HGNC:9588 ! PTEN), p(PFAM:PF00595 ! PDZ))
+HGNC:959	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:959 ! BAX))
+HGNC:9605	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9605 ! PTGS2))
+HGNC:9605	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:9605 ! PTGS2))
+HGNC:9611	activityPositivelyRegulatesActivityOf	HGNC:3942
+HGNC:9611	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9611 ! PTK2))
+HGNC:9618	partOf	complex(p(HGNC:3688 ! FGFR1), p(HGNC:9618 ! PTK7))
+HGNC:9644	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+HGNC:9644	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+HGNC:9644	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+HGNC:9644	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:9644	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7989
+HGNC:9644	activityDirectlyPositivelyRegulatesActivityOf	p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1016), pmod(Ph, Tyr, 1069), pmod(Ph, Tyr, 1092), pmod(Ph, Tyr, 1110), pmod(Ph, Tyr, 1172), pmod(Ph, Tyr, 1197))
+HGNC:9644	decreasesAmountOf	p(HGNC:5173 ! HRAS, pmod(Ph))
+HGNC:9644	decreasesAmountOf	p(HGNC:6126 ! IRS2, pmod(Ph))
+HGNC:9644	hasVariant	p(HGNC:9644 ! PTPN11, pmod(Ph))
+HGNC:9644	hasVariant	p(HGNC:9644 ! PTPN11, pmod(Ph, Tyr))
+HGNC:9644	hasVariant	p(HGNC:9644 ! PTPN11, pmod(Ph, Tyr, 304))
+HGNC:9644	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:4566 ! GRB2), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(FPLX:SHC ! SHC), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(FPLX:VAV ! VAV), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:10261 ! ROS1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:11584 ! TBK1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:1323 ! C4A), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:14458 ! GAB2), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:1541 ! CBL), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:1542 ! CBLB), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:16262 ! YAP1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:3691 ! FGFR4), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:3765 ! FLT3), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:4066 ! GAB1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9644 ! PTPN11, pmod(Ph)))
+HGNC:9644	partOf	complex(p(HGNC:4591 ! ARHGAP35), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:6126 ! IRS2), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8803 ! PDGFRA), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:8804 ! PDGFRB), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:8980 ! PIK3R2), p(HGNC:9644 ! PTPN11))
+HGNC:9644	partOf	complex(p(HGNC:9644 ! PTPN11), p(HGNC:9644 ! PTPN11))
+HGNC:9705	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:9705 ! PVR))
+HGNC:9709	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9709 ! PVT1))
+HGNC:9718	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9718 ! PXN))
+HGNC:9753	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9753 ! QPCT))
+HGNC:9769	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9769 ! RGL2))
+HGNC:9769	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9769 ! RGL2))
+HGNC:9769	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:9769 ! RGL2))
+HGNC:9769	partOf	complex(p(HGNC:9769 ! RGL2), p(HGNC:9801 ! RAC1))
+HGNC:9769	partOf	complex(p(HGNC:9769 ! RGL2), p(HGNC:9839 ! RALA))
+HGNC:9774	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9774 ! RAB35))
+HGNC:9783	partOf	complex(p(HGNC:6125 ! IRS1), p(HGNC:9783 ! RAB5A))
+HGNC:9788	hasVariant	p(HGNC:9788 ! RAB7A, pmod(Ph, Ser, 72))
+HGNC:9801	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7889
+HGNC:9801	activityPositivelyRegulatesActivityOf	HGNC:11584
+HGNC:9801	activityPositivelyRegulatesActivityOf	HGNC:16262
+HGNC:9801	activityPositivelyRegulatesActivityOf	HGNC:4591
+HGNC:9801	hasVariant	p(HGNC:9801 ! RAC1, pmod(Ph))
+HGNC:9801	hasVariant	p(HGNC:9801 ! RAC1, pmod(Ph, Ser, 71))
+HGNC:9801	hasVariant	p(HGNC:9801 ! RAC1, pmod(Ub))
+HGNC:9801	partOf	complex(a(CHEBI:15996 ! GTP), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(bp(MESH:D015427 ! "Reperfusion Injury"), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(FPLX:ERK ! ERK), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(FPLX:GEF ! GEF), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:10251 ! ROCK1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:11806 ! TIAM2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:12362 ! TSC1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:16059 ! PAK4), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:1736 ! CDC42), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:2319 ! CPNE6), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:2514 ! CTNNB1), p(HGNC:6886 ! MAPK9), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:30377 ! SCRIB), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:4591 ! ARHGAP35), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:667 ! RHOA), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:669 ! RHOC), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:682 ! ARHGEF2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:668 ! RHOB), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:669 ! RHOC), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:682 ! ARHGEF2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:7889 ! NOX1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:8590 ! PAK1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:8591 ! PAK2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:8592 ! PAK3), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:8822 ! PEA15), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:8975 ! PIK3CA), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:8979 ! PIK3R1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:9103 ! PLXNB1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:9769 ! RGL2), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9801 ! RAC1), p(HGNC:9801 ! RAC1))
+HGNC:9801	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9802 ! RAC2))
+HGNC:9801	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9803 ! RAC3))
+HGNC:9801	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9839 ! RALA))
+HGNC:9801	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9841 ! RALBP1))
+HGNC:9801	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:990 ! BCL2))
+HGNC:9802	partOf	complex(a(CHEBI:26523 ! "reactive oxygen species"), p(HGNC:9802 ! RAC2))
+HGNC:9802	partOf	complex(p(FPLX:AP1 ! AP1), p(HGNC:9802 ! RAC2))
+HGNC:9802	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:9802 ! RAC2))
+HGNC:9802	partOf	complex(p(HGNC:5350 ! ICMT), p(HGNC:9802 ! RAC2))
+HGNC:9802	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9802 ! RAC2))
+HGNC:9802	partOf	complex(p(HGNC:8591 ! PAK2), p(HGNC:9802 ! RAC2))
+HGNC:9802	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9802 ! RAC2))
+HGNC:9802	partOf	complex(p(HGNC:9802 ! RAC2), p(HGNC:9802 ! RAC2))
+HGNC:9802	partOf	complex(p(HGNC:9802 ! RAC2), p(HGNC:9803 ! RAC3))
+HGNC:9803	partOf	complex(p(HGNC:669 ! RHOC), p(HGNC:9803 ! RAC3))
+HGNC:9803	partOf	complex(p(HGNC:7782 ! NFE2L2), p(HGNC:9803 ! RAC3))
+HGNC:9803	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9803 ! RAC3))
+HGNC:9803	partOf	complex(p(HGNC:9802 ! RAC2), p(HGNC:9803 ! RAC3))
+HGNC:9816	partOf	complex(p(HGNC:6075 ! INPP4B), p(HGNC:9816 ! RAD50))
+HGNC:9817	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:9817 ! RAD51))
+HGNC:9817	partOf	complex(p(HGNC:9817 ! RAD51), p(HGNC:9824 ! RAD52))
+HGNC:9824	hasVariant	p(HGNC:9824 ! RAD52, pmod(Ac))
+HGNC:9824	hasVariant	p(HGNC:9824 ! RAD52, pmod(Ph))
+HGNC:9824	partOf	complex(p(HGNC:10845 ! SEM1), p(HGNC:9824 ! RAD52))
+HGNC:9824	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9824 ! RAD52))
+HGNC:9824	partOf	complex(p(HGNC:1101 ! BRCA2), p(HGNC:9824 ! RAD52))
+HGNC:9824	partOf	complex(p(HGNC:9588 ! PTEN), p(HGNC:9824 ! RAD52))
+HGNC:9824	partOf	complex(p(HGNC:9817 ! RAD51), p(HGNC:9824 ! RAD52))
+HGNC:9824	partOf	complex(p(HGNC:9824 ! RAD52), p(HGNC:9824 ! RAD52))
+HGNC:9829	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+HGNC:9829	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+HGNC:9829	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+HGNC:9829	activityNegativelyRegulatesActivityOf	HGNC:10252
+HGNC:9829	activityPositivelyRegulatesActivityOf	HGNC:7794
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 259))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 289))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 289), pmod(Ph, Ser, 621))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 29))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 29), pmod(Ph, Ser, 621))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 296))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 296), pmod(Ph, Ser, 621))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 301))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 301), pmod(Ph, Ser, 621))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 338))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 338), pmod(Ph, Ser, 494), pmod(Ph, Ser, 621), pmod(Ph, Thr, 491), pmod(Ph, Tyr, 341))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 338), pmod(Ph, Ser, 621))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 338), pmod(Ph, Thr, 269))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 339))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 43))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 471))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 471), pmod(Ph, Ser, 621))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 494), pmod(Ph, Ser, 621))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 497))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 619))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 621))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 621), pmod(Ph, Ser, 642))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 621), pmod(Ph, Thr, 268))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 621), pmod(Ph, Thr, 269))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 621), pmod(Ph, Thr, 491))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 621), pmod(Ph, Tyr, 341))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 642))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Thr, 268))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Thr, 268), pmod(Ph, Thr, 269))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Thr, 269))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Tyr))
+HGNC:9829	hasVariant	p(HGNC:9829 ! RAF1, pmod(Ph, Tyr, 340))
+HGNC:9829	increasesAmountOf	p(HGNC:1725 ! CDC25A, pmod(Ph))
+HGNC:9829	partOf	complex(p(FPLX:"p14_3_3" ! "p14_3_3"), p(HGNC:25550 ! RMDN3), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:10252 ! ROCK2), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:1097 ! BRAF), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:5173 ! HRAS), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:646 ! ARAF), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:11270 ! SPRY2), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:12657 ! VAV1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:7227 ! MRAS), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:15454 ! SHOC2), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:15533 ! SPRY4), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:1725 ! CDC25A), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:19701 ! CNKSR2), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:25550 ! RMDN3), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:391 ! AKT1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:4564 ! GRB10), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:646 ! ARAF), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:6871 ! MAPK1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:8630 ! PEBP1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:6840 ! MAP2K1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:6842 ! MAP2K2), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:6871 ! MAPK1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:7227 ! MRAS), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:7989 ! NRAS), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:8630 ! PEBP1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:8988 ! PIN1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:9829 ! RAF1), p(HGNC:9829 ! RAF1))
+HGNC:9829	partOf	complex(p(HGNC:9829 ! RAF1), p(HGNC:9842 ! RALGDS))
+HGNC:9829	partOf	complex(p(HGNC:9829 ! RAF1), p(HGNC:9875 ! RASGRF1))
+HGNC:9829	partOf	complex(p(HGNC:9829 ! RAF1), p(HGNC:9884 ! RB1))
+HGNC:9839	hasVariant	p(HGNC:9839 ! RALA, pmod(Ph, Ser, 183))
+HGNC:9839	partOf	complex(a(CHEBI:80961 ! "5-formyluracil"), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(FPLX:GAP ! GAP), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:12363 ! TSC2), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:19701 ! CNKSR2), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:23214 ! EXOC7), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:30297 ! RCC2), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:6948 ! MCM5), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:9769 ! RGL2), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:9839 ! RALA), p(HGNC:9839 ! RALA))
+HGNC:9839	partOf	complex(p(HGNC:9839 ! RALA), p(HGNC:9840 ! RALB))
+HGNC:9839	partOf	complex(p(HGNC:9839 ! RALA), p(HGNC:9841 ! RALBP1))
+HGNC:9839	partOf	complex(p(HGNC:9839 ! RALA), p(HGNC:9842 ! RALGDS))
+HGNC:9840	activityPositivelyRegulatesActivityOf	HGNC:20059
+HGNC:9840	partOf	complex(p(FPLX:RAS ! RAS), p(HGNC:9840 ! RALB))
+HGNC:9840	partOf	complex(p(HGNC:24659 ! EXOC8), p(HGNC:9840 ! RALB))
+HGNC:9840	partOf	complex(p(HGNC:24968 ! EXOC2), p(HGNC:9840 ! RALB))
+HGNC:9840	partOf	complex(p(HGNC:30378 ! EXOC3), p(HGNC:9840 ! RALB))
+HGNC:9840	partOf	complex(p(HGNC:30380 ! EXOC1), p(HGNC:9840 ! RALB))
+HGNC:9840	partOf	complex(p(HGNC:30389 ! EXOC4), p(HGNC:9840 ! RALB))
+HGNC:9840	partOf	complex(p(HGNC:9839 ! RALA), p(HGNC:9840 ! RALB))
+HGNC:9840	partOf	complex(p(HGNC:9840 ! RALB), p(HGNC:9841 ! RALBP1))
+HGNC:9841	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9841 ! RALBP1))
+HGNC:9841	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:9841 ! RALBP1))
+HGNC:9841	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:9841 ! RALBP1))
+HGNC:9841	partOf	complex(p(HGNC:7545 ! MYB), p(HGNC:9841 ! RALBP1))
+HGNC:9841	partOf	complex(p(HGNC:9502 ! CYTH2), p(HGNC:9841 ! RALBP1))
+HGNC:9841	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:9841 ! RALBP1))
+HGNC:9841	partOf	complex(p(HGNC:9839 ! RALA), p(HGNC:9841 ! RALBP1))
+HGNC:9841	partOf	complex(p(HGNC:9840 ! RALB), p(HGNC:9841 ! RALBP1))
+HGNC:9842	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9839
+HGNC:9842	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:16854 ! RAPGEF2), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:30281 ! RGL1), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:6877 ! MAPK3), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:7227 ! MRAS), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:8816 ! PDPK1), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:9829 ! RAF1), p(HGNC:9842 ! RALGDS))
+HGNC:9842	partOf	complex(p(HGNC:9839 ! RALA), p(HGNC:9842 ! RALGDS))
+HGNC:9871	activityDirectlyNegativelyRegulatesActivityOf	HGNC:5173
+HGNC:9871	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:9871	activityNegativelyRegulatesActivityOf	HGNC:10011
+HGNC:9871	activityPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:9871	hasVariant	p(HGNC:9871 ! RASA1, pmod(Ph, Tyr))
+HGNC:9871	hasVariant	p(HGNC:9871 ! RASA1, pmod(Ph, Tyr, 460))
+HGNC:9871	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9871 ! RASA1))
+HGNC:9871	partOf	complex(p(HGNC:3236 ! EGFR), p(HGNC:9871 ! RASA1))
+HGNC:9871	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9871 ! RASA1))
+HGNC:9871	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9871 ! RASA1))
+HGNC:9871	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9871 ! RASA1))
+HGNC:9871	partOf	complex(p(HGNC:6091 ! INSR), p(HGNC:9871 ! RASA1))
+HGNC:9871	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:9871 ! RASA1))
+HGNC:9871	partOf	complex(p(HGNC:8803 ! PDGFRA), p(HGNC:9871 ! RASA1))
+HGNC:9871	partOf	complex(p(HGNC:8804 ! PDGFRB), p(HGNC:9871 ! RASA1))
+HGNC:9872	activityDirectlyNegativelyRegulatesActivityOf	HGNC:5173
+HGNC:9872	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7989
+HGNC:9873	activityDirectlyNegativelyRegulatesActivityOf	HGNC:5173
+HGNC:9873	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6407
+HGNC:9873	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7989
+HGNC:9873	hasVariant	p(HGNC:9873 ! RASAL1, pmod(Me))
+HGNC:9873	partOf	complex(p(HGNC:10432 ! RPS6KA3), p(HGNC:9873 ! RASAL1))
+HGNC:9874	partOf	complex(p(HGNC:10840 ! SHC1), p(HGNC:9874 ! RASAL2))
+HGNC:9874	partOf	complex(p(HGNC:11805 ! TIAM1), p(HGNC:9874 ! RASAL2))
+HGNC:9874	partOf	complex(p(HGNC:3155 ! ECT2), p(HGNC:9874 ! RASAL2))
+HGNC:9874	partOf	complex(p(HGNC:6465 ! KSR1), p(HGNC:9874 ! RASAL2))
+HGNC:9874	partOf	complex(p(HGNC:7765 ! NF1), p(HGNC:9874 ! RASAL2))
+HGNC:9875	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:9875	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7989
+HGNC:9875	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:9875	hasVariant	p(HGNC:9875 ! RASGRF1, pmod(Ph))
+HGNC:9875	hasVariant	p(HGNC:9875 ! RASGRF1, pmod(Ph, Tyr))
+HGNC:9875	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9875 ! RASGRF1))
+HGNC:9875	partOf	complex(p(HGNC:9829 ! RAF1), p(HGNC:9875 ! RASGRF1))
+HGNC:9876	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:9876	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+HGNC:9876	activityPositivelyRegulatesActivityOf	HGNC:5173
+HGNC:9876	partOf	complex(p(HGNC:4568 ! RAPGEF1), p(HGNC:9876 ! RASGRF2))
+HGNC:9876	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9876 ! RASGRF2))
+HGNC:9876	partOf	complex(p(HGNC:9876 ! RASGRF2), p(HGNC:9876 ! RASGRF2))
+HGNC:9878	hasVariant	p(HGNC:9878 ! RASGRP1, pmod(Ph, Thr, 184))
+HGNC:9878	partOf	complex(p(FPLX:RAS ! RAS), p(HGNC:9878 ! RASGRP1))
+HGNC:9878	partOf	complex(p(FPLX:VAV ! VAV), p(HGNC:9878 ! RASGRP1))
+HGNC:9878	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9878 ! RASGRP1))
+HGNC:9878	partOf	complex(p(HGNC:11187 ! SOS1), p(HGNC:9878 ! RASGRP1))
+HGNC:9878	partOf	complex(p(HGNC:14545 ! RASGRP3), p(HGNC:9878 ! RASGRP1))
+HGNC:9878	partOf	complex(p(HGNC:9878 ! RASGRP1), p(HGNC:9879 ! RASGRP2))
+HGNC:9879	activityPositivelyRegulatesActivityOf	HGNC:6407
+HGNC:9879	activityPositivelyRegulatesActivityOf	HGNC:7989
+HGNC:9879	hasVariant	p(HGNC:9879 ! RASGRP2, pmod(Ph, Ser, 394))
+HGNC:9879	partOf	complex(p(HGNC:9878 ! RASGRP1), p(HGNC:9879 ! RASGRP2))
+HGNC:9882	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11406
+HGNC:9882	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11408
+HGNC:9882	activityNegativelyRegulatesActivityOf	HGNC:682
+HGNC:9882	activityPositivelyRegulatesActivityOf	HGNC:682
+HGNC:9882	hasVariant	p(HGNC:9882 ! RASSF1, pmod(Me))
+HGNC:9882	hasVariant	p(HGNC:9882 ! RASSF1, pmod(Ph, Ser, 135))
+HGNC:9882	hasVariant	p(HGNC:9882 ! RASSF1, pmod(Ph, Ser, 207))
+HGNC:9882	hasVariant	p(HGNC:9882 ! RASSF1, pmod(Ph, Thr, 206))
+HGNC:9882	increasesAmountOf	p(HGNC:6407 ! KRAS, pmod(Me))
+HGNC:9882	partOf	complex(p(HGNC:10011 ! RHEB), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:14271 ! RASSF3), p(HGNC:17609 ! RASSF5), p(HGNC:20796 ! RASSF6), p(HGNC:6973 ! MDM2), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1), p(HGNC:9883 ! RASSF2))
+HGNC:9882	partOf	complex(p(HGNC:17795 ! SAV1), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:9882 ! RASSF1))
+HGNC:9882	partOf	complex(p(HGNC:9882 ! RASSF1), p(HGNC:9882 ! RASSF1))
+HGNC:9883	partOf	complex(p(HGNC:11406 ! STK3), p(HGNC:9883 ! RASSF2))
+HGNC:9883	partOf	complex(p(HGNC:11408 ! STK4), p(HGNC:9883 ! RASSF2))
+HGNC:9883	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:17609 ! RASSF5), p(HGNC:9883 ! RASSF2))
+HGNC:9883	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1), p(HGNC:9883 ! RASSF2))
+HGNC:9883	partOf	complex(p(HGNC:17609 ! RASSF5), p(HGNC:9883 ! RASSF2))
+HGNC:9883	partOf	complex(p(HGNC:5173 ! HRAS), p(HGNC:9883 ! RASSF2))
+HGNC:9883	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9883 ! RASSF2))
+HGNC:9884	activityNegativelyRegulatesActivityOf	HGNC:3489
+HGNC:9884	decreasesAmountOf	p(HGNC:1784 ! CDKN1A, pmod(Ph))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph), pmod(Ph))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 249))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 567))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 608))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 612))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 780))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 788))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 795))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 807))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Ser, 811))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Thr, 252))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Thr, 821))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ph, Thr, 826))
+HGNC:9884	hasVariant	p(HGNC:9884 ! RB1, pmod(Ub))
+HGNC:9884	partOf	complex(p(FPLX:"Cyclin_A" ! "Cyclin_A"), p(HGNC:1771 ! CDK2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(FPLX:CDK ! CDK), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(FPLX:E2F ! E2F), p(FPLX:E2F ! E2F), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:11998 ! TP53), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(FPLX:E2F ! E2F), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1097 ! BRAF), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:11998 ! TP53), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1100 ! BRCA1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11749 ! TFDP1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11751 ! TFDP2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11850 ! TLR4), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1582 ! CCND1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1773 ! CDK4), p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:1784 ! CDKN1A), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9588 ! PTEN), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:12003 ! TP73), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1504 ! CASP3), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1508 ! CASP7), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1509 ! CASP8), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1577 ! CCNA1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1578 ! CCNA2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1582 ! CCND1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1583 ! CCND2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1585 ! CCND3), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1744 ! CDC6), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1771 ! CDK2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1773 ! CDK4), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1777 ! CDK6), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:1784 ! CDKN1A), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:1784 ! CDKN1A), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:23820 ! E2F7), p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:23820 ! E2F7), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:2976 ! DNMT1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3072 ! DUSP6), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3114 ! E2F2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1, pmod(Ph)))
+HGNC:9884	partOf	complex(p(HGNC:3114 ! E2F2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3115 ! E2F3), p(HGNC:9884 ! RB1, pmod(Ph)))
+HGNC:9884	partOf	complex(p(HGNC:3430 ! ERBB2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3488 ! ETS1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3796 ! FOS), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:3942 ! MTOR), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:4566 ! GRB2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:6407 ! KRAS), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:667 ! RHOA), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:6735 ! LYN), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:6947 ! MCM4), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:6950 ! MCM7), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:6973 ! MDM2), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:8550 ! PA2G4), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:8590 ! PAK1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:8981 ! PIK3R3), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:8988 ! PIN1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:9281 ! PPP1CA), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:9588 ! PTEN), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:9829 ! RAF1), p(HGNC:9884 ! RB1))
+HGNC:9884	partOf	complex(p(HGNC:9884 ! RB1), p(HGNC:9884 ! RB1))
+HGNC:989	hasVariant	p(HGNC:989 ! BCL10, pmod(Ph))
+HGNC:990	partOf	complex(p(HGNC:11998 ! TP53), p(HGNC:990 ! BCL2))
+HGNC:990	partOf	complex(p(HGNC:7553 ! MYC), p(HGNC:990 ! BCL2))
+HGNC:990	partOf	complex(p(HGNC:9801 ! RAC1), p(HGNC:990 ! BCL2))
+HGNC:9955	partOf	complex(p(HGNC:6204 ! JUN), p(HGNC:9955 ! RELA))
+HGNC:9955	partOf	complex(p(HGNC:8988 ! PIN1), p(HGNC:9955 ! RELA))
+HGNC:9967	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:786 ! ATF4), p(HGNC:9967 ! RET))
+HGNC:9967	partOf	complex(p(HGNC:15961 ! CBLC), p(HGNC:9967 ! RET))
+HGNC:9967	partOf	complex(p(HGNC:3689 ! FGFR2), p(HGNC:9967 ! RET))
+HGNC:9975	partOf	complex(p(HGNC:9588 ! PTEN), p(HGNC:9975 ! TRIM27))
+HGNC:998	partOf	complex(p(HGNC:7794 ! NFKB1), p(HGNC:998 ! BCL3))
+MESH:D011839	activityPositivelyRegulatesActivityOf	HGNC:10436
+MESH:D011839	increasesAmountOf	p(HGNC:11998 ! TP53, pmod(Ac, Lys, 382))
+MESH:D011839	partOf	complex(bp(MESH:D011839 ! "Radiation, Ionizing"), p(HGNC:1100 ! BRCA1))
+MESH:D011839	partOf	complex(bp(MESH:D011839 ! "Radiation, Ionizing"), p(HGNC:11998 ! TP53))
+MESH:D011839	partOf	complex(bp(MESH:D011839 ! "Radiation, Ionizing"), p(HGNC:1504 ! CASP3))
+MESH:D011839	partOf	complex(bp(MESH:D011839 ! "Radiation, Ionizing"), p(HGNC:3236 ! EGFR))
+MESH:D015427	partOf	complex(bp(MESH:D015427 ! "Reperfusion Injury"), p(HGNC:1504 ! CASP3))
+MESH:D015427	partOf	complex(bp(MESH:D015427 ! "Reperfusion Injury"), p(HGNC:9801 ! RAC1))
+PFAM:PF00595	partOf	complex(p(HGNC:9588 ! PTEN), p(PFAM:PF00595 ! PDZ))
+PFAM:PF02172	partOf	complex(p(HGNC:5147 ! HPD), p(HGNC:7553 ! MYC), p(PFAM:PF02172 ! KIX))
+PUBCHEM:"CID:10127622"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+PUBCHEM:"CID:10184653"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:"CID:10184653"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+PUBCHEM:"CID:10461815"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+PUBCHEM:"CID:11167602"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+PUBCHEM:"CID:11282283"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+PUBCHEM:"CID:11485656"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+PUBCHEM:"CID:11485656"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+PUBCHEM:"CID:11626560"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+PUBCHEM:"CID:11626560"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+PUBCHEM:"CID:11647372"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+PUBCHEM:"CID:11647372"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+PUBCHEM:"CID:11647372"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+PUBCHEM:"CID:11707110"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+PUBCHEM:"CID:11707110"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+PUBCHEM:"CID:11717001"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+PUBCHEM:"CID:11754511"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+PUBCHEM:"CID:123631"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:"CID:156414"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:"CID:16038120"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+PUBCHEM:"CID:1893730"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+PUBCHEM:"CID:216239"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+PUBCHEM:"CID:216239"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+PUBCHEM:"CID:23582824"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:"CID:23582824"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+PUBCHEM:"CID:23582824"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+PUBCHEM:"CID:23582824"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+PUBCHEM:"CID:25102847"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+PUBCHEM:"CID:25124816"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+PUBCHEM:"CID:25182616"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+PUBCHEM:"CID:25254071"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:"CID:25254071"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+PUBCHEM:"CID:25254071"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+PUBCHEM:"CID:25254071"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+PUBCHEM:"CID:25260757"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:"CID:25262965"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:"CID:3006531"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+PUBCHEM:"CID:42642645"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+PUBCHEM:"CID:44607530"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:"CID:46191454"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+PUBCHEM:"CID:46191454"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+PUBCHEM:"CID:46926350"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+PUBCHEM:"CID:4713"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+PUBCHEM:"CID:4713"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+PUBCHEM:"CID:49867926"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:"CID:49867926"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+PUBCHEM:"CID:49867926"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+PUBCHEM:"CID:49867926"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+PUBCHEM:"CID:5330286"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+PUBCHEM:"CID:5330286"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1583
+PUBCHEM:"CID:5330286"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+PUBCHEM:"CID:5330286"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+PUBCHEM:"CID:6442177"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:"CID:6445562"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:"CID:6450551"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+PUBCHEM:"CID:6852167"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+PUBCHEM:"CID:9886808"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:10029385	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+PUBCHEM:108047	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+PUBCHEM:108047	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+PUBCHEM:108047	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+PUBCHEM:11364421	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+PUBCHEM:11364421	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+PUBCHEM:11497983	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:11497983	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+PUBCHEM:11497983	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+PUBCHEM:11696609	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+PUBCHEM:11696609	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+PUBCHEM:11696609	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+PUBCHEM:11696609	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+PUBCHEM:11696609	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+PUBCHEM:11696609	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:11998575	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:1400	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+PUBCHEM:1400	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+PUBCHEM:1400	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:1400	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+PUBCHEM:1400	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+PUBCHEM:148191	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:148191	partOf	complex(a(PUBCHEM:148191 ! 148191), p(HGNC:3942 ! MTOR))
+PUBCHEM:23643976	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+PUBCHEM:24866313	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+PUBCHEM:24866313	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+PUBCHEM:25023738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10430
+PUBCHEM:25023738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10431
+PUBCHEM:25023738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+PUBCHEM:25023738	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10435
+PUBCHEM:25118925	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+PUBCHEM:25127713	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:25127713	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+PUBCHEM:25134326	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+PUBCHEM:25227436	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+PUBCHEM:25227436	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+PUBCHEM:25227436	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+PUBCHEM:25227436	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+PUBCHEM:25227436	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+PUBCHEM:25262792	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+PUBCHEM:35595	partOf	complex(a(PUBCHEM:35595 ! 35595), p(HGNC:2861 ! DHFR))
+PUBCHEM:3815	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+PUBCHEM:3815	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+PUBCHEM:44462758	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:44631912	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+PUBCHEM:44631912	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+PUBCHEM:446556	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12441
+PUBCHEM:446556	activityDirectlyNegativelyRegulatesActivityOf	HGNC:2861
+PUBCHEM:4566	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+PUBCHEM:4566	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1577
+PUBCHEM:4566	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+PUBCHEM:4566	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+PUBCHEM:46209401	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+PUBCHEM:46209401	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1578
+PUBCHEM:46209401	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+PUBCHEM:46209401	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+PUBCHEM:46209401	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+PUBCHEM:46216796	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:46220502	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+PUBCHEM:46220502	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+PUBCHEM:46944259	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+PUBCHEM:46944259	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+PUBCHEM:46944259	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+PUBCHEM:46944259	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+PUBCHEM:46944259	partOf	complex(a(PUBCHEM:46944259 ! 46944259), p(HGNC:3691 ! FGFR4))
+PUBCHEM:49792852	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:49831257	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:50878566	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10251
+PUBCHEM:50878566	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+PUBCHEM:50909854	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:50909854	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+PUBCHEM:50909854	partOf	complex(a(PUBCHEM:50909854 ! 50909854), p(HGNC:6763 ! MAD2L1))
+PUBCHEM:51001932	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+PUBCHEM:51001932	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+PUBCHEM:51001932	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+PUBCHEM:51371303	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+PUBCHEM:5315765	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+PUBCHEM:5315765	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+PUBCHEM:5315765	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+PUBCHEM:53239990	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+PUBCHEM:53239990	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+PUBCHEM:53246941	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+PUBCHEM:53246941	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+PUBCHEM:53246941	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:53246941	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+PUBCHEM:53396327	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+PUBCHEM:54575456	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+PUBCHEM:54575456	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+PUBCHEM:54764565	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+PUBCHEM:54764565	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:54764565	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+PUBCHEM:54764565	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+PUBCHEM:5702541	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+PUBCHEM:5702541	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+PUBCHEM:5702541	activityDirectlyNegativelyRegulatesActivityOf	HGNC:392
+PUBCHEM:5702541	activityDirectlyNegativelyRegulatesActivityOf	HGNC:393
+PUBCHEM:57390074	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10261
+PUBCHEM:57390074	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:57390074	activityDirectlyNegativelyRegulatesActivityOf	HGNC:427
+PUBCHEM:57519532	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+PUBCHEM:57519532	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+PUBCHEM:57519532	partOf	complex(a(PUBCHEM:57519532 ! 57519532), p(HGNC:3236 ! EGFR))
+PUBCHEM:57519532	partOf	complex(a(PUBCHEM:57519532 ! 57519532), p(HGNC:3430 ! ERBB2))
+PUBCHEM:57990869	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+PUBCHEM:57990869	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:57990869	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+PUBCHEM:57990869	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+PUBCHEM:59473233	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+PUBCHEM:66555680	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+PUBCHEM:66555680	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3689
+PUBCHEM:66555680	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3690
+PUBCHEM:6852167	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+PUBCHEM:6852167	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+PUBCHEM:68810458	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+PUBCHEM:68810458	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6842
+PUBCHEM:68810458	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+PUBCHEM:70934541	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+PUBCHEM:70934541	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8591
+PUBCHEM:70934541	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8592
+PUBCHEM:71727581	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+PUBCHEM:71727581	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+PUBCHEM:9549295	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+PUBCHEM:9549301	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+PUBCHEM:9797370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+PUBCHEM:9797370	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+TEXT:"Glycyl-H-1152"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10252
+TEXT:"HG-6-64-01"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+TEXT:"HG-6-64-01"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+TEXT:"HG-6-64-01"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+TEXT:"NCIT:C63927"	partOf	complex(a(TEXT:"NCIT:C63927"), p(HGNC:7029 ! MET))
+TEXT:"NVP-BGT226"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+TEXT:"NVP-BGT226"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+TEXT:"NVP-BGT226"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+TEXT:"NVP-BGT226"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+TEXT:"QL-X-138"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+TEXT:"WH-4-023"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+TEXT:"WZ-4-145"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+TEXT:"WZ-4-145"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3691
+TEXT:"WZ-4-145"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+TEXT:"WZ-4-145"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8804
+TEXT:"XMD16-144"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+TEXT:"XMD16-144"	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+TEXT:"protein tyrosine kinase"	partOf	complex(a(TEXT:"protein tyrosine kinase"), p(HGNC:3236 ! EGFR))
+TEXT:KU63794	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+TEXT:Rigosertib	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8975
+TEXT:Rigosertib	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8977
+TEXT:Rigosertib	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8978
+TEXT:TX	activityNegativelyRegulatesActivityOf	HGNC:6973
+TEXT:translocation	activityNegativelyRegulatesActivityOf	HGNC:10432
+UP:A0FKN4	partOf	complex(p(HGNC:3430 ! ERBB2), p(UP:A0FKN4 ! A0FKN4))
+UP:P62158	partOf	complex(p(HGNC:6407 ! KRAS), p(UP:P62158 ! P62158))
+complex(complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1)), p(HGNC:8978 ! PIK3CG))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+complex(p(HGNC:10011 ! RHEB), p(HGNC:12362 ! TSC1))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10011
+complex(p(HGNC:10251 ! ROCK1), p(HGNC:667 ! RHOA))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10251
+complex(p(HGNC:10430 ! RPS6KA1), p(HGNC:11998 ! TP53))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10430
+complex(p(HGNC:10840 ! SHC1), p(HGNC:11187 ! SOS1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11187
+complex(p(HGNC:10840 ! SHC1), p(HGNC:3236 ! EGFR))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+complex(p(HGNC:10840 ! SHC1), p(HGNC:3430 ! ERBB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+complex(p(HGNC:10840 ! SHC1), p(HGNC:4566 ! GRB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+complex(p(HGNC:1097 ! BRAF), p(HGNC:5173 ! HRAS))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+complex(p(HGNC:1097 ! BRAF), p(HGNC:6407 ! KRAS))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+complex(p(HGNC:1097 ! BRAF), p(HGNC:7989 ! NRAS))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+complex(p(HGNC:1097 ! BRAF), p(HGNC:9829 ! RAF1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+complex(p(HGNC:1100 ! BRCA1), p(HGNC:952 ! BARD1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+complex(p(HGNC:11270 ! SPRY2), p(HGNC:1542 ! CBLB))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1542
+complex(p(HGNC:11406 ! STK3), p(HGNC:20796 ! RASSF6))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+complex(p(HGNC:11406 ! STK3), p(HGNC:9882 ! RASSF1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11406
+complex(p(HGNC:11408 ! STK4), p(HGNC:17795 ! SAV1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11408
+complex(p(HGNC:11408 ! STK4), p(HGNC:9882 ! RASSF1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11408
+complex(p(HGNC:11749 ! TFDP1), p(HGNC:3113 ! E2F1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+complex(p(HGNC:11749 ! TFDP1), p(HGNC:3114 ! E2F2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11749
+complex(p(HGNC:11749 ! TFDP1), p(HGNC:3115 ! E2F3))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11749
+complex(p(HGNC:11805 ! TIAM1), p(HGNC:9801 ! RAC1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+complex(p(HGNC:12003 ! TP73), p(HGNC:16262 ! YAP1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12003
+complex(p(HGNC:12003 ! TP73), p(HGNC:6973 ! MDM2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10011
+complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12363
+complex(p(HGNC:12362 ! TSC1), p(HGNC:12363 ! TSC2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12362
+complex(p(HGNC:12657 ! VAV1), p(HGNC:1541 ! CBL))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1541
+complex(p(HGNC:1541 ! CBL), p(HGNC:1541 ! CBL))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1541
+complex(p(HGNC:1541 ! CBL), p(HGNC:3765 ! FLT3))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3765
+complex(p(HGNC:1577 ! CCNA1), p(HGNC:1771 ! CDK2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1771
+complex(p(HGNC:1578 ! CCNA2), p(HGNC:1771 ! CDK2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1744
+complex(p(HGNC:1578 ! CCNA2), p(HGNC:1771 ! CDK2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6947
+complex(p(HGNC:1578 ! CCNA2), p(HGNC:1771 ! CDK2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+complex(p(HGNC:1578 ! CCNA2), p(HGNC:1771 ! CDK2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1744
+complex(p(HGNC:1578 ! CCNA2), p(HGNC:1771 ! CDK2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1771
+complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+complex(p(HGNC:1582 ! CCND1), p(HGNC:1773 ! CDK4))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1773
+complex(p(HGNC:17609 ! RASSF5), p(HGNC:9882 ! RASSF1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9882
+complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+complex(p(HGNC:1771 ! CDK2), p(HGNC:1784 ! CDKN1A))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1771
+complex(p(HGNC:1773 ! CDK4), p(HGNC:1784 ! CDKN1A))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1773
+complex(p(HGNC:1777 ! CDK6), p(HGNC:1784 ! CDKN1A))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1777
+complex(p(HGNC:1784 ! CDKN1A), p(HGNC:392 ! AKT2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1784
+complex(p(HGNC:19700 ! CNKSR1), p(HGNC:9882 ! RASSF1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9882
+complex(p(HGNC:19701 ! CNKSR2), p(HGNC:9829 ! RAF1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+complex(p(HGNC:24825 ! MLST8), p(HGNC:3942 ! MTOR))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3942
+complex(p(HGNC:3113 ! E2F1), p(HGNC:9884 ! RB1))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3113
+complex(p(HGNC:3114 ! E2F2), p(HGNC:9884 ! RB1))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3114
+complex(p(HGNC:3236 ! EGFR), p(HGNC:3236 ! EGFR))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3430
+complex(p(HGNC:3236 ! EGFR), p(HGNC:3430 ! ERBB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9871
+complex(p(HGNC:3236 ! EGFR), p(HGNC:4566 ! GRB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+complex(p(HGNC:3236 ! EGFR), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+complex(p(HGNC:3236 ! EGFR), p(HGNC:9644 ! PTPN11))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9644
+complex(p(HGNC:3688 ! FGFR1), p(HGNC:3688 ! FGFR1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+complex(p(HGNC:3765 ! FLT3), p(HGNC:4564 ! GRB10))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4564
+complex(p(HGNC:3765 ! FLT3), p(HGNC:9644 ! PTPN11))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9644
+complex(p(HGNC:3796 ! FOS), p(HGNC:6204 ! JUN))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+complex(p(HGNC:4564 ! GRB10), p(HGNC:6091 ! INSR))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+complex(p(HGNC:4564 ! GRB10), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+complex(p(HGNC:4566 ! GRB2), p(HGNC:6125 ! IRS1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+complex(p(HGNC:5173 ! HRAS), p(HGNC:646 ! ARAF))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:646
+complex(p(HGNC:5173 ! HRAS), p(HGNC:8975 ! PIK3CA))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+complex(p(HGNC:5173 ! HRAS), p(HGNC:8977 ! PIK3CD))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8977
+complex(p(HGNC:5173 ! HRAS), p(HGNC:8978 ! PIK3CG))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+complex(p(HGNC:5173 ! HRAS), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+complex(p(HGNC:5173 ! HRAS), p(HGNC:9829 ! RAF1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+complex(p(HGNC:5173 ! HRAS), p(HGNC:9871 ! RASA1))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:5173
+complex(p(HGNC:6091 ! INSR), p(HGNC:6125 ! IRS1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+complex(p(HGNC:6091 ! INSR), p(HGNC:6126 ! IRS2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6126
+complex(p(HGNC:6125 ! IRS1), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+complex(p(HGNC:6126 ! IRS2), p(HGNC:8975 ! PIK3CA))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+complex(p(HGNC:6126 ! IRS2), p(HGNC:8978 ! PIK3CG))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+complex(p(HGNC:6407 ! KRAS), p(HGNC:8975 ! PIK3CA))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+complex(p(HGNC:6407 ! KRAS), p(HGNC:8977 ! PIK3CD))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8977
+complex(p(HGNC:6407 ! KRAS), p(HGNC:8978 ! PIK3CG))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+complex(p(HGNC:6407 ! KRAS), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+complex(p(HGNC:6407 ! KRAS), p(HGNC:9829 ! RAF1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+complex(p(HGNC:7029 ! MET), p(HGNC:7029 ! MET))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7029
+complex(p(HGNC:7553 ! MYC), p(HGNC:8988 ! PIN1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7553
+complex(p(HGNC:7989 ! NRAS), p(HGNC:8978 ! PIK3CG))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+complex(p(HGNC:7989 ! NRAS), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+complex(p(HGNC:8590 ! PAK1), p(HGNC:8590 ! PAK1))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+complex(p(HGNC:8630 ! PEBP1), p(HGNC:9829 ! RAF1))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+complex(p(HGNC:8803 ! PDGFRA), p(HGNC:8803 ! PDGFRA), p(HGNC:9644 ! PTPN11))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9644
+complex(p(HGNC:8804 ! PDGFRB), p(HGNC:8804 ! PDGFRB), p(HGNC:9644 ! PTPN11))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9644
+complex(p(HGNC:8816 ! PDPK1), p(HGNC:8978 ! PIK3CG))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8816
+complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8979
+complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8978
+complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+complex(p(HGNC:8975 ! PIK3CA), p(HGNC:8981 ! PIK3R3))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8975
+complex(p(HGNC:8977 ! PIK3CD), p(HGNC:8979 ! PIK3R1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8977
+complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12362
+complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9377 ! PRKAA2), p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1), p(HGNC:9386 ! PRKAG2), p(HGNC:9387 ! PRKAG3))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6091
+complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9379 ! PRKAB2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9376 ! PRKAA1), p(HGNC:9379 ! PRKAB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9379 ! PRKAB2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9379 ! PRKAB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9377 ! PRKAA2), p(HGNC:9385 ! PRKAG1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9377
+complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9378 ! PRKAB1), p(HGNC:9379 ! PRKAB2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9385 ! PRKAG1))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9386 ! PRKAG2))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9386 ! PRKAG2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9387 ! PRKAG3))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+complex(p(HGNC:9379 ! PRKAB2), p(HGNC:9387 ! PRKAG3))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9379
+p(HGNC:10261 ! ROS1, pmod(Ph, Tyr, 2110))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10261
+p(HGNC:10430 ! RPS6KA1, pmod(Ph, Ser, 221))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10430
+p(HGNC:10430 ! RPS6KA1, pmod(Ph, Ser, 363))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10430
+p(HGNC:10430 ! RPS6KA1, pmod(Ph, Ser, 380))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10430
+p(HGNC:10430 ! RPS6KA1, pmod(Ph, Ser, 732))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10430
+p(HGNC:10430 ! RPS6KA1, pmod(Ph, Thr, 359))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10430
+p(HGNC:10430 ! RPS6KA1, pmod(Ph, Thr, 573))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10430
+p(HGNC:10431 ! RPS6KA2, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10431
+p(HGNC:10432 ! RPS6KA3, pmod(Ph, Ser, 227))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10432
+p(HGNC:10432 ! RPS6KA3, pmod(Ph, Ser, 369))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10432
+p(HGNC:10432 ! RPS6KA3, pmod(Ph, Ser, 386))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10432
+p(HGNC:10432 ! RPS6KA3, pmod(Ph, Thr, 577))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10432
+p(HGNC:10432 ! RPS6KA3, pmod(Ph, Tyr, 529))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10432
+p(HGNC:10432 ! RPS6KA3, pmod(Ph, Tyr, 707))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10432
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 394))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 434))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 434))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Ser, 447))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 252))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 390))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 412))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 444))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10436 ! RPS6KB1, pmod(Ph, Thr, 444))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10436
+p(HGNC:10437 ! RPS6KB2, pmod(Ph, Ser, 370))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10437
+p(HGNC:10437 ! RPS6KB2, pmod(Ph, Ser, 473))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10437
+p(HGNC:10437 ! RPS6KB2, pmod(Ph, Ser, 473))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10437
+p(HGNC:10437 ! RPS6KB2, pmod(Ph, Thr, 228))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10437
+p(HGNC:10437 ! RPS6KB2, pmod(Ph, Thr, 388))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10437
+p(HGNC:10840 ! SHC1, pmod(Ph, Ser, 139))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:10840
+p(HGNC:10840 ! SHC1, pmod(Ph, Ser, 139))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+p(HGNC:10840 ! SHC1, pmod(Ph, Tyr, 349))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+p(HGNC:10840 ! SHC1, pmod(Ph, Tyr, 350))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+p(HGNC:10840 ! SHC1, pmod(Ph, Tyr, 427))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:10840
+p(HGNC:1097 ! BRAF, pmod(Ph, Ser))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 151))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 364))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 365))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 429))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 446))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 579))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Ser, 750))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Thr, 373))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Thr, 401))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, pmod(Ph, Thr, 753))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1097 ! BRAF, var("p.Val600Glu"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1097
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1143))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1191))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1280))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1330))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1387))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1423))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1466))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 1497))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 632))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 694))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1100 ! BRCA1, pmod(Ph, Ser, 988))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1100
+p(HGNC:1101 ! BRCA2, pmod(Ph, Ser, 193))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1101
+p(HGNC:1101 ! BRCA2, pmod(Ph, Ser, 205))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1101
+p(HGNC:1101 ! BRCA2, pmod(Ph, Ser, 206))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1101
+p(HGNC:1101 ! BRCA2, pmod(Ph, Thr, 203))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1101
+p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1132))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11187
+p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1167))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11187
+p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1178))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11187
+p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1193))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11187
+p(HGNC:11187 ! SOS1, pmod(Ph, Ser, 1197))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11187
+p(HGNC:11270 ! SPRY2, pmod(Ph, Ser, 112))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11270
+p(HGNC:11270 ! SPRY2, pmod(Ph, Thr, 75))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11270
+p(HGNC:11270 ! SPRY2, pmod(Ph, Tyr, 55))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11270
+p(HGNC:11389 ! STK11, pmod(Ph, Ser))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11389
+p(HGNC:11389 ! STK11, pmod(Ph, Ser, 307))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11389
+p(HGNC:11389 ! STK11, pmod(Ph, Ser, 428))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11389
+p(HGNC:11389 ! STK11, pmod(Ph, Ser, 428))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11389
+p(HGNC:11389 ! STK11, pmod(Ph, Thr, 185))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11389
+p(HGNC:11389 ! STK11, pmod(Ph, Thr, 367))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11389
+p(HGNC:11389 ! STK11, pmod(Ph, Thr, 402))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11389
+p(HGNC:11406 ! STK3, pmod(Ph, Thr, 117))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+p(HGNC:11406 ! STK3, pmod(Ph, Thr, 180))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11406
+p(HGNC:11406 ! STK3, pmod(Ph, Thr, 384))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11406
+p(HGNC:11406 ! STK3, pmod(Ph, Tyr, 81))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11406
+p(HGNC:11408 ! STK4, pmod(Ph, Ser, 327))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11408
+p(HGNC:11408 ! STK4, pmod(Ph, Thr, 120))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+p(HGNC:11408 ! STK4, pmod(Ph, Thr, 183))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11408
+p(HGNC:11408 ! STK4, pmod(Ph, Thr, 387))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11408
+p(HGNC:1148 ! BUB1, pmod(Ph, Thr, 609))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1148
+p(HGNC:11584 ! TBK1, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11584
+p(HGNC:11830 ! TK1, pmod(Ph, Ser, 13))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11830
+p(HGNC:11998 ! TP53, pmod(Ac, Lys, 120))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ac, Lys, 164))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ac, Lys, 370))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ac, Lys, 373))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ac, Lys, 381))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ac, Lys, 382))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ac, Lys, 386))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Me, Arg, 333))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Me, Arg, 335))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Me, Arg, 337))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Me, Lys, 372))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Me, Lys, 382))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 106))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 15))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 15))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 20))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 215))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 315))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 33))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 366))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 37))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 371))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 376))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 378))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 392))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 46))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Ser, 9))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Thr, 18))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Thr, 211))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Thr, 284))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Thr, 55))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Thr, 55))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ph, Thr, 81))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, pmod(Ub, Lys, 320))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Ala276Gly"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg156Pro"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg175His"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg175His"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:11998 ! TP53, var("p.Arg181Gly"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg181His"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg248Gln"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg248Trp"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg248Trp"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:11998 ! TP53, var("p.Arg249Ser"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg273His"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg273His"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:11998 ! TP53, var("p.Arg282Trp"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Arg337Gly"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Asn239Ser"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Asp281Asn"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Asp281Glu"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Asp281Gly"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:11998 ! TP53, var("p.Cys238Trp"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Cys242Tyr"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Glu258Lys"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Glu286Lys"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Gly244Ser"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Gly245Asp"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Gly245Asp"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:11998 ! TP53, var("p.Gly245Ser"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Gly266Glu"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Gly266Glu"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:11998 ! TP53, var("p.Gly279Glu"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.His233Leu"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Leu145Arg"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Leu194Phe"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Leu308Met"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Leu323Pro"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Met246Leu"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Phe134Ile"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Pro151His"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Pro278Ser"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Pro309Ser"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Ser241Phe"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Ser241Thr"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Thr230Ser"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Tyr126Ser"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Tyr163His"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Tyr205Asn"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Tyr220Cys"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Tyr220Cys"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:11998 ! TP53, var("p.Tyr234His"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:11998 ! TP53, var("p.Val274Phe"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:11998
+p(HGNC:12003 ! TP73, pmod(Ph, Thr, 27))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:12003 ! TP73, pmod(Ph, Thr, 86))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:12003 ! TP73, pmod(Ph, Thr, 86))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12003
+p(HGNC:12003 ! TP73, pmod(Ph, Tyr, 99))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12003
+p(HGNC:12003 ! TP73, var("p.Arg263Trp"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12003
+p(HGNC:12362 ! TSC1, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12362
+p(HGNC:12362 ! TSC1, pmod(Ph, Ser, 487))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12362
+p(HGNC:12362 ! TSC1, pmod(Ph, Ser, 584))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12362
+p(HGNC:12362 ! TSC1, pmod(Ph, Thr, 1047))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12362
+p(HGNC:12362 ! TSC1, pmod(Ph, Thr, 417))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12362
+p(HGNC:12363 ! TSC2, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12363
+p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 1387))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12363
+p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 1798))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12363
+p(HGNC:12363 ! TSC2, pmod(Ph, Ser, 540))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12363
+p(HGNC:12363 ! TSC2, pmod(Ph, Thr, 1462))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:12363
+p(HGNC:12657 ! VAV1, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12657
+p(HGNC:12657 ! VAV1, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9801
+p(HGNC:12657 ! VAV1, pmod(Ph, Tyr, 142))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12657
+p(HGNC:12657 ! VAV1, pmod(Ph, Tyr, 160))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12657
+p(HGNC:12657 ! VAV1, pmod(Ph, Tyr, 174))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:12657
+p(HGNC:14545 ! RASGRP3, pmod(Ph, Thr, 133))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:14545
+p(HGNC:1504 ! CASP3, pmod(Ph, Ser, 150))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1504
+p(HGNC:1504 ! CASP3, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1504
+p(HGNC:1508 ! CASP7, pmod(Ph, Ser, 30))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1508
+p(HGNC:1509 ! CASP8, pmod(Ph, Ser, 347))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1509
+p(HGNC:1509 ! CASP8, pmod(Ph, Ser, 387))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1509
+p(HGNC:1509 ! CASP8, pmod(Ph, Tyr, 334))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1509
+p(HGNC:1509 ! CASP8, pmod(Ph, Tyr, 380))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1509
+p(HGNC:1509 ! CASP8, pmod(Ph, Tyr, 448))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1509
+p(HGNC:1541 ! CBL, pmod(Ph, Ser, 619))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1541
+p(HGNC:1541 ! CBL, pmod(Ph, Tyr, 371))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1541
+p(HGNC:1541 ! CBL, pmod(Ph, Tyr, 700))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1541
+p(HGNC:1541 ! CBL, pmod(Ph, Tyr, 731))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1541
+p(HGNC:1541 ! CBL, pmod(Ph, Tyr, 774))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1541
+p(HGNC:1578 ! CCNA2, pmod(Ph, Ser, 154))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1578
+p(HGNC:1582 ! CCND1, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+p(HGNC:1582 ! CCND1, pmod(Ph, Thr, 286))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+p(HGNC:1582 ! CCND1, pmod(Ph, Thr, 288))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1582
+p(HGNC:1583 ! CCND2, pmod(Ph, Thr, 280))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1583
+p(HGNC:1585 ! CCND3, pmod(Ph, Thr, 283))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1585
+p(HGNC:16059 ! PAK4, pmod(Ph, Ser, 474))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:16059
+p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 127))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16262
+p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 397))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16262
+p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 400))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16262
+p(HGNC:16262 ! YAP1, pmod(Ph, Ser, 403))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16262
+p(HGNC:16262 ! YAP1, pmod(Ph, Tyr, 407))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:16262
+p(HGNC:16262 ! YAP1, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:16262
+p(HGNC:16854 ! RAPGEF2, pmod(Ph, Ser, 960))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:16854
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 116))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 124))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 178))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 263))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 279))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 293))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 295))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 76))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 79))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Ser, 82))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ph, Thr, 80))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1725
+p(HGNC:1725 ! CDC25A, pmod(Ub))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1725
+p(HGNC:17294 ! DAB2IP, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:17294
+p(HGNC:1744 ! CDC6, pmod(Ph, Ser, 106))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1744
+p(HGNC:1744 ! CDC6, pmod(Ph, Ser, 54))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1744
+p(HGNC:1744 ! CDC6, pmod(Ph, Ser, 54))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1744
+p(HGNC:1744 ! CDC6, pmod(Ph, Ser, 74))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1744
+p(HGNC:1744 ! CDC6, pmod(Ph, Ser, 74))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1744
+p(HGNC:1771 ! CDK2, pmod(Ph, Thr, 14))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+p(HGNC:1771 ! CDK2, pmod(Ph, Thr, 160))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1771
+p(HGNC:1771 ! CDK2, pmod(Ph, Thr, 39))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1771
+p(HGNC:1771 ! CDK2, pmod(Ph, Tyr, 15))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1771
+p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 130))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1784
+p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 130))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1784
+p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 146))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1784
+p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 146))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1771
+p(HGNC:1784 ! CDKN1A, pmod(Ph, Ser, 153))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1784
+p(HGNC:1784 ! CDKN1A, pmod(Ph, Thr, 145))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1784
+p(HGNC:1784 ! CDKN1A, pmod(Ph, Thr, 57))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1784
+p(HGNC:1784 ! CDKN1A, pmod(Ph, Thr, 57))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:1784
+p(HGNC:1784 ! CDKN1A, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:1784
+p(HGNC:18181 ! SHC3, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:18181
+p(HGNC:18610 ! KSR2, pmod(Ph, Ser, 198))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:18610
+p(HGNC:18610 ! KSR2, pmod(Ph, Thr, 290))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:18610
+p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 696))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 721))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 722))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 792))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:30287
+p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 855))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 859))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 863))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:30287
+p(HGNC:30287 ! RPTOR, pmod(Ph, Ser, 863))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+p(HGNC:30287 ! RPTOR, pmod(Ph, Thr, 908))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:30287
+p(HGNC:3064 ! DUSP1, pmod(Ac, Lys, 57))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3064
+p(HGNC:3064 ! DUSP1, pmod(Ph, Ser, 296))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3064
+p(HGNC:3064 ! DUSP1, pmod(Ph, Ser, 323))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3064
+p(HGNC:3064 ! DUSP1, pmod(Ph, Ser, 359))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3064
+p(HGNC:3069 ! DUSP3, pmod(Ph, Tyr, 138))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3069
+p(HGNC:3072 ! DUSP6, pmod(Ph, Ser, 159))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3072
+p(HGNC:3072 ! DUSP6, pmod(Ph, Ser, 197))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3072
+p(HGNC:3113 ! E2F1, pmod(Ac, Lys, 117))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+p(HGNC:3113 ! E2F1, pmod(Ac, Lys, 120))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+p(HGNC:3113 ! E2F1, pmod(Ac, Lys, 125))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 31))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 337))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 375))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3113
+p(HGNC:3113 ! E2F1, pmod(Ph, Ser, 403))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3113
+p(HGNC:3113 ! E2F1, pmod(Ph, Thr, 433))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3113
+p(HGNC:3155 ! ECT2, pmod(Ph, Thr, 359))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3155
+p(HGNC:3155 ! ECT2, pmod(Ph, Thr, 373))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3155
+p(HGNC:3155 ! ECT2, pmod(Ph, Thr, 846))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3155
+p(HGNC:3236 ! EGFR, pmod(Ph, Ser))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 1026))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 1071))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 1081))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 1120))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Ser, 768))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Thr, 678))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Thr, 678))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Thr, 693))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1016))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1069))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1069))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1092))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1092))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1110))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1125))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1172))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1172))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 1197))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ph, Tyr, 869))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, var("p.Leu858Arg"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3236 ! EGFR, var("p.Pro753Ser"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3236
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser, 112))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser, 65))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Ser, 83))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 36))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 37))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 41))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 45))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 46))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3288 ! EIF4EBP1, pmod(Ph, Thr, 70))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3288
+p(HGNC:3289 ! EIF4EBP2, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3289
+p(HGNC:3290 ! EIF4EBP3, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3290
+p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 324))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3321
+p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 383))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3321
+p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 383), pmod(Ph, Ser, 389))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 389))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3321
+p(HGNC:3321 ! ELK1, pmod(Ph, Ser, 422))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3321
+p(HGNC:3321 ! ELK1, pmod(Ph, Thr, 336))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3321
+p(HGNC:3321 ! ELK1, var("p.Ser383Ala"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3321
+p(HGNC:3321 ! ELK1, var("p.Trp379Ala"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3321
+p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3430
+p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1023))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1023))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3430
+p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1221))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3430
+p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 1248))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3430
+p(HGNC:3430 ! ERBB2, pmod(Ph, Tyr, 877))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3430
+p(HGNC:3430 ! ERBB2, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3430
+p(HGNC:3444 ! ERF, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3444
+p(HGNC:3444 ! ERF, pmod(Ph, Ser, 161))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3444
+p(HGNC:3444 ! ERF, pmod(Ph, Ser, 251))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3444
+p(HGNC:3488 ! ETS1, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3488
+p(HGNC:3488 ! ETS1, pmod(Ph, Ser))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3488
+p(HGNC:3488 ! ETS1, pmod(Ph, Ser, 251))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3488
+p(HGNC:3488 ! ETS1, pmod(Ph, Ser, 282))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3488
+p(HGNC:3488 ! ETS1, pmod(Ph, Ser, 285))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3488
+p(HGNC:3488 ! ETS1, pmod(Ph, Thr, 38))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3488
+p(HGNC:3489 ! ETS2, pmod(Ph, Ser))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3489
+p(HGNC:3489 ! ETS2, pmod(Ph, Ser, 246))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3489
+p(HGNC:3489 ! ETS2, pmod(Ph, Ser, 310))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3489
+p(HGNC:3489 ! ETS2, pmod(Ph, Thr, 72))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3489
+p(HGNC:3582 ! FANCA, pmod(Ph, Ser, 1449))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3582
+p(HGNC:3688 ! FGFR1, pmod(Ph, Ser, 777))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 280))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 307))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 463))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 583))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 585))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 653))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 654))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 730))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3688 ! FGFR1, pmod(Ph, Tyr, 766))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3688
+p(HGNC:3689 ! FGFR2, pmod(Ph, Ser, 782))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3689
+p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3690
+p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 577))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3690
+p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 647))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3690
+p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 724))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3690
+p(HGNC:3690 ! FGFR3, pmod(Ph, Tyr, 760))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3690
+p(HGNC:3691 ! FGFR4, pmod(Ph, Tyr, 642))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3691
+p(HGNC:3691 ! FGFR4, pmod(Ph, Tyr, 643))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3691
+p(HGNC:3765 ! FLT3, pmod(Ph, Tyr, 589))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3765
+p(HGNC:3765 ! FLT3, pmod(Ph, Tyr, 597))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3765
+p(HGNC:3765 ! FLT3, var("p.Asn841His"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3765
+p(HGNC:3796 ! FOS, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+p(HGNC:3796 ! FOS, pmod(Ph, Ser, 362))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+p(HGNC:3796 ! FOS, pmod(Ph, Ser, 374))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+p(HGNC:3796 ! FOS, pmod(Ph, Thr, 232))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+p(HGNC:3796 ! FOS, pmod(Ph, Thr, 325))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+p(HGNC:3796 ! FOS, pmod(Ph, Thr, 331))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3796
+p(HGNC:391 ! AKT1, pmod(Ac, Lys, 14))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Ser, 129))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Ser, 473))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Ser, 473), pmod(Ph, Thr, 308))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9842
+p(HGNC:391 ! AKT1, pmod(Ph, Ser, 475))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Ser, 477))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Thr, 308))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Thr, 34))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Thr, 450))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Thr, 479))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Tyr, 315))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Tyr, 326))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ph, Tyr, 474))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:391
+p(HGNC:391 ! AKT1, pmod(Ub, Lys, 284))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:391
+p(HGNC:392 ! AKT2, pmod(Ph, Ser, 474))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:392
+p(HGNC:392 ! AKT2, pmod(Ph, Thr, 309))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:392
+p(HGNC:393 ! AKT3, pmod(Ph, Ser, 472))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:393
+p(HGNC:393 ! AKT3, pmod(Ph, Ser, 474))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:393
+p(HGNC:393 ! AKT3, pmod(Ph, Thr, 305))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:393
+p(HGNC:3942 ! MTOR, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:3942
+p(HGNC:3942 ! MTOR, pmod(Ph, Ser, 2448))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3942
+p(HGNC:3942 ! MTOR, pmod(Ph, Ser, 2481))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3942
+p(HGNC:3942 ! MTOR, pmod(Ph, Thr, 2446))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3942
+p(HGNC:4564 ! GRB10, pmod(Ph, Ser, 150))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4564
+p(HGNC:4564 ! GRB10, pmod(Ph, Ser, 476))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4564
+p(HGNC:4564 ! GRB10, pmod(Ph, Tyr, 67))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:4564
+p(HGNC:4566 ! GRB2, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4566
+p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 209))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:4566
+p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 37))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:4566
+p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 52))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:4566
+p(HGNC:4566 ! GRB2, pmod(Ph, Tyr, 7))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:4566
+p(HGNC:4568 ! RAPGEF1, pmod(Ph, Tyr, 504))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4568
+p(HGNC:4591 ! ARHGAP35, pmod(Ph, Ser, 1236))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:4591
+p(HGNC:4591 ! ARHGAP35, pmod(Ph, Tyr, 1105))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:4591
+p(HGNC:5173 ! HRAS, var("p.Gly12Val"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+p(HGNC:6091 ! INSR, pmod(Ph, Ser))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 1185))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6091
+p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 1189))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6091
+p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 1190))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6091
+p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 992))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6091
+p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 999))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+p(HGNC:6091 ! INSR, pmod(Ph, Tyr, 999))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6091
+p(HGNC:6091 ! INSR, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6091
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 1101))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 1222))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 1223))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 24))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 270))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 272))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 274))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 307))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 312))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 315))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 323))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 531))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 616))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 616))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 636))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 636))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Ser, 639))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 1179))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 1229))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 465))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 612))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 632))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 896))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 941))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6125 ! IRS1, pmod(Ph, Tyr, 989))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6125
+p(HGNC:6126 ! IRS2, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6126
+p(HGNC:6204 ! JUN, pmod(Ph, Ser, 243))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Ser, 249))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Ser, 63))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Ser, 73))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Thr, 2))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Thr, 239))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Thr, 286))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Thr, 8))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Thr, 89))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Thr, 91))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6204 ! JUN, pmod(Ph, Thr, 93))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6204
+p(HGNC:6407 ! KRAS, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+p(HGNC:6407 ! KRAS, pmod(Ph, Tyr, 32))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6407
+p(HGNC:6407 ! KRAS, var("p.Gln61His"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+p(HGNC:6407 ! KRAS, var("p.Gln61Leu"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+p(HGNC:6407 ! KRAS, var("p.Gly12Cys"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+p(HGNC:6407 ! KRAS, var("p.Gly12Val"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+p(HGNC:6407 ! KRAS, var("p.Gly12Val"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:6407 ! KRAS, var("p.Gly13Asp"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+p(HGNC:646 ! ARAF, pmod(Ph, Ser, 299))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:646
+p(HGNC:646 ! ARAF, pmod(Ph, Tyr, 302))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:646
+p(HGNC:6465 ! KSR1, pmod(Ph, Ser, 406))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6465
+p(HGNC:667 ! RHOA, pmod(Ph, Ser, 188))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:667
+p(HGNC:667 ! RHOA, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:667
+p(HGNC:682 ! ARHGEF2, pmod(Ph, Ser, 886))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:682
+p(HGNC:682 ! ARHGEF2, pmod(Ph, Ser, 960))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:682
+p(HGNC:682 ! ARHGEF2, pmod(Ph, Thr, 679))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:682
+p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 218))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 218), pmod(Ph, Ser, 222))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 222))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+p(HGNC:6840 ! MAP2K1, pmod(Ph, Ser, 248))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+p(HGNC:6840 ! MAP2K1, pmod(Ph, Thr, 286))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+p(HGNC:6840 ! MAP2K1, pmod(Ph, Thr, 292))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+p(HGNC:6840 ! MAP2K1, pmod(Ph, Thr, 386))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6840
+p(HGNC:6842 ! MAP2K2, pmod(Ph, Ser, 222))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6842
+p(HGNC:6842 ! MAP2K2, pmod(Ph, Ser, 222), pmod(Ph, Ser, 226))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+p(HGNC:6842 ! MAP2K2, pmod(Ph, Ser, 226))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6842
+p(HGNC:6871 ! MAPK1, pmod(Ph, Ser))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6871
+p(HGNC:6871 ! MAPK1, pmod(Ph, Thr, 185))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6871
+p(HGNC:6871 ! MAPK1, pmod(Ph, Tyr, 187))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6871
+p(HGNC:6871 ! MAPK1, pmod(Ph, Tyr, 205))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6871
+p(HGNC:6877 ! MAPK3, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6877
+p(HGNC:6877 ! MAPK3, pmod(Ph, Thr, 202))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+p(HGNC:6877 ! MAPK3, pmod(Ph, Thr, 207))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+p(HGNC:6877 ! MAPK3, pmod(Ph, Tyr, 204))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6877
+p(HGNC:6947 ! MCM4, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6947
+p(HGNC:6947 ! MCM4, pmod(Ph, Ser, 32))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6947
+p(HGNC:6947 ! MCM4, pmod(Ph, Ser, 54))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6947
+p(HGNC:6947 ! MCM4, pmod(Ph, Thr, 110))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6947
+p(HGNC:6950 ! MCM7, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6950
+p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 166))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 186))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 188))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 253))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 370))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 395))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 395))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Ser, 407))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Thr, 216))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Tyr, 276))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Tyr, 394))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+p(HGNC:6973 ! MDM2, pmod(Ph, Tyr, 405))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:6973
+p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1003))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7029
+p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1234))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7029
+p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1235))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7029
+p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1349))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7029
+p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1356))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7029
+p(HGNC:7029 ! MET, pmod(Ph, Tyr, 1365))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7029
+p(HGNC:7029 ! MET, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7029
+p(HGNC:7553 ! MYC, pmod(Ph, Ser, 373))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7553
+p(HGNC:7553 ! MYC, pmod(Ph, Ser, 62))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7553
+p(HGNC:7553 ! MYC, pmod(Ph, Ser, 71))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7553
+p(HGNC:7553 ! MYC, pmod(Ph, Thr, 358))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7553
+p(HGNC:7553 ! MYC, pmod(Ph, Thr, 58))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7553
+p(HGNC:7553 ! MYC, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7553
+p(HGNC:7553 ! MYC, pmod(Ub))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7553
+p(HGNC:7782 ! NFE2L2, pmod(Ph, Ser, 40))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7782
+p(HGNC:7794 ! NFKB1, pmod(Ph, Ser, 337))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7794
+p(HGNC:7794 ! NFKB1, pmod(Ph, Ser, 923))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7794
+p(HGNC:7794 ! NFKB1, pmod(Ph, Ser, 927))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7794
+p(HGNC:7794 ! NFKB1, pmod(Ph, Ser, 932))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7794
+p(HGNC:7794 ! NFKB1, pmod(Ph, Thr, 931))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7794
+p(HGNC:7794 ! NFKB1, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7794
+p(HGNC:7989 ! NRAS, pmod(Ph, Tyr, 32))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:7989
+p(HGNC:7989 ! NRAS, var("p.Gln61Leu"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7989
+p(HGNC:7989 ! NRAS, var("p.Gln61Lys"))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7989
+p(HGNC:8590 ! PAK1, pmod(Ph, Ser, 199))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8590
+p(HGNC:8590 ! PAK1, pmod(Ph, Ser, 204))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8590
+p(HGNC:8590 ! PAK1, pmod(Ph, Ser, 57))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8590
+p(HGNC:8590 ! PAK1, pmod(Ph, Thr, 109))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+p(HGNC:8590 ! PAK1, pmod(Ph, Thr, 212))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+p(HGNC:8590 ! PAK1, pmod(Ph, Thr, 423))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8590
+p(HGNC:8590 ! PAK1, pmod(Ph, Thr, 84))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8590
+p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 19))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8591
+p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 192))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8591
+p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 197))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8591
+p(HGNC:8591 ! PAK2, pmod(Ph, Ser, 20))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8591
+p(HGNC:8591 ! PAK2, pmod(Ph, Thr, 402))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8591
+p(HGNC:8591 ! PAK2, pmod(Ph, Tyr, 130))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8591
+p(HGNC:8592 ! PAK3, pmod(Ph, Ser, 154))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8592
+p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr, 1018))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8803
+p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr, 742))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+p(HGNC:8803 ! PDGFRA, pmod(Ph, Tyr, 988))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8803
+p(HGNC:8803 ! PDGFRA, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8803
+p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 1009))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 1021))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 581))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 716))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 740))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 751))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+p(HGNC:8804 ! PDGFRB, pmod(Ph, Tyr, 771))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8804
+p(HGNC:8816 ! PDPK1, pmod(Ph, Ser, 241))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8816
+p(HGNC:8816 ! PDPK1, pmod(Ph, Ser, 241))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8816
+p(HGNC:8816 ! PDPK1, pmod(Ph, Ser, 241))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9842
+p(HGNC:8816 ! PDPK1, pmod(Ph, Tyr, 373))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8816
+p(HGNC:8816 ! PDPK1, pmod(Ph, Tyr, 376))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8816
+p(HGNC:8816 ! PDPK1, pmod(Ph, Tyr, 9))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8816
+p(HGNC:8822 ! PEA15, pmod(Ph, Ser, 104))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8822
+p(HGNC:8822 ! PEA15, pmod(Ph, Ser, 116))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8822
+p(HGNC:8979 ! PIK3R1, pmod(Ph, Ser, 608))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8979
+p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 368))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 580))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+p(HGNC:8979 ! PIK3R1, pmod(Ph, Tyr, 607))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:8979
+p(HGNC:8979 ! PIK3R1, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:8979
+p(HGNC:9281 ! PPP1CA, pmod(Ph, Thr, 320))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9281
+p(HGNC:9281 ! PPP1CA, pmod(Ph, Thr, 320))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9281
+p(HGNC:9376 ! PRKAA1, pmod(Ph, Ser, 486))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9376
+p(HGNC:9376 ! PRKAA1, pmod(Ph, Thr, 183))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9376
+p(HGNC:9377 ! PRKAA2, pmod(Ph, Ser, 173))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9377
+p(HGNC:9377 ! PRKAA2, pmod(Ph, Thr, 172))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9377
+p(HGNC:9379 ! PRKAB2, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9379
+p(HGNC:9379 ! PRKAB2, pmod(Ph))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9379
+p(HGNC:9387 ! PRKAG3, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9387
+p(HGNC:9502 ! CYTH2, pmod(Ph, Ser, 392))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9502
+p(HGNC:9588 ! PTEN, pmod(Ph, Ser, 370))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9588 ! PTEN, pmod(Ph, Ser, 380))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9588 ! PTEN, pmod(Ph, Ser, 385))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9588 ! PTEN, pmod(Ph, Thr, 366))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9588 ! PTEN, pmod(Ph, Thr, 382))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9588 ! PTEN, pmod(Ph, Thr, 383))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9588 ! PTEN, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9588 ! PTEN, pmod(Ph, Tyr, 315))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9588 ! PTEN, var("p.Gly251Cys"))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9588
+p(HGNC:9644 ! PTPN11, pmod(Ph))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9644
+p(HGNC:9644 ! PTPN11, pmod(Ph, Tyr, 304))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9644
+p(HGNC:9801 ! RAC1, pmod(Ph, Ser, 71))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9801
+p(HGNC:9801 ! RAC1, pmod(Ub))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9801
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 259))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 289))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 29))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 296))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 301))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 338))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 338), pmod(Ph, Thr, 269))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 339))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 43))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 471))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 497))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 619))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 621))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Ser, 621), pmod(Ph, Thr, 268))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+p(HGNC:9829 ! RAF1, pmod(Ph, Thr, 268))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Thr, 268), pmod(Ph, Thr, 269))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6840
+p(HGNC:9829 ! RAF1, pmod(Ph, Thr, 269))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9829 ! RAF1, pmod(Ph, Tyr, 340))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9829
+p(HGNC:9839 ! RALA, pmod(Ph, Ser, 183))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9839
+p(HGNC:9875 ! RASGRF1, pmod(Ph, Tyr))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9875
+p(HGNC:9878 ! RASGRP1, pmod(Ph, Thr, 184))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:5173
+p(HGNC:9878 ! RASGRP1, pmod(Ph, Thr, 184))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:6407
+p(HGNC:9878 ! RASGRP1, pmod(Ph, Thr, 184))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:7989
+p(HGNC:9878 ! RASGRP1, pmod(Ph, Thr, 184))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9878
+p(HGNC:9882 ! RASSF1, pmod(Ph, Ser, 135))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:9882
+p(HGNC:9882 ! RASSF1, pmod(Ph, Ser, 207))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9882
+p(HGNC:9882 ! RASSF1, pmod(Ph, Thr, 206))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9882
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 249))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 780))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 780))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3115
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 788))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 795))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 795))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3113
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 795))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3114
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 795))	activityDirectlyPositivelyRegulatesActivityOf	HGNC:3115
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 807))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+p(HGNC:9884 ! RB1, pmod(Ph, Ser, 811))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+p(HGNC:9884 ! RB1, pmod(Ph, Thr, 252))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+p(HGNC:9884 ! RB1, pmod(Ph, Thr, 821))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884
+p(HGNC:9884 ! RB1, pmod(Ph, Thr, 826))	activityDirectlyNegativelyRegulatesActivityOf	HGNC:9884

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -561,7 +561,7 @@ def _tf_cleanup_randomized(
     """
     if random_state is None:
         random_state = np.random.randint(0, 2 ** 32 - 1)
-        logger.warning(f'Using random_state=%s', random_state)
+        logger.warning('Using random_state=%s', random_state)
     if isinstance(random_state, int):
         random_state = np.random.RandomState(random_state)
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -421,6 +421,9 @@ class TriplesFactory:
         triples_groups = np.vsplit(self.triples[idx], split_idxs)
         logger.info(f'split triples to groups of sizes {[triples.shape[0] for triples in triples_groups]}')
 
+        # Make sure that the first element has all the right stuff in it
+        triples_groups = _fixall(triples_groups)
+
         # Make new triples factories for each group
         return [
             TriplesFactory(
@@ -511,3 +514,33 @@ class TriplesFactory:
         from IPython.core.display import HTML
         word_cloud = WordCloud()
         return HTML(word_cloud.get_embed_code(text=text, topn=top))
+
+
+def _fixall(triples_groups: List[np.ndarray]):
+    reference, *others = triples_groups
+    rv = []
+    for other in others:
+        reference, other = _move(reference, other)
+        rv.append(other)
+    return [reference, *rv]
+
+
+def _move(training: np.ndarray, testing: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    training_entities = set(training[:, 0]).union(training[:, 2])
+    testing_entities = set(testing[:, 0]).union(testing[:, 2])
+
+    testing_entities_move = testing_entities - training_entities
+    # print(len(testing_entities_move))
+
+    move_id_set = set(
+        i
+        for e in testing_entities_move
+        for i, x in enumerate((testing[:, 0] == e) | (testing[:, 2] == e))
+        if x
+    )
+    move_idxs = np.array(sorted(move_id_set))
+    # print('number edges to move', len(move_idxs))
+
+    training = np.concatenate([training, testing[move_idxs]])
+    testing = testing[np.array([i not in move_id_set for i in range(testing.shape[0])])]
+    return training, testing

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pykeen.datasets import Nations
 from pykeen.triples import TriplesFactory, TriplesNumericLiteralsFactory
-from pykeen.triples.triples_factory import INVERSE_SUFFIX, _tf_cleanup_all, _tf_cleanup
+from pykeen.triples.triples_factory import INVERSE_SUFFIX, _tf_cleanup, _tf_cleanup_all
 
 triples = np.array(
     [

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -9,8 +9,7 @@ import numpy as np
 from pykeen.datasets import Nations
 from pykeen.triples import TriplesFactory, TriplesNumericLiteralsFactory
 from pykeen.triples.triples_factory import (
-    INVERSE_SUFFIX, _tf_cleanup_all, _tf_cleanup_deterministic,
-    _tf_cleanup_randomized,
+    INVERSE_SUFFIX, _tf_cleanup_all, _tf_cleanup_deterministic, _tf_cleanup_randomized,
 )
 
 triples = np.array(

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from pykeen.datasets import Nations
 from pykeen.triples import TriplesFactory, TriplesNumericLiteralsFactory
-from pykeen.triples.triples_factory import INVERSE_SUFFIX
+from pykeen.triples.triples_factory import INVERSE_SUFFIX, _tf_cleanup_all, _tf_cleanup
 
 triples = np.array(
     [
@@ -144,6 +144,33 @@ class TestSplit(unittest.TestCase):
         self.assertEqual(expected_0_triples, t0.num_triples)
         self.assertEqual(expected_1_triples, t1.num_triples)
         self.assertEqual(expected_2_triples, t2.num_triples)
+
+    def test_move(self):
+        """Test that triples in a test set can get moved properly to the training set."""
+        training = np.array([
+            [1, 1000, 2],
+            [1, 1000, 3],
+        ])
+        testing = np.array([
+            [2, 1001, 3],
+            [1, 1002, 4],
+        ])
+        expected_training = [
+            [1, 1000, 2],
+            [1, 1000, 3],
+            [1, 1002, 4],
+        ]
+        expected_testing = [
+            [2, 1001, 3],
+        ]
+
+        new_training, new_testing = _tf_cleanup(training, testing)
+        self.assertEqual(expected_training, new_training.tolist())
+        self.assertEqual(expected_testing, new_testing.tolist())
+
+        new_testing, new_testing = _tf_cleanup_all([training, testing])
+        self.assertEqual(expected_training, new_training.tolist())
+        self.assertEqual(expected_testing, new_testing.tolist())
 
 
 class TestLiterals(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a bug where after splitting a triples factory, some entities could be in the testing and validation (or generally, any of the other sets that were created, since the functionality isn't limited to splitting 3-ways) but not in the training set. Now, the triples containing entities not in the training set are move there. This happens successively from the second through the last set.

This PR also re-adds the [Learning from BEL](https://github.com/pykeen/pykeen/blob/fix-splitting-bug/notebooks/learn_from_bel/Learning%20from%20BEL.ipynb) notebook, to show how a BEL graph can be retrieved from EMMAA to be split and trained.