### PR TITLE
Add triple generation utilities

### DIFF
--- a/src/pykeen/triples/generation.py
+++ b/src/pykeen/triples/generation.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+"""Utilities for generating triples."""
+
+from typing import Mapping
+from uuid import uuid4
+
+import numpy as np
+
+from .triples_factory import TriplesFactory
+from .utils import get_entities, get_relations
+from ..typing import RandomHint
+from ..utils import ensure_random_state
+
+__all__ = [
+    'generate_triples',
+    'generate_labeled_triples',
+    'generate_triples_factory',
+]
+
+
+def generate_triples(
+    num_entities: int = 33,
+    num_relations: int = 7,
+    num_triples: int = 101,
+    compact: bool = True,
+    random_state: RandomHint = None,
+) -> np.ndarray:
+    """Generate random triples."""
+    random_state = ensure_random_state(random_state)
+    rv = np.stack([
+        random_state.randint(num_entities, size=(num_triples,)),
+        random_state.randint(num_relations, size=(num_triples,)),
+        random_state.randint(num_entities, size=(num_triples,)),
+    ], axis=1)
+
+    if compact:
+        new_entity_id = {
+            entity: i
+            for i, entity in enumerate(sorted(get_entities(rv)))
+        }
+        new_relation_id = {
+            relation: i
+            for i, relation in enumerate(sorted(get_relations(rv)))
+        }
+        rv = np.asarray([
+            [new_entity_id[h], new_relation_id[r], new_entity_id[t]]
+            for h, r, t in rv
+        ], dtype=int)
+
+    return rv
+
+
+def generate_labeled_triples(
+    num_entities: int = 33,
+    num_relations: int = 7,
+    num_triples: int = 101,
+    random_state: RandomHint = None,
+) -> np.ndarray:
+    """Generate labeled random triples."""
+    t = generate_triples(
+        num_entities=num_entities,
+        num_relations=num_relations,
+        num_triples=num_triples,
+        compact=False,
+        random_state=random_state,
+    )
+    entity_id_to_label = _make_id_to_labels(num_entities)
+    relation_id_to_label = _make_id_to_labels(num_relations)
+    return np.asarray([
+        (
+            entity_id_to_label[h],
+            relation_id_to_label[r],
+            entity_id_to_label[t],
+        )
+        for h, r, t in t
+    ], dtype=str)
+
+
+def _make_id_to_labels(n: int) -> Mapping[int, str]:
+    return {
+        index: str(uuid4())
+        for index in range(n)
+    }
+
+
+def generate_triples_factory(
+    num_entities: int = 33,
+    num_relations: int = 7,
+    num_triples: int = 101,
+    random_state: RandomHint = None,
+    create_inverse_triples: bool = False,
+) -> TriplesFactory:
+    """Generate a triples factory with random triples."""
+    triples = generate_labeled_triples(
+        num_entities=num_entities,
+        num_relations=num_relations,
+        num_triples=num_triples,
+        random_state=random_state,
+    )
+    return TriplesFactory.from_labeled_triples(
+        triples=triples,
+        create_inverse_triples=create_inverse_triples,
+    )

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -2,7 +2,7 @@
 
 """Instance creation utilities."""
 
-from typing import Callable, Mapping, Optional, TextIO, Union
+from typing import Callable, Mapping, Optional, Set, TextIO, Union
 
 import numpy as np
 from pkg_resources import iter_entry_points
@@ -11,6 +11,8 @@ from ..typing import LabeledTriples
 
 __all__ = [
     'load_triples',
+    'get_entities',
+    'get_relations',
 ]
 
 
@@ -54,3 +56,13 @@ def load_triples(path: Union[str, TextIO], delimiter: str = '\t', encoding: Opti
         delimiter=delimiter,
         encoding=encoding,
     )
+
+
+def get_entities(triples) -> Set:
+    """Get all entities from the triples."""
+    return set(triples[:, [0, 2]].flatten().tolist())
+
+
+def get_relations(triples) -> Set:
+    """Get all relations from the triples."""
+    return set(triples[:, 1])

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for generating triples."""
+
+import unittest
+from typing import Set
+
+from pykeen.triples.generation import generate_triples
+from pykeen.triples.utils import get_entities, get_relations
+
+
+class TestGenerate(unittest.TestCase):
+    """Tests for generation of triples."""
+
+    num_entities: int = 33
+    num_relations: int = 7
+    num_triples: int = 101
+
+    def assert_consecutive(self, x: Set[int], msg=None):
+        """Assert that all of the things in the collection are consecutive integers."""
+        self.assertEqual(set(range(len(x))), x, msg=msg)
+
+    def test_compacted(self):
+        """Test that the results are compacted."""
+        for random_state in range(100):
+            x = generate_triples(
+                num_entities=self.num_entities,
+                num_relations=self.num_relations,
+                num_triples=self.num_triples,
+                random_state=random_state,
+            )
+            self.assertEqual(self.num_triples, x.shape[0])
+            self.assert_consecutive(get_entities(x))
+            self.assert_consecutive(get_relations(x))


### PR DESCRIPTION
Originally, this code was in #187, but I wanted to use it to generate triples for testing in #193, so I split it out to its own PR here. Since we're probably finishing #193 before #187, this is good because it will give us a chance to update it to use the new torch tensor-based triples factories (though since the target is master, we don't have to do those upgrades to accept this PR)