### PR TITLE
Add default implementations for reset_parameters_

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -1098,7 +1098,7 @@ class EntityEmbeddingModel(Model):
             device=self.device,
         )
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs):  # noqa: D105
         _annotate(cls)
         _tag(cls)
 
@@ -1157,7 +1157,7 @@ class EntityRelationEmbeddingModel(Model):
             device=self.device,
         )
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs):  # noqa: D105
         _annotate(cls)
         _tag(cls)
 

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -184,7 +184,7 @@ def _process_remove_known(df: pd.DataFrame, remove_known: bool, testing: Optiona
     return df
 
 
-def _annotate(cls):
+def _track_hyperparameters(cls: Type['Model']) -> None:
     """Initialize the subclass while keeping track of hyper-parameters."""
     # Keep track of the hyper-parameters that are used across all
     # subclasses of BaseModule
@@ -193,7 +193,7 @@ def _annotate(cls):
             Model._hyperparameter_usage[k].add(cls.__name__)
 
 
-def _tag(cls):
+def _add_post_reset_parameters(cls: Type['Model']) -> None:
     # The following lines add in a post-init hook to all subclasses
     # such that the reset_parameters_() function is run
     _original_init = cls.__init__
@@ -1098,9 +1098,10 @@ class EntityEmbeddingModel(Model):
             device=self.device,
         )
 
-    def __init_subclass__(cls, **kwargs):  # noqa: D105
-        _annotate(cls)
-        _tag(cls)
+    def __init_subclass__(cls, auto_reset_parameters: bool = True, **kwargs):  # noqa: D105
+        _track_hyperparameters(cls)
+        if auto_reset_parameters:
+            _add_post_reset_parameters(cls)
 
     def _reset_parameters_(self):  # noqa: D102
         self.entity_embeddings.reset_parameters()
@@ -1157,9 +1158,10 @@ class EntityRelationEmbeddingModel(Model):
             device=self.device,
         )
 
-    def __init_subclass__(cls, **kwargs):  # noqa: D105
-        _annotate(cls)
-        _tag(cls)
+    def __init_subclass__(cls, auto_reset_parameters: bool = True, **kwargs):  # noqa: D105
+        _track_hyperparameters(cls)
+        if auto_reset_parameters:
+            _add_post_reset_parameters(cls)
 
     def _reset_parameters_(self):  # noqa: D102
         self.entity_embeddings.reset_parameters()

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -1085,6 +1085,12 @@ class EntityEmbeddingModel(Model):
             device=self.device,
         )
 
+        # Finalize initialization
+        self.reset_parameters_()
+
+    def _reset_parameters_(self):  # noqa: D102
+        self.entity_embeddings.reset_parameters()
+
 
 class EntityRelationEmbeddingModel(EntityEmbeddingModel):
     """A base module for KGE models that have different embeddings for entities and relations."""
@@ -1131,6 +1137,13 @@ class EntityRelationEmbeddingModel(EntityEmbeddingModel):
             embedding_dim=self.relation_dim,
             device=self.device,
         )
+
+        # Finalize initialization
+        self.reset_parameters_()
+
+    def _reset_parameters_(self):  # noqa: D102
+        super()._reset_parameters_()
+        self.relation_embeddings.reset_parameters()
 
 
 def _can_slice(fn) -> bool:

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -103,9 +103,6 @@ class ComplEx(EntityRelationEmbeddingModel):
             regularizer=regularizer,
         )
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         # initialize with entity and relation embeddings with standard normal distribution, cf.
         # https://github.com/ttrouill/complex/blob/dc4eb93408d9a5288c986695b58488ac80b1cc17/efe/models.py#L481-L487

--- a/src/pykeen/models/unimodal/conv_e.py
+++ b/src/pykeen/models/unimodal/conv_e.py
@@ -261,9 +261,6 @@ class ConvE(EntityRelationEmbeddingModel):
         )
         self.fc = nn.Linear(num_in_features, self.embedding_dim)
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         # embeddings
         embedding_xavier_normal_(self.entity_embeddings)

