### PR TITLE
Switch config lookup to PyStow

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ PyKEEN
    reference/ablation
    reference/lookup
    reference/sealant
+   reference/constants
 
 .. toctree::
    :caption: Appendix

--- a/docs/source/reference/constants.rst
+++ b/docs/source/reference/constants.rst
@@ -1,0 +1,4 @@
+Constants
+=========
+.. automodule:: pykeen.constants
+    :members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
     optuna>=2.0.0
     pandas>=1.0.0
     tabulate
-    pystow
+    pystow>=0.0.3
 
 zip_safe = false
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     optuna>=2.0.0
     pandas>=1.0.0
     tabulate
+    pystow
 
 zip_safe = false
 include_package_data = True

--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -2,13 +2,18 @@
 
 """Constants for PyKEEN."""
 
-import os
+import pystow
 
 __all__ = [
     'PYKEEN_HOME',
+    'PYKEEN_DATASETS',
 ]
 
-PYKEEN_HOME = os.environ.get('PYKEEN_HOME') or os.path.join(os.path.expanduser('~'), '.pykeen')
+#: Can be modified by setting environment variable ``PYKEEN_HOME``
+#: For more information, see https://github.com/cthoyt/pystow
+PYKEEN_HOME = pystow.get('pykeen')
+PYKEEN_DATASETS = pystow.get('pykeen', 'datasets')
+
 DEFAULT_DROPOUT_HPO_RANGE = dict(type=float, low=0.0, high=0.5, q=0.1)
 # We define the embedding dimensions as a multiple of 16 because it is computational beneficial (on a GPU)
 # see: https://docs.nvidia.com/deeplearning/performance/index.html#optimizing-performance

--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -31,5 +31,5 @@ PYKEEN_CHECKPOINTS: Path = PYKEEN_MODULE.get('checkpoints')
 
 DEFAULT_DROPOUT_HPO_RANGE = dict(type=float, low=0.0, high=0.5, q=0.1)
 #: We define the embedding dimensions as a multiple of 16 because it is computational beneficial (on a GPU)
-#: .. seealso: https://docs.nvidia.com/deeplearning/performance/index.html#optimizing-performance
+#: see: https://docs.nvidia.com/deeplearning/performance/index.html#optimizing-performance
 DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE = dict(type=int, low=16, high=256, q=16)

--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -7,12 +7,18 @@ import pystow
 __all__ = [
     'PYKEEN_HOME',
     'PYKEEN_DATASETS',
+    'PYKEEN_BENCHMARKS',
+    'PYKEEN_EXPERIMENTS',
+    'PYKEEN_CHECKPOINTS',
 ]
 
 #: Can be modified by setting environment variable ``PYKEEN_HOME``
 #: For more information, see https://github.com/cthoyt/pystow
 PYKEEN_HOME = pystow.get('pykeen')
 PYKEEN_DATASETS = pystow.get('pykeen', 'datasets')
+PYKEEN_BENCHMARKS = pystow.get('pykeen', 'benchmarks')
+PYKEEN_EXPERIMENTS = pystow.get('pykeen', 'experiments')
+PYKEEN_CHECKPOINTS = pystow.get('pykeen', 'checkpoints')
 
 DEFAULT_DROPOUT_HPO_RANGE = dict(type=float, low=0.0, high=0.5, q=0.1)
 # We define the embedding dimensions as a multiple of 16 because it is computational beneficial (on a GPU)

--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -2,6 +2,8 @@
 
 """Constants for PyKEEN."""
 
