### PR TITLE
Use number of epochs as tracking step

### DIFF
--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -107,7 +107,7 @@ class Objective:
 
         def _stopped_callback(early_stopper: EarlyStopper, result: Union[float, int]) -> None:
             trial.set_user_attr(STOPPED_EPOCH_KEY, early_stopper.current_epoch)
-            trial.report(result, early_stopper.current_epoch)  # don't include a step because it's over
+            trial.report(result, early_stopper.current_epoch)
 
         for key, callback in zip(('continue_callbacks', 'stopped_callbacks'), (_continue_callback, _stopped_callback)):
             stopper_kwargs.setdefault(key, []).append(callback)

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -102,12 +102,12 @@ class Objective:
     def _update_stopper_callbacks(stopper_kwargs: Dict[str, Any], trial: Trial) -> None:
         """Make a subclass of the EarlyStopper that reports to the trial."""
 
-        def _continue_callback(early_stopper: EarlyStopper, result: Union[float, int]) -> None:
-            trial.report(result, step=early_stopper.current_epoch)
+        def _continue_callback(early_stopper: EarlyStopper, result: Union[float, int], epoch: int) -> None:
+            trial.report(result, step=epoch)
 
-        def _stopped_callback(early_stopper: EarlyStopper, result: Union[float, int]) -> None:
-            trial.set_user_attr(STOPPED_EPOCH_KEY, early_stopper.current_epoch)
-            trial.report(result, early_stopper.current_epoch)
+        def _stopped_callback(early_stopper: EarlyStopper, result: Union[float, int], epoch: int) -> None:
+            trial.set_user_attr(STOPPED_EPOCH_KEY, epoch)
+            trial.report(result, epoch)
 
         for key, callback in zip(('continue_callbacks', 'stopped_callbacks'), (_continue_callback, _stopped_callback)):
             stopper_kwargs.setdefault(key, []).append(callback)

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -107,7 +107,7 @@ class Objective:
 
         def _stopped_callback(early_stopper: EarlyStopper, result: Union[float, int], epoch: int) -> None:
             trial.set_user_attr(STOPPED_EPOCH_KEY, epoch)
-            trial.report(result, epoch)
+            trial.report(result, step=epoch)
 
         for key, callback in zip(('continue_callbacks', 'stopped_callbacks'), (_continue_callback, _stopped_callback)):
             stopper_kwargs.setdefault(key, []).append(callback)

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -103,13 +103,11 @@ class Objective:
         """Make a subclass of the EarlyStopper that reports to the trial."""
 
         def _continue_callback(early_stopper: EarlyStopper, result: Union[float, int]) -> None:
-            last_epoch = early_stopper.number_results * early_stopper.frequency
-            trial.report(result, step=last_epoch)
+            trial.report(result, step=early_stopper.current_epoch)
 
         def _stopped_callback(early_stopper: EarlyStopper, result: Union[float, int]) -> None:
-            current_epoch = (1 + early_stopper.number_results) * early_stopper.frequency
-            trial.set_user_attr(STOPPED_EPOCH_KEY, int(current_epoch))
-            trial.report(result, current_epoch)  # don't include a step because it's over
+            trial.set_user_attr(STOPPED_EPOCH_KEY, early_stopper.current_epoch)
+            trial.report(result, early_stopper.current_epoch)  # don't include a step because it's over
 
         for key, callback in zip(('continue_callbacks', 'stopped_callbacks'), (_continue_callback, _stopped_callback)):
             stopper_kwargs.setdefault(key, []).append(callback)

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -62,7 +62,7 @@ def larger_than_any_buffer_element(buffer: numpy.ndarray, result: float, delta: 
     return result > baseline
 
 
-StopperCallback = Callable[[Stopper, Union[int, float]], None]
+StopperCallback = Callable[[Stopper, Union[int, float], int], None]
 
 
 @fix_dataclass_init_docs

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -76,8 +76,6 @@ class EarlyStopper(Stopper):
     evaluator: Evaluator
     #: The triples to use for evaluation
     evaluation_triples_factory: Optional[TriplesFactory]
-    #: Current epoch
-    current_epoch: Optional[int] = None
     #: Size of the evaluation batches
     evaluation_batch_size: Optional[int] = None
     #: Slice size of the evaluation batches

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -165,7 +165,7 @@ class EarlyStopper(Stopper):
             if not self.improvement_criterion(buffer=self.buffer, result=result, delta=self.delta):
                 logger.info(f'Stopping early after {self.number_evaluations} evaluations with {self.metric}={result}')
                 for stopped_callback in self.stopped_callbacks:
-                    stopped_callback(self, result,epoch)
+                    stopped_callback(self, result, epoch)
                 self.stopped = True
                 return True
 

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -152,7 +152,7 @@ class EarlyStopper(Stopper):
 
         self.result_tracker.log_metrics(
             metrics=metric_results.to_flat_dict(),
-            step=self.number_evaluations,
+            step=(self.number_evaluations * self.frequency) + 1,
             prefix='validation',
         )
         result = metric_results.get_metric(self.metric)

--- a/src/pykeen/stoppers/stopper.py
+++ b/src/pykeen/stoppers/stopper.py
@@ -21,7 +21,7 @@ class Stopper(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def should_stop(self) -> bool:
+    def should_stop(self, epoch: int) -> bool:
         """Validate on validation set and check for termination condition."""
         raise NotImplementedError
 
@@ -33,6 +33,6 @@ class NopStopper(Stopper):
         """Return false; should never evaluate."""
         return False
 
-    def should_stop(self) -> bool:
+    def should_stop(self, epoch: int) -> bool:
         """Return false; should never stop."""
         return False

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -121,7 +121,7 @@ class WANDBResultTracker(ResultTracker):
         prefix: Optional[str] = None,
     ) -> None:  # noqa: D102
         metrics = flatten_dictionary(dictionary=metrics, prefix=prefix)
-        self.wandb.log(metrics)
+        self.wandb.log(metrics, step=step)
 
     def log_params(self, params: Dict[str, Any], prefix: Optional[str] = None) -> None:  # noqa: D102
         params = flatten_dictionary(dictionary=params, prefix=prefix)

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -400,7 +400,7 @@ class TrainingLoop(ABC):
                 'prev_loss': self.losses_per_epochs[-2] if epoch > 2 else float('nan'),
             })
 
