### PR TITLE
Reorganize Loss class hierarchy

### DIFF
--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -111,6 +111,7 @@ class TestCustomLossFunctions(unittest.TestCase):
     def test_negative_sampling_self_adversarial_loss(self):
         """Test the negative sampling self adversarial loss function."""
         loss_fct = NSSALoss(margin=1., adversarial_temperature=1.)
+        self.assertIs(loss_fct._reduction_method, torch.mean)
 
         pos_scores = torch.tensor([0., 0., -0.5, -0.5])
         neg_scores = torch.tensor([0., 0., -1., -1.])


### PR DESCRIPTION
This PR is related to #18 - it takes a small part of the changes there and puts them in their own PR to make review easier. This PR removes some redundant code in the hierarchy of loss functions. First, I refactored all of the code that looked like 

```python
    def __init__(self, reduction: str = 'mean'):
        super().__init__()
        self.reduction = reduction
        self._reduction_method = _REDUCTION_METHODS[reduction]
```

into our `Loss` class's `Loss.__init__()`. Then, I realized that the PyTorch base class for losses actually does exactly that. The only caveat is that their from `torch.nn.modules.loss._Loss` class is private, but I envision a near future PR that completely divests from this anyway.

The switching of the superclass order in `MarginRankingLoss` deals with that pesky multiple inheritance such that the kwargs for `torch.nn.MarginRankingLoss` take precedence.

