### PR TITLE
Fix TriplesFactory.split

### DIFF
--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 from collections import Counter, defaultdict
-from copy import deepcopy
 from typing import Collection, Dict, Iterable, List, Mapping, Optional, Sequence, Set, TextIO, Tuple, Union
 
 import numpy as np

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -540,7 +540,7 @@ def _tf_cleanup_all(
 
 def _tf_cleanup_deterministic(training: np.ndarray, testing: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Cleanup a triples array (testing) with respect to another (training)."""
-    training_entities, testing_entities, to_move, move_id_mask = _prepare_cleanup(training, testing)
+    move_id_mask = _prepare_cleanup(training, testing)
 
     training = np.concatenate([training, testing[move_id_mask]])
     testing = testing[~move_id_mask]
@@ -565,7 +565,7 @@ def _tf_cleanup_randomized(
     if isinstance(random_state, int):
         random_state = np.random.RandomState(random_state)
 
-    training_entities, testing_entities, to_move, move_id_mask = _prepare_cleanup(training, testing)
+    move_id_mask = _prepare_cleanup(training, testing)
 
     # While there are still triples that should be moved to the training set
     while move_id_mask.any():
@@ -579,18 +579,22 @@ def _tf_cleanup_randomized(
         testing = testing[testing_mask]
 
         # Recalculate the training entities, testing entities, to_move, and move_id_mask
-        training_entities, testing_entities, to_move, move_id_mask = _prepare_cleanup(training, testing)
+        move_id_mask = _prepare_cleanup(training, testing)
 
     return training, testing
 
 
-def _prepare_cleanup(training: np.ndarray, testing: np.ndarray):
-    training_entities = _get_unique(training)
-    testing_entities = _get_unique(testing)
-    to_move = testing_entities[~np.isin(testing_entities, training_entities)]
-    move_id_mask = np.isin(testing[:, [0, 2]], to_move).any(axis=1)
-    return training_entities, testing_entities, to_move, move_id_mask
+def _prepare_cleanup(training: np.ndarray, testing: np.ndarray) -> np.ndarray:
+    to_move_mask = None
+    for col in [[0, 2], 1]:
+        training_ids, test_ids = [np.unique(triples[:, col]) for triples in [training, testing]]
+        to_move = test_ids[~np.isin(test_ids, training_ids)]
+        this_to_move_mask = np.isin(testing[:, col], to_move)
+        if this_to_move_mask.ndim > 1:
+            this_to_move_mask = this_to_move_mask.any(axis=1)
+        if to_move_mask is None:
+            to_move_mask = this_to_move_mask
+        else:
+            to_move_mask = this_to_move_mask | to_move_mask
 
-
-def _get_unique(x):
-    return np.unique(x[:, [0, 2]])
+    return to_move_mask

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -441,6 +441,7 @@ class TriplesFactory:
                 triples=triples,
                 entity_to_id=self.entity_to_id,
                 relation_to_id=self.relation_to_id,
+                compact_id=False,
             )
             for triples in triples_groups
         ]

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -439,8 +439,8 @@ class TriplesFactory:
         return [
             TriplesFactory(
                 triples=triples,
-                entity_to_id=deepcopy(self.entity_to_id),
-                relation_to_id=deepcopy(self.relation_to_id),
+                entity_to_id=self.entity_to_id,
+                relation_to_id=self.relation_to_id,
             )
             for triples in triples_groups
         ]

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -431,8 +431,8 @@ class TriplesFactory:
         return [
             TriplesFactory(
                 triples=triples,
-                entity_to_id=deepcopy(self.entity_to_id),
-                relation_to_id=deepcopy(self.relation_to_id),
+                entity_to_id=self.entity_to_id,
+                relation_to_id=self.relation_to_id,
                 compact_id=False,
             )
             for triples in triples_groups

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -433,7 +433,6 @@ class TriplesFactory:
                 triples=triples,
                 entity_to_id=self.entity_to_id,
                 relation_to_id=self.relation_to_id,
-                compact_id=False,
             )
             for triples in triples_groups
         ]

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -431,8 +431,8 @@ class TriplesFactory:
         return [
             TriplesFactory(
                 triples=triples,
-                entity_to_id=self.entity_to_id,
-                relation_to_id=self.relation_to_id,
+                entity_to_id=deepcopy(self.entity_to_id),
+                relation_to_id=deepcopy(self.relation_to_id),
             )
             for triples in triples_groups
         ]

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -433,6 +433,7 @@ class TriplesFactory:
                 triples=triples,
                 entity_to_id=deepcopy(self.entity_to_id),
                 relation_to_id=deepcopy(self.relation_to_id),
+                compact_id=False,
             )
             for triples in triples_groups
         ]

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -128,30 +128,49 @@ class TestSplit(unittest.TestCase):
         self.triples_factory = Nations().training
         self.assertEqual(1592, self.triples_factory.num_triples)
 
+    def _test_invariants(self, training_triples_factory: TriplesFactory, *other_factories: TriplesFactory) -> None:
+        """Test invariants for result of triples factory splitting."""
+        # verify that all entities and relations are present in the training factory
+        assert training_triples_factory.num_entities == self.triples_factory.num_entities
+        assert training_triples_factory.num_relations == self.triples_factory.num_relations
+
+        all_factories = (training_triples_factory,) + other_factories
+
+        # verify that no triple got lost
+        self.assertEqual(sum(t.num_triples for t in all_factories), self.triples_factory.num_triples)
+
+        # verify that the label-to-id mappings match
+        self.assertSetEqual({
+            id(factory.entity_to_id)
+            for factory in all_factories
+        }, {
+            id(self.triples_factory.entity_to_id)
+        })
+        self.assertSetEqual({
+            id(factory.relation_to_id)
+            for factory in all_factories
+        }, {
+            id(self.triples_factory.relation_to_id)
+        })
+
     def test_split_naive(self):
         """Test splitting a factory in two with a given ratio."""
         ratio = 0.8
         train_triples_factory, test_triples_factory = self.triples_factory.split(ratio)
-        expected_train_triples = int(self.triples_factory.num_triples * ratio)
-        self.assertEqual(expected_train_triples, train_triples_factory.num_triples)
-        self.assertEqual(self.triples_factory.num_triples - expected_train_triples, test_triples_factory.num_triples)
+        self._test_invariants(train_triples_factory, test_triples_factory)
 
     def test_split_multi(self):
         """Test splitting a factory in three."""
-        ratios = r0, r1 = 0.80, 0.10
+        ratios = 0.80, 0.10
         t0, t1, t2 = self.triples_factory.split(ratios)
-        expected_0_triples = int(self.triples_factory.num_triples * r0)
-        expected_1_triples = int(self.triples_factory.num_triples * r1)
-        expected_2_triples = self.triples_factory.num_triples - expected_0_triples - expected_1_triples
-        self.assertEqual(expected_0_triples, t0.num_triples)
-        self.assertEqual(expected_1_triples, t1.num_triples)
-        self.assertEqual(expected_2_triples, t2.num_triples)
+        self._test_invariants(t0, t1, t2)
 
     def test_cleanup_deterministic(self):
         """Test that triples in a test set can get moved properly to the training set."""
         training = np.array([
             [1, 1000, 2],
             [1, 1000, 3],
+            [1, 1001, 3],
         ])
         testing = np.array([
             [2, 1001, 3],
@@ -160,6 +179,7 @@ class TestSplit(unittest.TestCase):
         expected_training = [
             [1, 1000, 2],
             [1, 1000, 3],
+            [1, 1001, 3],
             [1, 1002, 4],
         ]
         expected_testing = [
@@ -181,37 +201,44 @@ class TestSplit(unittest.TestCase):
             [1, 1000, 3],
         ])
         testing = np.array([
-            [2, 1001, 3],
-            [1, 1002, 4],
-            [1, 1003, 4],
+            [2, 1000, 3],
+            [1, 1000, 4],
+            [1, 1000, 4],
+            [1, 1001, 3],
         ])
-        expected_training_1 = [
-            [1, 1000, 2],
-            [1, 1000, 3],
-            [1, 1002, 4],
-        ]
-        expected_testing_1 = [
-            [2, 1001, 3],
-            [1, 1003, 4],
+        expected_training_1 = {
+            (1, 1000, 2),
+            (1, 1000, 3),
+            (1, 1000, 4),
+            (1, 1001, 3),
+        }
+        expected_testing_1 = {
+            (2, 1000, 3),
+            (1, 1000, 4),
+        }
+
+        expected_training_2 = {
+            (1, 1000, 2),
+            (1, 1000, 3),
+            (1, 1000, 4),
+            (1, 1001, 3),
+        }
+        expected_testing_2 = {
+            (2, 1000, 3),
+            (1, 1000, 4),
+        }
+
+        new_training, new_testing = [
+            set(tuple(row) for row in arr.tolist())
+            for arr in _tf_cleanup_randomized(training, testing)
         ]
 
-        expected_training_2 = [
-            [1, 1000, 2],
-            [1, 1000, 3],
-            [1, 1003, 4],
-        ]
-        expected_testing_2 = [
-            [2, 1001, 3],
-            [1, 1002, 4],
-        ]
-
-        new_training, new_testing = _tf_cleanup_randomized(training, testing)
-
-        if expected_training_1 == new_training.tolist():
-            self.assertEqual(expected_testing_1, new_testing.tolist())
-        elif expected_training_2 == new_training.tolist():
-            self.assertEqual(expected_testing_2, new_testing.tolist())
+        if expected_training_1 == new_training:
+            self.assertEqual(expected_testing_1, new_testing)
+        elif expected_training_2 == new_training:
+            self.assertEqual(expected_testing_2, new_testing)
         else:
+            print(new_testing, new_training)
             self.fail('training was not correct')
 
 

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -203,7 +203,7 @@ class TestSplit(unittest.TestCase):
         testing = np.array([
             [2, 1000, 3],
             [1, 1000, 4],
-            [1, 1000, 4],
+            [2, 1000, 4],
             [1, 1001, 3],
         ])
         expected_training_1 = {
@@ -214,13 +214,13 @@ class TestSplit(unittest.TestCase):
         }
         expected_testing_1 = {
             (2, 1000, 3),
-            (1, 1000, 4),
+            (2, 1000, 4),
         }
 
         expected_training_2 = {
             (1, 1000, 2),
             (1, 1000, 3),
-            (1, 1000, 4),
+            (2, 1000, 4),
             (1, 1001, 3),
         }
         expected_testing_2 = {

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -238,7 +238,6 @@ class TestSplit(unittest.TestCase):
         elif expected_training_2 == new_training:
             self.assertEqual(expected_testing_2, new_testing)
         else:
-            print(new_testing, new_training)
             self.fail('training was not correct')
 
 


### PR DESCRIPTION
Fix not providing `compact_id=False` to triples factories with dependent label-to-id mappings

Closes #58 