### PR TITLE
Add AppVeyor CI configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,6 @@ install:
   - cmd: pip install tox
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
-  - cmd: "%cd%"
   - cmd: pip install -e .
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,12 +2,12 @@
 
 environment:
   # Appveyor machines come with miniconda already installed.
-  CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
   CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\continuous-integration\\appveyor\\run_with_env.cmd"
   matrix:
     - TARGET_ARCH: "x64"
       PYTHON_BUILD_RESTRICTIONS: "3.7*"
       CONDA_PY: "37"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.
@@ -32,7 +32,7 @@ install:
 #test_script:
 #  - "%CMD_IN_ENV% tox -e py,integration"
 test_script:
-  - "%CMD_IN_ENV% pip show pykeen tox"
+  - pip show pykeen tox
 
 
 # References:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,7 @@ install:
 #  - cmd: pip install -e .
 
 test_script:
+  - dir %CONDA_INSTALL_LOCN%\DLLs
   - python -c "import sqlite3; print(sqlite3.version)"
 #  - coverage run -p -m pytest --durations=20 tests -m slow
 #  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,16 +25,15 @@ install:
   - cmd: conda info
   - cmd: conda config --set always_yes true
   - cmd: conda install pip setuptools wheel pytest coverage sqlite
-  - cmd: pip install tox mlflow
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
-  - cmd: pip install -e .
+  - cmd: pip install -e .[mlflow,wandb]
 
 test_script:
   # We have to activate the conda environment explicitly
   - activate
-  - coverage run -p -m pytest --durations=20 tests -m slow
-  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
+  - pytest --durations=20 tests -m "not slow"
+  - pytest --durations=20 tests -m slow
 
 # References:
 # 1. https://github.com/astropy/conda-build-tools/blob/master/appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ build: off
 install:
   - "%PYTHON%\\python.exe -m pip install -U pip"
   - "%PYTHON%\\python.exe -m pip install -U --force-reinstall setuptools tox"
+  - "%PYTHON%\\python.exe -m pip install torch==1.6.0 --find-links https://download.pytorch.org/whl/torch_stable.html"
 
 test_script:
   - "%PYTHON%\\python.exe -m tox -e py,integration"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,7 @@
 environment:
   # Appveyor machines come with miniconda already installed.
   CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+  CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\continuous-integration\\appveyor\\run_with_env.cmd"
   matrix:
     - TARGET_ARCH: "x64"
       PYTHON_BUILD_RESTRICTIONS: "3.7*"
@@ -26,7 +27,7 @@ install:
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 
 test_script:
-  - "%CMD_IN_ENV% tox"
+  - "%CMD_IN_ENV% tox -e py,integration"
 
 
 # References:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,8 +27,8 @@ install:
   - cmd: conda install pip setuptools wheel pytest coverage sqlite
   - cmd: pip install tox mlflow
   - cmd: conda update --quiet conda
-#  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
-#  - cmd: pip install -e .
+  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+  - cmd: pip install -e .
 
 test_script:
   # We have to activate the conda environment explicitly

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,6 +28,8 @@ install:
   - cmd: pip install tox
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+  - cmd: %cd%
+  - cmd: pip install -e .
 
 test_script:
   - conda info

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,16 +1,32 @@
-# See: https://packaging.python.org/guides/supporting-windows-using-appveyor/
+# Configuration for AppVeyor builds
+
 environment:
+  # Appveyor machines come with miniconda already installed.
+  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
   matrix:
-    - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python37-x64"
+    - TARGET_ARCH: "x64"
+      PYTHON_BUILD_RESTRICTIONS: "3.7*"
+      CONDA_PY: "37"
+
+# We always use a 64-bit machine, but can build x86 distributions
+# with the TARGET_ARCH variable.
+platform:
+    - x64
 
 # See: https://help.appveyor.com/discussions/problems/12705-custom-build-script-script-mode
 build: off
 
 install:
-  - "%PYTHON%\\python.exe -m pip install -U pip"
-  - "%PYTHON%\\python.exe -m pip install -U --force-reinstall setuptools tox"
-  - "%PYTHON%\\python.exe -m pip install torch==1.6.0+cpu --find-links https://download.pytorch.org/whl/torch_stable.html"
+  # No need to install miniconda because appveyor comes with it.
+  - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
+  - cmd: conda config --set always_yes true
+  - cmd: conda update pip setuptools wheel tox
+  - cmd: conda update --quiet conda
+  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 
 test_script:
-  - "%PYTHON%\\python.exe -m tox -e py,integration"
+  - "%CMD_IN_ENV% tox"
+
+
+# References:
+# 1. https://github.com/astropy/conda-build-tools/blob/master/appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,7 @@ install:
   # No need to install miniconda because appveyor comes with it.
   - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
   - cmd: conda config --set always_yes true
-  - cmd: conda update pip setuptools wheel tox
+  - cmd: conda install pip setuptools wheel tox
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,8 +31,7 @@ install:
   - cmd: pip install -e .
 
 test_script:
-  - conda info
-  - pip show tox pykeen torch
+  - tox -e py,integration
 
 # References:
 # 1. https://github.com/astropy/conda-build-tools/blob/master/appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ build: off
 
 install:
   # No need to install miniconda because appveyor comes with it.
-  - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
+  - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%CONDA_INSTALL_LOCN%\DLLs;%PATH%
   # Check that we have the expected version and architecture for Python
   - cmd: python --version
   - cmd: conda info
@@ -31,8 +31,6 @@ install:
 #  - cmd: pip install -e .
 
 test_script:
-  - python -c "import sqlite3; print(sqlite3.version)"
-  - conda activate
   - python -c "import sqlite3; print(sqlite3.version)"
 #  - coverage run -p -m pytest --durations=20 tests -m slow
 #  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,8 +24,8 @@ install:
   - cmd: python --version
   - cmd: conda info
   - cmd: conda config --set always_yes true
-  - cmd: conda install pip setuptools wheel pytest coverage mlflow
-  - cmd: pip install tox
+  - cmd: conda install pip setuptools wheel pytest coverage
+  - cmd: pip install tox mlflow
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
   - cmd: pip install -e .

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ build: off
 
 install:
   # No need to install miniconda because appveyor comes with it.
-  - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%CONDA_INSTALL_LOCN%\DLLs;%PATH%
+  - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
   # Check that we have the expected version and architecture for Python
   - cmd: python --version
   - cmd: conda info

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ build: off
 install:
   - "%PYTHON%\\python.exe -m pip install -U pip"
   - "%PYTHON%\\python.exe -m pip install -U --force-reinstall setuptools tox"
-  - "%PYTHON%\\python.exe -m pip install torch==1.6.0 --find-links https://download.pytorch.org/whl/torch_stable.html"
+  - "%PYTHON%\\python.exe -m pip install torch==1.6.0+cpu --find-links https://download.pytorch.org/whl/torch_stable.html"
 
 test_script:
   - "%PYTHON%\\python.exe -m tox -e py,integration"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,14 +24,15 @@ install:
   - cmd: python --version
   - cmd: conda info
   - cmd: conda config --set always_yes true
-  - cmd: conda install pip setuptools wheel
+  - cmd: conda install pip setuptools wheel pytest coverage mlflow
   - cmd: pip install tox
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
   - cmd: pip install -e .
 
 test_script:
-  - tox -e py,integration
+  - coverage run -p -m pytest --durations=20 tests -m slow
+  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
 
 # References:
 # 1. https://github.com/astropy/conda-build-tools/blob/master/appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,8 @@ build: off
 install:
   # No need to install miniconda because appveyor comes with it.
   - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
+  # Check that we have the expected version and architecture for Python
+  - cmd: python --version"
   - cmd: conda config --set always_yes true
   - cmd: conda install pip setuptools wheel
   - cmd: pip install tox

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ install:
   - cmd: python --version
   - cmd: conda info
   - cmd: conda config --set always_yes true
