### PR TITLE
Use maximum value of default int type as upper bound of randint

### DIFF
--- a/src/pykeen/ablation/ablation.py
+++ b/src/pykeen/ablation/ablation.py
@@ -81,7 +81,7 @@ def prepare_ablation_from_config(config: Mapping[str, Any], directory: str, save
 
         # TODO incorporate setting of random seed
         # pipeline_kwargs=dict(
-        #    random_seed=random.randint(1, 2 ** 32 - 1),
+        #    random_seed=random_non_negative_int(),
         # ),
 
         def _set_arguments(key: str, value: str) -> None:

--- a/src/pykeen/datasets/generate.py
+++ b/src/pykeen/datasets/generate.py
@@ -8,6 +8,7 @@ import os
 import click
 import numpy as np
 
+from pykeen.utils import random_non_negative_int
 from .base import PathDataSet
 from ..triples import TriplesFactory
 
@@ -30,7 +31,7 @@ def main(path: str, directory: str, test_ratios, no_validation: bool, validation
     ratios = test_ratios if no_validation else validation_ratios
 
     if seed is None:
-        seed = np.random.randint(0, 2 ** 32 - 1)
+        seed = random_non_negative_int()
     sub_triples_factories = triples_factory.split(ratios, random_state=seed)
 
     for subset_name, subset_tf in zip(LABELS, sub_triples_factories):

--- a/src/pykeen/datasets/generate.py
+++ b/src/pykeen/datasets/generate.py
@@ -8,9 +8,9 @@ import os
 import click
 import numpy as np
 
-from pykeen.utils import random_non_negative_int
 from .base import PathDataSet
 from ..triples import TriplesFactory
+from ..utils import random_non_negative_int
 
 LABELS = ['train', 'test', 'valid']
 

--- a/src/pykeen/models/cli/options.py
+++ b/src/pykeen/models/cli/options.py
@@ -14,7 +14,7 @@ from ...optimizers import get_optimizer_cls, optimizers
 from ...stoppers import _STOPPER_SUFFIX, get_stopper_cls, stoppers
 from ...training import _TRAINING_LOOP_SUFFIX, get_training_loop_cls, training_loops
 from ...triples import TriplesFactory
-from ...utils import normalize_string, resolve_device
+from ...utils import normalize_string, random_non_negative_int, resolve_device
 
 
 def _make_callback(f):
@@ -197,7 +197,7 @@ num_workers_option = click.option(
 random_seed_option = click.option(
     '--random-seed',
     type=int,
-    default=random.randint(0, 2 ** 32 - 1),
+    default=random_non_negative_int(),
     show_default=True,
     help='Random seed for PyTorch, NumPy, and Python.',
 )

--- a/src/pykeen/models/cli/options.py
+++ b/src/pykeen/models/cli/options.py
@@ -2,7 +2,6 @@
 
 """Click options for building magical KGE model CLIs."""
 
-import random
 from typing import Optional
 
 import click

--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -168,7 +168,6 @@ import ftplib
 import json
 import logging
 import os
-import random
 import time
 from dataclasses import dataclass, field
 from typing import Any, Collection, Dict, Iterable, List, Mapping, Optional, Type, Union
@@ -192,7 +191,7 @@ from .training import SLCWATrainingLoop, TrainingLoop, get_training_loop_cls
 from .triples import TriplesFactory
 from .utils import (
     Result, ensure_ftp_directory, fix_dataclass_init_docs, get_json_bytes_io, get_model_io,
-    resolve_device, set_random_seed,
+    random_non_negative_int, resolve_device, set_random_seed,
 )
 from .version import get_git_hash, get_version
 
@@ -648,7 +647,7 @@ def pipeline(  # noqa: C901
         If true, use the testing triples. Otherwise, use the validation triples. Defaults to true - use testing triples.
     """
     if random_seed is None:
-        random_seed = random.randint(0, 2 ** 32 - 1)
+        random_seed = random_non_negative_int()
         logger.warning(f'No random seed is specified. Setting to {random_seed}.')
     set_random_seed(random_seed)
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -359,7 +359,7 @@ class TriplesFactory:
         )
         sp, multi_o = zip(*s_p_to_multi_tails.items())
         mapped_triples: torch.LongTensor = torch.tensor(sp, dtype=torch.long)
-        labels = np.array([np.array(item) for item in multi_o])
+        labels = np.array([np.array(item) for item in multi_o], dtype=object)
 
         return LCWAInstances(
             mapped_triples=mapped_triples,

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -16,7 +16,7 @@ from .instances import LCWAInstances, SLCWAInstances
 from .utils import load_triples
 from ..tqdmw import tqdm
 from ..typing import EntityMapping, LabeledTriples, MappedTriples, RelationMapping
-from ..utils import compact_mapping, invert_mapping, slice_triples
+from ..utils import compact_mapping, invert_mapping, random_non_negative_int, slice_triples
 
 __all__ = [
     'TriplesFactory',
@@ -418,7 +418,7 @@ class TriplesFactory:
         # Prepare shuffle index
         idx = np.arange(n_triples)
         if random_state is None:
-            random_state = np.random.randint(0, np.iinfo(np.int_).max)
+            random_state = random_non_negative_int()
             logger.warning(f'Using random_state={random_state} to split {self}')
         if isinstance(random_state, int):
             random_state = np.random.RandomState(random_state)

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -713,7 +713,7 @@ def _tf_cleanup_randomized(
     3. Continue until move_id_mask has no true bits
     """
     if random_state is None:
-        random_state = np.random.randint(0, 2 ** 32 - 1)
+        random_state = random_non_negative_int()
         logger.warning('Using random_state=%s', random_state)
     if isinstance(random_state, int):
         random_state = np.random.RandomState(random_state)

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -418,7 +418,7 @@ class TriplesFactory:
         # Prepare shuffle index
         idx = np.arange(n_triples)
         if random_state is None:
-            random_state = np.random.randint(0, 2 ** 32 - 1)
+            random_state = np.random.randint(0, np.iinfo(np.int_).max)
             logger.warning(f'Using random_state={random_state} to split {self}')
         if isinstance(random_state, int):
             random_state = np.random.RandomState(random_state)

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -469,4 +469,5 @@ def invert_mapping(mapping: Mapping[str, int]) -> Mapping[int, str]:
 
 def random_non_negative_int() -> int:
     """Generate a random positive integer."""
-    return np.random.randint(0, np.iinfo(np.int_).max)
+    sq = np.random.SeedSequence(np.random.randint(0, np.iinfo(np.int_).max))
+    return sq.generate_state()

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -470,4 +470,4 @@ def invert_mapping(mapping: Mapping[str, int]) -> Mapping[int, str]:
 def random_non_negative_int() -> int:
     """Generate a random positive integer."""
     sq = np.random.SeedSequence(np.random.randint(0, np.iinfo(np.int_).max))
-    return sq.generate_state(1)[0]
+    return int(sq.generate_state(1)[0])

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -470,4 +470,4 @@ def invert_mapping(mapping: Mapping[str, int]) -> Mapping[int, str]:
 def random_non_negative_int() -> int:
     """Generate a random positive integer."""
     sq = np.random.SeedSequence(np.random.randint(0, np.iinfo(np.int_).max))
-    return sq.generate_state()
+    return sq.generate_state(1)[0]

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -23,6 +23,7 @@ __all__ = [
     'invert_mapping',
     'l2_regularization',
     'is_cuda_oom_error',
+    'random_non_negative_int',
     'real_part',
     'resolve_device',
     'slice_triples',
@@ -464,3 +465,8 @@ def invert_mapping(mapping: Mapping[str, int]) -> Mapping[int, str]:
         value: key
         for key, value in mapping.items()
     }
+
+
+def random_non_negative_int() -> int:
+    """Generate a random positive integer."""
+    return np.random.randint(0, np.iinfo(np.int_).max)

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -37,6 +37,7 @@ instance_labels = np.array(
         np.array([0, 4]),
         np.array([3]),
     ],
+    dtype=object,
 )
 
 numeric_triples = np.array(


### PR DESCRIPTION
Instead of using a hard-coded maximum value for a random int, switch to using the maximum value of the default int dtype.

References
* [numpy.int_](https://numpy.org/doc/stable/user/basics.types.html?highlight=int_)
* [numpy.iinfo](https://numpy.org/doc/stable/reference/generated/numpy.iinfo.html)

Closes #92 