### PR TITLE
Add generalized metadata storage to TriplesFactory and improve repr

### DIFF
--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -211,7 +211,7 @@ class TriplesFactory:
         relation_to_id: Optional[RelationMapping] = None,
         compact_id: bool = True,
         filter_out_candidate_inverse_relations: bool = True,
-        metadata: Optional[Mapping[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> 'TriplesFactory':
         """
         Create a new triples factory from label-based triples.
@@ -290,6 +290,7 @@ class TriplesFactory:
         entity_to_id: Optional[EntityMapping] = None,
         relation_to_id: Optional[RelationMapping] = None,
         compact_id: bool = True,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> 'TriplesFactory':
         """
         Create a new triples factory from triples stored in a file.
@@ -304,6 +305,10 @@ class TriplesFactory:
             The mapping from relations labels to ID. If None, create a new one from the triples.
         :param compact_id:
             Whether to compact IDs such that the IDs are consecutive.
+        :param metadata:
+            Arbitrary key/value pairs to store as metadata with the triples factory. Do not
+            include ``path`` as a key because it is automatically taken from the ``path``
+            kwarg to this function.
 
         :return:
             A new triples factory.
@@ -324,7 +329,10 @@ class TriplesFactory:
             entity_to_id=entity_to_id,
             relation_to_id=relation_to_id,
             compact_id=compact_id,
-            metadata=dict(path=path),
+            metadata={
+                'path': path,
+                **(metadata or {}),
+            },
         )
 
     def clone_and_exchange_triples(
@@ -341,6 +349,9 @@ class TriplesFactory:
 
         :param mapped_triples:
             The new mapped triples.
+        :param extra_metadata
+            Extra metadata to include in the new triples factory. If ``keep_metadata`` is true,
+            the dictionaries will be unioned with precedence taken on keys from ``extra_metadata``.
         :param keep_metadata:
             Pass the current factory's metadata to the new triples factory
 
@@ -389,7 +400,7 @@ class TriplesFactory:
     def extra_repr(self) -> str:
         """Extra representation string."""
         d = [
-            ('num_entities', self.num_entities,),
+            ('num_entities', self.num_entities),
             ('num_relations', self.num_relations),
             ('num_triples', self.num_triples),
             ('inverse_triples', self.create_inverse_triples),

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -164,6 +164,10 @@ class TriplesFactory:
     #: Whether to create inverse triples
     create_inverse_triples: bool = False
 
+    #: The path to the file/resource from which this factory was created.
+    #: Typically a file path, or none if created directly from triples
+    path: Optional[str] = None
+
     # The following fields get generated automatically
 
     #: The inverse mapping for entity_label_to_id; initialized automatically
@@ -205,6 +209,7 @@ class TriplesFactory:
         relation_to_id: Optional[RelationMapping] = None,
         compact_id: bool = True,
         filter_out_candidate_inverse_relations: bool = True,
+        path: Optional[str] = None,
     ) -> 'TriplesFactory':
         """
         Create a new triples factory from label-based triples.
@@ -221,6 +226,8 @@ class TriplesFactory:
             Whether to compact IDs such that the IDs are consecutive.
         :param filter_out_candidate_inverse_relations:
             Whether to remove triples with relations with the inverse suffix.
+        :param path:
+            An optional path/resource name from which the triples were created
 
         :return:
             A new triples factory.
@@ -270,6 +277,7 @@ class TriplesFactory:
             relation_to_id=relation_to_id,
             mapped_triples=mapped_triples,
             create_inverse_triples=create_inverse_triples,
+            path=path,
         )
 
     @classmethod
@@ -314,11 +322,13 @@ class TriplesFactory:
             entity_to_id=entity_to_id,
             relation_to_id=relation_to_id,
             compact_id=compact_id,
+            path=path,
         )
 
     def clone_and_exchange_triples(
         self,
         mapped_triples: MappedTriples,
+        keep_path: bool = True,
     ) -> "TriplesFactory":
         """
         Create a new triples factory sharing everything except the triples.
@@ -328,6 +338,8 @@ class TriplesFactory:
 
         :param mapped_triples:
             The new mapped triples.
+        :param keep_path:
+            Pass the current path to the new triples factory
 
         :return:
             The new factory.
@@ -337,6 +349,7 @@ class TriplesFactory:
             relation_to_id=self.relation_to_id,
             mapped_triples=mapped_triples,
             create_inverse_triples=self.create_inverse_triples,
+            path=self.path if keep_path else None,
         )
 
     @property

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -349,7 +349,7 @@ class TriplesFactory:
 
         :param mapped_triples:
             The new mapped triples.
-        :param extra_metadata
+        :param extra_metadata:
             Extra metadata to include in the new triples factory. If ``keep_metadata`` is true,
             the dictionaries will be unioned with precedence taken on keys from ``extra_metadata``.
         :param keep_metadata:

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -384,11 +384,16 @@ class TriplesFactory:
 
     def extra_repr(self) -> str:
         """Extra representation string."""
-        return (
-            f"num_entities={self.num_entities}, "
-            f"num_relations={self.num_relations}, "
-            f"num_triples={self.num_triples}, "
-            f"inverse_triples={self.create_inverse_triples}"
+        d = [
+            ('num_entities', self.num_entities,),
+            ('num_relations', self.num_relations),
+            ('num_triples', self.num_triples),
+            ('inverse_triples', self.create_inverse_triples),
+        ]
+        d.extend(sorted(self.metadata.items()))
+        return ', '.join(
+            f'{k}="{v}"' if isinstance(v, str) else f'{k}={v}'
+            for k, v in d
         )
 
     def __repr__(self):  # noqa: D105

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -731,5 +731,5 @@ class TriplesFactory:
         logger.info(f"keeping {format_relative_comparison(num_triples, self.num_triples)} triples.")
         return self.clone_and_exchange_triples(
             mapped_triples=self.mapped_triples[keep_mask],
-            # extra_metadata=extra_metadata,
+            extra_metadata=extra_metadata,
         )

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 from pykeen.datasets import Nations
+from pykeen.datasets.nations import NATIONS_TRAIN_PATH
 from pykeen.triples import LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory
 from pykeen.triples.generation import generate_triples
 from pykeen.triples.splitting import (
@@ -431,6 +432,19 @@ class TestLiterals(unittest.TestCase):
             triples_factory.num_relations,
             msg='Wrong number of relations in factory',
         )
+
+    def test_path(self):
+        """Test repr() for triples factories."""
+        t = Nations().training
+        self.assertEqual(NATIONS_TRAIN_PATH, t.path)
+
+        first = list(t.entity_to_id)[0]
+        x = t.new_with_restriction(entities=[first])
+        self.assertEqual(NATIONS_TRAIN_PATH, x.path)
+
+        y, z = t.split()
+        self.assertEqual(NATIONS_TRAIN_PATH, y.path)
+        self.assertEqual(NATIONS_TRAIN_PATH, z.path)
 
 
 def test_get_absolute_split_sizes():

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -467,15 +467,11 @@ class TestLiterals(unittest.TestCase):
             repr(v),
         )
 
-
         w = t.clone_and_exchange_triples(t.triples[0:5], keep_metadata=False)
         self.assertIsInstance(w, TriplesFactory)
         self.assertNotIn('path', w.metadata)
         self.assertEqual(
-            (
-                f'TriplesFactory(num_entities=14, num_relations=55, num_triples=5,'
-                f' inverse_triples=False)'
-            ),
+            'TriplesFactory(num_entities=14, num_relations=55, num_triples=5, inverse_triples=False)',
             repr(w),
         )
 

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -437,14 +437,34 @@ class TestLiterals(unittest.TestCase):
         """Test metadata passing for triples factories."""
         t = Nations().training
         self.assertEqual(NATIONS_TRAIN_PATH, t.metadata['path'])
+        self.assertEqual(
+            (
+                f'TriplesFactory(num_entities=14, num_relations=55, num_triples=1592,'
+                f' inverse_triples=False, path="{NATIONS_TRAIN_PATH}")'
+            ),
+            repr(t),
+        )
 
-        first = list(t.entity_to_id)[0]
-        x = t.new_with_restriction(entities=[first])
+        x = t.new_with_restriction(entities=['poland', 'ussr'])
         self.assertEqual(NATIONS_TRAIN_PATH, x.metadata['path'])
+        self.assertEqual(
+            (
+                f'TriplesFactory(num_entities=14, num_relations=55, num_triples=37,'
+                f' inverse_triples=False, path="{NATIONS_TRAIN_PATH}")'
+            ),
+            repr(x),
+        )
 
         w = t.clone_and_exchange_triples(t.triples[0:5], keep_metadata=False)
         self.assertIsInstance(w, TriplesFactory)
         self.assertNotIn('path', w.metadata)
+        self.assertEqual(
+            (
+                f'TriplesFactory(num_entities=14, num_relations=55, num_triples=5,'
+                f' inverse_triples=False)'
+            ),
+            repr(w),
+        )
 
         y, z = t.split()
         self.assertEqual(NATIONS_TRAIN_PATH, y.metadata['path'])

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -445,15 +445,28 @@ class TestLiterals(unittest.TestCase):
             repr(t),
         )
 
