### PR TITLE
Use entity_to_id/relation_to_id to determine num_entities/relations

### DIFF
--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -231,8 +231,6 @@ class TriplesFactory:
             self.path = '<None>'
             self.triples = triples
 
-        self._num_entities = len(set(self.triples[:, 0]).union(self.triples[:, 2]))
-
         relations = self.triples[:, 1]
         unique_relations = set(relations)
 
@@ -291,6 +289,9 @@ class TriplesFactory:
         if compact_id:
             relation_to_id = compact_mapping(mapping=relation_to_id)[0]
         self.relation_to_id = relation_to_id
+
+        self._num_entities = len(self.entity_to_id)
+        self._num_relations = len(self.relation_to_id)
 
         # Map triples of labels to triples of IDs.
         self.mapped_triples = _map_triples_elements_to_ids(

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -264,12 +264,10 @@ class TriplesFactory:
                 )
                 # extend original triples with inverse ones
                 self.triples = np.concatenate([self.triples, inverse_triples], axis=0)
-                self._num_relations = 2 * len(unique_relations)
 
         else:
             self.create_inverse_triples = False
             self.relation_to_inverse = None
-            self._num_relations = len(unique_relations)
 
         # Generate entity mapping if necessary
         if entity_to_id is None:
@@ -290,15 +288,15 @@ class TriplesFactory:
             relation_to_id = compact_mapping(mapping=relation_to_id)[0]
         self.relation_to_id = relation_to_id
 
-        self._num_entities = len(self.entity_to_id)
-        self._num_relations = len(self.relation_to_id)
-
         # Map triples of labels to triples of IDs.
         self.mapped_triples = _map_triples_elements_to_ids(
             triples=self.triples,
             entity_to_id=self.entity_to_id,
             relation_to_id=self.relation_to_id,
         )
+
+        self._num_entities = len(set(self.mapped_triples[:, 0]).union(self.mapped_triples[:, 2]))
+        self._num_relations = len(set(self.mapped_triples[:, 1]))
 
     @property
     def num_entities(self) -> int:  # noqa: D401


### PR DESCRIPTION
If `entity_to_id/relation_to_id` is provide externally, the final number of entities/relations can be different from the number of entities/relations contained initially in `triples`.
