### PR TITLE
Generalize specification of tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ in ``pykeen``.
 | Mean Reciprocal Rank    | The mean over all reciprocal ranks: mean_i (1/r_i). Higher is better.                                              | rankbased   | `pykeen.evaluation.RankBasedMetricResults` |
 | Roc Auc Score           | The area under the ROC curve between [0.0, 1.0]. Higher is better.                                                 | sklearn     | `pykeen.evaluation.SklearnMetricResults`   |
 
+### Trackers (1)
+
+| Name   | Reference                             | Description           |
+|--------|---------------------------------------|-----------------------|
+| mlflow | `pykeen.trackers.MLFlowResultTracker` | A tracker for MLFlow. |
+
 ## Hyper-parameter Optimization
 
 ### Samplers (3)

--- a/docs/source/tutorial/using_mlflow.rst
+++ b/docs/source/tutorial/using_mlflow.rst
@@ -19,8 +19,11 @@ This example shows using MLflow with the :func:`pykeen.pipeline.pipeline` functi
     results = pipeline(
         model='RotatE',
         dataset='Kinships',
-        mlflow_tracking_uri='http://localhost:5000',
-        mlflow_experiment_name='Tutorial Training of RotatE on Kinships',
+        result_tracker='mlflow'
+        result_tracker_kwargs=dict(
+            tracking_uri='http://localhost:5000',
+            experiment_name='Tutorial Training of RotatE on Kinships',
+        ),
     )
 
 If you navigate to the MLflow UI at http://localhost:5000, you'll see the experiment appeared
@@ -45,8 +48,11 @@ This example shows using MLflow with the :func:`pykeen.hpo.hpo_pipeline` functio
     results = hpo_pipeline(
         model='RotatE',
         dataset='Kinships',
-        mlflow_tracking_uri='http://localhost:5000',
-        mlflow_experiment_name='Tutorial HPO Training of RotatE on Kinships',
+        result_tracker='mlflow'
+        result_tracker_kwargs=dict(
+            tracking_uri='http://localhost:5000',
+            experiment_name='Tutorial HPO Training of RotatE on Kinships',
+        ),
     )
 
 The same navigation through MLflow can be done for this example.
@@ -54,8 +60,8 @@ The same navigation through MLflow can be done for this example.
 Reusing Experiments
 -------------------
 In the MLflow UI, you'll see that experiments are assigned an ID. This means you can re-use the same ID to group
-different sub-experiments together using the ``mlflow_experiment_id`` keyword argument instead of
-``mlflow_experiment_name``.
+different sub-experiments together using the ``experiment_id`` keyword argument instead of
+``experiment_name``.
 
 .. code-block:: python
 
@@ -65,6 +71,12 @@ different sub-experiments together using the ``mlflow_experiment_id`` keyword ar
     results = pipeline(
         model='RotatE',
         dataset='Kinships',
-        mlflow_tracking_uri='http://localhost:5000',
-        mlflow_experiment_id=4,
+        result_tracker='mlflow'
+        result_tracker_kwargs=dict(
+            tracking_uri='http://localhost:5000',
+            experiment_id=4,
+        ),
     )
+
+Additional documentation of the valid keyword arguments can be found
+under :class:`pykeen.trackers.MLFlowResultTracker`.

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -35,6 +35,7 @@ from .optimizers import optimizers as optimizers_dict
 from .regularizers import regularizers as regularizers_dict
 from .sampling import negative_samplers as negative_samplers_dict
 from .stoppers import stoppers as stoppers_dict
+from .trackers import trackers as trackers_dict
 from .training import training_loops as training_dict
 from .triples.utils import EXTENSION_IMPORTERS, PREFIX_IMPORTERS
 from .utils import get_until_first_blank
@@ -281,6 +282,22 @@ def _help_metrics(tablefmt):
 
 @ls.command()
 @tablefmt_option
+def trackers(tablefmt: str):
+    """List trackers."""
+    click.echo(_help_trackers(tablefmt))
+
+
+def _help_trackers(tablefmt):
+    lines = _get_lines(trackers_dict, tablefmt, 'trackers')
+    return tabulate(
+        lines,
+        headers=['Name', 'Reference', 'Description'],
+        tablefmt=tablefmt,
+    )
+
+
+@ls.command()
+@tablefmt_option
 def hpo_samplers(tablefmt: str):
     """List HPO samplers."""
     click.echo(_help_hpo_samplers(tablefmt))
