### PR TITLE
Allow failure on tests when resource is not available

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 graft src
 graft tests
 
+prune docs/source/api
 prune notebooks
 
 recursive-include docs/source *.py

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -8,6 +8,7 @@ import unittest
 from typing import Type, Union
 
 import pytest
+from requests.exceptions import ConnectionError
 
 from pykeen.datasets import FB15k, FB15k237, Kinships, Nations, UMLS, WN18, WN18RR, YAGO310
 from pykeen.datasets.base import DataSet
@@ -50,7 +51,11 @@ class _DataSetTestCase:
         assert not self.dataset._loaded_validation
 
         # Load
-        self.dataset._load()
+        try:
+            self.dataset._load()
+        except (ConnectionError, EOFError):
+            self.skipTest('Problem with connection. Try this test again later.')
+
         assert isinstance(self.dataset.training, TriplesFactory)
         assert isinstance(self.dataset.testing, TriplesFactory)
         assert self.dataset._loaded


### PR DESCRIPTION
This wasn't the original solution I had envisioned with mocks, but since the point of these tests is not to check the ability of requests to do its job, then I think we can take a medium pass on it. Closes #101 

An alternative would be to better test the parent classes (like RemoteDataSet) on mock data