-            if stopper is not None and stopper.should_evaluate(epoch) and stopper.should_stop():
+            if stopper is not None and stopper.should_evaluate(epoch) and stopper.should_stop(epoch):
                 return self.losses_per_epochs
 
         return self.losses_per_epochs

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -179,7 +179,7 @@ class TestEarlyStopping(unittest.TestCase):
     def test_initialization(self):
         """Test warm-up phase."""
         for it in range(self.patience):
-            should_stop = self.stopper.should_stop()
+            should_stop = self.stopper.should_stop(epoch=it)
             assert self.stopper.number_evaluations == it + 1
             assert not should_stop
 
@@ -187,7 +187,7 @@ class TestEarlyStopping(unittest.TestCase):
         """Test that the mock evaluation of the early stopper always gives the right loss."""
         for stop in range(1, 1 + len(self.mock_losses)):
             # Step early stopper
-            should_stop = self.stopper.should_stop()
+            should_stop = self.stopper.should_stop(epoch=stop)
 
             if not should_stop:
                 # check storing of results
@@ -199,9 +199,9 @@ class TestEarlyStopping(unittest.TestCase):
 
     def test_should_stop(self):
         """Test that the stopper knows when to stop."""
-        for _ in range(self.stop_constant):
-            self.assertFalse(self.stopper.should_stop())
-        self.assertTrue(self.stopper.should_stop())
+        for epoch in range(self.stop_constant):
+            self.assertFalse(self.stopper.should_stop(epoch=epoch))
+        self.assertTrue(self.stopper.should_stop(epoch=epoch))
 
     def test_result_logging_with_mlflow(self):
         """Test whether the MLFLow result logger works."""
@@ -209,7 +209,7 @@ class TestEarlyStopping(unittest.TestCase):
         wrapper = LogCallWrapper()
         real_log_metrics = self.stopper.result_tracker.mlflow.log_metrics
         self.stopper.result_tracker.mlflow.log_metrics = wrapper.wrap(real_log_metrics)
-        self.stopper.should_stop()
+        self.stopper.should_stop(epoch=0)
         assert wrapper.was_called(real_log_metrics)
 
 

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -178,24 +178,24 @@ class TestEarlyStopping(unittest.TestCase):
 
     def test_initialization(self):
         """Test warm-up phase."""
-        for it in range(self.patience):
-            should_stop = self.stopper.should_stop(epoch=it)
-            assert self.stopper.number_evaluations == it + 1
+        for epoch in range(self.patience):
+            should_stop = self.stopper.should_stop(epoch=epoch)
+            assert self.stopper.number_evaluations == epoch + 1
             assert not should_stop
 
     def test_result_processing(self):
         """Test that the mock evaluation of the early stopper always gives the right loss."""
-        for stop in range(1, 1 + len(self.mock_losses)):
+        for epoch in range(1, 1 + len(self.mock_losses)):
             # Step early stopper
-            should_stop = self.stopper.should_stop(epoch=stop)
+            should_stop = self.stopper.should_stop(epoch=epoch)
 
             if not should_stop:
                 # check storing of results
-                assert self.stopper.results == self.mock_losses[:stop]
+                assert self.stopper.results == self.mock_losses[:epoch]
 
                 # check ring buffer
-                if stop >= self.patience:
-                    assert set(self.stopper.buffer) == set(self.mock_losses[stop - self.patience:stop])
+                if epoch >= self.patience:
+                    assert set(self.stopper.buffer) == set(self.mock_losses[epoch - self.patience:epoch])
 
     def test_should_stop(self):
         """Test that the stopper knows when to stop."""


### PR DESCRIPTION
Currently, we use different tracking steps when tracking the loss and the evaluation metrics.

In this PR, we:
- Track consistenly based on the current epoch. 
- Pass current epoch to early stopper
- Provide current step (epoch) to WANDB-tracker.