### PR TITLE
Update to Optuna 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,3 @@ venv.bak/
 docs/source/reference/generated/*
 docs/source/api/*
 .DS_Store
-
-# MLflow artifacts
-mlruns

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ venv.bak/
 docs/source/reference/generated/*
 docs/source/api/*
 .DS_Store
+
+# MLflow artifacts
+mlruns

--- a/README.md
+++ b/README.md
@@ -229,10 +229,11 @@ in ``pykeen``.
 
 ## Hyper-parameter Optimization
 
-### Samplers (2)
+### Samplers (3)
 
 | Name   | Reference                       | Description                                                     |
 |--------|---------------------------------|-----------------------------------------------------------------|
+| grid   | `optuna.samplers.GridSampler`   | Sampler using grid search.                                      |
 | random | `optuna.samplers.RandomSampler` | Sampler using random sampling.                                  |
 | tpe    | `optuna.samplers.TPESampler`    | Sampler using TPE (Tree-structured Parzen Estimator) algorithm. |
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     torch
     tqdm
     requests
-    optuna==2.0.0rc0
+    optuna>=2.0.0
     pandas>=1.0.0
     tabulate
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     torch
     tqdm
     requests
-    optuna>=1.0.0,<1.2.0
+    optuna==2.0.0rc0
     pandas>=1.0.0
     tabulate
 

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -109,7 +109,7 @@ class Objective:
         def _stopped_callback(early_stopper: EarlyStopper, result: Union[float, int]) -> None:
             current_epoch = (1 + early_stopper.number_results) * early_stopper.frequency
             trial.set_user_attr(STOPPED_EPOCH_KEY, int(current_epoch))
-            trial.report(result)  # don't include a step because it's over
+            trial.report(result, current_epoch)  # don't include a step because it's over
 
         for key, callback in zip(('continue_callbacks', 'stopped_callbacks'), (_continue_callback, _stopped_callback)):
             stopper_kwargs.setdefault(key, []).append(callback)

--- a/src/pykeen/hpo/samplers.py
+++ b/src/pykeen/hpo/samplers.py
@@ -5,6 +5,7 @@
 ======  ======================================
 Name    Reference
 ======  ======================================
+grid    :class:`optuna.samplers.GridSampler`
 random  :class:`optuna.samplers.RandomSampler`
 tpe     :class:`optuna.samplers.TPESampler`
 ======  ======================================
@@ -16,7 +17,7 @@ tpe     :class:`optuna.samplers.TPESampler`
 
 from typing import Mapping, Set, Type, Union
 
-from optuna.samplers import BaseSampler, RandomSampler, TPESampler
+from optuna.samplers import BaseSampler, GridSampler, RandomSampler, TPESampler
 
 from ..utils import get_cls, normalize_string
 
@@ -28,7 +29,8 @@ __all__ = [
 _SAMPLER_SUFFIX = 'Sampler'
 _SAMPLERS: Set[Type[BaseSampler]] = {
     RandomSampler,
-    TPESampler
+    TPESampler,
+    GridSampler,
 }
 
 #: A mapping of HPO samplers' names to their implementations

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -256,5 +256,5 @@ class TestEarlyStoppingRealWorld(unittest.TestCase):
             batch_size=self.batch_size,
             stopper=stopper,
         )
-        assert stopper.number_results == len(losses) // stopper.frequency
+        self.assertEqual(stopper.number_results, len(losses) // stopper.frequency)
         self.assertEqual(self.stop_epoch, len(losses), msg='Did not stop early like it should have')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -535,7 +535,7 @@ class TestHolE(_ModelTestCase, unittest.TestCase):
 
         Entity embeddings have to have at most unit L2 norm.
         """
-        assert all_in_bounds(self.model.entity_embeddings.weight.norm(p=2, dim=-1), high=1.)
+        assert all_in_bounds(self.model.entity_embeddings.weight.norm(p=2, dim=-1), high=1., a_tol=1.0e-06)
 
 
 class _TestKG2E(_ModelTestCase):


### PR DESCRIPTION
Closes #33. ~Since this PR relies on the release candidate of Optuna and not the actual release, do not merge this PR until the Optuna 2.0 release has happened~ (Optuna 2.0.0 release was on 29 July 2020)