### PR TITLE
Fix initialization of ConvE

### DIFF
--- a/src/pykeen/models/unimodal/conv_e.py
+++ b/src/pykeen/models/unimodal/conv_e.py
@@ -278,7 +278,8 @@ class ConvE(EntityRelationEmbeddingModel):
             self.bn2,
             self.fc,
         ]:
-            module.reset_parameters()
+            if not isinstance(module, nn.BatchNorm1d) and not isinstance(module, nn.BatchNorm2d):
+                module.reset_parameters()
 
     def _convolve_entity_relation(self, h: torch.LongTensor, r: torch.LongTensor) -> torch.FloatTensor:
         """Perform the main calculations of the ConvE model."""

--- a/src/pykeen/models/unimodal/conv_e.py
+++ b/src/pykeen/models/unimodal/conv_e.py
@@ -278,8 +278,9 @@ class ConvE(EntityRelationEmbeddingModel):
             self.bn2,
             self.fc,
         ]:
-            if not isinstance(module, nn.BatchNorm1d) and not isinstance(module, nn.BatchNorm2d):
-                module.reset_parameters()
+            if module is None:
+                continue
+            module.reset_parameters()
 
     def _convolve_entity_relation(self, h: torch.LongTensor, r: torch.LongTensor) -> torch.FloatTensor:
         """Perform the main calculations of the ConvE model."""


### PR DESCRIPTION
When turning batch normalization off, batch normalization layers are set to None. Therefore, we cannot initiliaze these modules in `_reset_parameters_()`