@@ -388,6 +405,8 @@ def get_readme() -> str:
         n_evaluators=len(evaluators_dict),
         metrics=_help_metrics(tablefmt),
         n_metrics=len(get_metric_list()),
+        trackers=_help_trackers(tablefmt),
+        n_trackers=len(trackers_dict),
         hpo_samplers=_help_hpo_samplers(tablefmt),
         n_hpo_samplers=len(hpo_samplers_dict),
     )

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -28,6 +28,7 @@ from ..pipeline import pipeline, replicate_pipeline_from_config
 from ..regularizers import Regularizer, get_regularizer_cls
 from ..sampling import NegativeSampler, get_negative_sampler_cls
 from ..stoppers import EarlyStopper, Stopper, get_stopper_cls
+from ..trackers import ResultTracker, get_result_tracker_cls
 from ..training import SLCWATrainingLoop, TrainingLoop, get_training_loop_cls
 from ..triples import TriplesFactory
 from ..utils import (
@@ -59,6 +60,7 @@ class Objective:
     optimizer: Type[Optimizer]  # 5.
     training_loop: Type[TrainingLoop]  # 6.
     evaluator: Type[Evaluator]  # 8.
+    result_tracker: Type[ResultTracker]  # 9.
 
     # 1. Dataset
     dataset_kwargs: Optional[Mapping[str, Any]] = None
@@ -89,10 +91,8 @@ class Objective:
     # 8. Evaluation
     evaluator_kwargs: Optional[Mapping[str, Any]] = None
     evaluation_kwargs: Optional[Mapping[str, Any]] = None
-    # 9. MLFlow
-    mlflow_tracking_uri: Optional[str] = None
-    mlflow_experiment_id: Optional[int] = None
-    mlflow_experiment_name: Optional[str] = None
+    # 9. Trackers
+    result_tracker_kwargs: Optional[Mapping[str, Any]] = None
     # Misc.
     metric: str = None
     device: Union[None, str, torch.device] = None
@@ -214,10 +214,9 @@ class Objective:
                 evaluator=self.evaluator,
                 evaluator_kwargs=self.evaluator_kwargs,
                 evaluation_kwargs=self.evaluation_kwargs,
-                # 9. MLFlow
-                mlflow_tracking_uri=self.mlflow_tracking_uri,
-                mlflow_experiment_id=self.mlflow_experiment_id,
-                mlflow_experiment_name=self.mlflow_experiment_name,
+                # 9. Tracker
+                result_tracker=self.result_tracker,
+                result_tracker_kwargs=self.result_tracker_kwargs,
                 # Misc.
                 use_testing_data=False,  # use validation set during HPO!
                 device=self.device,
@@ -440,10 +439,9 @@ def hpo_pipeline(
     evaluator_kwargs: Optional[Mapping[str, Any]] = None,
     evaluation_kwargs: Optional[Mapping[str, Any]] = None,
     metric: Optional[str] = None,
-    # MLFlow
-    mlflow_tracking_uri: Optional[str] = None,
-    mlflow_experiment_id: Optional[int] = None,
-    mlflow_experiment_name: Optional[str] = None,
+    # 9. Tracking
+    result_tracker: Union[None, str, Type[ResultTracker]] = None,
+    result_tracker_kwargs: Optional[Mapping[str, Any]] = None,
     # 6. Misc
     device: Union[None, str, torch.device] = None,
     #  Optuna Study Settings
@@ -537,14 +535,10 @@ def hpo_pipeline(
     :param evaluation_kwargs:
         Keyword arguments to pass to the evaluator's evaluate function on call
 
-    :param mlflow_tracking_uri:
-        The MLFlow tracking URL. If None is given, MLFlow is not used to track results.
-    :param mlflow_experiment_id:
-        The experiment ID. If given, this has to be the ID of an existing experiment in MFLow. Has priority over
-        experiment_name. Only effective if mlflow_tracking_uri is not None.
-    :param mlflow_experiment_name:
-        The experiment name. If this experiment name exists, add the current run to this experiment. Otherwise
-        create an experiment of the given name. Only effective if mlflow_tracking_uri is not None.
+    :param result_tracker:
+        The ResultsTracker class or name
+    :param result_tracker_kwargs:
+        The keyword arguments passed to the results tracker on instantiation
 
     :param metric:
         The metric to optimize over. Defaults to ``adjusted_mean_rank``.
@@ -628,6 +622,9 @@ def hpo_pipeline(
     study.set_user_attr('metric', metric)
     logger.info(f'Attempting to {direction} {metric}')
 
+    # 9. Tracking
+    result_tracker: Type[ResultTracker] = get_result_tracker_cls(result_tracker)
+
     objective = Objective(
         # 1. Dataset
         dataset=dataset,
@@ -665,10 +662,9 @@ def hpo_pipeline(
         evaluator=evaluator,
         evaluator_kwargs=evaluator_kwargs,
         evaluation_kwargs=evaluation_kwargs,
-        # 9. MLFlow
-        mlflow_tracking_uri=mlflow_tracking_uri,
-        mlflow_experiment_id=mlflow_experiment_id,
-        mlflow_experiment_name=mlflow_experiment_name,
+        # 9. Tracker
+        result_tracker=result_tracker,
+        result_tracker_kwargs=result_tracker_kwargs,
         # Optuna Misc.
         metric=metric,
         save_model_directory=save_model_directory,

--- a/src/pykeen/models/cli/builders.py
+++ b/src/pykeen/models/cli/builders.py
@@ -142,6 +142,15 @@ def build_cli_from_cls(model: Type[Model]) -> click.Command:  # noqa: D202
         )
         from ...pipeline import pipeline
 
+        if mlflow_tracking_uri:
+            result_tracker = 'mlflow'
+            result_tracker_kwargs = {
+                'tracking_uri': mlflow_tracking_uri
+            }
+        else:
+            result_tracker = None
+            result_tracker_kwargs = None
+
         pipeline_result = pipeline(
             device=device,
             model=model,
@@ -163,7 +172,8 @@ def build_cli_from_cls(model: Type[Model]) -> click.Command:  # noqa: D202
                 num_workers=num_workers,
             ),
             stopper=stopper,
-            mlflow_tracking_uri=mlflow_tracking_uri,
+            result_tracker=result_tracker,
+            result_tracker_kwargs=result_tracker_kwargs,
             metadata=dict(
                 title=title,
             ),

--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -187,7 +187,7 @@ from .optimizers import get_optimizer_cls
 from .regularizers import Regularizer, get_regularizer_cls
 from .sampling import NegativeSampler, get_negative_sampler_cls
 from .stoppers import EarlyStopper, Stopper, get_stopper_cls
-from .trackers import MLFlowResultTracker, ResultTracker
+from .trackers import ResultTracker, get_result_tracker_cls
 from .training import SLCWATrainingLoop, TrainingLoop, get_training_loop_cls
 from .triples import TriplesFactory
 from .utils import (
@@ -556,10 +556,9 @@ def pipeline(  # noqa: C901
     evaluator: Union[None, str, Type[Evaluator]] = None,
     evaluator_kwargs: Optional[Mapping[str, Any]] = None,
     evaluation_kwargs: Optional[Mapping[str, Any]] = None,
-    # 9. MLFlow
-    mlflow_tracking_uri: Optional[str] = None,
-    mlflow_experiment_id: Optional[int] = None,
-    mlflow_experiment_name: Optional[str] = None,
+    # 9. Tracking
+    result_tracker: Union[None, str, Type[ResultTracker]] = None,
+    result_tracker_kwargs: Optional[Mapping[str, Any]] = None,
     # Misc
     metadata: Optional[Dict[str, Any]] = None,
     device: Union[None, str, torch.device] = None,
@@ -628,14 +627,10 @@ def pipeline(  # noqa: C901
     :param evaluation_kwargs:
         Keyword arguments to pass to the evaluator's evaluate function on call
 
-    :param mlflow_tracking_uri:
-        The MLFlow tracking URL. If None is given, MLFlow is not used to track results.
-    :param mlflow_experiment_id:
-        The experiment ID. If given, this has to be the ID of an existing experiment in MFLow. Has priority over
-        experiment_name. Only effective if mlflow_tracking_uri is not None.
-    :param mlflow_experiment_name:
-        The experiment name. If this experiment name exists, add the current run to this experiment. Otherwise
-        create an experiment of the given name. Only effective if mlflow_tracking_uri is not None.
+    :param result_tracker:
+        The ResultsTracker class or name
+    :param result_tracker_kwargs:
+        The keyword arguments passed to the results tracker on instantiation
 
     :param metadata: A JSON dictionary to store with the experiment
     :param use_testing_data: If true, use the testing triples. Otherwise, use the validation triples.
@@ -646,15 +641,8 @@ def pipeline(  # noqa: C901
         logger.warning(f'No random seed is specified. Setting to {random_seed}.')
     set_random_seed(random_seed)
 
-    # Create result store
-    if mlflow_tracking_uri is not None:
-        result_tracker = MLFlowResultTracker(
-            tracking_uri=mlflow_tracking_uri,
-            experiment_id=mlflow_experiment_id,
-            experiment_name=mlflow_experiment_name,
-        )
-    else:
-        result_tracker = ResultTracker()
+    result_tracker: Type[ResultTracker] = get_result_tracker_cls(result_tracker)
+    result_tracker = result_tracker(**(result_tracker_kwargs or {}))
 
     if not metadata:
         metadata = {}

--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -489,32 +489,27 @@ def save_pipeline_results_to_directory(
 
 def pipeline_from_path(
     path: str,
-    mlflow_tracking_uri: Optional[str] = None,
     **kwargs,
 ) -> PipelineResult:
     """Run the pipeline with configuration in a JSON file at the given path.
 
     :param path: The path to an experiment JSON file
-    :param mlflow_tracking_uri: The URL of the MLFlow tracking server. If None, do not use MLFlow for result tracking.
     """
     with open(path) as file:
         config = json.load(file)
     return pipeline_from_config(
         config=config,
-        mlflow_tracking_uri=mlflow_tracking_uri,
         **kwargs,
     )
 
 
 def pipeline_from_config(
     config: Mapping[str, Any],
-    mlflow_tracking_uri: Optional[str] = None,
     **kwargs,
 ) -> PipelineResult:
     """Run the pipeline with a configuration dictionary.
 
     :param config: The experiment configuration dictionary
-    :param mlflow_tracking_uri: The URL of the MLFlow tracking server. If None, do not use MLFlow for result tracking.
     """
     metadata, pipeline_kwargs = config['metadata'], config['pipeline']
     title = metadata.get('title')
@@ -522,7 +517,6 @@ def pipeline_from_config(
         logger.info(f'Running: {title}')
 
     return pipeline(
-        mlflow_tracking_uri=mlflow_tracking_uri,
         metadata=metadata,
         **pipeline_kwargs,
         **kwargs,

--- a/src/pykeen/templates/README.md
+++ b/src/pykeen/templates/README.md
@@ -149,6 +149,10 @@ in ``pykeen``.
 
 {{ metrics }}
 
+### Trackers ({{ n_trackers }})
+
+{{ trackers }}
+
 ## Hyper-parameter Optimization
 
 ### Samplers ({{ n_hpo_samplers }})

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -2,11 +2,12 @@
 
 """Result trackers in PyKEEN."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional, Type, Union
 
-from .utils import flatten_dictionary
+from .utils import flatten_dictionary, get_cls, normalize_string
 
 __all__ = [
+    'get_result_tracker_cls',
     'ResultTracker',
     'MLFlowResultTracker',
 ]
@@ -85,3 +86,20 @@ class MLFlowResultTracker(ResultTracker):
 
     def end_run(self) -> None:  # noqa: D102
         self.mlflow.end_run()
+
+
+#: A mapping of trackers' names to their implementations
+trackers: Mapping[str, Type[ResultTracker]] = {
+    normalize_string(tracker.__name__, suffix='ResultTracker'): tracker
+    for tracker in ResultTracker.__subclasses__()
+}
+
+
+def get_result_tracker_cls(query: Union[None, str, Type[ResultTracker]]) -> Type[ResultTracker]:
+    """Get the tracker class."""
+    return get_cls(
+        query,
+        base=ResultTracker,
+        lookup_dict=trackers,
+        default=ResultTracker,
+    )


### PR DESCRIPTION
This PR generalizes the way that the tracker is specified such that the `pipeline()` and `hpo_pipeline()` can remain agnostic. Before, there were several MLflow-specific arguments, and now they can be specified dynamically based on what trackers are implemented.

This PR also updates all of the relevant docs. I would suggest we finish this PR before accepting #68 to reduce the burden of making design choices on @migalkin. I will then help make sure that #68 conforms properly

This PR also adds the list of implemented trackers to the README, which will get auto-updated for future ones :)