### PR TITLE
Remove python 3.6 requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ Steps to reproduce the behavior:
 
 **Environment (please complete the following information):**
  - OS: [e.g. macOS]
- - Python version: [e.g. 3.6.8]
+ - Python version: [e.g. 3.8.1]
  - Version of this software: [e.g. 0.0.1-dev] # run ``pip list | grep -Eiw 'pykeen'`` in your environment shell
  - Versions of required Python packages: # run pip list | grep -Eiw 'torch|numpy|Click|click-default-group|tqdm'
    - Torch: [e.g. 1.1.0]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests_on_comment.yml
+++ b/.github/workflows/tests_on_comment.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8 ]
     steps:
       - uses: actions/github-script@v3
         id: get-pr

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3 :: Only
@@ -50,7 +49,6 @@ keywords =
 
 [options]
 install_requires =
-    dataclasses; python_version < "3.7"
     dataclasses-json
     numpy
     click
@@ -65,7 +63,7 @@ install_requires =
 
 zip_safe = false
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 
 # Where is my code
 packages = find:

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -7,8 +7,6 @@ import timeit
 import unittest
 from typing import ClassVar, Optional, Type
 
-from requests.exceptions import ConnectionError
-
 from pykeen.datasets.base import LazyDataSet
 from pykeen.triples import TriplesFactory
 
@@ -47,7 +45,7 @@ class DatasetTestCase(unittest.TestCase):
         # Load
         try:
             self.dataset._load()
-        except (ConnectionError, EOFError):
+        except (EOFError, IOError):
             self.skipTest('Problem with connection. Try this test again later.')
 
         self.assertIsInstance(self.dataset.training, TriplesFactory)


### PR DESCRIPTION
Closes #173

@mberr reminded that ubuntu is shipping with a newer version of python than 3.6 so we should be 💃 