### PR TITLE
Make sure HPO default lookup is based on class for losses

### DIFF
--- a/docs/source/reference/losses.rst
+++ b/docs/source/reference/losses.rst
@@ -4,7 +4,3 @@ Loss Functions
     :no-heading:
     :headings: --
     :skip: Loss
-
-HPO Defaults
-------------
-.. autodata:: losses_hpo_defaults

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -20,7 +20,7 @@ from .pruners import get_pruner_cls
 from .samplers import get_sampler_cls
 from ..datasets.base import DataSet
 from ..evaluation import Evaluator, get_evaluator_cls
-from ..losses import Loss, _LOSS_SUFFIX, get_loss_cls, losses_hpo_defaults
+from ..losses import Loss, _LOSS_SUFFIX, get_loss_cls
 from ..models import get_model_cls
 from ..models.base import Model
 from ..optimizers import Optimizer, get_optimizer_cls, optimizers_hpo_defaults
@@ -136,7 +136,7 @@ class Objective:
         _loss_kwargs = _get_kwargs(
             trial=trial,
             prefix='loss',
-            default_kwargs_ranges=losses_hpo_defaults[self.loss],
+            default_kwargs_ranges=self.loss.hpo_default,
             kwargs=self.loss_kwargs,
             kwargs_ranges=self.loss_kwargs_ranges,
         )

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -132,11 +132,18 @@ class Objective:
             kwargs=self.model_kwargs,
             kwargs_ranges=self.model_kwargs_ranges,
         )
+
+        try:
+            loss_default_kwargs_ranges = self.loss.hpo_default
+        except AttributeError:
+            logger.warning('using a loss function with no hpo_default field: %s', self.loss)
+            loss_default_kwargs_ranges = {}
+
         # 3. Loss
         _loss_kwargs = _get_kwargs(
             trial=trial,
             prefix='loss',
-            default_kwargs_ranges=self.loss.hpo_default,
+            default_kwargs_ranges=loss_default_kwargs_ranges,
             kwargs=self.loss_kwargs,
             kwargs_ranges=self.loss_kwargs_ranges,
         )


### PR DESCRIPTION
This PR uses the internal PyKEEN loss class hierarchy to make it possible to more elegantly define the HPO defaults, as in several other modules like models.