--- a/src/pykeen/models/unimodal/conv_kb.py
+++ b/src/pykeen/models/unimodal/conv_kb.py
@@ -107,8 +107,7 @@ class ConvKB(EntityRelationEmbeddingModel):
     def _reset_parameters_(self):  # noqa: D102
         # embeddings
         logger.warning('To be consistent with the paper, initialize entity and relation embeddings from TransE.')
-        self.entity_embeddings.reset_parameters()
-        self.relation_embeddings.reset_parameters()
+        super()._reset_parameters_()
 
         # Use Xavier initialization for weight; bias to zero
         nn.init.xavier_uniform_(self.linear.weight, gain=nn.init.calculate_gain('relu'))

--- a/src/pykeen/models/unimodal/conv_kb.py
+++ b/src/pykeen/models/unimodal/conv_kb.py
@@ -104,9 +104,6 @@ class ConvKB(EntityRelationEmbeddingModel):
         self.hidden_dropout = nn.Dropout(p=hidden_dropout_rate)
         self.linear = nn.Linear(embedding_dim * num_filters, 1, bias=True)
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         # embeddings
         logger.warning('To be consistent with the paper, initialize entity and relation embeddings from TransE.')

--- a/src/pykeen/models/unimodal/distmult.py
+++ b/src/pykeen/models/unimodal/distmult.py
@@ -12,12 +12,11 @@ from torch.nn import functional
 from ..base import EntityRelationEmbeddingModel
 from ...losses import Loss
 from ...regularizers import LpRegularizer, Regularizer
+from ...triples import TriplesFactory
 
 __all__ = [
     'DistMult',
 ]
-
-from ...triples import TriplesFactory
 
 
 class DistMult(EntityRelationEmbeddingModel):

--- a/src/pykeen/models/unimodal/distmult.py
+++ b/src/pykeen/models/unimodal/distmult.py
@@ -2,17 +2,13 @@
 
 """Implementation of DistMult."""
 
-from typing import Optional
-
 import torch
 import torch.autograd
 from torch import nn
 from torch.nn import functional
 
 from ..base import EntityRelationEmbeddingModel
-from ...losses import Loss
-from ...regularizers import LpRegularizer, Regularizer
-from ...triples import TriplesFactory
+from ...regularizers import LpRegularizer
 
 __all__ = [
     'DistMult',

--- a/src/pykeen/models/unimodal/distmult.py
+++ b/src/pykeen/models/unimodal/distmult.py
@@ -65,32 +65,6 @@ class DistMult(EntityRelationEmbeddingModel):
         normalize=True,
     )
 
-    def __init__(
-        self,
-        triples_factory: TriplesFactory,
-        embedding_dim: int = 50,
-        automatic_memory_optimization: Optional[bool] = None,
-        loss: Optional[Loss] = None,
-        preferred_device: Optional[str] = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
-    ) -> None:
-        r"""Initialize DistMult.
-
-        :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 300]$.
-        """
-        super().__init__(
-            triples_factory=triples_factory,
-            embedding_dim=embedding_dim,
-            automatic_memory_optimization=automatic_memory_optimization,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
-        )
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         # xavier uniform, cf.
         # https://github.com/thunlp/OpenKE/blob/adeed2c0d2bef939807ed4f69c1ea4db35fd149b/models/DistMult.py#L16-L17

--- a/src/pykeen/models/unimodal/distmult.py
+++ b/src/pykeen/models/unimodal/distmult.py
@@ -2,17 +2,22 @@
 
 """Implementation of DistMult."""
 
+from typing import Optional
+
 import torch
 import torch.autograd
 from torch import nn
 from torch.nn import functional
 
 from ..base import EntityRelationEmbeddingModel
