### PR TITLE
Forbid line break operator

### DIFF
--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -189,8 +189,10 @@ class PathDataSet(LazyDataSet):
         )
 
     def __repr__(self) -> str:  # noqa: D105
-        return f'{self.__class__.__name__}(training_path="{self.training_path}", testing_path="{self.testing_path}",' \
-               f' validation_path="{self.validation_path}")'
+        return (
+            f'{self.__class__.__name__}(training_path="{self.training_path}", testing_path="{self.testing_path}",'
+            f' validation_path="{self.validation_path}")'
+        )
 
 
 def _urlretrieve(url, path, clean_on_failure: bool = True) -> None:

--- a/src/pykeen/models/multimodal/distmult_literal.py
+++ b/src/pykeen/models/multimodal/distmult_literal.py
@@ -137,8 +137,11 @@ class DistMultLiteral(MultimodalModel):
         """Compute the mean ranking loss for the positive and negative scores."""
         # Choose y = -1 since a smaller score is better.
         # In TransE for example, the scores represent distances
-        assert self.compute_mr_loss, 'The chosen loss does not allow the calculation of Margin Ranking losses. ' \
-                                     'Please use the compute_label_loss method instead'
+        if not self.compute_mr_loss:
+            raise RuntimeError(
+                'The chosen loss does not allow the calculation of Margin Ranking losses. '
+                'Please use the compute_label_loss method instead'
+            )
         y = torch.ones_like(negative_scores, device=self.device) * -1
         loss = self.loss(positive_scores, negative_scores, y)
         return loss

--- a/src/pykeen/models/unimodal/conv_e.py
+++ b/src/pykeen/models/unimodal/conv_e.py
@@ -254,10 +254,11 @@ class ConvE(EntityRelationEmbeddingModel):
             self.bn0 = None
             self.bn1 = None
             self.bn2 = None
-        num_in_features = \
-            output_channels \
-            * (2 * self.embedding_height - kernel_height + 1) \
+        num_in_features = (
+            output_channels
+            * (2 * self.embedding_height - kernel_height + 1)
             * (self.embedding_width - kernel_width + 1)
+        )
         self.fc = nn.Linear(num_in_features, self.embedding_dim)
 
         # Finalize initialization

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -171,10 +171,14 @@ class LCWATrainingLoop(TrainingLoop):
         if self.model.can_slice_t:
             return
         elif supports_sub_batching:
-            report = "This model supports sub-batching, but it also requires slicing," \
-                     " which is not implemented for this model yet."
+            report = (
+                "This model supports sub-batching, but it also requires slicing,"
+                " which is not implemented for this model yet."
+            )
         else:
-            report = "This model doesn't support sub-batching and slicing is not" \
-                     " implemented for this model yet."
+            report = (
+                "This model doesn't support sub-batching and slicing is not"
+                " implemented for this model yet."
+            )
         logger.warning(report)
         raise MemoryError("The current model can't be trained on this hardware with these parameters.")

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -170,8 +170,7 @@ class SLCWATrainingLoop(TrainingLoop):
     ) -> None:  # noqa: D102
         # Slicing is not possible for sLCWA
         if supports_sub_batching:
-            report = "This model supports sub-batching, but it also requires slicing," \
-                     " which is not possible for sLCWA"
+            report = "This model supports sub-batching, but it also requires slicing, which is not possible for sLCWA"
         else:
             report = "This model doesn't support sub-batching and slicing is not possible for sLCWA"
         logger.warning(report)

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -47,8 +47,10 @@ class SubBatchingNotSupportedError(NotImplementedError):
         self.model = model
 
     def __str__(self):  # noqa: D105
-        return f'No sub-batching support for {self.model.__class__.__name__} due to modules ' \
-               f'{self.model.modules_not_supporting_sub_batching}.'
+        return (
+            f'No sub-batching support for {self.model.__class__.__name__} due to modules '
+            f'{self.model.modules_not_supporting_sub_batching}.'
+        )
 
 
 def _get_optimizer_kwargs(optimizer: Optimizer) -> Mapping[str, Any]:

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -85,8 +85,10 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         self._create_numeric_literals()
 
     def __repr__(self):  # noqa: D105
-        return f'{self.__class__.__name__}(path="{self.path}", ' \
-               f'path_to_numeric_triples="{self.path_to_numeric_triples}")'
+        return (
+            f'{self.__class__.__name__}(path="{self.path}", '
+            f'path_to_numeric_triples="{self.path_to_numeric_triples}")'
+        )
 
     def _create_numeric_literals(self) -> None:
         self.numeric_literals, self.literals_to_id = create_matrix_of_literals(

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -11,8 +11,10 @@ from torch.nn import functional
 
 from pykeen.datasets import Nations
 from pykeen.models import ConvKB, RESCAL, TransH
-from pykeen.regularizers import CombinedRegularizer, LpRegularizer, NoRegularizer, PowerSumRegularizer, Regularizer, \
-    TransHRegularizer
+from pykeen.regularizers import (
+    CombinedRegularizer, LpRegularizer, NoRegularizer, PowerSumRegularizer, Regularizer,
+    TransHRegularizer,
+)
 from pykeen.triples import TriplesFactory
 from pykeen.typing import MappedTriples
 from pykeen.utils import resolve_device

--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ deps =
     flake8-docstrings
     flake8-import-order
     flake8-bugbear
+    flake8-broken-line
     pep8-naming
     pydocstyle
 commands =


### PR DESCRIPTION
Any time a `\` might get used, there's a better alternative - for long strings you can either use a triple quoted string, or wrap the string in parentheses. For long math expressions, they can be put in parentheses and broken up by operator too.

This PR adds the [flake8-broken-line](https://github.com/sobolevn/flake8-broken-line) flake8 plugin to enforce this and provides fixes in the short number of cases where the backslash was used for line breaks.