-        x = t.new_with_restriction(entities=['poland', 'ussr'])
+        entities = ['poland', 'ussr']
+        x = t.new_with_restriction(entities=entities)
         self.assertEqual(NATIONS_TRAIN_PATH, x.metadata['path'])
         self.assertEqual(
             (
                 f'TriplesFactory(num_entities=14, num_relations=55, num_triples=37,'
-                f' inverse_triples=False, path="{NATIONS_TRAIN_PATH}")'
+                f' inverse_triples=False, entity_restriction={repr(entities)}, path="{NATIONS_TRAIN_PATH}")'
             ),
             repr(x),
         )
+
+        relations = ['negativebehavior']
+        v = t.new_with_restriction(relations=relations)
+        self.assertEqual(NATIONS_TRAIN_PATH, x.metadata['path'])
+        self.assertEqual(
+            (
+                f'TriplesFactory(num_entities=14, num_relations=55, num_triples=29,'
+                f' inverse_triples=False, path="{NATIONS_TRAIN_PATH}", relation_restriction={repr(relations)})'
+            ),
+            repr(v),
+        )
+
 
         w = t.clone_and_exchange_triples(t.triples[0:5], keep_metadata=False)
         self.assertIsInstance(w, TriplesFactory)

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -433,18 +433,22 @@ class TestLiterals(unittest.TestCase):
             msg='Wrong number of relations in factory',
         )
 