-from ...regularizers import LpRegularizer
+from ...losses import Loss
+from ...regularizers import LpRegularizer, Regularizer
 
 __all__ = [
     'DistMult',
 ]
+
+from ...triples import TriplesFactory
 
 
 class DistMult(EntityRelationEmbeddingModel):
@@ -60,6 +65,30 @@ class DistMult(EntityRelationEmbeddingModel):
         p=2.0,
         normalize=True,
     )
+
+    def __init__(
+        self,
+        triples_factory: TriplesFactory,
+        embedding_dim: int = 50,
+        automatic_memory_optimization: Optional[bool] = None,
+        loss: Optional[Loss] = None,
+        preferred_device: Optional[str] = None,
+        random_seed: Optional[int] = None,
+        regularizer: Optional[Regularizer] = None,
+    ) -> None:
+        r"""Initialize DistMult.
+
+        :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 300]$.
+        """
+        super().__init__(
+            triples_factory=triples_factory,
+            embedding_dim=embedding_dim,
+            automatic_memory_optimization=automatic_memory_optimization,
+            loss=loss,
+            preferred_device=preferred_device,
+            random_seed=random_seed,
+            regularizer=regularizer,
+        )
 
     def _reset_parameters_(self):  # noqa: D102
         # xavier uniform, cf.

--- a/src/pykeen/models/unimodal/ermlp.py
+++ b/src/pykeen/models/unimodal/ermlp.py
@@ -79,7 +79,7 @@ class ERMLP(EntityRelationEmbeddingModel):
 
     def _reset_parameters_(self):  # noqa: D102
         # The authors do not specify which initialization was used. Hence, we use the pytorch default.
-        self._reset_parameters_()
+        super()._reset_parameters_()
 
         # weight initialization
         nn.init.zeros_(self.linear1.bias)

--- a/src/pykeen/models/unimodal/ermlp.py
+++ b/src/pykeen/models/unimodal/ermlp.py
@@ -79,8 +79,7 @@ class ERMLP(EntityRelationEmbeddingModel):
 
     def _reset_parameters_(self):  # noqa: D102
         # The authors do not specify which initialization was used. Hence, we use the pytorch default.
-        self.entity_embeddings.reset_parameters()
-        self.relation_embeddings.reset_parameters()
+        self._reset_parameters_()
 
         # weight initialization
         nn.init.zeros_(self.linear1.bias)

--- a/src/pykeen/models/unimodal/ermlp.py
+++ b/src/pykeen/models/unimodal/ermlp.py
@@ -77,9 +77,6 @@ class ERMLP(EntityRelationEmbeddingModel):
             self.linear2,
         )
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         # The authors do not specify which initialization was used. Hence, we use the pytorch default.
         self.entity_embeddings.reset_parameters()

--- a/src/pykeen/models/unimodal/ermlpe.py
+++ b/src/pykeen/models/unimodal/ermlpe.py
@@ -93,9 +93,6 @@ class ERMLPE(EntityRelationEmbeddingModel):
             nn.ReLU(),
         )
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         self.entity_embeddings.reset_parameters()
         self.relation_embeddings.reset_parameters()

--- a/src/pykeen/models/unimodal/ermlpe.py
+++ b/src/pykeen/models/unimodal/ermlpe.py
@@ -94,8 +94,7 @@ class ERMLPE(EntityRelationEmbeddingModel):
         )
 
     def _reset_parameters_(self):  # noqa: D102