-  - cmd: conda install pip setuptools wheel pytest coverage
+  - cmd: conda install pip setuptools wheel pytest coverage sqlite
   - cmd: pip install tox mlflow
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ install:
   - cmd: pip install tox
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
-  - cmd: %cd%
+  - cmd: "%cd%"
   - cmd: pip install -e .
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,8 +31,9 @@ install:
 #  - cmd: pip install -e .
 
 test_script:
-  - conda env list
-  - pip show sqlite3
+  - python -c "import sqlite3; print(sqlite3.version)"
+  - conda activate
+  - python -c "import sqlite3; print(sqlite3.version)"
 #  - coverage run -p -m pytest --durations=20 tests -m slow
 #  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,13 +31,10 @@ install:
 #  - cmd: pip install -e .
 
 test_script:
-  - echo %PATH%
+  # We have to activate the conda environment explicitly
   - activate
-  - echo %PATH%
-  - dir %CONDA_INSTALL_LOCN%\DLLs
-  - python -c "import sqlite3; print(sqlite3.version)"
-#  - coverage run -p -m pytest --durations=20 tests -m slow
-#  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
+  - coverage run -p -m pytest --durations=20 tests -m slow
+  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
 
 # References:
 # 1. https://github.com/astropy/conda-build-tools/blob/master/appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,16 +23,16 @@ install:
   # Check that we have the expected version and architecture for Python
   - cmd: python --version
   - cmd: conda info
-#  - cmd: conda config --set always_yes true
-#  - cmd: conda install pip setuptools wheel
-#  - cmd: pip install tox
-#  - cmd: conda update --quiet conda
-#  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+  - cmd: conda config --set always_yes true
+  - cmd: conda install pip setuptools wheel
+  - cmd: pip install tox
+  - cmd: conda update --quiet conda
+  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 
 #test_script:
 #  - "%CMD_IN_ENV% tox -e py,integration"
-test_script:
-  - pip show pykeen tox
+#test_script:
+#  - pip show pykeen tox
 
 
 # References:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,8 @@ install:
   # No need to install miniconda because appveyor comes with it.
   - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
   - cmd: conda config --set always_yes true
-  - cmd: conda install pip setuptools wheel tox
+  - cmd: conda install pip setuptools wheel
+  - cmd: conda install -c conda-forge tox
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 
 environment:
   # Appveyor machines come with miniconda already installed.
-  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
+  CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
   CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\continuous-integration\\appveyor\\run_with_env.cmd"
   matrix:
     - TARGET_ARCH: "x64"
@@ -21,15 +21,18 @@ install:
   # No need to install miniconda because appveyor comes with it.
   - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
   # Check that we have the expected version and architecture for Python
-  - cmd: python --version"
-  - cmd: conda config --set always_yes true
-  - cmd: conda install pip setuptools wheel
-  - cmd: pip install tox
-  - cmd: conda update --quiet conda
-  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+  - cmd: python --version
+  - cmd: conda info
+#  - cmd: conda config --set always_yes true
+#  - cmd: conda install pip setuptools wheel
+#  - cmd: pip install tox
+#  - cmd: conda update --quiet conda
+#  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 
+#test_script:
+#  - "%CMD_IN_ENV% tox -e py,integration"
 test_script:
-  - "%CMD_IN_ENV% tox -e py,integration"
+  - "%CMD_IN_ENV% pip show pykeen tox"
 
 
 # References:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,11 +29,9 @@ install:
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 
-#test_script:
-#  - "%CMD_IN_ENV% tox -e py,integration"
-#test_script:
-#  - pip show pykeen tox
-
+test_script:
+  - conda info
+  - pip show tox pykeen torch
 
 # References:
 # 1. https://github.com/astropy/conda-build-tools/blob/master/appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,9 @@ install:
 #  - cmd: pip install -e .
 
 test_script:
+  - echo %PATH%
+  - conda activate
+  - echo %PATH%
   - dir %CONDA_INSTALL_LOCN%\DLLs
   - python -c "import sqlite3; print(sqlite3.version)"
 #  - coverage run -p -m pytest --durations=20 tests -m slow

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+# See: https://packaging.python.org/guides/supporting-windows-using-appveyor/
+environment:
+  matrix:
+    - PYTHON: "C:\\Python37"
+    - PYTHON: "C:\\Python37-x64"
+
+# See: https://help.appveyor.com/discussions/problems/12705-custom-build-script-script-mode
+build: off
+
+install:
+  - "%PYTHON%\\python.exe -m pip install -U pip"
+  - "%PYTHON%\\python.exe -m pip install -U --force-reinstall setuptools tox"
+
+test_script:
+  - "%PYTHON%\\python.exe -m tox -e py,integration"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ install:
   - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
   - cmd: conda config --set always_yes true
   - cmd: conda install pip setuptools wheel
-  - cmd: conda install -c conda-forge tox
+  - cmd: pip install tox
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,12 +27,14 @@ install:
   - cmd: conda install pip setuptools wheel pytest coverage sqlite
   - cmd: pip install tox mlflow
   - cmd: conda update --quiet conda
-  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
-  - cmd: pip install -e .
+#  - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+#  - cmd: pip install -e .
 
 test_script:
-  - coverage run -p -m pytest --durations=20 tests -m slow
-  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
+  - conda env list
+  - pip show sqlite3
+#  - coverage run -p -m pytest --durations=20 tests -m slow
+#  - coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
 
 # References:
 # 1. https://github.com/astropy/conda-build-tools/blob/master/appveyor.yml

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ install:
 
 test_script:
   - echo %PATH%
-  - conda activate
+  - activate
   - echo %PATH%
   - dir %CONDA_INSTALL_LOCN%\DLLs
   - python -c "import sqlite3; print(sqlite3.version)"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ install:
   - cmd: python --version
   - cmd: conda info
   - cmd: conda config --set always_yes true
-  - cmd: conda install pip setuptools wheel pytest coverage sqlite
+  - cmd: conda install pip setuptools wheel pytest sqlite
   - cmd: conda update --quiet conda
   - cmd: conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
   - cmd: pip install -e .[mlflow,wandb]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,5 +13,5 @@ include config/config.ini
 
 global-exclude *.py[cod] __pycache__ *.so *.dylib .DS_Store *.gpickle
 
-exclude .bumpversion.cfg .coveragerc .flake8 .travis.yml .readthedocs.yml tox.ini .pre-commit-config.yaml
+exclude .appveyor.yml .bumpversion.cfg .coveragerc .flake8 .travis.yml .readthedocs.yml tox.ini .pre-commit-config.yaml
 include LICENSE *.md *.rst

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   </a>
 
   <a href="https://ci.appveyor.com/project/cthoyt/pykeen/branch/master">
-    <img src="https://ci.appveyor.com/api/projects/status/c35rlorj03h790ai/branch/master?svg=true"
+    <img src="https://ci.appveyor.com/api/projects/status/yow5ihwy3yigsv5c/branch/master?svg=true"
          alt="AppVeyor">
   </a>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
          alt="Travis CI">
   </a>
 
