### PR TITLE
Pass **kwargs from children of Evaluator to parent class

### DIFF
--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -218,6 +218,7 @@ class RankBasedEvaluator(Evaluator):
         self,
         ks: Optional[Iterable[Union[int, float]]] = None,
         filtered: bool = True,
+        **kwargs,
     ):
         """Initialize rank-based evaluator.
 
@@ -227,7 +228,7 @@ class RankBasedEvaluator(Evaluator):
             Whether to use the filtered evaluation protocol. If enabled, ranking another true triple higher than the
             currently considered one will not decrease the score.
         """
-        super().__init__(filtered=filtered)
+        super().__init__(filtered=filtered, **kwargs)
         self.ks = tuple(ks) if ks is not None else (1, 3, 5, 10)
         for k in self.ks:
             if isinstance(k, float) and not (0 < k < 1):

--- a/src/pykeen/evaluation/sklearn.py
+++ b/src/pykeen/evaluation/sklearn.py
@@ -68,8 +68,8 @@ class SklearnMetricResults(MetricResults):
 class SklearnEvaluator(Evaluator):
     """An evaluator that uses a Scikit-learn metric."""
 
-    def __init__(self):
-        super().__init__(filtered=False, requires_positive_mask=True)
+    def __init__(self, **kwargs):
+        super().__init__(filtered=False, requires_positive_mask=True, **kwargs)
         self.all_scores = {}
         self.all_positives = {}
 


### PR DESCRIPTION
### Link to the relevant Bug(s)

It's a pretty minor thing - but if you like then I will open up an issue and link it to this PR.


### Description of the Change

Currently, it is not possible to set Evaluator attributes, because the call to `super()` is not passing them on.

Usage:

```python
from pykeen import evaluation
Evaluator = evaluation.get_evaluator_cls('RankBasedEvaluator')
evaluator = Evaluator(batch_size=256)
```


### Possible Drawbacks

None, as far as I can see.


### Verification Process

I successfully set the evaluators `batch_size` to prevent an automatic batch size search which (not reproducibly) fails with OOM errors while validating from time to time (as part of the early stopping). 


### Release Notes

- pass RankBasedEvaluators kwargs to parent class