### PR TITLE
Fix failing RTD documentation process

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,3 +18,4 @@ python:
       path: .
       extra_requirements:
         - docs
+  system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,10 @@ version: 2
 sphinx:
   configuration: docs/source/conf.py
 
+# Build HTML only
+formats:
+  - htmlzip
+
 python:
   version: 3.7
   pip_install: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,12 @@
-# See: https://docs.readthedocs.io/en/latest/yaml-config.html
+# See: https://docs.readthedocs.io/en/stable/config-file/v2.html#formats
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
 python:
   version: 3.7
   pip_install: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 # See: https://docs.readthedocs.io/en/latest/yaml-config.html
 python:
-  version: 3
+  version: 3.7
   pip_install: true
   extra_requirements:
     - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,8 @@ formats:
 
 python:
   version: 3.7
-  pip_install: true
-  extra_requirements:
-    - docs
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -229,7 +229,7 @@ texinfo_documents = [
 # -- Options for Epub output -------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = project
+# epub_title = project
 
 # The unique identifier of the text. This can be a ISBN number
 # or the project homepage.
@@ -241,7 +241,7 @@ epub_title = project
 # epub_uid = ''
 
 # A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
+# epub_exclude_files = ['search.html']
 
 # -- Extension configuration -------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -164,36 +164,36 @@ htmlhelp_basename = 'PyKEENdoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
-latex_elements = {
-    # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
-
-    # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
-
-    # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
-
-    # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
-}
+# latex_elements = {
+#     The paper size ('letterpaper' or 'a4paper').
+#
+#     'papersize': 'letterpaper',
+#
+#     The font size ('10pt', '11pt' or '12pt').
+#
+#     'pointsize': '10pt',
+#
+#     Additional stuff for the LaTeX preamble.
+#
+#     'preamble': '',
+#
+#     Latex figure (float) alignment
+#
+#     'figure_align': 'htbp',
+# }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (
-        master_doc,
-        'pykeen.tex',
-        'PyKEEN Documentation',
-        author,
-        'manual',
-    ),
-]
+# latex_documents = [
+#     (
+#         master_doc,
+#         'pykeen.tex',
+#         'PyKEEN Documentation',
+#         author,
+#         'manual',
+#     ),
+# ]
 
 # -- Options for manual page output ------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,7 @@ docs =
     sphinx-autodoc-typehints
     sphinx_automodapi
     texext
+    numpy
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,6 @@ docs =
     sphinx-autodoc-typehints
     sphinx_automodapi
     texext
-    numpy
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
### Link to the relevant Bug(s)

We previously had a failing ReadTheDocs (RTD) documentation process, since some of the used formats we have in our documentation are not LaTeX compatible.

### Description of the Change

The RTD configuration is now changed to the new version 2 format and is set to produce HTML output only.

### Possible Drawbacks

None.

### Verification Process

I have run the current branch through the RTD generation process and the resulting build succeeds without any errors.
