### PR TITLE
Improve checking for abstract classes and applying post init hooks

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -306,10 +306,11 @@ class Model(nn.Module, ABC):
     def _is_abstract(cls) -> bool:
         return inspect.isabstract(cls)
 
-    def __init_subclass__(cls, **kwargs):  # noqa:D105
+    def __init_subclass__(cls, reset_parameters_post_init: bool = True, **kwargs):  # noqa:D105
         if not cls._is_abstract():
             _track_hyperparameters(cls)
-            _add_post_reset_parameters(cls)
+            if reset_parameters_post_init:
+                _add_post_reset_parameters(cls)
 
     @property
     def can_slice_h(self) -> bool:

--- a/src/pykeen/models/cli/builders.py
+++ b/src/pykeen/models/cli/builders.py
@@ -111,6 +111,7 @@ def build_cli_from_cls(model: Type[Model]) -> click.Command:  # noqa: D202
     @options.num_workers_option
     @options.random_seed_option
     @_decorate_model_kwargs
+    @click.option('--silent', is_flag=True)
     @click.option('--output', type=click.File('w'), default=sys.stdout, help='Where to dump the metric results')
     def main(
         *,
@@ -132,6 +133,7 @@ def build_cli_from_cls(model: Type[Model]) -> click.Command:  # noqa: D202
         validation_triples_factory,
         num_workers,
         random_seed,
+        silent: bool,
         **model_kwargs,
     ):
         """CLI for PyKEEN."""
@@ -180,8 +182,9 @@ def build_cli_from_cls(model: Type[Model]) -> click.Command:  # noqa: D202
             random_seed=random_seed,
         )
 
-        json.dump(pipeline_result.metric_results.to_dict(), output, indent=2)
-        click.echo('')
+        if not silent:
+            json.dump(pipeline_result.metric_results.to_dict(), output, indent=2)
+            click.echo('')
         return sys.exit(0)
 
     return main

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -423,7 +423,7 @@ class Decoder(nn.Module):
         return (h * r * t).sum(dim=-1)
 
 
-class RGCN(Model):
+class RGCN(Model, reset_parameters_post_init=False):
     """An implementation of R-GCN from [schlichtkrull2018]_.
 
     This model uses graph convolutions with relation-specific weights.

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -423,7 +423,7 @@ class Decoder(nn.Module):
         return (h * r * t).sum(dim=-1)
 
 
-class RGCN(Model, reset_parameters_post_init=False):
+class RGCN(Model):
     """An implementation of R-GCN from [schlichtkrull2018]_.
 
     This model uses graph convolutions with relation-specific weights.
@@ -539,10 +539,6 @@ class RGCN(Model, reset_parameters_post_init=False):
         )
         # TODO: Dummy
         self.decoder = Decoder()
-
-        # Finalize initialization, needs to be done manually instead of with
-        # a post-init hook because this model is very special :)
-        self.reset_parameters_()
 
     def post_parameter_update(self) -> None:  # noqa: D102
         super().post_parameter_update()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,7 @@ import tempfile
 import traceback
 import unittest
 from typing import Any, ClassVar, Mapping, Optional, Type
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import numpy
 import pytest
@@ -466,16 +466,16 @@ Traceback
 
     def test_reset_parameters_constructor_call(self):
         """Tests whether reset_parameters is called in the constructor."""
-        self.model_cls.reset_parameters_ = MagicMock(return_value=None)
-        try:
-            self.model_cls(
-                triples_factory=self.factory,
-                embedding_dim=self.embedding_dim,
-                **(self.model_kwargs or {}),
-            )
-        except TypeError as error:
-            assert error.args == ("'NoneType' object is not callable",)
-        self.model.reset_parameters_.assert_called_once()
+        with patch.object(self.model_cls, 'reset_parameters_', return_value=None) as mock_method:
+            try:
+                self.model_cls(
+                    triples_factory=self.factory,
+                    embedding_dim=self.embedding_dim,
+                    **(self.model_kwargs or {}),
+                )
+            except TypeError as error:
+                assert error.args == ("'NoneType' object is not callable",)
+            mock_method.assert_called_once()
 
     def test_custom_representations(self):
         """Tests whether we can provide custom representations."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -302,7 +302,9 @@ class _ModelTestCase:
     @property
     def cli_extras(self):
         kwargs = self.model_kwargs or {}
-        extras = []
+        extras = [
+            '--silent',
+        ]
         for k, v in kwargs.items():
             extras.append('--' + k.replace('_', '-'))
             extras.append(str(v))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,6 +22,7 @@ import pykeen.experiments
 import pykeen.models
 from pykeen.datasets.kinships import KINSHIPS_TRAIN_PATH
 from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH, Nations
+from pykeen.models import _MODELS
 from pykeen.models.base import (
     EntityEmbeddingModel,
     EntityRelationEmbeddingModel,
@@ -463,10 +464,10 @@ Traceback
 
     def test_reset_parameters_constructor_call(self):
         """Tests whether reset_parameters is called in the constructor."""
-        self.model.reset_parameters_ = MagicMock(return_value=None)
+        self.model_cls.reset_parameters_ = MagicMock(return_value=None)
         try:
-            self.model.__init__(
-                self.factory,
+            self.model_cls(
+                triples_factory=self.factory,
                 embedding_dim=self.embedding_dim,
                 **(self.model_kwargs or {}),
             )
@@ -1238,3 +1239,17 @@ def test_get_novelty_mask():
     )
     assert mask.shape == query_ids.shape
     assert (mask == exp_novel).all()
+
+
+class TestRandom(unittest.TestCase):
+    """Extra tests."""
+
+    def test_abstract(self):
+        """Test that classes are checked as abstract properly."""
+        self.assertTrue(Model._is_abstract())
+        self.assertTrue(EntityEmbeddingModel._is_abstract())
+        self.assertTrue(EntityRelationEmbeddingModel._is_abstract())
+        for model_cls in _MODELS:
+            if issubclass(model_cls, MultimodalModel):
+                continue
+            self.assertFalse(model_cls._is_abstract(), msg=f'{model_cls.__name__} should not be abstract')


### PR DESCRIPTION
Previously, the `Model.reset_parameters_()` function was added as a post-init hook using `__init_subclasses__`, however, this was being applied recursively for each subclass (it's not obvious to me how to isolate the appropriate one inside this function) so I just clobbered the function in each base class. This wasn't a good solution either. This PR adds a solution that uses the abstract base class (ABC) label on each class and uses the `inspect` module to check if a given class is abstract. If not, then it applies the post-init hook. This should be robust to arbitrary depth of abstract classes, though will be an issue if a concrete class is subclassed (we haven't had a reason to do this yet and I don't think we will, so I'm not going to cross that bridge here).

This PR also updates the test that checks to make sure the `reset_parameters_()` gets called exactly once to better make use of the patching machinery offered by `unittest`.

This PR also adds an unrelated change to the CLI because I was getting upset at all of the stdout printing during the tests for the CLI.

Right now #107 is failing because the reset_parameter hook doesn't actually work. This should fix that.