### PR TITLE
Begin testing on Windows on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,25 @@ jobs:
     - name: "Test slow unit tests"
       stage: slow_tests
       env: TOXENV=integration
+    - name: "Test slow unit tests (Windows)"
+      stage: slow_tests
+      os: windows           # Windows 10.0.17134 N/A Build 17134
+      language: shell       # 'language: python' is an error on Travis CI Windows
+      before_install:
+        - choco install openssl.light
+        - choco install miniconda3
+        - conda update --yes conda
+      install:
+        - conda create --yes -n test python=3.7
+        - source activate test
+        - conda install pytorch torchvision cudatoolkit=10.2 -c pytorch --yes
+        - pip install -e .[mlflow]
+        - pip install pytest
+      script:
+        - pytest --durations=20 tests/ -m "slow"
+      env: PATH=/c/tools/miniconda3/Scripts:$PATH
+      after_success:
+        - tox -e coverage-report
   allow_failures:
     - env: TOXENV=darglint
     # - env: TOXENV=mypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
       install:
         - conda create --yes -n test python=3.7
         - source activate test
-        - conda install pytorch torchvisioncudatoolkit=10.2 -c pytorch --yes
+        - conda install pytorch torchvision cudatoolkit=10.2 -c pytorch --yes
         - pip install -e .
         - pip install pytest
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,18 @@ jobs:
       os: windows           # Windows 10.0.17134 N/A Build 17134
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
-        - choco install python --version 3.7.4
-        - python --version
+        - choco install openssl.light
+        - choco install miniconda3
+        - conda update --yes conda
       install:
-        - pip install pytorch torchvision cudatoolkit=10.2
+        - conda create --yes -n test python=3.7
+        - source activate test
+        - conda install pytorch torchvisioncudatoolkit=10.2 -c pytorch --yes
         - pip install -e .
         - pip install pytest
       script:
-        pytest tests/
-      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH TOXENV=py
+        - pytest --durations=20 tests/ -m "not slow"
+      env: PATH=/c/tools/miniconda3/Scripts:$PATH
       after_success:
         - tox -e coverage-report
     - name: "Test slow unit tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
         - conda create --yes -n test python=3.7
         - source activate test
         - conda install pytorch torchvision cudatoolkit=10.2 -c pytorch --yes
-        - pip install -e .
+        - pip install -e .[mlflow]
         - pip install pytest
       script:
         - pytest --durations=20 tests/ -m "not slow"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,23 @@ jobs:
     - name: "Test fast unit tests"
       stage: fast_tests
       env: TOXENV=py
+    # borrowed windows testing config from https://github.com/shaypal5/cachier/blob/master/.travis.yml
+    - name: "Test fast unit tests (Windows)"
+      stage: fast_tests
+      os: windows           # Windows 10.0.17134 N/A Build 17134
+      language: shell       # 'language: python' is an error on Travis CI Windows
+      before_install:
+        - choco install python --version 3.7.4
+        - python --version
+      install:
+        - pip install pytorch torchvision cudatoolkit=10.2
+        - pip install -e .
+        - pip install pytest
+      script:
+        pytest tests/
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH TOXENV=py
+      after_success:
+        - tox -e coverage-report
     - name: "Test slow unit tests"
       stage: slow_tests
       env: TOXENV=integration


### PR DESCRIPTION
After taking inspiration from https://github.com/shaypal5/cachier and https://github.com/rusty1s/pytorch_geometric, I've prepared configuration for testing PyKEEN on Windows inside Travis.

Example successful build: https://travis-ci.com/github/pykeen/pykeen/builds/202868915

We can also leave the AppVeyor build running. Depends what you all think @mali-git @mberr @lvermue 

**Caveat** we may actually have to stop using Travis soon since it's not unlimited free anymore. We might want to switch over to GitHub actions, but at least this seems to work for now. 