-    def test_path(self):
-        """Test repr() for triples factories."""
+    def test_metadata(self):
+        """Test metadata passing for triples factories."""
         t = Nations().training
-        self.assertEqual(NATIONS_TRAIN_PATH, t.path)
+        self.assertEqual(NATIONS_TRAIN_PATH, t.metadata['path'])
 
         first = list(t.entity_to_id)[0]
         x = t.new_with_restriction(entities=[first])
-        self.assertEqual(NATIONS_TRAIN_PATH, x.path)
+        self.assertEqual(NATIONS_TRAIN_PATH, x.metadata['path'])
+
+        w = t.clone_and_exchange_triples(t.triples[0:5], keep_metadata=False)
+        self.assertIsInstance(w, TriplesFactory)
+        self.assertNotIn('path', w.metadata)
 
         y, z = t.split()
-        self.assertEqual(NATIONS_TRAIN_PATH, y.path)
-        self.assertEqual(NATIONS_TRAIN_PATH, z.path)
+        self.assertEqual(NATIONS_TRAIN_PATH, y.metadata['path'])
+        self.assertEqual(NATIONS_TRAIN_PATH, z.metadata['path'])
 
 
 def test_get_absolute_split_sizes():


### PR DESCRIPTION
Closes #142, Deprecates #144, Deprecates #145

Since #193, triples factories don't *need* paths. However, they're useful to have around, so this PR is a re-write of #145 such that they can be passed around in a metadata dictionary, along with any other information.