### PR TITLE
Split TriplesFactory constructor into two factories

### DIFF
--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -97,7 +97,7 @@ class Dataset:
     @classmethod
     def from_path(cls, path: str, ratios: Optional[List[float]] = None) -> 'Dataset':
         """Create a dataset from a single triples factory by splitting it in 3."""
-        tf = TriplesFactory(path=path)
+        tf = TriplesFactory.from_path(path=path)
         return cls.from_tf(tf=tf, ratios=ratios)
 
     @staticmethod
@@ -221,11 +221,11 @@ class PathDataset(LazyDataset):
             self._load_validation()
 
     def _load(self) -> None:
-        self._training = TriplesFactory(
+        self._training = TriplesFactory.from_path(
             path=self.training_path,
             create_inverse_triples=self.create_inverse_triples,
         )
-        self._testing = TriplesFactory(
+        self._testing = TriplesFactory.from_path(
             path=self.testing_path,
             entity_to_id=self._training.entity_to_id,  # share entity index with training
             relation_to_id=self._training.relation_to_id,  # share relation index with training
@@ -234,7 +234,7 @@ class PathDataset(LazyDataset):
     def _load_validation(self) -> None:
         # don't call this function by itself. assumes called through the `validation`
         # property and the _training factory has already been loaded
-        self._validation = TriplesFactory(
+        self._validation = TriplesFactory.from_path(
             path=self.validation_path,
             entity_to_id=self._training.entity_to_id,  # share entity index with training
             relation_to_id=self._training.relation_to_id,  # share relation index with training
@@ -494,7 +494,7 @@ class PackedZipRemoteDataset(LazyDataset):
                     header=self.header,
                     sep=self.sep,
                 )
-                rv = TriplesFactory(
+                rv = TriplesFactory.from_labeled_triples(
                     triples=df.values,
                     create_inverse_triples=self.create_inverse_triples,
                 )
@@ -569,7 +569,7 @@ class TarFileSingleDataset(LazyDataset):
                 tf.extract(self._relative_path, self.cache_root)
 
         df = pd.read_csv(_actual_path, sep=self.delimiter)
-        tf = TriplesFactory(triples=df.values, create_inverse_triples=self.create_inverse_triples)
+        tf = TriplesFactory.from_labeled_triples(triples=df.values, create_inverse_triples=self.create_inverse_triples)
         tf.path = self._get_path()
         self._training, self._testing, self._validation = tf.split(
             ratios=self.ratios,
@@ -638,7 +638,7 @@ class SingleTabbedDataset(LazyDataset):
             logger.info('downloading data from %s to %s', self.url, self._get_path())
             _urlretrieve(self.url, self._get_path())  # noqa:S310
         df = pd.read_csv(self._get_path(), sep=self.delimiter)
-        tf = TriplesFactory(triples=df.values, create_inverse_triples=self.create_inverse_triples)
+        tf = TriplesFactory.from_labeled_triples(triples=df.values, create_inverse_triples=self.create_inverse_triples)
         tf.path = self._get_path()
         self._training, self._testing, self._validation = tf.split(
             ratios=self.ratios,

--- a/src/pykeen/datasets/generate.py
+++ b/src/pykeen/datasets/generate.py
@@ -27,7 +27,7 @@ def main(path: str, directory: str, test_ratios, no_validation: bool, validation
     """Make a dataset from the given triples."""
     os.makedirs(directory, exist_ok=True)
 
-    triples_factory = TriplesFactory(path=path)
+    triples_factory = TriplesFactory.from_path(path=path)
     ratios = test_ratios if no_validation else validation_ratios
 
     if seed is None:

--- a/src/pykeen/datasets/ogb.py
+++ b/src/pykeen/datasets/ogb.py
@@ -63,7 +63,7 @@ class OGBLoader(LazyDataset):
         # FIXME these are already identifiers
         triples = triples.astype(np.str)
 
-        return TriplesFactory(
+        return TriplesFactory.from_labeled_triples(
             triples=triples,
             create_inverse_triples=self.create_inverse_triples,
             entity_to_id=entity_to_id,

--- a/src/pykeen/models/cli/options.py
+++ b/src/pykeen/models/cli/options.py
@@ -36,7 +36,7 @@ def _get_default(f, suffix=None):
 
 def triples_factory_callback(_, __, path: Optional[str]) -> Optional[TriplesFactory]:
     """Generate a triples factory using the given path."""
-    return path and TriplesFactory(path=path)
+    return path and TriplesFactory.from_path(path=path)
 
 
 CLI_OPTIONS = {

--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -985,10 +985,10 @@ def pipeline(  # noqa: C901
         logging.debug(f"dataset: {dataset}")
         logging.debug(f"dataset_kwargs: {dataset_kwargs}")
     else:
-        logging.debug('training: %s', training.path)
-        logging.debug('testing: %s', testing.path)
+        logging.debug('training: %s', training)
+        logging.debug('testing: %s', testing)
         if validation:
-            logging.debug('validation: %s', validation.path)
+            logging.debug('validation: %s', validation)
     logging.debug(f"model: {model}")
     logging.debug(f"model_kwargs: {model_kwargs}")
     logging.debug(f"loss: {loss}")

--- a/src/pykeen/triples/leakage.py
+++ b/src/pykeen/triples/leakage.py
@@ -208,7 +208,7 @@ def reindex(*triples_factories: TriplesFactory) -> List[TriplesFactory]:
     relation_to_id = create_relation_mapping(set(triples[:, 1]))
 
     return [
-        TriplesFactory(
+        TriplesFactory.from_labeled_triples(
             triples=triples_factory.triples,
             entity_to_id=entity_to_id,
             relation_to_id=relation_to_id,

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -562,7 +562,7 @@ class TriplesFactory:
             f'keeping {len(relations)}/{self.num_relations} relations'
             f' and {idx.sum()}/{self.num_triples} triples in {self}',
         )
-        return TriplesFactory(triples=self.triples[idx])
+        return TriplesFactory.from_labeled_triples(triples=self.triples[idx])
 
     def new_without_relations(self, relations: Collection[str]) -> 'TriplesFactory':
         """Make a new triples factory without the given relations."""

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -203,7 +203,7 @@ class TriplesFactory:
         entity_to_id: Optional[EntityMapping] = None,
         relation_to_id: Optional[RelationMapping] = None,
         compact_id: bool = True,
-    ) -> "TriplesFactory":
+    ) -> 'TriplesFactory':
         """
         Create a new triples factory from label-based triples.
 
@@ -221,13 +221,14 @@ class TriplesFactory:
         :return:
             A new triples factory.
         """
-        _num_entities = len(set(triples[:, 0]).union(triples[:, 2]))
+        # TODO remove
+        # _num_entities = len(set(triples[:, 0]).union(triples[:, 2]))
 
         relations = triples[:, 1]
         unique_relations = set(relations)
 
         # Check if the triples are inverted already
-        relations_already_inverted = TriplesFactory._check_already_inverted_relations(unique_relations)
+        relations_already_inverted = cls._check_already_inverted_relations(unique_relations)
 
         if create_inverse_triples or relations_already_inverted:
             create_inverse_triples = True
@@ -256,19 +257,20 @@ class TriplesFactory:
                 )
                 # extend original triples with inverse ones
                 triples = np.concatenate([triples, inverse_triples], axis=0)
-                _num_relations = 2 * len(unique_relations)
+                # TODO remove
+                # _num_relations = 2 * len(unique_relations)
 
         else:
             create_inverse_triples = False
             relation_to_inverse = None
-            _num_relations = len(unique_relations)
+            # TODO remove
+            # _num_relations = len(unique_relations)
 
         # Generate entity mapping if necessary
         if entity_to_id is None:
             entity_to_id = create_entity_mapping(triples=triples)
         if compact_id:
             entity_to_id = compact_mapping(mapping=entity_to_id)[0]
-        entity_to_id = entity_to_id
 
         # Generate relation mapping if necessary
         if relation_to_id is None:
@@ -280,7 +282,6 @@ class TriplesFactory:
                 relation_to_id = create_relation_mapping(unique_relations)
         if compact_id:
             relation_to_id = compact_mapping(mapping=relation_to_id)[0]
-        relation_to_id = relation_to_id
 
         # Map triples of labels to triples of IDs.
         mapped_triples = _map_triples_elements_to_ids(
@@ -289,7 +290,7 @@ class TriplesFactory:
             relation_to_id=relation_to_id,
         )
 
-        return TriplesFactory(
+        return cls(
             entity_to_id=entity_to_id,
             relation_to_id=relation_to_id,
             triples=triples,
@@ -305,7 +306,7 @@ class TriplesFactory:
         entity_to_id: Optional[EntityMapping] = None,
         relation_to_id: Optional[RelationMapping] = None,
         compact_id: bool = True,
-    ) -> "TriplesFactory":
+    ) -> 'TriplesFactory':
         """
         Create a new triples factory from triples stored in a file.
 
@@ -382,8 +383,10 @@ class TriplesFactory:
         return self.relation_to_id[inverse_relation]
 
     def __repr__(self):  # noqa: D105
-        return f'{self.__class__.__name__}(num_entities={self.num_entities}, num_relations={self.num_relations}, ' \
-               f'num_triples={self.num_triples}, inverse_triples={self.create_inverse_triples})'
+        return (
+            f'{self.__class__.__name__}(num_entities={self.num_entities}, num_relations={self.num_relations}, '
+            f'num_triples={self.num_triples}, inverse_triples={self.create_inverse_triples})',
+        )
 
     @staticmethod
     def _check_already_inverted_relations(relations: Iterable[str]) -> bool:

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -221,15 +221,13 @@ class TriplesFactory:
         :return:
             A new triples factory.
         """
-        # TODO remove
-        # _num_entities = len(set(triples[:, 0]).union(triples[:, 2]))
-
         relations = triples[:, 1]
         unique_relations = set(relations)
 
         # Check if the triples are inverted already
         relations_already_inverted = cls._check_already_inverted_relations(unique_relations)
 
+        # TODO: invert triples id-based
         if create_inverse_triples or relations_already_inverted:
             create_inverse_triples = True
             if relations_already_inverted:
@@ -257,14 +255,10 @@ class TriplesFactory:
                 )
                 # extend original triples with inverse ones
                 triples = np.concatenate([triples, inverse_triples], axis=0)
-                # TODO remove
-                # _num_relations = 2 * len(unique_relations)
 
         else:
             create_inverse_triples = False
             relation_to_inverse = None
-            # TODO remove
-            # _num_relations = len(unique_relations)
 
         # Generate entity mapping if necessary
         if entity_to_id is None:
@@ -355,10 +349,7 @@ class TriplesFactory:
     @property
     def num_relations(self) -> int:  # noqa: D401
         """The number of unique relations."""
-        num_relations = len(self.relation_to_id)
-        if self.create_inverse_triples:
-            num_relations = 2 * num_relations
-        return num_relations
+        return len(self.relation_to_id)
 
     @property
     def num_triples(self) -> int:  # noqa: D401

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -382,11 +382,17 @@ class TriplesFactory:
         inverse_relation = self.relation_to_inverse[relation]
         return self.relation_to_id[inverse_relation]
 
-    def __repr__(self):  # noqa: D105
+    def extra_repr(self) -> str:
+        """Extra representation string."""
         return (
-            f'{self.__class__.__name__}(num_entities={self.num_entities}, num_relations={self.num_relations}, '
-            f'num_triples={self.num_triples}, inverse_triples={self.create_inverse_triples})',
+            f"num_entities={self.num_entities}, "
+            f"num_relations={self.num_relations}, "
+            f"num_triples={self.num_triples}, "
+            f"inverse_triples={self.create_inverse_triples}"
         )
+
+    def __repr__(self):  # noqa: D105
+        return f'{self.__class__.__name__}({self.extra_repr()})'
 
     @staticmethod
     def _check_already_inverted_relations(relations: Iterable[str]) -> bool:

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -358,7 +358,7 @@ class TriplesFactory:
         return self.mapped_triples.shape[0]
 
     @property
-    def triples(self) -> np.ndarray:
+    def triples(self) -> np.ndarray:  # noqa: D401
         """The labeled triples."""
         # TODO: Deprecation warning. Will be replaced by re-constructing them from ID-based + mapping soon.
         return self._triples

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -184,9 +184,10 @@ class TriplesFactory:
     #: The mapping from relations' labels to their indices
     relation_to_id: RelationMapping
 
+    # TODO: Deprecation warning. Will be replaced by re-constructing them from ID-based + mapping soon.
     #: A three-column matrix where each row are the head label,
     #: relation label, then tail label
-    triples: LabeledTriples
+    _triples: LabeledTriples
 
     #: A three-column matrix where each row are the head identifier,
     #: relation identifier, then tail identifier
@@ -287,7 +288,7 @@ class TriplesFactory:
         return cls(
             entity_to_id=entity_to_id,
             relation_to_id=relation_to_id,
-            triples=triples,
+            _triples=triples,
             mapped_triples=mapped_triples,
             relation_to_inverse=relation_to_inverse,
         )
@@ -355,6 +356,12 @@ class TriplesFactory:
     def num_triples(self) -> int:  # noqa: D401
         """The number of triples."""
         return self.mapped_triples.shape[0]
+
+    @property
+    def triples(self) -> np.ndarray:
+        """The labeled triples."""
+        # TODO: Deprecation warning. Will be replaced by re-constructing them from ID-based + mapping soon.
+        return self._triples
 
     @property
     def entity_id_to_label(self) -> Mapping[int, str]:  # noqa: D401

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -2,6 +2,7 @@
 
 """Implementation of basic instance factory which creates just instances based on standard KG triples."""
 
+import dataclasses
 import logging
 import os
 import re
@@ -173,6 +174,7 @@ def _map_triples_elements_to_ids(
     return torch.tensor(unique_mapped_triples, dtype=torch.long)
 
 
+@dataclasses.dataclass
 class TriplesFactory:
     """Create instances given the path to triples."""
 
@@ -193,121 +195,169 @@ class TriplesFactory:
     #: A dictionary mapping each relation to its inverse, if inverse triples were created
     relation_to_inverse: Optional[Mapping[str, str]]
 
-    def __init__(
-        self,
-        *,
-        path: Union[None, str, TextIO] = None,
-        triples: Optional[LabeledTriples] = None,
+    @classmethod
+    def from_labeled_triples(
+        cls,
+        triples: LabeledTriples,
         create_inverse_triples: bool = False,
         entity_to_id: Optional[EntityMapping] = None,
         relation_to_id: Optional[RelationMapping] = None,
         compact_id: bool = True,
-    ) -> None:
-        """Initialize the triples factory.
-
-        :param path: The path to a 3-column TSV file with triples in it. If not specified,
-         you should specify ``triples``.
-        :param triples:  A 3-column numpy array with triples in it. If not specified,
-         you should specify ``path``
-        :param create_inverse_triples: Should inverse triples be created? Defaults to False.
-        :param compact_id:
-            Whether to compact the IDs such that they range from 0 to (num_entities or num_relations)-1
+    ) -> "TriplesFactory":
         """
-        if path is None and triples is None:
-            raise ValueError('Must specify either triples or path')
-        elif path is not None and triples is not None:
-            raise ValueError('Must not specify both triples and path')
-        elif path is not None:
-            if isinstance(path, str):
-                self.path = os.path.abspath(path)
-            elif isinstance(path, TextIO):
-                self.path = os.path.abspath(path.name)
-            else:
-                raise TypeError(f'path is invalid type: {type(path)}')
+        Create a new triples factory from label-based triples.
 
-            # TODO: Check if lazy evaluation would make sense
-            self.triples = load_triples(path)
-        else:  # triples is not None
-            self.path = '<None>'
-            self.triples = triples
+        :param triples: shape: (n, 3), dtype: str
+            The label-based triples.
+        :param create_inverse_triples:
+            Whether to create inverse triples.
+        :param entity_to_id:
+            The mapping from entity labels to ID. If None, create a new one from the triples.
+        :param relation_to_id:
+            The mapping from relations labels to ID. If None, create a new one from the triples.
+        :param compact_id:
+            Whether to compact IDs such that the IDs are consecutive.
 
-        self._num_entities = len(set(self.triples[:, 0]).union(self.triples[:, 2]))
+        :return:
+            A new triples factory.
+        """
+        _num_entities = len(set(triples[:, 0]).union(triples[:, 2]))
 
-        relations = self.triples[:, 1]
+        relations = triples[:, 1]
         unique_relations = set(relations)
 
         # Check if the triples are inverted already
-        relations_already_inverted = self._check_already_inverted_relations(unique_relations)
+        relations_already_inverted = TriplesFactory._check_already_inverted_relations(unique_relations)
 
         if create_inverse_triples or relations_already_inverted:
-            self.create_inverse_triples = True
+            create_inverse_triples = True
             if relations_already_inverted:
                 logger.info(
                     f'Some triples already have suffix {INVERSE_SUFFIX}. '
                     f'Creating TriplesFactory based on inverse triples',
                 )
-                self.relation_to_inverse = {
+                relation_to_inverse = {
                     re.sub('_inverse$', '', relation): f"{re.sub('_inverse$', '', relation)}{INVERSE_SUFFIX}"
                     for relation in unique_relations
                 }
 
             else:
-                self.relation_to_inverse = {
+                relation_to_inverse = {
                     relation: f"{relation}{INVERSE_SUFFIX}"
                     for relation in unique_relations
                 }
                 inverse_triples = np.stack(
                     [
-                        self.triples[:, 2],
-                        np.array([self.relation_to_inverse[relation] for relation in relations], dtype=np.str),
-                        self.triples[:, 0],
+                        triples[:, 2],
+                        np.array([relation_to_inverse[relation] for relation in relations], dtype=np.str),
+                        triples[:, 0],
                     ],
                     axis=-1,
                 )
                 # extend original triples with inverse ones
-                self.triples = np.concatenate([self.triples, inverse_triples], axis=0)
-                self._num_relations = 2 * len(unique_relations)
+                triples = np.concatenate([triples, inverse_triples], axis=0)
+                _num_relations = 2 * len(unique_relations)
 
         else:
-            self.create_inverse_triples = False
-            self.relation_to_inverse = None
-            self._num_relations = len(unique_relations)
+            create_inverse_triples = False
+            relation_to_inverse = None
+            _num_relations = len(unique_relations)
 
         # Generate entity mapping if necessary
         if entity_to_id is None:
-            entity_to_id = create_entity_mapping(triples=self.triples)
+            entity_to_id = create_entity_mapping(triples=triples)
         if compact_id:
             entity_to_id = compact_mapping(mapping=entity_to_id)[0]
-        self.entity_to_id = entity_to_id
+        entity_to_id = entity_to_id
 
         # Generate relation mapping if necessary
         if relation_to_id is None:
-            if self.create_inverse_triples:
+            if create_inverse_triples:
                 relation_to_id = create_relation_mapping(
-                    set(self.relation_to_inverse.keys()).union(set(self.relation_to_inverse.values())),
+                    set(relation_to_inverse.keys()).union(set(relation_to_inverse.values())),
                 )
             else:
                 relation_to_id = create_relation_mapping(unique_relations)
         if compact_id:
             relation_to_id = compact_mapping(mapping=relation_to_id)[0]
-        self.relation_to_id = relation_to_id
+        relation_to_id = relation_to_id
 
         # Map triples of labels to triples of IDs.
-        self.mapped_triples = _map_triples_elements_to_ids(
-            triples=self.triples,
-            entity_to_id=self.entity_to_id,
-            relation_to_id=self.relation_to_id,
+        mapped_triples = _map_triples_elements_to_ids(
+            triples=triples,
+            entity_to_id=entity_to_id,
+            relation_to_id=relation_to_id,
         )
+
+        return TriplesFactory(
+            entity_to_id=entity_to_id,
+            relation_to_id=relation_to_id,
+            triples=triples,
+            mapped_triples=mapped_triples,
+            relation_to_inverse=relation_to_inverse,
+        )
+
+    @classmethod
+    def from_path(
+        cls,
+        path: Union[str, TextIO],
+        create_inverse_triples: bool = False,
+        entity_to_id: Optional[EntityMapping] = None,
+        relation_to_id: Optional[RelationMapping] = None,
+        compact_id: bool = True,
+    ) -> "TriplesFactory":
+        """
+        Create a new triples factory from triples stored in a file.
+
+        :param path:
+            The path where the label-based triples are stored.
+        :param create_inverse_triples:
+            Whether to create inverse triples.
+        :param entity_to_id:
+            The mapping from entity labels to ID. If None, create a new one from the triples.
+        :param relation_to_id:
+            The mapping from relations labels to ID. If None, create a new one from the triples.
+        :param compact_id:
+            Whether to compact IDs such that the IDs are consecutive.
+
+        :return:
+            A new triples factory.
+        """
+        if isinstance(path, str):
+            path = os.path.abspath(path)
+        elif isinstance(path, TextIO):
+            path = os.path.abspath(path.name)
+        else:
+            raise TypeError(f'path is invalid type: {type(path)}')
+
+        # TODO: Check if lazy evaluation would make sense
+        triples = load_triples(path)
+
+        return cls.from_labeled_triples(
+            triples=triples,
+            create_inverse_triples=create_inverse_triples,
+            entity_to_id=entity_to_id,
+            relation_to_id=relation_to_id,
+            compact_id=compact_id,
+        )
+
+    @property
+    def create_inverse_triples(self) -> bool:  # noqa: D401
+        """Whether inverse triples are added."""
+        return self.relation_to_inverse is not None
 
     @property
     def num_entities(self) -> int:  # noqa: D401
         """The number of unique entities."""
-        return self._num_entities
+        return len(self.entity_to_id)
 
     @property
     def num_relations(self) -> int:  # noqa: D401
         """The number of unique relations."""
-        return self._num_relations
+        num_relations = len(self.relation_to_id)
+        if self.create_inverse_triples:
+            num_relations = 2 * num_relations
+        return num_relations
 
     @property
     def num_triples(self) -> int:  # noqa: D401
@@ -332,7 +382,8 @@ class TriplesFactory:
         return self.relation_to_id[inverse_relation]
 
     def __repr__(self):  # noqa: D105
-        return f'{self.__class__.__name__}(path="{self.path}")'
+        return f'{self.__class__.__name__}(num_entities={self.num_entities}, num_relations={self.num_relations}, ' \
+               f'num_triples={self.num_triples}, inverse_triples={self.create_inverse_triples})'
 
     @staticmethod
     def _check_already_inverted_relations(relations: Iterable[str]) -> bool:
@@ -460,7 +511,7 @@ class TriplesFactory:
 
         # Make new triples factories for each group
         return [
-            TriplesFactory(
+            TriplesFactory.from_labeled_triples(
                 triples=triples,
                 entity_to_id=self.entity_to_id,
                 relation_to_id=self.relation_to_id,
@@ -520,7 +571,7 @@ class TriplesFactory:
             f'removing {len(relations)}/{self.num_relations} relations'
             f' and {idx.sum()}/{self.num_triples} triples',
         )
-        return TriplesFactory(triples=self.triples[idx])
+        return TriplesFactory.from_labeled_triples(triples=self.triples[idx])
 
     def entity_word_cloud(self, top: Optional[int] = None):
         """Make a word cloud based on the frequency of occurrence of each entity in a Jupyter notebook.
@@ -658,7 +709,7 @@ class TriplesFactory:
             return self
 
         logger.info('Keeping %d/%d triples', keep_mask.sum(), self.num_triples)
-        factory = TriplesFactory(
+        factory = TriplesFactory.from_labeled_triples(
             triples=self.triples[keep_mask],
             create_inverse_triples=False,
             entity_to_id=self.entity_to_id,
@@ -668,9 +719,7 @@ class TriplesFactory:
 
         # manually copy the inverse relation mappings
         if self.create_inverse_triples:
-            factory.create_inverse_triples = True
             factory.relation_to_inverse = self.relation_to_inverse
-            factory._num_relations = self._num_relations
 
         return factory
 

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -54,6 +54,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         triples: Optional[LabeledTriples] = None,
         path_to_numeric_triples: Union[None, str, TextIO] = None,
         numeric_triples: Optional[np.ndarray] = None,
+        **kwargs,
     ) -> None:
         """Initialize the multi-modal triples factory.
 
@@ -66,44 +67,38 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         :param numeric_triples:  A 3-column numpy array with numeric triples in it. If not
          specified, you should specify ``path_to_numeric_triples``.
         """
-        super().__init__(path=path, triples=triples)
+        if path is None:
+            base = TriplesFactory.from_labeled_triples(triples=triples, **kwargs)
+        else:
+            base = TriplesFactory.from_path(path=path, **kwargs)
+        super().__init__(
+            entity_to_id=base.entity_to_id,
+            relation_to_id=base.relation_to_id,
+            triples=base.triples,
+            mapped_triples=base.mapped_triples,
+            relation_to_inverse=base.relation_to_inverse,
+        )
 
         if path_to_numeric_triples is None and numeric_triples is None:
             raise ValueError('Must specify one of path_to_numeric_triples or numeric_triples')
         elif path_to_numeric_triples is not None and numeric_triples is not None:
             raise ValueError('Must not specify both path_to_numeric_triples and numeric_triples')
         elif path_to_numeric_triples is not None:
-            self.path_to_numeric_triples = path_to_numeric_triples
-            self.numeric_triples = load_triples(self.path_to_numeric_triples)
-        else:  # numeric_triples is not None:
-            self.path_to_numeric_triples = '<None>'
-            self.numeric_triples = numeric_triples
+            numeric_triples = load_triples(path_to_numeric_triples)
 
-        self.numeric_literals = None
-        self.literals_to_id = None
-
-        self._create_numeric_literals()
-
-    def __repr__(self):  # noqa: D105
-        return (
-            f'{self.__class__.__name__}(path="{self.path}", '
-            f'path_to_numeric_triples="{self.path_to_numeric_triples}")'
+        self.numeric_literals, self.literals_to_id = create_matrix_of_literals(
+            numeric_triples=numeric_triples,
+            entity_to_id=self.entity_to_id,
         )
 
-    def _create_numeric_literals(self) -> None:
-        self.numeric_literals, self.literals_to_id = create_matrix_of_literals(
-            numeric_triples=self.numeric_triples,
-            entity_to_id=self.entity_to_id,
+    def extra_repr(self) -> str:  # noqa: D102
+        return super().extra_repr() + (
+            f"num_literals={len(self.literals_to_id)}"
         )
 
     def create_slcwa_instances(self) -> MultimodalSLCWAInstances:
         """Create multi-modal sLCWA instances for this factory's triples."""
         slcwa_instances = super().create_slcwa_instances()
-
-        # FIXME is this ever possible, since this function is called in __init__?
-        if self.numeric_literals is None:
-            self._create_numeric_literals()
-
         return MultimodalSLCWAInstances(
             mapped_triples=slcwa_instances.mapped_triples,
             entity_to_id=slcwa_instances.entity_to_id,
@@ -115,10 +110,6 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
     def create_lcwa_instances(self, use_tqdm: Optional[bool] = None) -> MultimodalLCWAInstances:
         """Create multi-modal LCWA instances for this factory's triples."""
         lcwa_instances = super().create_lcwa_instances(use_tqdm=use_tqdm)
-
-        if self.numeric_literals is None:
-            self._create_numeric_literals()
-
         return MultimodalLCWAInstances(
             mapped_triples=lcwa_instances.mapped_triples,
             entity_to_id=lcwa_instances.entity_to_id,

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -74,7 +74,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         super().__init__(
             entity_to_id=base.entity_to_id,
             relation_to_id=base.relation_to_id,
-            triples=base.triples,
+            _triples=base.triples,
             mapped_triples=base.mapped_triples,
             relation_to_inverse=base.relation_to_inverse,
         )

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -32,7 +32,7 @@ class TestLeakage(unittest.TestCase):
             ['i', 'r3', 'j'],
             ['k', 'r3', 'l'],
         ]
-        triples_factory = TriplesFactory(triples=np.array(t, dtype=np.str))
+        triples_factory = TriplesFactory.from_labeled_triples(triples=np.array(t, dtype=np.str))
         frequencies = get_candidate_inverse_relations(triples_factory, minimum_frequency=0.0, symmetric=False)
         self.assertEqual(
             {
@@ -71,8 +71,8 @@ class TestLeakage(unittest.TestCase):
         test = [
             ['-2', test_relation_inverse, '-1'],  # this one was leaked!
         ]
-        train_factory = TriplesFactory(triples=np.array(train, dtype=np.str))
-        test_factory = TriplesFactory(triples=np.array(test, dtype=np.str))
+        train_factory = TriplesFactory.from_labeled_triples(triples=np.array(train, dtype=np.str))
+        test_factory = TriplesFactory.from_labeled_triples(triples=np.array(test, dtype=np.str))
 
         sealant = Sealant(train_factory, symmetric=False)
 

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -66,7 +66,7 @@ class TestTriplesFactory(unittest.TestCase):
             ['e1', 'a', 'e2'],
         ]
         t = np.array(t, dtype=np.str)
-        factory = TriplesFactory(triples=t, create_inverse_triples=True)
+        factory = TriplesFactory.from_labeled_triples(triples=t, create_inverse_triples=True)
         reference_relation_to_id = {'a': 0, f'a{INVERSE_SUFFIX}': 1, 'a.': 2, f'a.{INVERSE_SUFFIX}': 3}
         self.assertEqual(reference_relation_to_id, factory.relation_to_id)
 
@@ -79,7 +79,7 @@ class TestTriplesFactory(unittest.TestCase):
             ['e4', f'a{INVERSE_SUFFIX}', 'e5'],
         ]
         t = np.array(t, dtype=np.str)
-        factory = TriplesFactory(triples=t, create_inverse_triples=False)
+        factory = TriplesFactory.from_labeled_triples(triples=t, create_inverse_triples=False)
         reference_relation_to_id = {'a': 0, f'a{INVERSE_SUFFIX}': 1, 'a.': 2, f'a.{INVERSE_SUFFIX}': 3}
         self.assertEqual(reference_relation_to_id, factory.relation_to_id)
         self.assertTrue(factory.create_inverse_triples)
@@ -92,7 +92,7 @@ class TestTriplesFactory(unittest.TestCase):
             ['e1', 'a.', 'e5'],
         ]
         t = np.array(t, dtype=np.str)
-        factory = TriplesFactory(triples=t, create_inverse_triples=False)
+        factory = TriplesFactory.from_labeled_triples(triples=t, create_inverse_triples=False)
         reference_relation_to_id = {'a': 0, f'a{INVERSE_SUFFIX}': 1, 'a.': 2, f'a.{INVERSE_SUFFIX}': 3}
         self.assertEqual(reference_relation_to_id, factory.relation_to_id)
         self.assertTrue(factory.create_inverse_triples)
@@ -110,7 +110,7 @@ class TestTriplesFactory(unittest.TestCase):
             ['e1', f'abc{INVERSE_SUFFIX}', 'e1'],
         ]
         t = np.array(t, dtype=np.str)
-        factory = TriplesFactory(triples=t, create_inverse_triples=False)
+        factory = TriplesFactory.from_labeled_triples(triples=t, create_inverse_triples=False)
         reference_relation_to_id = {
             'a': 0,
             f'a{INVERSE_SUFFIX}': 1,
@@ -366,14 +366,14 @@ class TestLiterals(unittest.TestCase):
 
     def test_triples(self):
         """Test properties of the triples factory."""
-        triples_factory = TriplesFactory(triples=triples)
+        triples_factory = TriplesFactory.from_labeled_triples(triples=triples)
         self.assertEqual(set(range(triples_factory.num_entities)), set(triples_factory.entity_to_id.values()))
         self.assertEqual(set(range(triples_factory.num_relations)), set(triples_factory.relation_to_id.values()))
         self.assertTrue((triples_factory.mapped_triples == triples_factory.map_triples_to_id(triples)).all())
 
     def test_inverse_triples(self):
         """Test that the right number of entities and triples exist after inverting them."""
-        triples_factory = TriplesFactory(triples=triples, create_inverse_triples=True)
+        triples_factory = TriplesFactory.from_labeled_triples(triples=triples, create_inverse_triples=True)
         self.assertEqual(0, triples_factory.num_relations % 2)
         self.assertEqual(
             set(range(triples_factory.num_entities)),

--- a/tests/training/test_utils.py
+++ b/tests/training/test_utils.py
@@ -48,7 +48,7 @@ class LossTensorTest(unittest.TestCase):
 
     def test_lcwa_margin_ranking_loss_helper(self):
         """Test if output is correct for the LCWA training loop use case."""
-        factory = TriplesFactory(triples=self.triples)
+        factory = TriplesFactory.from_labeled_triples(triples=self.triples)
 
         loss_cls = MarginRankingLoss(
             margin=0,


### PR DESCRIPTION
This PR splits the TriplesFactory's constructor into two separate ones

1. From path
2. From labeled triples

This PR is in anticipation of changes towards reducing information stored more than once, and using ID-based triples internally where possible.

Some additional changes:
* [x] replace inferred attributes by properties.
* [x] update `__repr__` of `TriplesFactory`.
