### PR TITLE
Fix evaluation code in "First Steps" docs

### DIFF
--- a/docs/source/tutorial/first_steps.rst
+++ b/docs/source/tutorial/first_steps.rst
@@ -51,11 +51,11 @@ executed with one of the previous examples.
 
     # Pick an evaluator
     from pykeen.evaluation import RankBasedEvaluator
-    evaluator = RankBasedEvaluator(model)
+    evaluator = RankBasedEvaluator()
 
     # Get triples to test
     mapped_triples = dataset.testing.mapped_triples
 
     # Evaluate
-    results = evaluator.evaluate(mapped_triples, batch_size=1024)
+    results = evaluator.evaluate(model, mapped_triples, batch_size=1024)
     print(results)


### PR DESCRIPTION
On the "First Steps" page in the docs, the last code block does not work with pykeen 1.0.5. After a minor change, the code runs:

Pass model to evaluator.evaluate(), not to RankBasedEvaluator()
