### PR TITLE
Simplify EarlyStopper

### DIFF
--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -102,14 +102,13 @@ class Objective:
     def _update_stopper_callbacks(stopper_kwargs: Dict[str, Any], trial: Trial) -> None:
         """Make a subclass of the EarlyStopper that reports to the trial."""
 
-        def _continue_callback(early_stopper: EarlyStopper, result: Union[float, int], epoch: int) -> None:
+        def _result_callback(_early_stopper: EarlyStopper, result: Union[float, int], epoch: int) -> None:
             trial.report(result, step=epoch)
 
-        def _stopped_callback(early_stopper: EarlyStopper, result: Union[float, int], epoch: int) -> None:
+        def _stopped_callback(_early_stopper: EarlyStopper, _result: Union[float, int], epoch: int) -> None:
             trial.set_user_attr(STOPPED_EPOCH_KEY, epoch)
-            trial.report(result, step=epoch)
 
-        for key, callback in zip(('continue_callbacks', 'stopped_callbacks'), (_continue_callback, _stopped_callback)):
+        for key, callback in zip(('result_callbacks', 'stopped_callbacks'), (_result_callback, _stopped_callback)):
             stopper_kwargs.setdefault(key, []).append(callback)
 
     def __call__(self, trial: Trial) -> Optional[float]:

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -22,7 +22,7 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-StopperCallback = Callable[[Stopper, Union[int, float]], None]
+StopperCallback = Callable[[Stopper, Union[int, float], int], None]
 
 
 def is_improvement(

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -88,8 +88,6 @@ class EarlyStopper(Stopper):
     remaining_patience: int = dataclasses.field(init=False)
     #: The metric results from all evaluations
     results: List[float] = dataclasses.field(default_factory=list, repr=False)
-    #: A counter for the ring buffer
-    number_evaluations: int = 0
     #: Whether a larger value is better, or a smaller
     larger_is_better: bool = True
     #: The result tracker
@@ -147,7 +145,6 @@ class EarlyStopper(Stopper):
 
         # Append to history
         self.results.append(result)
-        self.number_evaluations += 1
 
         # check for improvement
         if self.best_metric is None or is_improvement(
@@ -164,7 +161,7 @@ class EarlyStopper(Stopper):
 
         # Stop if the result did not improve more than delta for patience evaluations
         if self.remaining_patience <= 0:
-            logger.info(f'Stopping early after {self.number_evaluations} evaluations with {self.metric}={result}')
+            logger.info(f'Stopping early after {self.number_results} evaluations with {self.metric}={result}')
             for stopped_callback in self.stopped_callbacks:
                 stopped_callback(self, result, epoch)
             self.stopped = True

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -92,6 +92,8 @@ class EarlyStopper(Stopper):
     larger_is_better: bool = True
     #: The result tracker
     result_tracker: Optional[ResultTracker] = None
+    #: Callbacks when after results are calculated
+    result_callbacks: List[StopperCallback] = dataclasses.field(default_factory=list, repr=False)
     #: Callbacks when training gets continued
     continue_callbacks: List[StopperCallback] = dataclasses.field(default_factory=list, repr=False)
     #: Callbacks when training is stopped early
@@ -146,6 +148,9 @@ class EarlyStopper(Stopper):
         # Append to history
         self.results.append(result)
         self.number_evaluations += 1
+
+        for result_callback in self.result_callbacks:
+            result_callback(self, result, epoch)
 
         # check for improvement
         if self.best_metric is None or is_improvement(

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -80,6 +80,8 @@ class EarlyStopper(Stopper):
     delta: float = 0.005
     #: The best result so far
     best_result: Optional[float] = None
+    #: The epoch at which the best result occurred
+    best_epoch: Optional[int] = None
     #: The remaining patience
     remaining_patience: int = dataclasses.field(init=False)
     #: The metric results from all evaluations
@@ -152,9 +154,9 @@ class EarlyStopper(Stopper):
             larger_is_better=self.larger_is_better,
             absolute_delta=self.delta,
         ):
+            self.best_epoch = epoch
             self.best_result = result
             self.remaining_patience = self.patience
-            # TODO: Save best epoch
         else:
             self.remaining_patience -= 1
 

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -181,7 +181,7 @@ class EarlyStopper(Stopper):
         return dict(
             frequency=self.frequency,
             patience=self.patience,
-            delta=self.relative_delta,
+            relative_delta=self.relative_delta,
             metric=self.metric,
             larger_is_better=self.larger_is_better,
             results=self.results,

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -161,7 +161,10 @@ class EarlyStopper(Stopper):
 
         # Stop if the result did not improve more than delta for patience evaluations
         if self.remaining_patience <= 0:
-            logger.info(f'Stopping early after {self.number_results} evaluations with {self.metric}={result}')
+            logger.info(
+                f'Stopping early after {self.number_results} evaluations at epoch {epoch}. The best result '
+                f'{self.metric}={self.best_metric} occurred at epoch {self.best_epoch}.'
+            )
             for stopped_callback in self.stopped_callbacks:
                 stopped_callback(self, result, epoch)
             self.stopped = True

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -136,7 +136,7 @@ class EarlyStopper(Stopper):
 
         self.result_tracker.log_metrics(
             metrics=metric_results.to_flat_dict(),
-            step=epoch,  # TODO: Replace by number of epochs
+            step=epoch,
             prefix='validation',
         )
         result = metric_results.get_metric(self.metric)

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -78,8 +78,8 @@ class EarlyStopper(Stopper):
     patience: int = 2
     #: The name of the metric to use
     metric: str = 'hits_at_k'
-    #: The minimum improvement between two iterations
-    delta: float = 0.005
+    #: The minimum relative improvement necessary to consider it an improved result
+    relative_delta: float = 0.01
     #: The best result so far
     best_metric: Optional[float] = None
     #: The epoch at which the best result occurred
@@ -154,7 +154,7 @@ class EarlyStopper(Stopper):
             best_value=self.best_metric,
             current_value=result,
             larger_is_better=self.larger_is_better,
-            absolute_delta=self.delta,
+            relative_delta=self.relative_delta,
         ):
             self.best_epoch = epoch
             self.best_metric = result
@@ -179,7 +179,7 @@ class EarlyStopper(Stopper):
         return dict(
             frequency=self.frequency,
             patience=self.patience,
-            delta=self.delta,
+            delta=self.relative_delta,
             metric=self.metric,
             larger_is_better=self.larger_is_better,
             results=self.results,

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -30,6 +30,7 @@ def is_improvement(
     current_value: float,
     larger_is_better: bool,
     absolute_delta: float = 0.0,
+    relative_delta: float = 0.0,
 ) -> bool:
     """
     Decide whether the current value is an improvement over the best value.
@@ -42,16 +43,17 @@ def is_improvement(
         Whether a larger value is better.
     :param absolute_delta:
         A minimum absolute improvement until it is considered as an improvement.
+    :param relative_delta:
+        A minimum relative improvement until it is considered as an improvement.
 
     :return:
         Whether the current value is better.
     """
     if larger_is_better:
-        best_value = -best_value
-        current_value = -current_value
+        return current_value > (1.0 + relative_delta) * best_value + absolute_delta
 
     # now: smaller is better
-    return current_value < (best_value - absolute_delta)
+    return current_value < (1.0 - relative_delta) * best_value - absolute_delta
 
 
 @fix_dataclass_init_docs

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -7,8 +7,6 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable, List, Mapping, Optional, Union
 
-import numpy
-
 from .stopper import Stopper
 from ..evaluation import Evaluator
 from ..models.base import Model

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -79,7 +79,7 @@ class EarlyStopper(Stopper):
     #: The minimum improvement between two iterations
     delta: float = 0.005
     #: The best result so far
-    best_result: Optional[float] = None
+    best_metric: Optional[float] = None
     #: The epoch at which the best result occurred
     best_epoch: Optional[int] = None
     #: The remaining patience
@@ -148,14 +148,14 @@ class EarlyStopper(Stopper):
         self.number_evaluations += 1
 
         # check for improvement
-        if self.best_result is None or is_improvement(
-            best_value=self.best_result,
+        if self.best_metric is None or is_improvement(
+            best_value=self.best_metric,
             current_value=result,
             larger_is_better=self.larger_is_better,
             absolute_delta=self.delta,
         ):
             self.best_epoch = epoch
-            self.best_result = result
+            self.best_metric = result
             self.remaining_patience = self.patience
         else:
             self.remaining_patience -= 1
@@ -182,4 +182,6 @@ class EarlyStopper(Stopper):
             larger_is_better=self.larger_is_better,
             results=self.results,
             stopped=self.stopped,
+            best_epoch=self.best_epoch,
+            best_metric=self.best_metric,
         )

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -44,7 +44,7 @@ def is_improvement(
         A minimum absolute improvement until it is considered as an improvement.
 
     :return:
-         Whether the current value is better.
+        Whether the current value is better.
     """
     if larger_is_better:
         best_value = -best_value

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -29,7 +29,6 @@ def is_improvement(
     best_value: float,
     current_value: float,
     larger_is_better: bool,
-    absolute_delta: float = 0.0,
     relative_delta: float = 0.0,
 ) -> bool:
     """
@@ -41,8 +40,6 @@ def is_improvement(
         The current value.
     :param larger_is_better:
         Whether a larger value is better.
-    :param absolute_delta:
-        A minimum absolute improvement until it is considered as an improvement.
     :param relative_delta:
         A minimum relative improvement until it is considered as an improvement.
 
@@ -50,10 +47,10 @@ def is_improvement(
         Whether the current value is better.
     """
     if larger_is_better:
-        return current_value > (1.0 + relative_delta) * best_value + absolute_delta
+        return current_value > (1.0 + relative_delta) * best_value
 
     # now: smaller is better
-    return current_value < (1.0 - relative_delta) * best_value - absolute_delta
+    return current_value < (1.0 - relative_delta) * best_value
 
 
 @fix_dataclass_init_docs

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -199,7 +199,7 @@ class TestEarlyStopping(unittest.TestCase):
 
                 # check ring buffer
                 if epoch >= self.patience:
-                    assert self.stopper.best_result == self.best_results[epoch]
+                    assert self.stopper.best_metric == self.best_results[epoch]
 
     def test_should_stop(self):
         """Test that the stopper knows when to stop."""

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -176,7 +176,7 @@ class TestEarlyStopping(unittest.TestCase):
             evaluator=self.mock_evaluator,
             evaluation_triples_factory=nations.validation,
             patience=self.patience,
-            delta=self.delta,
+            relative_delta=self.delta,
             larger_is_better=False,
         )
 
@@ -233,7 +233,7 @@ class TestEarlyStoppingRealWorld(unittest.TestCase):
     #: The (zeroed) index  - 1 at which stopping will occur
     stop_constant: int = 4
     #: The minimum improvement
-    delta: float = 0.1
+    relative_delta: float = 0.1
     #: The random seed to use for reproducibility
     seed: int = 42
     #: The maximum number of epochs to train. Should be large enough to allow for early stopping.
@@ -260,7 +260,7 @@ class TestEarlyStoppingRealWorld(unittest.TestCase):
             evaluator=evaluator,
             evaluation_triples_factory=nations.validation,
             patience=self.patience,
-            delta=self.delta,
+            relative_delta=self.relative_delta,
             metric='mean_rank',
         )
         training_loop = SLCWATrainingLoop(

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -195,7 +195,7 @@ class TestEarlyStopping(unittest.TestCase):
 
             if not should_stop:
                 # check storing of results
-                assert self.stopper.results == self.mock_losses[:epoch]
+                assert self.stopper.results == self.mock_losses[:epoch + 1]
 
                 # check ring buffer
                 if epoch >= self.patience:

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -23,7 +23,7 @@ from pykeen.typing import MappedTriples
 
 def test_is_improvement():
     """Test is_improvement()."""
-    for best_value, current_value, larger_is_better, absolute_delta, is_better in [
+    for best_value, current_value, larger_is_better, relative_delta, is_better in [
         # equal value; larger is better
         (1.0, 1.0, True, 0.0, False),
         # equal value; smaller is better
@@ -37,7 +37,7 @@ def test_is_improvement():
             best_value=best_value,
             current_value=current_value,
             larger_is_better=larger_is_better,
-            absolute_delta=absolute_delta,
+            relative_delta=relative_delta,
         )
 
 

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -184,7 +184,6 @@ class TestEarlyStopping(unittest.TestCase):
         """Test warm-up phase."""
         for epoch in range(self.patience):
             should_stop = self.stopper.should_stop(epoch=epoch)
-            assert self.stopper.number_evaluations == epoch + 1
             assert not should_stop
 
     def test_result_processing(self):


### PR DESCRIPTION
This PR simplifies the EarlyStopper implementation, and adds a few smaller features:

* [x] Change evaluation epochs from `1, (frequency + 1), (2 * frequency + 1), ...` to `frequency, (2 * frequency), ...`
* [x] Save epoch at which we had the best result
* [x] Export best epoch and best result via `get_summary_dict`
* [x] Replace ring buffer by `remaining_patience` counter, which gets decreased every time we evaluate and do not observe an improvement. If we observe such, the counter is reset to `patience`.
* [x] Change detection of significant improvement from using an absolute delta to a relative one (which should be easier to set).

Depends on #72 