### PR TITLE
Add mlflow set tags function

### DIFF
--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -834,9 +834,11 @@ def pipeline(  # noqa: C901
     if not metadata:
         metadata = {}
     title = metadata.get('title')
+    tags = metadata.get('run_tags', None)
 
     # Start tracking
     result_tracker.start_run(run_name=title)
+    result_tracker.set_tags(tags)
 
     device = resolve_device(device)
 

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -34,7 +34,7 @@ class ResultTracker:
         :param step: An optional step to attach the metrics to (e.g. the epoch).
         :param prefix: An optional prefix to prepend to every key in metrics.
         """
-        
+
     def set_tags(self, tags: Dict[str, Any], prefix: Optional[str] = None) -> None:
         """
         Log tags in the result store.
@@ -100,8 +100,15 @@ class MLFlowResultTracker(ResultTracker):
     def set_tags(
             self,
             tags: Dict[str, Any],
-            prefix: Optional[str] = None
+            prefix: Optional[str] = None,
     ) -> None:
+        """
+        Log tags in the mlflow tracking store
+
+        :param tags: The additional run details which are presented as tags to be logged
+        :param prefix: An optional prefix to prepend to every key in metrics.
+        :return:
+        """
         tags = flatten_dictionary(dictionary=tags, prefix=prefix)
         self.mlflow.set_tags(tags)
 

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -101,14 +101,7 @@ class MLFlowResultTracker(ResultTracker):
             self,
             tags: Dict[str, Any],
             prefix: Optional[str] = None,
-    ) -> None:
-        """
-        Log tags in the mlflow tracking store
-
-        :param tags: The additional run details which are presented as tags to be logged
-        :param prefix: An optional prefix to prepend to every key in metrics.
-        :return:
-        """
+    ) -> None: # noqa: D102
         tags = flatten_dictionary(dictionary=tags, prefix=prefix)
         self.mlflow.set_tags(tags)
 

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -34,6 +34,14 @@ class ResultTracker:
         :param step: An optional step to attach the metrics to (e.g. the epoch).
         :param prefix: An optional prefix to prepend to every key in metrics.
         """
+        
+    def set_tags(self, tags: Dict[str, Any], prefix: Optional[str] = None) -> None:
+        """
+        Log tags in the result store.
+
+        :param tags: The additional run details which are presented as tags to be logged
+        :param prefix: An optional prefix to prepend to every key in metrics.
+        """
 
     def end_run(self) -> None:
         """End a run.

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -89,6 +89,14 @@ class MLFlowResultTracker(ResultTracker):
         params = flatten_dictionary(dictionary=params, prefix=prefix)
         self.mlflow.log_params(params=params)
 
+    def set_tags(
+            self,
+            tags: Dict[str, Any],
+            prefix: Optional[str] = None
+    ) -> None:
+        tags = flatten_dictionary(dictionary=tags, prefix=prefix)
+        self.mlflow.set_tags(tags)
+
     def end_run(self) -> None:  # noqa: D102
         self.mlflow.end_run()
 


### PR DESCRIPTION
This PR adds set_tags function to MLFlowResultTracker in tracker.py file

Link to the relevant feature request - https://github.com/pykeen/pykeen/issues/135

Description of the Change - Currently the code doesn't provide any provision for adding tags related to a run. For example, adding details regarding the s3 version of a particular file for one run of an experiment cannot be done using the existing code. 

Alternatives - Use the original API.

Possible Drawbacks - We could probably need mlflow API still for logging the model directly and versioning, but apart from that - I can't think of any possible drawbacks.

[closing cause failed to do tox on my end.. will recreate a separate request using proper procedure in contributing.]