### PR TITLE
Add HPO documentation for constrained evaluation

### DIFF
--- a/docs/source/tutorial/understanding_evaluation.rst
+++ b/docs/source/tutorial/understanding_evaluation.rst
@@ -121,4 +121,16 @@ evaluation. This can be done with the following:
 
 By restricting evaluation to the edges of interest, models more appropriate for drug repositioning can
 be identified during hyper-parameter optimization instead of models that are good at predicting all
-types of relations.
+types of relations. The HPO pipeline accepts the same arguments:
+
+.. code-block:: python
+
+    from pykeen.hpo import hpo_pipeline
+
+    evaluation_relation_whitelist = {'CtD', 'CpD'}
+    hpo_pipeline_result = hpo_pipeline(
+        n_trials=30,
+        dataset='Hetionet',
+        model='RotatE',
+        evaluation_relation_whitelist=evaluation_relation_whitelist,
+    )

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -8,7 +8,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping, Optional, Type, Union
+from typing import Any, Collection, Dict, Mapping, Optional, Type, Union
 
 import torch
 from optuna import Study, Trial, create_study
@@ -67,6 +67,8 @@ class Objective:
     training_triples_factory: Optional[TriplesFactory] = None
     testing_triples_factory: Optional[TriplesFactory] = None
     validation_triples_factory: Optional[TriplesFactory] = None
+    evaluation_entity_whitelist: Optional[Collection[str]] = None
+    evaluation_relation_whitelist: Optional[Collection[str]] = None
     # 2. Model
     model_kwargs: Optional[Mapping[str, Any]] = None
     model_kwargs_ranges: Optional[Mapping[str, Any]] = None
@@ -186,6 +188,8 @@ class Objective:
                 training_triples_factory=self.training_triples_factory,
                 testing_triples_factory=self.testing_triples_factory,
                 validation_triples_factory=self.validation_triples_factory,
+                evaluation_entity_whitelist=self.evaluation_entity_whitelist,
+                evaluation_relation_whitelist=self.evaluation_relation_whitelist,
                 # 2. Model
                 model=self.model,
                 model_kwargs=_model_kwargs,


### PR DESCRIPTION
This PR adds the constrained evaluation to the HPO pipeline and example usage, which we forgot in #62. cc @ddomingof 