-  <a href="https://ci.appveyor.com/project/cthoyt/pykeen/branch/master">
+  <a href="https://ci.appveyor.com/project/lvermue/pykeen/branch/master">
     <img src="https://ci.appveyor.com/api/projects/status/yow5ihwy3yigsv5c/branch/master?svg=true"
          alt="AppVeyor">
   </a>

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ source on [GitHub](https://github.com/pykeen/pykeen) with:
 pip install git+https://github.com/pykeen/pykeen.git
 ```
 
-More information about installation extras can be found in the
-[installation documentation](https://pykeen.readthedocs.io/en/latest/installation.html).
+More information about installation (e.g., development mode, Windows installation, extras)
+can be found in the [installation documentation](https://pykeen.readthedocs.io/en/latest/installation.html).
 
 ## Quickstart [![Documentation Status](https://readthedocs.org/projects/pykeen/badge/?version=latest)](https://pykeen.readthedocs.io/en/latest/?badge=latest)
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
          alt="Travis CI">
   </a>
 
-  <a href="https://ci.appveyor.com/project/lvermue/pykeen/branch/master">
-    <img src="https://ci.appveyor.com/api/projects/status/yow5ihwy3yigsv5c/branch/master?svg=true"
+  <a href="https://ci.appveyor.com/project/pykeen/pykeen/branch/master">
+    <img src="https://ci.appveyor.com/api/projects/status/lwp9cfnsa8d5yx62/branch/master?svg=true"
          alt="AppVeyor">
   </a>
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
          alt="Travis CI">
   </a>
 
+  <a href="https://ci.appveyor.com/project/cthoyt/pykeen/branch/master">
+    <img src="https://ci.appveyor.com/api/projects/status/c35rlorj03h790ai/branch/master?svg=true"
+         alt="AppVeyor">
+  </a>
+
   <a href='https://opensource.org/licenses/MIT'>
     <img src='https://img.shields.io/badge/License-MIT-blue.svg' alt='License'/>
   </a>

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,5 +1,7 @@
 Installation
 ============
+Linux and Mac Users
+-------------------
 The latest stable version of PyKEEN can be downloaded and installed from
 `PyPI <https://pypi.org/project/pykeen>`_ with:
 
@@ -14,6 +16,36 @@ source on `GitHub <https://github.com/pykeen/pykeen>`_ with:
 
     $ pip install git+https://github.com/pykeen/pykeen.git
 
+Windows Users
+-------------
+We've added experimental support for Windows as of `!95 <https://github.com/pykeen/pykeen/pull/95>`_.
+However, be warned, it's much less straightforward to install PyTorch and therefore PyKEEN on Windows.
+
+First, to install PyTorch, you must install `Anaconda <https://www.anaconda.com/>`_ and follow
+the instructions on the PyTorch website. For example, if you're using CUDA version 10.2, use
+the following command:
+
+.. code-block:: bash
+
+    $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+
+Then, assuming your `python` and `pip` command are linked to the same place where conda is installing,
+you can proceed with the normal installation (or the installation from GitHub as shown above):
+
+.. code-block:: bash
+
+    $ pip install pytorch
+
+If you're having trouble with ``pip`` or ``sqlite``, you might also have to use
+``conda install pip setuptools wheel sqlite``. See our
+`AppVeyor configuration <https://github.com/pykeen/pykeen/blob/master/.appveyor.yml>`_
+on GitHub for inspiration.
+
+If you know better ways to install on Windows or would like to share some references,
+we'd really appreciate it.
+
+Development
+-----------
 Alternatively, the latest code can be installed in development mode
 with:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,8 @@ install_requires =
     click
     click_default_group
     sklearn
-    torch
+    torch; platform_system!="Windows"
+    torch -f https://download.pytorch.org/whl/torch_stable.html; platform_system=="Windows"
     tqdm
     requests
     optuna>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ install_requires =
     click_default_group
     sklearn
     torch; platform_system != "Windows"
-    https://download.pytorch.org/whl/cu102/torch-1.6.0-cp37-cp37m-win_amd64.whl; platform_system=="Windows"
     tqdm
     requests
     optuna>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,8 +56,8 @@ install_requires =
     click
     click_default_group
     sklearn
-    torch; platform_system!="Windows"
-    torch -f https://download.pytorch.org/whl/torch_stable.html; platform_system=="Windows"
+    torch; platform_system != "Windows"
+    https://download.pytorch.org/whl/cu102/torch-1.6.0-cp37-cp37m-win_amd64.whl; platform_system=="Windows"
     tqdm
     requests
     optuna>=2.0.0

--- a/src/pykeen/templates/README.md
+++ b/src/pykeen/templates/README.md
@@ -12,6 +12,11 @@
          alt="Travis CI">
   </a>
 
+  <a href="https://ci.appveyor.com/project/cthoyt/pykeen/branch/master">
+    <img src="https://ci.appveyor.com/api/projects/status/c35rlorj03h790ai/branch/master?svg=true"
+         alt="AppVeyor">
+  </a>
+
   <a href='https://opensource.org/licenses/MIT'>
     <img src='https://img.shields.io/badge/License-MIT-blue.svg' alt='License'/>
   </a>
@@ -55,8 +60,8 @@ source on [GitHub](https://github.com/pykeen/pykeen) with:
 pip install git+https://github.com/pykeen/pykeen.git
 ```
 
-More information about installation extras can be found in the
-[installation documentation](https://pykeen.readthedocs.io/en/latest/installation.html).
+More information about installation (e.g., development mode, Windows installation, extras)
+can be found in the [installation documentation](https://pykeen.readthedocs.io/en/latest/installation.html).
 
 ## Quickstart [![Documentation Status](https://readthedocs.org/projects/pykeen/badge/?version=latest)](https://pykeen.readthedocs.io/en/latest/?badge=latest)
 

--- a/src/pykeen/templates/README.md
+++ b/src/pykeen/templates/README.md
@@ -12,8 +12,8 @@
          alt="Travis CI">
   </a>
 
-  <a href="https://ci.appveyor.com/project/lvermue/pykeen/branch/master">
-    <img src="https://ci.appveyor.com/api/projects/status/yow5ihwy3yigsv5c/branch/master?svg=true"
+  <a href="https://ci.appveyor.com/project/pykeen/pykeen/branch/master">
+    <img src="https://ci.appveyor.com/api/projects/status/lwp9cfnsa8d5yx62/branch/master?svg=true"
          alt="AppVeyor">
   </a>
 

--- a/src/pykeen/templates/README.md
+++ b/src/pykeen/templates/README.md
@@ -12,8 +12,8 @@
          alt="Travis CI">
   </a>
 
-  <a href="https://ci.appveyor.com/project/cthoyt/pykeen/branch/master">
-    <img src="https://ci.appveyor.com/api/projects/status/c35rlorj03h790ai/branch/master?svg=true"
+  <a href="https://ci.appveyor.com/project/lvermue/pykeen/branch/master">
+    <img src="https://ci.appveyor.com/api/projects/status/yow5ihwy3yigsv5c/branch/master?svg=true"
          alt="AppVeyor">
   </a>
 

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -2,7 +2,7 @@
 
 """Instance creation utilities."""
 
-from typing import Callable, Mapping, TextIO, Union
+from typing import Callable, Mapping, Optional, TextIO, Union
 
 import numpy as np
 from pkg_resources import iter_entry_points
@@ -27,7 +27,7 @@ PREFIX_IMPORTERS: Mapping[str, Callable[[str], LabeledTriples]] = _load_importer
 EXTENSION_IMPORTERS: Mapping[str, Callable[[str], LabeledTriples]] = _load_importers('extension_importer')
 
 
-def load_triples(path: Union[str, TextIO], delimiter: str = '\t') -> LabeledTriples:
+def load_triples(path: Union[str, TextIO], delimiter: str = '\t', encoding: Optional[str] = None) -> LabeledTriples:
     """Load triples saved as tab separated values.
 
     Besides TSV handling, PyKEEN does not come with any importers pre-installed. A few can be found at:
@@ -44,10 +44,13 @@ def load_triples(path: Union[str, TextIO], delimiter: str = '\t') -> LabeledTrip
             if path.startswith(f'{prefix}:'):
                 return handler(path[len(f'{prefix}:'):])
 
+    if encoding is None:
+        encoding = 'utf-8'
+
     return np.loadtxt(
         fname=path,
         dtype=str,
         comments='@Comment@ Head Relation Tail',
         delimiter=delimiter,
-        encoding='utf-8',
+        encoding=encoding,
     )

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -49,4 +49,5 @@ def load_triples(path: Union[str, TextIO], delimiter: str = '\t') -> LabeledTrip
         dtype=str,
         comments='@Comment@ Head Relation Tail',
         delimiter=delimiter,
+        encoding='utf-8',
     )


### PR DESCRIPTION
This PR will be useful for addressing #92, which is likely a Windows-only problem. It does the following:

- adds the appropriate AppVeyor configuration for automating testing on Windows
- fixes a unicode loading problem with numpy that only happens on windows
- adds user documentation for installation on Windows with Anaconda