### PR TITLE
Fix RotatE relation embeddings re-initialization

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -185,6 +185,7 @@ class Model(nn.Module):
     def reset_parameters_(self) -> 'Model':  # noqa: D401
         """Reset all parameters of the model and enforce model constraints."""
         self._reset_parameters_()
+        self.to_device_()
         self.post_parameter_update()
         return self
 

--- a/src/pykeen/models/unimodal/rotate.py
+++ b/src/pykeen/models/unimodal/rotate.py
@@ -77,9 +77,9 @@ class RotatE(EntityRelationEmbeddingModel):
     def _reset_parameters_(self):  # noqa: D102
         embedding_xavier_uniform_(self.entity_embeddings)
         # phases randomly between 0 and 2 pi
-        phases = 2 * np.pi * torch.rand(self.num_relations, self.real_embedding_dim)
+        phases = 2 * np.pi * torch.rand(self.num_relations, self.real_embedding_dim, device=self.device)
         relations = torch.stack([torch.cos(phases), torch.sin(phases)], dim=-1).detach()
-        assert torch.allclose(torch.norm(relations, p=2, dim=-1), torch.ones(1, 1))
+        assert torch.allclose(torch.norm(relations, p=2, dim=-1), phases.new_ones(size=(1, 1)))
         self.relation_embeddings.weight.data = relations.view(self.num_relations, self.embedding_dim)
 
     def post_parameter_update(self):  # noqa: D102

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -432,6 +432,18 @@ Traceback
 
         assert torch.allclose(scores_t, scores_hrt, atol=1e-06)
 
+    def test_reset_parameters_constructor_call(self):
+        """Tests whether reset_parameters is called in the constructor."""
+        self.model.reset_parameters_ = None
+        try:
+            self.model.__init__(
+                self.factory,
+                embedding_dim=self.embedding_dim,
+                **(self.model_kwargs or {})
+            )
+        except TypeError as error:
+            assert error.args == ("'NoneType' object is not callable",)
+
 
 class _DistanceModelTestCase(_ModelTestCase):
     """A test case for distance-based models."""


### PR DESCRIPTION
Fixes #24

The relation embeddings have been always re-initialized on `cpu` irrespective of the model's device. This was not caught by the existing unittests since they run in a cpu-only environment, and hence the default device matches the model's device.