### PR TITLE
Normalize usage of datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ can be found in the [installation documentation](https://pykeen.readthedocs.io/e
 
 ## Quickstart [![Documentation Status](https://readthedocs.org/projects/pykeen/badge/?version=latest)](https://pykeen.readthedocs.io/en/latest/?badge=latest)
 
-This example shows how to train a model on a data set and test on another data set.
+This example shows how to train a model on a dataset and test on another dataset.
 
 The fastest way to get up and running is to use the pipeline function. It
 provides a high-level entry into the extensible functionality of this package.
@@ -98,32 +98,32 @@ The full documentation can be found at https://pykeen.readthedocs.io.
 
 ## Implementation
 
-Below are the models, data sets, training modes, evaluators, and metrics implemented
+Below are the models, datasets, training modes, evaluators, and metrics implemented
 in ``pykeen``.
 
 ### Datasets (19)
 
-| Name          | Reference                       | Description                                                                                        |
-|---------------|---------------------------------|----------------------------------------------------------------------------------------------------|
-| codexlarge    | `pykeen.datasets.CoDExLarge`    | The CoDEx large dataset.                                                                           |
-| codexmedium   | `pykeen.datasets.CoDExMedium`   | The CoDEx medium dataset.                                                                          |
-| codexsmall    | `pykeen.datasets.CoDExSmall`    | The CoDEx small dataset.                                                                           |
-| drkg          | `pykeen.datasets.DRKG`          | The DRKG dataset.                                                                                  |
-| fb15k         | `pykeen.datasets.FB15k`         | The FB15k data set.                                                                                |
-| fb15k237      | `pykeen.datasets.FB15k237`      | The FB15k-237 data set.                                                                            |
-| hetionet      | `pykeen.datasets.Hetionet`      | The Hetionet dataset is a large biological network.                                                |
-| kinships      | `pykeen.datasets.Kinships`      | The Kinships data set.                                                                             |
-| nations       | `pykeen.datasets.Nations`       | The Nations data set.                                                                              |
-| ogbbiokg      | `pykeen.datasets.OGBBioKG`      | The OGB BioKG dataset.                                                                             |
-| ogbwikikg     | `pykeen.datasets.OGBWikiKG`     | The OGB WikiKG dataset.                                                                            |
-| openbiolink   | `pykeen.datasets.OpenBioLink`   | The OpenBioLink dataset.                                                                           |
-| openbiolinkf1 | `pykeen.datasets.OpenBioLinkF1` | The PyKEEN First Filtered OpenBioLink 2020 Dataset.                                                |
-| openbiolinkf2 | `pykeen.datasets.OpenBioLinkF2` | The PyKEEN Second Filtered OpenBioLink 2020 Dataset.                                               |
-| openbiolinklq | `pykeen.datasets.OpenBioLinkLQ` | The low-quality variant of the OpenBioLink dataset.                                                |
-| umls          | `pykeen.datasets.UMLS`          | The UMLS data set.                                                                                 |
-| wn18          | `pykeen.datasets.WN18`          | The WN18 data set.                                                                                 |
-| wn18rr        | `pykeen.datasets.WN18RR`        | The WN18-RR data set.                                                                              |
-| yago310       | `pykeen.datasets.YAGO310`       | The YAGO3-10 data set is a subset of YAGO3 that only contains entities with at least 10 relations. |
+| Name          | Reference                       | Description                                                                                       |
+|---------------|---------------------------------|---------------------------------------------------------------------------------------------------|
+| codexlarge    | `pykeen.datasets.CoDExLarge`    | The CoDEx large dataset.                                                                          |
+| codexmedium   | `pykeen.datasets.CoDExMedium`   | The CoDEx medium dataset.                                                                         |
+| codexsmall    | `pykeen.datasets.CoDExSmall`    | The CoDEx small dataset.                                                                          |
+| drkg          | `pykeen.datasets.DRKG`          | The DRKG dataset.                                                                                 |
+| fb15k         | `pykeen.datasets.FB15k`         | The FB15k dataset.                                                                                |
+| fb15k237      | `pykeen.datasets.FB15k237`      | The FB15k-237 dataset.                                                                            |
+| hetionet      | `pykeen.datasets.Hetionet`      | The Hetionet dataset is a large biological network.                                               |
+| kinships      | `pykeen.datasets.Kinships`      | The Kinships dataset.                                                                             |
+| nations       | `pykeen.datasets.Nations`       | The Nations dataset.                                                                              |
+| ogbbiokg      | `pykeen.datasets.OGBBioKG`      | The OGB BioKG dataset.                                                                            |
+| ogbwikikg     | `pykeen.datasets.OGBWikiKG`     | The OGB WikiKG dataset.                                                                           |
+| openbiolink   | `pykeen.datasets.OpenBioLink`   | The OpenBioLink dataset.                                                                          |
+| openbiolinkf1 | `pykeen.datasets.OpenBioLinkF1` | The PyKEEN First Filtered OpenBioLink 2020 Dataset.                                               |
+| openbiolinkf2 | `pykeen.datasets.OpenBioLinkF2` | The PyKEEN Second Filtered OpenBioLink 2020 Dataset.                                              |
+| openbiolinklq | `pykeen.datasets.OpenBioLinkLQ` | The low-quality variant of the OpenBioLink dataset.                                               |
+| umls          | `pykeen.datasets.UMLS`          | The UMLS dataset.                                                                                 |
+| wn18          | `pykeen.datasets.WN18`          | The WN18 dataset.                                                                                 |
+| wn18rr        | `pykeen.datasets.WN18RR`        | The WN18-RR dataset.                                                                              |
+| yago310       | `pykeen.datasets.YAGO310`       | The YAGO3-10 dataset is a subset of YAGO3 that only contains entities with at least 10 relations. |
 
 ### Models (23)
 
@@ -253,7 +253,7 @@ experiments. They can be accessed and run like:
 pykeen experiments reproduce tucker balazevic2019 fb15k
 ```
 
-Where the three arguments are the model name, the reference, and the data set.
+Where the three arguments are the model name, the reference, and the dataset.
 The output directory can be optionally set with `-d`.
 
 ### Ablation

--- a/docs/source/tutorial/first_steps.rst
+++ b/docs/source/tutorial/first_steps.rst
@@ -29,7 +29,7 @@ executed with one of the previous examples.
 
 .. code-block:: python
 
-    # Get a training data set
+    # Get a training dataset
     from pykeen.datasets import Nations
     dataset = Nations()
     training_triples_factory = dataset.training

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -2,7 +2,7 @@
 
 """Sample datasets for use with PyKEEN, borrowed from https://github.com/ZhenfengLei/KGDatasets.
 
-New datasets (inheriting from :class:`pykeen.datasets.base.DataSet`) can be registered with PyKEEN using the
+New datasets (inheriting from :class:`pykeen.datasets.base.Dataset`) can be registered with PyKEEN using the
 `pykeen.datasets` group in Python entrypoints in your own `setup.py` or `setup.cfg` package configuration.
 They are loaded automatically with :func:`pkg_resources.iter_entry_points`.
 """
@@ -14,8 +14,8 @@ from typing import Any, Mapping, Optional, Set, Type, Union
 from pkg_resources import iter_entry_points
 
 from .base import (  # noqa:F401
-    DataSet, EagerDataset, LazyDataSet, PackedZipRemoteDataSet, PathDataSet, RemoteDataSet, SingleTabbedDataset,
-    TarFileRemoteDataSet, UnpackedRemoteDataSet, ZipFileRemoteDataSet,
+    Dataset, EagerDataset, LazyDataset, PackedZipRemoteDataset, PathDataset, RemoteDataset, SingleTabbedDataset,
+    TarFileRemoteDataset, UnpackedRemoteDataset, ZipFileRemoteDataset,
 )
 from .codex import CoDExLarge, CoDExMedium, CoDExSmall
 from .freebase import FB15k, FB15k237
@@ -55,7 +55,7 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-_DATASETS: Set[Type[DataSet]] = {
+_DATASETS: Set[Type[Dataset]] = {
     entry.load()
     for entry in iter_entry_points(group='pykeen.datasets')
 }
@@ -63,17 +63,17 @@ if not _DATASETS:
     raise RuntimeError('Datasets have been loaded with entrypoints since PyKEEN v1.0.5. Please reinstall.')
 
 #: A mapping of datasets' names to their classes
-datasets: Mapping[str, Type[DataSet]] = normalized_lookup(_DATASETS)
+datasets: Mapping[str, Type[Dataset]] = normalized_lookup(_DATASETS)
 
 
 def get_dataset(
     *,
-    dataset: Union[None, str, DataSet, Type[DataSet]] = None,
+    dataset: Union[None, str, Dataset, Type[Dataset]] = None,
     dataset_kwargs: Optional[Mapping[str, Any]] = None,
     training: Union[None, str, TriplesFactory] = None,
     testing: Union[None, str, TriplesFactory] = None,
     validation: Union[None, str, TriplesFactory] = None,
-) -> DataSet:
+) -> Dataset:
     """Get the dataset.
 
     :raises ValueError:
@@ -85,29 +85,29 @@ def get_dataset(
     if dataset is not None and (training is not None or testing is not None):
         raise ValueError('Can not specify both dataset and training/testing triples factories.')
 
-    if isinstance(dataset, DataSet):
+    if isinstance(dataset, Dataset):
         if dataset_kwargs:
             logger.warning('dataset_kwargs not used since a pre-instantiated dataset was given')
         return dataset
 
     if isinstance(dataset, str):
         if has_dataset(dataset):
-            dataset: Type[DataSet] = datasets[normalize_string(dataset)]
+            dataset: Type[Dataset] = datasets[normalize_string(dataset)]
         elif not os.path.exists(dataset):
             raise ValueError('dataset is neither a pre-defined dataset string nor a filepath')
         else:
-            return DataSet.from_path(dataset)
+            return Dataset.from_path(dataset)
 
-    if isinstance(dataset, type) and issubclass(dataset, DataSet):
+    if isinstance(dataset, type) and issubclass(dataset, Dataset):
         return dataset(**(dataset_kwargs or {}))
 
     if dataset is not None:
-        raise TypeError(f'Data set is invalid type: {type(dataset)}')
+        raise TypeError(f'Dataset is invalid type: {type(dataset)}')
 
     if isinstance(training, str) and isinstance(testing, str):
         if validation is not None and not isinstance(validation, str):
             raise TypeError(f'Validation is invalid type: {type(validation)}')
-        return PathDataSet(
+        return PathDataset(
             training_path=training,
             testing_path=testing,
             validation_path=validation,

--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -24,15 +24,15 @@ from ..triples import TriplesFactory
 from ..utils import normalize_string
 
 __all__ = [
-    'DataSet',
+    'Dataset',
     'EagerDataset',
-    'LazyDataSet',
-    'PathDataSet',
-    'RemoteDataSet',
-    'UnpackedRemoteDataSet',
-    'TarFileRemoteDataSet',
-    'ZipFileRemoteDataSet',
-    'PackedZipRemoteDataSet',
+    'LazyDataset',
+    'PathDataset',
+    'RemoteDataset',
+    'UnpackedRemoteDataset',
+    'TarFileRemoteDataset',
+    'ZipFileRemoteDataset',
+    'PackedZipRemoteDataset',
     'TarFileSingleDataset',
     'SingleTabbedDataset',
 ]
@@ -40,8 +40,8 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-class DataSet:
-    """Contains a lazy reference to a training, testing, and validation data set."""
+class Dataset:
+    """Contains a lazy reference to a training, testing, and validation dataset."""
 
     #: A factory wrapping the training triples
     training: TriplesFactory
@@ -49,7 +49,7 @@ class DataSet:
     testing: TriplesFactory
     #: A factory wrapping the validation triples, that share indices with the training triples
     validation: TriplesFactory
-    #: All data sets should take care of inverse triple creation
+    #: All datasets should take care of inverse triple creation
     create_inverse_triples: bool
 
     @property
@@ -95,13 +95,13 @@ class DataSet:
         return f'{self.__class__.__name__}(num_entities={self.num_entities}, num_relations={self.num_relations})'
 
     @classmethod
-    def from_path(cls, path: str, ratios: Optional[List[float]] = None) -> 'DataSet':
+    def from_path(cls, path: str, ratios: Optional[List[float]] = None) -> 'Dataset':
         """Create a dataset from a single triples factory by splitting it in 3."""
         tf = TriplesFactory(path=path)
         return cls.from_tf(tf=tf, ratios=ratios)
 
     @staticmethod
-    def from_tf(tf: TriplesFactory, ratios: Optional[List[float]] = None) -> 'DataSet':
+    def from_tf(tf: TriplesFactory, ratios: Optional[List[float]] = None) -> 'Dataset':
         """Create a dataset from a single triples factory by splitting it in 3."""
         training, testing, validation = tf.split(ratios or [0.8, 0.1, 0.1])
         return EagerDataset(training=training, testing=testing, validation=validation)
@@ -112,7 +112,7 @@ class DataSet:
         return normalize_string(cls.__name__)
 
 
-class EagerDataset(DataSet):
+class EagerDataset(Dataset):
     """A dataset that has already been loaded."""
 
     def __init__(self, training: TriplesFactory, testing: TriplesFactory, validation: TriplesFactory) -> None:
@@ -126,8 +126,8 @@ class EagerDataset(DataSet):
         )
 
 
-class LazyDataSet(DataSet):
-    """A data set that has lazy loading."""
+class LazyDataset(Dataset):
+    """A dataset that has lazy loading."""
 
     #: The actual instance of the training factory, which is exposed to the user through `training`
     _training: Optional[TriplesFactory] = None
@@ -181,7 +181,7 @@ class LazyDataSet(DataSet):
         :param cache_root: If none is passed, defaults to a subfolder of the
             PyKEEN home directory defined in :data:`pykeen.constants.PYKEEN_HOME`.
             The subfolder is named based on the class inheriting from
-            :class:`pykeen.datasets.base.DataSet`.
+            :class:`pykeen.datasets.base.Dataset`.
         """
         if cache_root is None:
             cache_root = PYKEEN_HOME
@@ -191,8 +191,8 @@ class LazyDataSet(DataSet):
         return cache_root
 
 
-class PathDataSet(LazyDataSet):
-    """Contains a lazy reference to a training, testing, and validation data set."""
+class PathDataset(LazyDataset):
+    """Contains a lazy reference to a training, testing, and validation dataset."""
 
     def __init__(
         self,
@@ -202,7 +202,7 @@ class PathDataSet(LazyDataSet):
         eager: bool = False,
         create_inverse_triples: bool = False,
     ) -> None:
-        """Initialize the data set.
+        """Initialize the dataset.
 
         :param training_path: Path to the training triples file or training triples file.
         :param testing_path: Path to the testing triples file or testing triples file.
@@ -279,7 +279,7 @@ def _urlretrieve(url: str, path: str, clean_on_failure: bool = True, stream: boo
             raise
 
 
-class UnpackedRemoteDataSet(PathDataSet):
+class UnpackedRemoteDataset(PathDataset):
     """A dataset with all three of train, test, and validation sets as URLs."""
 
     def __init__(
@@ -334,7 +334,7 @@ class UnpackedRemoteDataSet(PathDataSet):
         )
 
 
-class RemoteDataSet(PathDataSet):
+class RemoteDataset(PathDataset):
     """Contains a lazy reference to a remote dataset that is loaded if needed."""
 
     def __init__(
@@ -406,7 +406,7 @@ class RemoteDataSet(PathDataSet):
         super()._load()
 
 
-class TarFileRemoteDataSet(RemoteDataSet):
+class TarFileRemoteDataset(RemoteDataset):
     """A remote dataset stored as a tar file."""
 
     def _extract(self, archive_file: BytesIO) -> None:  # noqa: D102
@@ -415,7 +415,7 @@ class TarFileRemoteDataSet(RemoteDataSet):
 
 
 # TODO replace this with the new zip remote dataset class
-class ZipFileRemoteDataSet(RemoteDataSet):
+class ZipFileRemoteDataset(RemoteDataset):
     """A remote dataset stored as a zip file."""
 
     def _extract(self, archive_file: BytesIO) -> None:  # noqa: D102
@@ -423,7 +423,7 @@ class ZipFileRemoteDataSet(RemoteDataSet):
             zf.extractall(path=self.cache_root)
 
 
-class PackedZipRemoteDataSet(LazyDataSet):
+class PackedZipRemoteDataset(LazyDataset):
     """Contains a lazy reference to a remote dataset that is loaded if needed."""
 
     head_column: int = 0
@@ -502,7 +502,7 @@ class PackedZipRemoteDataSet(LazyDataSet):
                 return rv
 
 
-class TarFileSingleDataset(LazyDataSet):
+class TarFileSingleDataset(LazyDataset):
     """Loads a dataset that's a single file inside a tar.gz archive."""
 
     ratios = (0.8, 0.1, 0.1)
@@ -582,7 +582,7 @@ class TarFileSingleDataset(LazyDataSet):
         pass  # already loaded by _load()
 
 
-class SingleTabbedDataset(LazyDataSet):
+class SingleTabbedDataset(LazyDataset):
     """This class is for when you've got a single TSV of edges and want them to get auto-split."""
 
     ratios = (0.8, 0.1, 0.1)

--- a/src/pykeen/datasets/codex.py
+++ b/src/pykeen/datasets/codex.py
@@ -6,7 +6,7 @@
 - Paper: https://arxiv.org/pdf/2009.07810.pdf
 """
 
-from .base import UnpackedRemoteDataSet
+from .base import UnpackedRemoteDataset
 
 BASE_URL = 'https://raw.githubusercontent.com/tsafavi/codex/master/data/triples/'
 SMALL_VALID_URL = f'{BASE_URL}/codex-s/valid.txt'
@@ -26,14 +26,14 @@ LARGE_TRAIN_URL = f'{BASE_URL}/codex-l/train.txt'
 # the data posted at https://github.com/pykeen/pykeen/pull/154#issuecomment-730462039
 
 
-class CoDExSmall(UnpackedRemoteDataSet):
+class CoDExSmall(UnpackedRemoteDataset):
     """The CoDEx small dataset."""
 
     def __init__(self, create_inverse_triples: bool = False, **kwargs):
         """Initialize the `CoDEx <https://github.com/tsafavi/codex>`_ small dataset from [safavi2020]_.
 
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataSet`.
+        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         # GitHub's raw.githubusercontent.com service rejects requests that are streamable. This is
         # normally the default for all of PyKEEN's remote datasets, so just switch the default here.
@@ -47,14 +47,14 @@ class CoDExSmall(UnpackedRemoteDataSet):
         )
 
 
-class CoDExMedium(UnpackedRemoteDataSet):
+class CoDExMedium(UnpackedRemoteDataset):
     """The CoDEx medium dataset."""
 
     def __init__(self, create_inverse_triples: bool = False, **kwargs):
         """Initialize the `CoDEx <https://github.com/tsafavi/codex>`_ medium dataset from [safavi2020]_.
 
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataSet`.
+        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         kwargs.setdefault('stream', False)  # See comment in CoDExSmall
         super().__init__(
@@ -66,14 +66,14 @@ class CoDExMedium(UnpackedRemoteDataSet):
         )
 
 
-class CoDExLarge(UnpackedRemoteDataSet):
+class CoDExLarge(UnpackedRemoteDataset):
     """The CoDEx large dataset."""
 
     def __init__(self, create_inverse_triples: bool = False, **kwargs):
         """Initialize the `CoDEx <https://github.com/tsafavi/codex>`_ large dataset from [safavi2020]_.
 
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataSet`.
+        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         kwargs.setdefault('stream', False)  # See comment in CoDExSmall
         super().__init__(

--- a/src/pykeen/datasets/freebase.py
+++ b/src/pykeen/datasets/freebase.py
@@ -9,7 +9,7 @@
 import os
 from typing import Optional
 
-from .base import TarFileRemoteDataSet, ZipFileRemoteDataSet
+from .base import TarFileRemoteDataset, ZipFileRemoteDataset
 
 __all__ = [
     'FB15k',
@@ -17,8 +17,8 @@ __all__ = [
 ]
 
 
-class FB15k(TarFileRemoteDataSet):
-    """The FB15k data set."""
+class FB15k(TarFileRemoteDataset):
+    """The FB15k dataset."""
 
     def __init__(self, cache_root: Optional[str] = None, **kwargs):
         super().__init__(
@@ -31,8 +31,8 @@ class FB15k(TarFileRemoteDataSet):
         )
 
 
-class FB15k237(ZipFileRemoteDataSet):
-    """The FB15k-237 data set."""
+class FB15k237(ZipFileRemoteDataset):
+    """The FB15k-237 dataset."""
 
     def __init__(self, cache_root: Optional[str] = None, **kwargs):
         super().__init__(

--- a/src/pykeen/datasets/generate.py
+++ b/src/pykeen/datasets/generate.py
@@ -8,7 +8,7 @@ import os
 import click
 import numpy as np
 
-from .base import PathDataSet
+from .base import PathDataset
 from ..triples import TriplesFactory
 from ..utils import random_non_negative_int
 
@@ -51,7 +51,7 @@ def main(path: str, directory: str, test_ratios, no_validation: bool, validation
         if no_validation:
             click.secho('Can not load as dataset if --no-validation was flagged.', fg='red')
             return
-        d = PathDataSet(
+        d = PathDataset(
             training_path=os.path.join(directory, 'train.txt'),
             testing_path=os.path.join(directory, 'test.txt'),
             validation_path=os.path.join(directory, 'valid.txt'),

--- a/src/pykeen/datasets/kinships/__init__.py
+++ b/src/pykeen/datasets/kinships/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-"""Get triples from the Kinships data set."""
+"""Get triples from the Kinships dataset."""
 
 import os
 
-from ..base import PathDataSet
+from ..base import PathDataset
 
 __all__ = [
     'KINSHIPS_TRAIN_PATH',
@@ -20,8 +20,8 @@ KINSHIPS_TEST_PATH = os.path.join(HERE, 'test.txt')
 KINSHIPS_VALIDATE_PATH = os.path.join(HERE, 'valid.txt')
 
 
-class Kinships(PathDataSet):
-    """The Kinships data set."""
+class Kinships(PathDataset):
+    """The Kinships dataset."""
 
     def __init__(self, **kwargs):
         super().__init__(

--- a/src/pykeen/datasets/nations/__init__.py
+++ b/src/pykeen/datasets/nations/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-"""Get triples from the Nations data set."""
+"""Get triples from the Nations dataset."""
 
 import os
 
-from ..base import PathDataSet
+from ..base import PathDataset
 
 __all__ = [
     'NATIONS_TRAIN_PATH',
@@ -20,8 +20,8 @@ NATIONS_TEST_PATH = os.path.join(HERE, 'test.txt')
 NATIONS_VALIDATE_PATH = os.path.join(HERE, 'valid.txt')
 
 
-class Nations(PathDataSet):
-    """The Nations data set."""
+class Nations(PathDataset):
+    """The Nations dataset."""
 
     def __init__(self, **kwargs):
         super().__init__(

--- a/src/pykeen/datasets/ogb.py
+++ b/src/pykeen/datasets/ogb.py
@@ -9,7 +9,7 @@ from typing import ClassVar, Optional
 
 import numpy as np
 
-from .base import LazyDataSet
+from .base import LazyDataset
 from ..triples import TriplesFactory
 
 __all__ = [
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-class OGBLoader(LazyDataSet):
+class OGBLoader(LazyDataset):
     """Load from the Open Graph Benchmark (OGB)."""
 
     #: The name of the dataset to download

--- a/src/pykeen/datasets/openbiolink.py
+++ b/src/pykeen/datasets/openbiolink.py
@@ -9,7 +9,7 @@ import logging
 
 import click
 
-from .base import PackedZipRemoteDataSet
+from .base import PackedZipRemoteDataset
 
 __all__ = [
     'OpenBioLink',
@@ -24,13 +24,13 @@ F2_URL = 'https://github.com/PyKEEN/pykeen-openbiolink-benchmark/raw/master/filt
 LQ_URL = 'https://samwald.info/res/OpenBioLink_2020_final/ALL_DIR.zip'
 
 
-class OpenBioLink(PackedZipRemoteDataSet):
+class OpenBioLink(PackedZipRemoteDataset):
     """The OpenBioLink dataset.
 
     OpenBioLink is an open-source, reproducible framework for generating biological
     knowledge graphs for benchmarking link prediction. It is available on GitHub
     at https://github.com/openbiolink/openbiolink and published in [breit2020]_. There are four
-    available data sets - this class represents the high quality, directed set.
+    available datasets - this class represents the high quality, directed set.
 
     .. [breit2020] Breit, A. (2020) `OpenBioLink: A benchmarking framework for large-scale biomedical link
        prediction <https://doi.org/10.1093/bioinformatics/btaa274>`_, *Bioinformatics*
@@ -48,7 +48,7 @@ class OpenBioLink(PackedZipRemoteDataSet):
         )
 
 
