### PR TITLE
Add MLflow set tags function

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,4 +15,4 @@
 - [Maximilian Hünemörder](https://github.com/huenemoerder)
 - [Michael Galkin](https://github.com/migalkin)
 - [Felix Hamann](https://github.com/kantholtz)
-- [sunny1401](https://github.com/sunny1401)
+- [Sankranti Joshi](https://github.com/sunny1401)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,3 +15,4 @@
 - [Maximilian Hünemörder](https://github.com/huenemoerder)
 - [Michael Galkin](https://github.com/migalkin)
 - [Felix Hamann](https://github.com/kantholtz)
+- [sunny1401](https://github.com/sunny1401)

--- a/docs/source/tutorial/trackers/using_mlflow.rst
+++ b/docs/source/tutorial/trackers/using_mlflow.rst
@@ -25,9 +25,6 @@ Minimally, the `tracking_uri` and `experiment_name` are required in the
         result_tracker_kwargs=dict(
             tracking_uri='http://localhost:5000',
             experiment_name='Tutorial Training of RotatE on Kinships',
-            tags={
-            "input_file_h_version_id": s3_version_id
-            }
         ),
     )
 
@@ -87,9 +84,38 @@ Adding Tags
 -----------
 What are tags?
 
+Tags are additional information that you might want to add to the experiment.
+By default, mlflow adds tags given here -
+https://www.mlflow.org/docs/latest/tracking.html#id41.
+
 Why should you use tags?
 
+Tags can be used to add additional information to a particular run to make
+it reusable.
+
+For Example- if the input store for your data is S3, you might want to add
+which version of the input file produced the results; to make the run reproducible.
+This can be added in tags.
+
 Runnable code example using tags.
+The following code block shows how to pass custom tags.
+
+.. code-block:: python
+
+    from pykeen.pipeline import pipeline
+
+    pipeline_result = pipeline(
+        model='RotatE',
+        dataset='Kinships',
+        result_tracker='mlflow',
+        result_tracker_kwargs=dict(
+            tracking_uri='http://localhost:5000',
+            experiment_name='Tutorial Training of RotatE on Kinships',
+            tags={
+            "input_file_hash": md5_hash
+            }
+        ),
+    )
 
 Additional documentation of the valid keyword arguments can be found
 under :class:`pykeen.trackers.MLFlowResultTracker`.

--- a/docs/source/tutorial/trackers/using_mlflow.rst
+++ b/docs/source/tutorial/trackers/using_mlflow.rst
@@ -23,6 +23,9 @@ This example shows using MLflow with the :func:`pykeen.pipeline.pipeline` functi
         result_tracker_kwargs=dict(
             tracking_uri='http://localhost:5000',
             experiment_name='Tutorial Training of RotatE on Kinships',
+            tags={
+            "input_file_h_version_id": s3_version_id
+            }
         ),
     )
 

--- a/docs/source/tutorial/trackers/using_mlflow.rst
+++ b/docs/source/tutorial/trackers/using_mlflow.rst
@@ -11,6 +11,8 @@ by default.
 Pipeline Example
 ----------------
 This example shows using MLflow with the :func:`pykeen.pipeline.pipeline` function.
+Minimally, the `tracking_uri` and `experiment_name` are required in the
+`result_tracker_kwargs`.
 
 .. code-block:: python
 
@@ -80,6 +82,14 @@ different sub-experiments together using the ``experiment_id`` keyword argument 
             experiment_id=4,
         ),
     )
+
+Adding Tags
+-----------
+What are tags?
+
+Why should you use tags?
+
+Runnable code example using tags.
 
 Additional documentation of the valid keyword arguments can be found
 under :class:`pykeen.trackers.MLFlowResultTracker`.

--- a/docs/source/tutorial/trackers/using_mlflow.rst
+++ b/docs/source/tutorial/trackers/using_mlflow.rst
@@ -82,38 +82,31 @@ different sub-experiments together using the ``experiment_id`` keyword argument 
 
 Adding Tags
 -----------
-What are tags?
-
-Tags are additional information that you might want to add to the experiment.
-By default, mlflow adds tags given here -
+Tags are additional key/value information that you might want to add to the experiment
+and store in MLflow. By default, MLflow adds the tags listed on
 https://www.mlflow.org/docs/latest/tracking.html#id41.
 
-Why should you use tags?
-
-Tags can be used to add additional information to a particular run to make
-it reusable.
-
-For Example- if the input store for your data is S3, you might want to add
-which version of the input file produced the results; to make the run reproducible.
-This can be added in tags.
-
-Runnable code example using tags.
-The following code block shows how to pass custom tags.
+For example, if you're using custom input,  you might want to add which version
+of the input file produced the results as follows:
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
+    data_version = ...
+
     pipeline_result = pipeline(
         model='RotatE',
-        dataset='Kinships',
+        training=...,
+        testing=...,
+        validation=...,
         result_tracker='mlflow',
         result_tracker_kwargs=dict(
             tracking_uri='http://localhost:5000',
             experiment_name='Tutorial Training of RotatE on Kinships',
             tags={
-            "input_file_hash": md5_hash
-            }
+                "data_version": md5_hash,
+            },
         ),
     )
 

--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -834,9 +834,11 @@ def pipeline(  # noqa: C901
     if not metadata:
         metadata = {}
     title = metadata.get('title')
+    tags = metadata.get('run_tags', None)
 
     # Start tracking
     result_tracker.start_run(run_name=title)
+    result_tracker.set_tags(tags)
 
     device = resolve_device(device)
 

--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -834,11 +834,9 @@ def pipeline(  # noqa: C901
     if not metadata:
         metadata = {}
     title = metadata.get('title')
-    tags = metadata.get('run_tags', None)
 
     # Start tracking
     result_tracker.start_run(run_name=title)
-    result_tracker.set_tags(tags)
 
     device = resolve_device(device)
 

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -35,6 +35,14 @@ class ResultTracker:
         :param prefix: An optional prefix to prepend to every key in metrics.
         """
 
+    def set_tags(self, tags: Dict[str, Any], prefix: Optional[str] = None) -> None:
+        """
+        Log tags in the result store.
+
+        :param tags: The additional run details which are presented as tags to be logged
+        :param prefix: An optional prefix to prepend to every key in metrics.
+        """
+
     def end_run(self) -> None:
         """End a run.
 
@@ -92,8 +100,8 @@ class MLFlowResultTracker(ResultTracker):
     def set_tags(
             self,
             tags: Dict[str, Any],
-            prefix: Optional[str] = None
-    ) -> None:
+            prefix: Optional[str] = None,
+    ) -> None:  # noqa: D102
         tags = flatten_dictionary(dictionary=tags, prefix=prefix)
         self.mlflow.set_tags(tags)
 

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -34,6 +34,7 @@ class ResultTracker:
         :param step: An optional step to attach the metrics to (e.g. the epoch).
         :param prefix: An optional prefix to prepend to every key in metrics.
         """
+
     def end_run(self) -> None:
         """End a run.
 
@@ -67,7 +68,7 @@ class MLFlowResultTracker(ResultTracker):
         """
         import mlflow as _mlflow
         self.mlflow = _mlflow
-        self.__tags = dict()
+        self.tags = tags
 
         self.mlflow.set_tracking_uri(tracking_uri)
         if experiment_id is not None:
@@ -75,13 +76,11 @@ class MLFlowResultTracker(ResultTracker):
             experiment_name = experiment.name
         if experiment_name is not None:
             self.mlflow.set_experiment(experiment_name)
-        if tags is not None:
-            self.__tags = tags
 
     def start_run(self, run_name: Optional[str] = None) -> None:  # noqa: D102
         self.mlflow.start_run(run_name=run_name)
-        if len(self.__tags):
-            self.mlflow.set_tags(tags=self.__tags)
+        if self.tags is not None:
+            self.mlflow.set_tags(tags=self.tags)
 
     def log_metrics(
         self,

--- a/src/pykeen/trackers.py
+++ b/src/pykeen/trackers.py
@@ -89,6 +89,14 @@ class MLFlowResultTracker(ResultTracker):
         params = flatten_dictionary(dictionary=params, prefix=prefix)
         self.mlflow.log_params(params=params)
 
+    def set_tags(
+            self,
+            tags: Dict[str, Any],
+            prefix: Optional[str] = None
+    ) -> None:
+        tags = flatten_dictionary(dictionary=tags, prefix=prefix)
+        self.mlflow.set_tags(tags)
+
     def end_run(self) -> None:  # noqa: D102
         self.mlflow.end_run()
 


### PR DESCRIPTION
This PR adds set_tags function to MLFlowResultTracker in tracker.py file

Link to the relevant feature request - https://github.com/pykeen/pykeen/issues/135

Description of the Change - Currently the code doesn't provide any provision for adding tags related to a run. For example, adding details regarding the s3 version of a particular file for one run of an experiment cannot be done using the existing code. 

Alternatives - Use the original API.

Possible Drawbacks - We could probably need mlflow API still for logging the model directly and versioning, but apart from that - I can't think of any possible drawbacks.

Verification Process - Ran tox. Got the following- 
manifest: commands succeeded
  flake8: commands succeeded
ERROR:   darglint: commands failed (fails in file I have not touched)
  pyroma: commands succeeded
  readme: commands succeeded
  doc8: commands succeeded
ERROR:   docs: commands failed (Warning, treated as error:
dot command 'dot' cannot be run (needed for graphviz output), check the graphviz_dot setting
)
  py: commands succeeded
  integration: commands succeeded