-        self.entity_embeddings.reset_parameters()
-        self.relation_embeddings.reset_parameters()
+        super()._reset_parameters_()
         for module in [
             self.linear1,
             self.linear2,

--- a/src/pykeen/models/unimodal/hole.py
+++ b/src/pykeen/models/unimodal/hole.py
@@ -2,16 +2,11 @@
 
 """Implementation of the HolE model."""
 
-from typing import Optional
-
 import torch
 import torch.autograd
 
 from ..base import EntityRelationEmbeddingModel
 from ..init import embedding_xavier_uniform_
-from ...losses import Loss
-from ...regularizers import Regularizer
-from ...triples import TriplesFactory
 from ...utils import clamp_norm
 
 __all__ = [

--- a/src/pykeen/models/unimodal/hole.py
+++ b/src/pykeen/models/unimodal/hole.py
@@ -52,29 +52,6 @@ class HolE(EntityRelationEmbeddingModel):
         embedding_dim=dict(type=int, low=50, high=350, q=25),
     )
 
-    def __init__(
-        self,
-        triples_factory: TriplesFactory,
-        embedding_dim: int = 200,
-        automatic_memory_optimization: Optional[bool] = None,
-        loss: Optional[Loss] = None,
-        preferred_device: Optional[str] = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
-    ) -> None:
-        """Initialize the model."""
-        super().__init__(
-            triples_factory=triples_factory,
-            embedding_dim=embedding_dim,
-            loss=loss,
-            automatic_memory_optimization=automatic_memory_optimization,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
-        )
-        # Finalize initialization
-        self.reset_parameters_()
-
     def post_parameter_update(self) -> None:  # noqa: D102
         # Make sure to call super first
         super().post_parameter_update()

--- a/src/pykeen/models/unimodal/hole.py
+++ b/src/pykeen/models/unimodal/hole.py
@@ -2,11 +2,16 @@
 
 """Implementation of the HolE model."""
 
+from typing import Optional
+
 import torch
 import torch.autograd
 
 from ..base import EntityRelationEmbeddingModel
 from ..init import embedding_xavier_uniform_
+from ...losses import Loss
+from ...regularizers import Regularizer
+from ...triples import TriplesFactory
 from ...utils import clamp_norm
 
 __all__ = [
@@ -46,6 +51,27 @@ class HolE(EntityRelationEmbeddingModel):
     hpo_default = dict(
         embedding_dim=dict(type=int, low=50, high=350, q=25),
     )
+
+    def __init__(
+        self,
+        triples_factory: TriplesFactory,
+        embedding_dim: int = 200,
+        automatic_memory_optimization: Optional[bool] = None,
+        loss: Optional[Loss] = None,
+        preferred_device: Optional[str] = None,
+        random_seed: Optional[int] = None,
+        regularizer: Optional[Regularizer] = None,
+    ) -> None:
+        """Initialize the model."""
+        super().__init__(
+            triples_factory=triples_factory,
+            embedding_dim=embedding_dim,
+            loss=loss,
+            automatic_memory_optimization=automatic_memory_optimization,
+            preferred_device=preferred_device,
+            random_seed=random_seed,
+            regularizer=regularizer,
+        )
 
     def post_parameter_update(self) -> None:  # noqa: D102
         # Make sure to call super first

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -111,10 +111,9 @@ class KG2E(EntityRelationEmbeddingModel):
 
     def _reset_parameters_(self):  # noqa: D102
         # Constraints are applied through post_parameter_update
+        super()._reset_parameters_()
         for emb in [
-            self.entity_embeddings,
             self.entity_covariances,
-            self.relation_embeddings,
             self.relation_covariances,
         ]:
             emb.reset_parameters()

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -109,9 +109,6 @@ class KG2E(EntityRelationEmbeddingModel):
             device=self.device,
         )
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         # Constraints are applied through post_parameter_update
         for emb in [

--- a/src/pykeen/models/unimodal/ntn.py
+++ b/src/pykeen/models/unimodal/ntn.py
@@ -115,7 +115,7 @@ class NTN(EntityEmbeddingModel):
         self.non_linearity = non_linearity
 
     def _reset_parameters_(self):  # noqa: D102
-        self.entity_embeddings.reset_parameters()
+        super()._reset_parameters_()
         nn.init.normal_(self.w)
         nn.init.normal_(self.vh)
         nn.init.normal_(self.vt)

--- a/src/pykeen/models/unimodal/ntn.py
+++ b/src/pykeen/models/unimodal/ntn.py
@@ -114,9 +114,6 @@ class NTN(EntityEmbeddingModel):
             non_linearity = nn.Tanh()
         self.non_linearity = non_linearity
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         self.entity_embeddings.reset_parameters()
         nn.init.normal_(self.w)

--- a/src/pykeen/models/unimodal/proj_e.py
+++ b/src/pykeen/models/unimodal/proj_e.py
@@ -91,9 +91,6 @@ class ProjE(EntityRelationEmbeddingModel):
             inner_non_linearity = nn.Tanh()
         self.inner_non_linearity = inner_non_linearity
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         embedding_xavier_uniform_(self.entity_embeddings)
         embedding_xavier_uniform_(self.relation_embeddings)

--- a/src/pykeen/models/unimodal/rescal.py
+++ b/src/pykeen/models/unimodal/rescal.py
@@ -77,12 +77,6 @@ class RESCAL(EntityRelationEmbeddingModel):
             random_seed=random_seed,
             regularizer=regularizer,
         )
-        # Finalize initialization
-        self.reset_parameters_()
-
-    def _reset_parameters_(self):  # noqa: D102
-        self.entity_embeddings.reset_parameters()
-        self.relation_embeddings.reset_parameters()
 
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -331,9 +331,6 @@ class RGCN(Model):
         else:
             self.batch_norms = None
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def post_parameter_update(self) -> None:  # noqa: D102
         super().post_parameter_update()
 

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -331,6 +331,10 @@ class RGCN(Model):
         else:
             self.batch_norms = None
 
+        # Finalize initialization, needs to be done manually instead of with
+        # a post-init hook because this model is very special :)
+        self.reset_parameters_()
+
     def post_parameter_update(self) -> None:  # noqa: D102
         super().post_parameter_update()
 

--- a/src/pykeen/models/unimodal/rotate.py
+++ b/src/pykeen/models/unimodal/rotate.py
@@ -71,9 +71,6 @@ class RotatE(EntityRelationEmbeddingModel):
         )
         self.real_embedding_dim = embedding_dim
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         embedding_xavier_uniform_(self.entity_embeddings)
         # phases randomly between 0 and 2 pi