-class OpenBioLinkF1(PackedZipRemoteDataSet):
+class OpenBioLinkF1(PackedZipRemoteDataset):
     """The PyKEEN First Filtered OpenBioLink 2020 Dataset."""
 
     def __init__(self, create_inverse_triples: bool = False, eager: bool = False):
@@ -63,7 +63,7 @@ class OpenBioLinkF1(PackedZipRemoteDataSet):
         )
 
 
-class OpenBioLinkF2(PackedZipRemoteDataSet):
+class OpenBioLinkF2(PackedZipRemoteDataset):
     """The PyKEEN Second Filtered OpenBioLink 2020 Dataset."""
 
     def __init__(self, create_inverse_triples: bool = False, eager: bool = False):
@@ -78,7 +78,7 @@ class OpenBioLinkF2(PackedZipRemoteDataSet):
         )
 
 
-class OpenBioLinkLQ(PackedZipRemoteDataSet):
+class OpenBioLinkLQ(PackedZipRemoteDataset):
     """The low-quality variant of the OpenBioLink dataset."""
 
     def __init__(self, create_inverse_triples: bool = False, eager: bool = False):

--- a/src/pykeen/datasets/umls/__init__.py
+++ b/src/pykeen/datasets/umls/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-"""Get triples from the UMLS data set."""
+"""Get triples from the UMLS dataset."""
 
 import os
 
