### PR TITLE
Fix compose

### DIFF
--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -7,7 +7,7 @@ import json
 import logging
 import random
 from io import BytesIO
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Generic, Iterable, List, Mapping, Optional, Tuple, Type, TypeVar, Union
 
 import numpy
 import numpy as np
@@ -231,17 +231,18 @@ def clamp_norm(
     return mask * x + (1 - mask) * (x / norm.clamp_min(eps) * maxnorm)
 
 
-def compose(
-    *op_: Callable[[torch.Tensor], torch.Tensor],
-) -> Callable[[torch.Tensor], torch.Tensor]:
-    """Compose functions working on a single tensor."""
+class compose(Generic[X]):  # noqa:N801
+    """A class representing the composition of several functions."""
 
-    def chained_op(x: torch.Tensor):
-        for op in op_:
-            x = op(x)
+    def __init__(self, *operations: Callable[[X], X]):
+        """Initialize the composition with a sequence of operations."""
+        self.operations = operations
+
+    def __call__(self, x: X) -> X:
+        """Apply the operations in order to the given tensor."""
+        for operation in self.operations:
+            x = operation(x)
         return x
-
-    return chained_op
 
 
 def set_random_seed(seed: int):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -182,6 +182,11 @@ class _ModelTestCase:
         # check whether a gradient can be back-propgated
         scores.mean().backward()
 
+    def test_save(self) -> None:
+        """Test that the model can be saved properly."""
+        with tempfile.TemporaryDirectory() as temp_directory:
+            torch.save(self.model, os.path.join(temp_directory, 'model.pickle'))
+
     def test_score_hrt(self) -> None:
         """Test the model's ``score_hrt()`` function."""
         batch = self.factory.mapped_triples[:self.batch_size, :].to(self.model.device)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,12 +10,27 @@ import torch
 
 from pykeen.nn import Embedding
 from pykeen.utils import (
-    clamp_norm,
-    compact_mapping,
-    flatten_dictionary,
-    get_until_first_blank,
-    l2_regularization,
+    clamp_norm, compact_mapping, compose, flatten_dictionary, get_until_first_blank, l2_regularization,
 )
+
+
+class TestCompose(unittest.TestCase):
+    """Tests for composition."""
+
+    def test_compose(self):
+        """Test composition."""
+
+        def _f(x):
+            return x + 2
+
+        def _g(x):
+            return 2 * x
+
+        fog = compose(_f, _g)
+        for i in range(5):
+            with self.subTest(i=i):
+                self.assertEqual(_g(_f(i)), fog(i))
+                self.assertEqual(_g(_f(i ** 2)), fog(i ** 2))
 
 
 class L2RegularizationTest(unittest.TestCase):


### PR DESCRIPTION
Closes #169 by turning `compose()` into a class with a `__call__()`.

Blocked by https://github.com/pykeen/pykeen/pull/174 because the `Generic[X]` requires python 3.7+