--- a/src/pykeen/models/unimodal/simple.py
+++ b/src/pykeen/models/unimodal/simple.py
@@ -98,9 +98,6 @@ class SimplE(EntityRelationEmbeddingModel):
             clamp_score = (-clamp_score, clamp_score)
         self.clamp = clamp_score
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         for emb in [
             self.entity_embeddings,

--- a/src/pykeen/models/unimodal/structured_embedding.py
+++ b/src/pykeen/models/unimodal/structured_embedding.py
@@ -84,9 +84,6 @@ class StructuredEmbedding(EntityEmbeddingModel):
             device=self.device,
         )
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         embedding_xavier_uniform_(self.entity_embeddings)
 

--- a/src/pykeen/models/unimodal/trans_d.py
+++ b/src/pykeen/models/unimodal/trans_d.py
@@ -137,9 +137,6 @@ class TransD(EntityRelationEmbeddingModel):
             device=self.device,
         )
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def post_parameter_update(self) -> None:  # noqa: D102
         # Make sure to call super first
         super().post_parameter_update()

--- a/src/pykeen/models/unimodal/trans_e.py
+++ b/src/pykeen/models/unimodal/trans_e.py
@@ -76,9 +76,6 @@ class TransE(EntityRelationEmbeddingModel):
         )
         self.scoring_fct_norm = scoring_fct_norm
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         embedding_xavier_uniform_(self.entity_embeddings)
         embedding_xavier_uniform_(self.relation_embeddings)