+from pathlib import Path
+
 import pystow
 
 __all__ = [
@@ -12,15 +14,22 @@ __all__ = [
     'PYKEEN_CHECKPOINTS',
 ]
 
-#: Can be modified by setting environment variable ``PYKEEN_HOME``
+#: A manager around the PyKEEN data folder. It defaults to ``~/.data/pykeen``.
+#  This can be overridden with the envvar ``PYKEEN_HOME``.
 #: For more information, see https://github.com/cthoyt/pystow
-PYKEEN_HOME = pystow.get('pykeen')
-PYKEEN_DATASETS = pystow.get('pykeen', 'datasets')
-PYKEEN_BENCHMARKS = pystow.get('pykeen', 'benchmarks')
-PYKEEN_EXPERIMENTS = pystow.get('pykeen', 'experiments')
-PYKEEN_CHECKPOINTS = pystow.get('pykeen', 'checkpoints')
+PYKEEN_MODULE: pystow.Module = pystow.module('pykeen')
+#: A path representing the PyKEEN data folder
+PYKEEN_HOME: Path = PYKEEN_MODULE.base
+#: A subdirectory of the PyKEEN data folder for datasets, defaults to ``~/.data/pykeen/datasets``
+PYKEEN_DATASETS: Path = PYKEEN_MODULE.get('datasets')
+#: A subdirectory of the PyKEEN data folder for benchmarks, defaults to ``~/.data/pykeen/benchmarks``
+PYKEEN_BENCHMARKS: Path = PYKEEN_MODULE.get('benchmarks')
+#: A subdirectory of the PyKEEN data folder for experiments, defaults to ``~/.data/pykeen/experiments``
+PYKEEN_EXPERIMENTS: Path = PYKEEN_MODULE.get('experiments')
+#: A subdirectory of the PyKEEN data folder for checkpoints, defaults to ``~/.data/pykeen/checkpoints``
+PYKEEN_CHECKPOINTS: Path = PYKEEN_MODULE.get('checkpoints')
 
 DEFAULT_DROPOUT_HPO_RANGE = dict(type=float, low=0.0, high=0.5, q=0.1)
-# We define the embedding dimensions as a multiple of 16 because it is computational beneficial (on a GPU)
-# see: https://docs.nvidia.com/deeplearning/performance/index.html#optimizing-performance
+#: We define the embedding dimensions as a multiple of 16 because it is computational beneficial (on a GPU)
+#: .. seealso: https://docs.nvidia.com/deeplearning/performance/index.html#optimizing-performance
 DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE = dict(type=int, low=16, high=256, q=16)

--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -18,7 +18,7 @@ import pandas as pd
 import requests
 from tabulate import tabulate
 
-from ..constants import PYKEEN_HOME
+from ..constants import PYKEEN_DATASETS
 from ..triples import TriplesFactory
 from ..typing import RandomHint
 from ..utils import normalize_string
@@ -184,7 +184,7 @@ class LazyDataset(Dataset):
             :class:`pykeen.datasets.base.Dataset`.
         """
         if cache_root is None:
-            cache_root = PYKEEN_HOME
+            cache_root = PYKEEN_DATASETS
         cache_root = pathlib.Path(cache_root) / self.__class__.__name__.lower()
         cache_root.mkdir(parents=True, exist_ok=True)
         logger.debug('using cache root at %s', cache_root)


### PR DESCRIPTION
I've written this pattern so many times, that I figured it was time to put it in a package.

```python
PYKEEN_HOME = os.environ.get('PYKEEN_HOME') or os.path.join(os.path.expanduser('~'), '.pykeen')
```

`pystow` does just that, except shorter:

```python
PYKEEN_HOME = pystow.get('pykeen')
```

It also puts an intermediate directory, `~/.data` in the middle, since I can imagine using this in the 10+ packages I maintain that all have some kind of data storage that's mucking up my home directory. So after this PR gets merged, you should run the following commands so you don't have to re-download all of your datasets:

```bash
mkdir ~/.data/pykeen/
mv ~/.pykeen/ ~/.data/pykeen/datasets
```

Before, the pykeen directory was only storing datasets, but now I also want to store results of benchmarks and experiments there too by default, so that's why we're introducing a deeper folder hierarchy here.

@mberr will also be happy because `pystow` is completely using `pathlib`