-from ..base import PathDataSet
+from ..base import PathDataset
 
 __all__ = [
     'UMLS_TRAIN_PATH',
@@ -20,8 +20,8 @@ UMLS_TEST_PATH = os.path.join(HERE, 'test.txt')
 UMLS_VALIDATE_PATH = os.path.join(HERE, 'valid.txt')
 
 
-class UMLS(PathDataSet):
-    """The UMLS data set."""
+class UMLS(PathDataset):
+    """The UMLS dataset."""
 
     def __init__(self, **kwargs):
         super().__init__(

--- a/src/pykeen/datasets/wordnet.py
+++ b/src/pykeen/datasets/wordnet.py
@@ -5,7 +5,7 @@
 import os
 from typing import Optional
 
-from .base import TarFileRemoteDataSet
+from .base import TarFileRemoteDataset
 
 __all__ = [
     'WN18',
@@ -13,8 +13,8 @@ __all__ = [
 ]
 
 
-class WN18(TarFileRemoteDataSet):
-    """The WN18 data set."""
+class WN18(TarFileRemoteDataset):
+    """The WN18 dataset."""
 
     def __init__(self, cache_root: Optional[str] = None, **kwargs):
         super().__init__(
@@ -27,8 +27,8 @@ class WN18(TarFileRemoteDataSet):
         )
 
 
-class WN18RR(TarFileRemoteDataSet):
-    """The WN18-RR data set."""
+class WN18RR(TarFileRemoteDataset):
+    """The WN18-RR dataset."""
 
     def __init__(self, cache_root: Optional[str] = None, **kwargs):
         super().__init__(

--- a/src/pykeen/datasets/yago.py
+++ b/src/pykeen/datasets/yago.py
@@ -4,15 +4,15 @@
 
 from typing import Optional
 
-from .base import TarFileRemoteDataSet
+from .base import TarFileRemoteDataset
 
 __all__ = [
     'YAGO310',
 ]
 
 
-class YAGO310(TarFileRemoteDataSet):
-    """The YAGO3-10 data set is a subset of YAGO3 that only contains entities with at least 10 relations."""
+class YAGO310(TarFileRemoteDataset):
+    """The YAGO3-10 dataset is a subset of YAGO3 that only contains entities with at least 10 relations."""
 
     def __init__(self, cache_root: Optional[str] = None, **kwargs):
         super().__init__(

--- a/src/pykeen/experiments/complex/trouillon2016_complex_fb15k.json
+++ b/src/pykeen/experiments/complex/trouillon2016_complex_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with ComplEx as described by Trouillon et al., 2016",
+    "title": "Learn FB15K Dataset with ComplEx as described by Trouillon et al., 2016",
     "comments": "In the paper it is not mentioned that they compute the mean of the vector norms as done in the published code base. The rank type can be found at https://github.com/ttrouill/complex/blob/67fef2324d5a7695f7b932b5606d2e4b6de09a41/efe/evaluation.py#L295."
   },
   "pipeline": {

--- a/src/pykeen/experiments/complex/trouillon2016_complex_wn18.json
+++ b/src/pykeen/experiments/complex/trouillon2016_complex_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with ComplEx as described by Trouillon et al., 2016",
+    "title": "Learn WN18 Dataset with ComplEx as described by Trouillon et al., 2016",
     "comments": "In the paper it is not mentioned that they compute the mean of the vector norms as done in the published code base.  The rank type can be found at https://github.com/ttrouill/complex/blob/67fef2324d5a7695f7b932b5606d2e4b6de09a41/efe/evaluation.py#L295."
   },
   "pipeline": {

--- a/src/pykeen/experiments/conve/dettmers2018_conve_fb15k.json
+++ b/src/pykeen/experiments/conve/dettmers2018_conve_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with ConvE as described by Dettmers et al., 2018",
+    "title": "Learn FB15K Dataset with ConvE as described by Dettmers et al., 2018",
     "comment": "For evaluation, the non-deterministic rank definition is used, cf. https://github.com/TimDettmers/ConvE/blob/5feb358eb7dbd1f534978cdc4c20ee0bf919148a/evaluation.py#L67."
   },
   "pipeline": {

--- a/src/pykeen/experiments/conve/dettmers2018_conve_fb15k237.json
+++ b/src/pykeen/experiments/conve/dettmers2018_conve_fb15k237.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K-237 Data Set with ConvE as described by Dettmers et al., 2018",
+    "title": "Learn FB15K-237 Dataset with ConvE as described by Dettmers et al., 2018",
     "comment": "For evaluation, the non-deterministic rank definition is used, cf. https://github.com/TimDettmers/ConvE/blob/5feb358eb7dbd1f534978cdc4c20ee0bf919148a/evaluation.py#L67."
   },
   "pipeline": {

--- a/src/pykeen/experiments/conve/dettmers2018_conve_wn18.json
+++ b/src/pykeen/experiments/conve/dettmers2018_conve_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with ConvE as described by Dettmers et al., 2018",
+    "title": "Learn WN18 Dataset with ConvE as described by Dettmers et al., 2018",
     "comment": "For evaluation, the non-deterministic rank definition is used, cf. https://github.com/TimDettmers/ConvE/blob/5feb358eb7dbd1f534978cdc4c20ee0bf919148a/evaluation.py#L67."
   },
   "pipeline": {

--- a/src/pykeen/experiments/conve/dettmers2018_conve_wn18rr.json
+++ b/src/pykeen/experiments/conve/dettmers2018_conve_wn18rr.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18RR Data Set with ConvE as described by Dettmers et al., 2018",
+    "title": "Learn WN18RR Dataset with ConvE as described by Dettmers et al., 2018",
     "comment": "For evaluation, the non-deterministic rank definition is used, cf. https://github.com/TimDettmers/ConvE/blob/5feb358eb7dbd1f534978cdc4c20ee0bf919148a/evaluation.py#L67."
   },
   "pipeline": {

--- a/src/pykeen/experiments/convkb/nguyen2018_convkb_fb15k237.json
+++ b/src/pykeen/experiments/convkb/nguyen2018_convkb_fb15k237.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15k-237 Data Set with ConvKB as described by Nguyen et al., 2018",
+    "title": "Learn FB15k-237 Dataset with ConvKB as described by Nguyen et al., 2018",
     "comments": "regularization weight is set to 0.0005, because in the paper the regularization term is multiplied with (regularization weight)/2. The evaluation is done with the optimistic rank, cf. https://github.com/daiquocnguyen/ConvKB/blob/ba02c0665a80751676289a8d5570dc420465a9ff/eval.py#L207-L236."
   },
   "pipeline": {

--- a/src/pykeen/experiments/convkb/nguyen2018_convkb_wn18rr.json
+++ b/src/pykeen/experiments/convkb/nguyen2018_convkb_wn18rr.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18RR Data Set with ConvKB as described by Nguyen et al., 2018",
+    "title": "Learn WN18RR Dataset with ConvKB as described by Nguyen et al., 2018",
     "comments": "regularization weight is set to 0.0005, because in the paper the regularization term is multiplied with (regularization weight)/2. The evaluation is done with the optimistic rank, cf. https://github.com/daiquocnguyen/ConvKB/blob/ba02c0665a80751676289a8d5570dc420465a9ff/eval.py#L207-L236."
   },
   "pipeline": {

--- a/src/pykeen/experiments/convkb/nguyen2018_transe_fb15k237.json
+++ b/src/pykeen/experiments/convkb/nguyen2018_transe_fb15k237.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15k-237 Data Set with ConvKB as described by Nguyen et al., 2018",
+    "title": "Learn FB15k-237 Dataset with ConvKB as described by Nguyen et al., 2018",
     "comments": "TransE was used to initialize the emebddigns. Could not find batch size and number of epochs."
   },
   "pipeline": {

--- a/src/pykeen/experiments/convkb/nguyen2018_transe_wn18rr.json
+++ b/src/pykeen/experiments/convkb/nguyen2018_transe_wn18rr.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15k-237 Data Set with TransE as described by Nguyen et al., 2018",
+    "title": "Learn FB15k-237 Dataset with TransE as described by Nguyen et al., 2018",
     "commenrs": "TransE was used to initialize the emebddings. Could not find batch size and number of epochs."
   },
   "pipeline": {

--- a/src/pykeen/experiments/distmult/yang2014_distmult_fb15k.json
+++ b/src/pykeen/experiments/distmult/yang2014_distmult_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with DistMult as described by Yang et al., 2014",
+    "title": "Learn FB15K Dataset with DistMult as described by Yang et al., 2014",
     "comments": "For each positive triple, DistMult creates two negatives where head and tail are corrupted"
   },
   "pipeline": {

--- a/src/pykeen/experiments/distmult/yang2014_distmult_wn18.json
+++ b/src/pykeen/experiments/distmult/yang2014_distmult_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with DistMult as described by Yang et al., 2014",
+    "title": "Learn WN18 Dataset with DistMult as described by Yang et al., 2014",
     "comments": "For each positive triple, DistMult create two negatives where head and tail are corrupted"
   },
   "pipeline": {

--- a/src/pykeen/experiments/hole/nickel2016_hole_fb15k.json
+++ b/src/pykeen/experiments/hole/nickel2016_hole_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with HolE as described by Nickel et al., 2016",
+    "title": "Learn FB15K Dataset with HolE as described by Nickel et al., 2016",
     "comments": " We use same setting as for WN18 (based on https://github.com/mnick/holographic-embeddings/blob/c2db6e1554e671ab8e6acace78ec1fd91d6a4b90/run_hole_wn18.sh, however it is not sure whether this is the correct setting) since we couldn't find the setting for FB15k. The evaluation uses the non-deterministic rank, as seen from https://github.com/mnick/holographic-embeddings/blob/c2db6e1554e671ab8e6acace78ec1fd91d6a4b90/kg/base.py#L198."
   },
   "pipeline": {

--- a/src/pykeen/experiments/hole/nickel2016_hole_wn18.json
+++ b/src/pykeen/experiments/hole/nickel2016_hole_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with HolE as described by Nickel et al., 2016",
+    "title": "Learn WN18 Dataset with HolE as described by Nickel et al., 2016",
     "comments": "Based on https://github.com/mnick/holographic-embeddings/blob/master/run_hole_wn18.sh, however it is not sure whether this is the correct setting. The evaluation uses the non-deterministic rank, as seen from https://github.com/mnick/holographic-embeddings/blob/c2db6e1554e671ab8e6acace78ec1fd91d6a4b90/kg/base.py#L198."
   },
   "pipeline": {

--- a/src/pykeen/experiments/kg2e/he2015_kg2e_fb15k.json
+++ b/src/pykeen/experiments/kg2e/he2015_kg2e_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with KG2E as described by He et al., 2015"
+    "title": "Learn FB15K Dataset with KG2E as described by He et al., 2015"
   },
   "pipeline": {
     "dataset": "fb15k",

--- a/src/pykeen/experiments/kg2e/he2015_kg2e_wn18.json
+++ b/src/pykeen/experiments/kg2e/he2015_kg2e_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with KG2E as described by He et al., 2015"
+    "title": "Learn WN18 Dataset with KG2E as described by He et al., 2015"
   },
   "pipeline": {
     "dataset": "wn18",

--- a/src/pykeen/experiments/rgcn/schlichtkrull2018_rgcn_fb15k.json
+++ b/src/pykeen/experiments/rgcn/schlichtkrull2018_rgcn_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15k Data Set with R-GCN as described by Schlichtkrull et al., 2018",
+    "title": "Learn FB15k Dataset with R-GCN as described by Schlichtkrull et al., 2018",
     "comments": ""
   },
   "pipeline": {

--- a/src/pykeen/experiments/rgcn/schlichtkrull2018_rgcn_wn18.json
+++ b/src/pykeen/experiments/rgcn/schlichtkrull2018_rgcn_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with R-GCN as described by Schlichtkrull et al., 2018",
+    "title": "Learn WN18 Dataset with R-GCN as described by Schlichtkrull et al., 2018",
     "comments": ""
   },
   "pipeline": {

--- a/src/pykeen/experiments/rotate/sun2019_rotate_fb15k.json
+++ b/src/pykeen/experiments/rotate/sun2019_rotate_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with RotatE as described by Sun et al., 2019",
+    "title": "Learn FB15K Dataset with RotatE as described by Sun et al., 2019",
     "comments": "Could not find number of epochs; https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/master/best_config.sh. The evaluation uses the non-deterministic rank, cf. https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/a0a3cf75e8e324ef113472489a16927c39c997b2/codes/model.py#L406."
   },
   "pipeline": {

--- a/src/pykeen/experiments/rotate/sun2019_rotate_fb15k237.json
+++ b/src/pykeen/experiments/rotate/sun2019_rotate_fb15k237.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K-237 Data Set with RotatE as described by Sun et al., 2019",
+    "title": "Learn FB15K-237 Dataset with RotatE as described by Sun et al., 2019",
     "comments": "Could not find number of epochs; https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/master/best_config.sh. The evaluation uses the non-deterministic rank, cf. https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/a0a3cf75e8e324ef113472489a16927c39c997b2/codes/model.py#L406 ."
   },
   "pipeline": {

--- a/src/pykeen/experiments/rotate/sun2019_rotate_wn18.json
+++ b/src/pykeen/experiments/rotate/sun2019_rotate_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with RotatE as described by Sun et al., 2019;",
+    "title": "Learn WN18 Dataset with RotatE as described by Sun et al., 2019;",
     "comments": "Could not find number of epochs; https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/master/best_config.sh. The evaluation uses the non-deterministic rank, cf. https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/a0a3cf75e8e324ef113472489a16927c39c997b2/codes/model.py#L406 ."
   },
   "pipeline": {

--- a/src/pykeen/experiments/rotate/sun2019_rotate_wn18rr.json
+++ b/src/pykeen/experiments/rotate/sun2019_rotate_wn18rr.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18RR Data Set with RotatE as described by Sun et al., 2019; https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/master/best_config.sh",
+    "title": "Learn WN18RR Dataset with RotatE as described by Sun et al., 2019; https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/master/best_config.sh",
     "comments": "Could not find number of epochs. The evaluation uses the non-deterministic rank, cf. https://github.com/DeepGraphLearning/KnowledgeGraphEmbedding/blob/a0a3cf75e8e324ef113472489a16927c39c997b2/codes/model.py#L406 ."
   },
   "pipeline": {

--- a/src/pykeen/experiments/simple/kazemi2018_simple_fb15k.json
+++ b/src/pykeen/experiments/simple/kazemi2018_simple_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15k Data Set with SimplE as described by Kazemi et al., 2018",
+    "title": "Learn FB15k Dataset with SimplE as described by Kazemi et al., 2018",
     "comments": "They make use of inverse relations. Normalization argument of regularizer is set to false. SimplE uses the optimistic rank definition for evaluation, cf. https://github.com/Mehran-k/SimplE/blob/29108230b63920afa38067b1aff8b8d53d07ed01/reader.py#L148."
   },
   "pipeline": {

--- a/src/pykeen/experiments/simple/kazemi2018_simple_wn18.json
+++ b/src/pykeen/experiments/simple/kazemi2018_simple_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with SimplE as described by Kazemi et al., 2018",
+    "title": "Learn WN18 Dataset with SimplE as described by Kazemi et al., 2018",
     "comments": "They make use of inverse relations. Normalization argument of regularizer is set to false. SimplE uses the optimistic rank definition for evaluation, cf. https://github.com/Mehran-k/SimplE/blob/29108230b63920afa38067b1aff8b8d53d07ed01/reader.py#L148."
   },
   "pipeline": {

--- a/src/pykeen/experiments/transd/ji2015_transd_fb15k.json
+++ b/src/pykeen/experiments/transd/ji2015_transd_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with TransD as described by Ji et al., 2015",
+    "title": "Learn FB15K Dataset with TransD as described by Ji et al., 2015",
     "comments": "We assumed the learning rate for Adadelta as the default from PyTorch since it was not explicitly stated in the original paper"
   },
   "pipeline": {

--- a/src/pykeen/experiments/transd/ji2015_transd_wn18.json
+++ b/src/pykeen/experiments/transd/ji2015_transd_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with TransD as described by Ji et al., 2015",
+    "title": "Learn WN18 Dataset with TransD as described by Ji et al., 2015",
     "comments": "We assumed the learning rate for Adadelta as the default from PyTorch since it was not explicitly stated in the original paper"
   },
   "pipeline": {

--- a/src/pykeen/experiments/transe/bordes2013_transe_fb15k.json
+++ b/src/pykeen/experiments/transe/bordes2013_transe_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with TransE as described by Bordes et al., 2013",
+    "title": "Learn FB15K Dataset with TransE as described by Bordes et al., 2013",
     "comments": "Batch_size is not mentioned in the paper. We found out that this value works."
   },
   "pipeline": {

--- a/src/pykeen/experiments/transe/bordes2013_transe_wn18.json
+++ b/src/pykeen/experiments/transe/bordes2013_transe_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WordNet Data Set with TransE as described by Bordes et al., 2013",
+    "title": "Learn WordNet Dataset with TransE as described by Bordes et al., 2013",
     "comments": "Num_epochs varies from the value reported in the paper, and batch_size is not mentioned in the paper. We found out that these values work."
   },
   "pipeline": {

--- a/src/pykeen/experiments/transh/wang2014_transh_fb15k.json
+++ b/src/pykeen/experiments/transh/wang2014_transh_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with TransH as described by Wang et al., 2014"
+    "title": "Learn FB15K Dataset with TransH as described by Wang et al., 2014"
   },
   "pipeline": {
     "dataset": "fb15k",

--- a/src/pykeen/experiments/transh/wang2014_transh_wn18.json
+++ b/src/pykeen/experiments/transh/wang2014_transh_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with TransH as described by Wang et al., 2014"
+    "title": "Learn WN18 Dataset with TransH as described by Wang et al., 2014"
   },
   "pipeline": {
     "dataset": "wn18",

--- a/src/pykeen/experiments/transr/li2015_transr_fb15k.json
+++ b/src/pykeen/experiments/transr/li2015_transr_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with TransR as described by Li et al., 2015. For evaluation, the non-deterministic rank is used, cf. https://github.com/Mrlyk423/Relation_Extraction/blob/9f311285abd7e29273be7e4fd8c680dd761f40eb/TransR/Test_TransR.cpp#L177-L206."
+    "title": "Learn FB15K Dataset with TransR as described by Li et al., 2015. For evaluation, the non-deterministic rank is used, cf. https://github.com/Mrlyk423/Relation_Extraction/blob/9f311285abd7e29273be7e4fd8c680dd761f40eb/TransR/Test_TransR.cpp#L177-L206."
   },
   "pipeline": {
     "dataset": "fb15k",

--- a/src/pykeen/experiments/transr/li2015_transr_wn18.json
+++ b/src/pykeen/experiments/transr/li2015_transr_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with TransR as described by Li et al., 2015. For evaluation, the non-deterministic rank is used, cf. https://github.com/Mrlyk423/Relation_Extraction/blob/9f311285abd7e29273be7e4fd8c680dd761f40eb/TransR/Test_TransR.cpp#L177-L206."
+    "title": "Learn WN18 Dataset with TransR as described by Li et al., 2015. For evaluation, the non-deterministic rank is used, cf. https://github.com/Mrlyk423/Relation_Extraction/blob/9f311285abd7e29273be7e4fd8c680dd761f40eb/TransR/Test_TransR.cpp#L177-L206."
   },
   "pipeline": {
     "dataset": "wn18",

--- a/src/pykeen/experiments/tucker/balazevic2019_tucker_fb15k.json
+++ b/src/pykeen/experiments/tucker/balazevic2019_tucker_fb15k.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K Data Set with TuckER as described by Balazevic et al., 2019",
+    "title": "Learn FB15K Dataset with TuckER as described by Balazevic et al., 2019",
     "comments": "No label smoothing has been used for FB15k. Check whether dropouts are used correctly. They make use of inverse relations. Could not find number of epochs. In the code 500 was the default value for all datasets, that's why we assume that this is the number of epochs. For evaluation, the non-deterministic rank is used, cf. https://github.com/ibalazevic/TuckER/blob/63dbba8751670db0d807579303679c0a2c266130/main.py#L78 ."
   },
   "pipeline": {

--- a/src/pykeen/experiments/tucker/balazevic2019_tucker_fb15k237.json
+++ b/src/pykeen/experiments/tucker/balazevic2019_tucker_fb15k237.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn FB15K-237 Data Set with TuckER as described by Balazevic et al., 2019",
+    "title": "Learn FB15K-237 Dataset with TuckER as described by Balazevic et al., 2019",
     "comments": "No label smoothing has been used for FB15k. Check whether dropouts are used correctly. They make use of inverse relations. Could not find number of epochs. In the code 500 was the default value for all datasets, that's why we assume that this is the number of epochs. For evaluation, the non-deterministic rank is used, cf. https://github.com/ibalazevic/TuckER/blob/63dbba8751670db0d807579303679c0a2c266130/main.py#L78 ."
   },
   "pipeline": {

--- a/src/pykeen/experiments/tucker/balazevic2019_tucker_wn18.json
+++ b/src/pykeen/experiments/tucker/balazevic2019_tucker_wn18.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18 Data Set with TuckER as described by Balazevic et al., 2019",
+    "title": "Learn WN18 Dataset with TuckER as described by Balazevic et al., 2019",
     "comments": "Check whether dropouts are used correctly. They make use of inverse relations. Could not find number of epochs.In the code 500 was the default value for all datasets, that's we assume that this is the number of epochs. For evaluation, the non-deterministic rank is used, cf. https://github.com/ibalazevic/TuckER/blob/63dbba8751670db0d807579303679c0a2c266130/main.py#L78 ."
   },
   "pipeline": {

--- a/src/pykeen/experiments/tucker/balazevic2019_tucker_wn18rr.json
+++ b/src/pykeen/experiments/tucker/balazevic2019_tucker_wn18rr.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "title": "Learn WN18RR Data Set with TuckER as described by Balazevic et al., 2019",
+    "title": "Learn WN18RR Dataset with TuckER as described by Balazevic et al., 2019",
     "comments": "Check whether dropouts are used correctly. They make use of inverse relations. Could not find number of epochs.In the code 500 was the default value for all datasets, that's we assume that this is the number of epochs. For evaluation, the non-deterministic rank is used, cf. https://github.com/ibalazevic/TuckER/blob/63dbba8751670db0d807579303679c0a2c266130/main.py#L78 ."
   },
   "pipeline": {

--- a/src/pykeen/hpo/__init__.py
+++ b/src/pykeen/hpo/__init__.py
@@ -3,7 +3,7 @@
 """The easiest way to optimize a model is with the :func:`pykeen.hpo.hpo_pipeline` function.
 
 All of the following examples are about getting the best model
-when training TransE on the Nations data set. Each gives a bit
+when training TransE on the Nations dataset. Each gives a bit
 of insight into usage of the :func:`hpo_pipeline` function.
 
 The minimal usage of the hyper-parameter optimization is to specify the

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -19,7 +19,7 @@ from optuna.storages import BaseStorage
 from .pruners import get_pruner_cls
 from .samplers import get_sampler_cls
 from ..datasets import get_dataset, has_dataset
-from ..datasets.base import DataSet
+from ..datasets.base import Dataset
 from ..evaluation import Evaluator, get_evaluator_cls
 from ..losses import Loss, _LOSS_SUFFIX, get_loss_cls
 from ..models import get_model_cls
@@ -54,7 +54,7 @@ STOPPED_EPOCH_KEY = 'stopped_epoch'
 class Objective:
     """A dataclass containing all of the information to make an objective function."""
 
-    dataset: Union[None, str, Type[DataSet]]  # 1.
+    dataset: Union[None, str, Type[Dataset]]  # 1.
     model: Type[Model]  # 2.
     loss: Type[Loss]  # 3.
     regularizer: Type[Regularizer]  # 4.
@@ -415,7 +415,7 @@ def hpo_pipeline_from_config(config: Mapping[str, Any], **kwargs) -> HpoPipeline
 def hpo_pipeline(
     *,
     # 1. Dataset
-    dataset: Union[None, str, DataSet, Type[DataSet]] = None,
+    dataset: Union[None, str, Dataset, Type[Dataset]] = None,
     dataset_kwargs: Optional[Mapping[str, Any]] = None,
     training: Union[None, str, TriplesFactory] = None,
     testing: Union[None, str, TriplesFactory] = None,
@@ -476,7 +476,7 @@ def hpo_pipeline(
     """Train a model on the given dataset.
 
     :param dataset:
-        The name of the dataset (a key from :data:`pykeen.datasets.datasets`) or the :class:`pykeen.datasets.DataSet`
+        The name of the dataset (a key from :data:`pykeen.datasets.datasets`) or the :class:`pykeen.datasets.Dataset`
         instance. Alternatively, the ``training_triples_factory`` and ``testing_triples_factory`` can be specified.
     :param dataset_kwargs:
         The keyword arguments passed to the dataset upon instantiation
@@ -803,7 +803,7 @@ def suggest_discrete_power_two_int(trial: Trial, name, low, high) -> int:
 
 def _get_dataset_name(
     *,
-    dataset: Union[None, str, DataSet, Type[DataSet]] = None,
+    dataset: Union[None, str, Dataset, Type[Dataset]] = None,
     dataset_kwargs: Optional[Mapping[str, Any]] = None,
     training: Union[None, str, TriplesFactory] = None,
     testing: Union[None, str, TriplesFactory] = None,
@@ -812,8 +812,8 @@ def _get_dataset_name(
     """Make a useful name for the dataset for storage in HPO."""
     if (
         (isinstance(dataset, str) and has_dataset(dataset))
-        or isinstance(dataset, DataSet)
-        or (isinstance(dataset, type) and issubclass(dataset, DataSet))
+        or isinstance(dataset, Dataset)
+        or (isinstance(dataset, type) and issubclass(dataset, Dataset))
     ):
         return get_dataset(dataset=dataset).get_normalized_name()
 

--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -35,8 +35,8 @@ could be used as in:
 ... )
 >>> pipeline_result.save_to_directory('nations_transe')
 
-In this example, the data set was given as a string. A list of available data sets can be found in
-:mod:`pykeen.datasets`. Alternatively, the instance of the :class:`pykeen.datasets.DataSet` could be
+In this example, the dataset was given as a string. A list of available datasets can be found in
+:mod:`pykeen.datasets`. Alternatively, the instance of the :class:`pykeen.datasets.Dataset` could be
 used as in:
 
 >>> from pykeen.pipeline import pipeline
@@ -177,7 +177,7 @@ import torch
 from torch.optim.optimizer import Optimizer
 
 from .datasets import get_dataset
-from .datasets.base import DataSet
+from .datasets.base import Dataset
 from .evaluation import Evaluator, MetricResults, get_evaluator_cls
 from .losses import Loss, _LOSS_SUFFIX, get_loss_cls
 from .models import get_model_cls
@@ -702,7 +702,7 @@ def pipeline_from_config(
 def pipeline(  # noqa: C901
     *,
     # 1. Dataset
-    dataset: Union[None, str, DataSet, Type[DataSet]] = None,
+    dataset: Union[None, str, Dataset, Type[Dataset]] = None,
     dataset_kwargs: Optional[Mapping[str, Any]] = None,
     training: Union[None, TriplesFactory, str] = None,
     testing: Union[None, TriplesFactory, str] = None,
@@ -747,7 +747,7 @@ def pipeline(  # noqa: C901
     """Train and evaluate a model.
 
     :param dataset:
-        The name of the dataset (a key from :data:`pykeen.datasets.datasets`) or the :class:`pykeen.datasets.DataSet`
+        The name of the dataset (a key from :data:`pykeen.datasets.datasets`) or the :class:`pykeen.datasets.Dataset`
         instance. Alternatively, the ``training_triples_factory`` and ``testing_triples_factory`` can be specified.
     :param dataset_kwargs:
         The keyword arguments passed to the dataset upon instantiation
@@ -841,7 +841,7 @@ def pipeline(  # noqa: C901
 
     device = resolve_device(device)
 
-    dataset_instance: DataSet = get_dataset(
+    dataset_instance: Dataset = get_dataset(
         dataset=dataset,
         dataset_kwargs=dataset_kwargs,
         training=training,

--- a/src/pykeen/templates/README.md
+++ b/src/pykeen/templates/README.md
@@ -65,7 +65,7 @@ can be found in the [installation documentation](https://pykeen.readthedocs.io/e
 
 ## Quickstart [![Documentation Status](https://readthedocs.org/projects/pykeen/badge/?version=latest)](https://pykeen.readthedocs.io/en/latest/?badge=latest)
 
-This example shows how to train a model on a data set and test on another data set.
+This example shows how to train a model on a dataset and test on another dataset.
 
 The fastest way to get up and running is to use the pipeline function. It
 provides a high-level entry into the extensible functionality of this package.
@@ -98,7 +98,7 @@ The full documentation can be found at https://pykeen.readthedocs.io.
 
 ## Implementation
 
-Below are the models, data sets, training modes, evaluators, and metrics implemented
+Below are the models, datasets, training modes, evaluators, and metrics implemented
 in ``pykeen``.
 
 ### Datasets ({{ n_datasets }})
@@ -162,7 +162,7 @@ experiments. They can be accessed and run like:
 pykeen experiments reproduce tucker balazevic2019 fb15k
 ```
 
-Where the three arguments are the model name, the reference, and the data set.
+Where the three arguments are the model name, the reference, and the dataset.
 The output directory can be optionally set with `-d`.
 
 ### Ablation

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -7,7 +7,7 @@ import timeit
 import unittest
 from typing import ClassVar, Optional, Type
 
-from pykeen.datasets.base import LazyDataSet
+from pykeen.datasets.base import LazyDataset
 from pykeen.triples import TriplesFactory
 
 
@@ -24,16 +24,16 @@ class DatasetTestCase(unittest.TestCase):
     exp_num_triples_tolerance: ClassVar[Optional[int]] = None
 
     #: The dataset to test
-    dataset_cls: ClassVar[Type[LazyDataSet]]
+    dataset_cls: ClassVar[Type[LazyDataset]]
     #: The instantiated dataset
-    dataset: LazyDataSet
+    dataset: LazyDataset
 
     #: Should the validation be assumed to have been loaded with train/test?
     autoloaded_validation: ClassVar[bool] = False
 
     def test_dataset(self):
         """Generic test for datasets."""
-        self.assertIsInstance(self.dataset, LazyDataSet)
+        self.assertIsInstance(self.dataset, LazyDataset)
 
         # Not loaded
         self.assertIsNone(self.dataset._training)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -79,7 +79,7 @@ class TestTarFileSingle(cases.CachedDatasetCase):
 
 
 class TestTarRemote(cases.CachedDatasetCase):
-    """Test the :class:`pykeen.datasets.base.TarFileRemoteDataSet` class."""
+    """Test the :class:`pykeen.datasets.base.TarFileRemoteDataset` class."""
 
     exp_num_entities = 14
     exp_num_relations = 55

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -8,7 +8,7 @@ from io import BytesIO
 import pytest
 
 from pykeen.datasets import FB15k, FB15k237, Kinships, Nations, UMLS, WN18, WN18RR, YAGO310
-from pykeen.datasets.base import SingleTabbedDataset, TarFileRemoteDataSet, TarFileSingleDataset
+from pykeen.datasets.base import SingleTabbedDataset, TarFileRemoteDataset, TarFileSingleDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
 from tests import cases, constants
 
@@ -33,7 +33,7 @@ class MockTarFileSingleDataset(TarFileSingleDataset):
         return os.path.join(constants.RESOURCES, 'nations.tar.gz')
 
 
-class MockTarFileRemoteDataset(TarFileRemoteDataSet):
+class MockTarFileRemoteDataset(TarFileRemoteDataset):
     """Mock downloading a tar.gz archive with three pre-stratified files."""
 
     def __init__(self, cache_root: str):


### PR DESCRIPTION
Closes #161

This PR removes the space between "data set" everywhere it shows up throughout the code, documentation, tests, and experimental metadata. It also renames the classes to not have the capitalization denoting different words.

A concern for this PR is that changing the name of the class might make previously pickled data including instances of old datasets impossible to reload. Otherwise, the top level user API doesn't change since it is all case-insensitive. If anyone objects to the class name change, I could remove that from this PR and we could reconsider later.