--- a/src/pykeen/models/unimodal/trans_h.py
+++ b/src/pykeen/models/unimodal/trans_h.py
@@ -96,9 +96,6 @@ class TransH(EntityRelationEmbeddingModel):
             device=self.device,
         )
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         for emb in [
             self.entity_embeddings,

--- a/src/pykeen/models/unimodal/trans_r.py
+++ b/src/pykeen/models/unimodal/trans_r.py
@@ -91,9 +91,6 @@ class TransR(EntityRelationEmbeddingModel):
             device=self.device,
         )
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def post_parameter_update(self) -> None:  # noqa: D102
         # Make sure to call super first
         super().post_parameter_update()

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -128,9 +128,6 @@ class TuckER(EntityRelationEmbeddingModel):
             self.bn_0 = nn.BatchNorm1d(self.embedding_dim)
             self.bn_1 = nn.BatchNorm1d(self.embedding_dim)
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         embedding_xavier_normal_(self.entity_embeddings)
         embedding_xavier_normal_(self.relation_embeddings)

--- a/src/pykeen/models/unimodal/unstructured_model.py
+++ b/src/pykeen/models/unimodal/unstructured_model.py
@@ -69,9 +69,6 @@ class UnstructuredModel(EntityEmbeddingModel):
         )
         self.scoring_fct_norm = scoring_fct_norm
 
-        # Finalize initialization
-        self.reset_parameters_()
-
     def _reset_parameters_(self):  # noqa: D102
         embedding_xavier_uniform_(self.entity_embeddings)
 

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -127,7 +127,7 @@ class MockModel(EntityRelationEmbeddingModel):
         return self._generate_fake_scores(batch=rt_batch)
 
     def reset_parameters_(self) -> Model:  # noqa: D102
-        raise NotImplementedError('Not needed for unittest')
+        pass  # Not needed for unittest
 
 
 class LogCallWrapper:

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -453,7 +453,7 @@ class DummyModel(EntityRelationEmbeddingModel):
         return self._generate_fake_scores(batch=rt_batch)
 
     def reset_parameters_(self) -> Model:  # noqa: D102
-        raise NotImplementedError('Not needed for unittest')
+        pass  # Not needed for unittest
 
 
 class TestEvaluationStructure(unittest.TestCase):

--- a/tests/test_model_mode.py
+++ b/tests/test_model_mode.py
@@ -175,7 +175,7 @@ class SimpleInteractionModel(EntityRelationEmbeddingModel):
         return torch.sum(h + r + t, dim=1)
 
     def reset_parameters_(self) -> Model:  # noqa: D102
-        raise NotImplementedError('Not needed for unittest')
+        pass  # Not needed for unittest
 
 
 @dataclass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -151,7 +151,7 @@ class _ModelTestCase:
     def _check_scores(self, batch, scores) -> None:
         """Check the scores produced by a forward function."""
         # check for finite values by default
-        assert torch.all(torch.isfinite(scores)).item()
+        self.assertTrue(torch.all(torch.isfinite(scores)).item(), f'Some scores were not finite:\n{scores}')
 
         # check whether a gradient can be back-propgated
         scores.mean().backward()


### PR DESCRIPTION
> @mberr currently, it's not enough just to implement `Model.score_hrt()` but also you have to minimally implement `Model._reset_parameters_()`.

_originally posted by @cthoyt  in https://github.com/pykeen/pykeen/pull/127#issuecomment-720791132_

This PR adds post-init hook functionality to the `EntityEmbeddingModel` and `EntityRelationEmbeddingModel` classes such that any trivial subclasses do not need to override either `__init__()` nor `_reset_parameters_()`. Now, the basic functionality of resetting the entity (and relation) embeddings is default. This way, it's possible to remove the final line with `_reset_parameters_()` on all current models, which made it possible to even remove some now trivial `__init__()` methods such as in DistMult and HolE.

## Potential Issues

There are some non-optimal aspects, like the `EntityRelationEmbeddingModel` initializing the entity embeddings (at least) twice.