### PR TITLE
Allow instantiation of TriplesFactory without label-to-id mapping

### DIFF
--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -3,7 +3,7 @@
 """Sample datasets for use with PyKEEN, borrowed from https://github.com/ZhenfengLei/KGDatasets.
 
 New datasets (inheriting from :class:`pykeen.datasets.base.Dataset`) can be registered with PyKEEN using the
-`pykeen.datasets` group in Python entrypoints in your own `setup.py` or `setup.cfg` package configuration.
+:mod:`pykeen.datasets` group in Python entrypoints in your own `setup.py` or `setup.cfg` package configuration.
 They are loaded automatically with :func:`pkg_resources.iter_entry_points`.
 """
 

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -30,7 +30,7 @@ from .openbiolink import OpenBioLink, OpenBioLinkF1, OpenBioLinkF2, OpenBioLinkL
 from .umls import UMLS
 from .wordnet import WN18, WN18RR
 from .yago import YAGO310
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory, TriplesFactory
 from ..utils import normalize_string, normalized_lookup
 
 __all__ = [
@@ -120,8 +120,8 @@ def get_dataset(
             **(dataset_kwargs or {}),
         )
 
-    if isinstance(training, TriplesFactory) and isinstance(testing, TriplesFactory):
-        if validation is not None and not isinstance(validation, TriplesFactory):
+    if isinstance(training, CoreTriplesFactory) and isinstance(testing, CoreTriplesFactory):
+        if validation is not None and not isinstance(validation, CoreTriplesFactory):
             raise TypeError(f'Validation is invalid type: {type(validation)}')
         if dataset_kwargs:
             logger.warning('dataset_kwargs are disregarded when passing pre-instantiated triples factories')

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -942,7 +942,7 @@ class Model(nn.Module, ABC):
             'score_t function. This might cause the calculations to take longer than necessary.',
         )
         # Extend the hr_batch such that each (h, r) pair is combined with all possible tails
-        hrt_batch = _extend_batch(batch=hr_batch, all_ids=list(self.triples_factory.entity_to_id.values()), dim=2)
+        hrt_batch = _extend_batch(batch=hr_batch, all_ids=list(self.triples_factory.get_entity_ids()), dim=2)
         # Calculate the scores for each (h, r, t) triple using the generic interaction function
         expanded_scores = self.score_hrt(hrt_batch=hrt_batch)
         # Reshape the scores to match the pre-defined output shape of the score_t function.
@@ -975,7 +975,7 @@ class Model(nn.Module, ABC):
             'score_h function. This might cause the calculations to take longer than necessary.',
         )
         # Extend the rt_batch such that each (r, t) pair is combined with all possible heads
-        hrt_batch = _extend_batch(batch=rt_batch, all_ids=list(self.triples_factory.entity_to_id.values()), dim=0)
+        hrt_batch = _extend_batch(batch=rt_batch, all_ids=list(self.triples_factory.get_entity_ids()), dim=0)
         # Calculate the scores for each (h, r, t) triple using the generic interaction function
         expanded_scores = self.score_hrt(hrt_batch=hrt_batch)
         # Reshape the scores to match the pre-defined output shape of the score_h function.
@@ -1007,7 +1007,7 @@ class Model(nn.Module, ABC):
             'score_r function. This might cause the calculations to take longer than necessary.',
         )
         # Extend the ht_batch such that each (h, t) pair is combined with all possible relations
-        hrt_batch = _extend_batch(batch=ht_batch, all_ids=list(self.triples_factory.relation_to_id.values()), dim=1)
+        hrt_batch = _extend_batch(batch=ht_batch, all_ids=list(self.triples_factory.get_relation_ids()), dim=1)
         # Calculate the scores for each (h, r, t) triple using the generic interaction function
         expanded_scores = self.score_hrt(hrt_batch=hrt_batch)
         # Reshape the scores to match the pre-defined output shape of the score_r function.

--- a/src/pykeen/triples/__init__.py
+++ b/src/pykeen/triples/__init__.py
@@ -5,7 +5,7 @@
 from .instances import (
     Instances, LCWAInstances, MultimodalInstances, MultimodalLCWAInstances, MultimodalSLCWAInstances, SLCWAInstances,
 )
-from .triples_factory import TriplesFactory
+from .triples_factory import CoreTriplesFactory, TriplesFactory
 from .triples_numeric_literals_factory import TriplesNumericLiteralsFactory
 
 __all__ = [
@@ -15,6 +15,7 @@ __all__ = [
     'MultimodalSLCWAInstances',
     'MultimodalLCWAInstances',
     'SLCWAInstances',
+    'CoreTriplesFactory',
     'TriplesFactory',
     'TriplesNumericLiteralsFactory',
 ]

--- a/src/pykeen/triples/generation.py
+++ b/src/pykeen/triples/generation.py
@@ -2,20 +2,15 @@
 
 """Utilities for generating triples."""
 
-from typing import Mapping
-from uuid import uuid4
-
-import numpy as np
 import torch
 
-from .triples_factory import TriplesFactory
+from .triples_factory import CoreTriplesFactory
 from .utils import get_entities, get_relations
 from ..typing import TorchRandomHint
-from ..utils import ensure_torch_random_state, invert_mapping
+from ..utils import ensure_torch_random_state
 
 __all__ = [
     'generate_triples',
-    'generate_labeled_triples',
     'generate_triples_factory',
 ]
 
@@ -56,50 +51,13 @@ def generate_triples(
     return rv
 
 
-def generate_labeled_triples(
-    num_entities: int = 33,
-    num_relations: int = 7,
-    num_triples: int = 101,
-    random_state: TorchRandomHint = None,
-) -> np.ndarray:
-    """Generate labeled random triples."""
-    mapped_triples = generate_triples(
-        num_entities=num_entities,
-        num_relations=num_relations,
-        num_triples=num_triples,
-        compact=False,
-        random_state=random_state,
-    )
-    entity_id_to_label = _make_id_to_labels(num_entities)
-    relation_id_to_label = _make_id_to_labels(num_relations)
-    return np.asarray([
-        (
-            entity_id_to_label[h],
-            relation_id_to_label[r],
-            entity_id_to_label[t],
-        )
-        for h, r, t in mapped_triples
-    ], dtype=str)
-
-
-def _make_id_to_labels(n: int) -> Mapping[int, str]:
-    return {
-        index: str(uuid4())
-        for index in range(n)
-    }
-
-
-def _make_label_to_ids(n: int) -> Mapping[str, int]:
-    return invert_mapping(mapping=_make_id_to_labels(n))
-
-
 def generate_triples_factory(
     num_entities: int = 33,
     num_relations: int = 7,
     num_triples: int = 101,
     random_state: TorchRandomHint = None,
     create_inverse_triples: bool = False,
-) -> TriplesFactory:
+) -> CoreTriplesFactory:
     """Generate a triples factory with random triples."""
     mapped_triples = generate_triples(
         num_entities=num_entities,
@@ -107,9 +65,7 @@ def generate_triples_factory(
         num_triples=num_triples,
         random_state=random_state,
     )
-    return TriplesFactory(
-        entity_to_id=_make_label_to_ids(num_entities),
-        relation_to_id=_make_label_to_ids(num_relations),
+    return CoreTriplesFactory.create(
         mapped_triples=mapped_triples,
         create_inverse_triples=create_inverse_triples,
     )

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -322,15 +322,16 @@ class CoreTriplesFactory:
 
     def _add_inverse_triples_if_necessary(self, mapped_triples: MappedTriples) -> MappedTriples:
         """Add inverse triples if they shall be created."""
-        if self.create_inverse_triples:
-            logger.info("Creating inverse triples.")
-            h, r, t = mapped_triples.t()
-            r = 2 * r
-            mapped_triples = torch.cat([
-                torch.stack([h, r, t], dim=-1),
-                torch.stack([t, self._get_inverse_relation_id(r), h], dim=-1),
-            ])
-        return mapped_triples
+        if not self.create_inverse_triples:
+            return mapped_triples
+
+        logger.info("Creating inverse triples.")
+        h, r, t = mapped_triples.t()
+        r = 2 * r
+        return torch.cat([
+            torch.stack([h, r, t], dim=-1),
+            torch.stack([t, self._get_inverse_relation_id(r), h], dim=-1),
+        ])
 
     def create_slcwa_instances(self) -> Instances:
         """Create sLCWA instances for this factory's triples."""

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -150,23 +150,22 @@ class Labeling:
     """A mapping between labels and IDs."""
 
     #: The mapping from labels to IDs.
-    label_to_id: Optional[Mapping[str, int]]
+    label_to_id: Mapping[str, int]
 
     #: The inverse mapping for label_to_id; initialized automatically
-    id_to_label: Optional[Mapping[int, str]] = None
+    id_to_label: Mapping[int, str] = dataclasses.field(init=False)
 
     #: A vectorized version of entity_label_to_id; initialized automatically
-    _vectorized_mapper: Optional[Callable[..., np.ndarray]] = None
+    _vectorized_mapper: Callable[..., np.ndarray] = dataclasses.field(init=False)
 
     #: A vectorized version of entity_id_to_label; initialized automatically
-    _vectorized_labeler: Optional[Callable[..., np.ndarray]] = None
+    _vectorized_labeler: Callable[..., np.ndarray] = dataclasses.field(init=False)
 
     def __post_init__(self):
         """Precompute inverse mappings."""
-        if self.label_to_id is not None:
-            self.id_to_label = invert_mapping(mapping=self.label_to_id)
-            self._vectorized_mapper = np.vectorize(self.label_to_id.get)
-            self._vectorized_labeler = np.vectorize(self.id_to_label.get)
+        self.id_to_label = invert_mapping(mapping=self.label_to_id)
+        self._vectorized_mapper = np.vectorize(self.label_to_id.get)
+        self._vectorized_labeler = np.vectorize(self.id_to_label.get)
 
     def label(
         self,
@@ -176,7 +175,7 @@ class Labeling:
         """Convert IDs to labels."""
         # Normalize input
         if torch.is_tensor(ids):
-            ids = ids.cpu().numpy()
+            ids = ids.cpu().numpy()  # type: ignore
         if isinstance(ids, int):
             ids = [ids]
         ids = np.asanyarray(ids)

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -174,8 +174,8 @@ class Labeling:
     ) -> np.ndarray:
         """Convert IDs to labels."""
         # Normalize input
-        if torch.is_tensor(ids):
-            ids = ids.cpu().numpy()  # type: ignore
+        if isinstance(ids, torch.Tensor):
+            ids = ids.cpu().numpy()
         if isinstance(ids, int):
             ids = [ids]
         ids = np.asanyarray(ids)
@@ -508,8 +508,8 @@ class CoreTriplesFactory:
         # Additional columns
         for key, values in kwargs.items():
             # convert PyTorch tensors to numpy
-            if torch.is_tensor(values):
-                values = values.cpu().numpy()  # type: ignore
+            if isinstance(values, torch.Tensor):
+                values = values.cpu().numpy()
             data[key] = values
 
         # convert to dataframe

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -418,7 +418,7 @@ class TriplesFactory:
         entity_to_id: Mapping[str, int],
         relation_to_id: Mapping[str, int],
     ) -> "TriplesFactory":
-        """Adds labeling to the TriplesFactory."""
+        """Add labeling to the TriplesFactory."""
         if self.entity_to_id is not None or self.relation_to_id is not None:
             raise ValueError("TriplesFactory already has a labeling.")
         return TriplesFactory(

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -279,6 +279,14 @@ class CoreTriplesFactory:
         """The number of triples."""
         return self.mapped_triples.shape[0]
 
+    def get_entity_ids(self) -> Collection[int]:
+        """Get the set of entity identifiers."""
+        raise NotImplementedError  # TODO @mberr should these be pre-cached on __init__?
+
+    def get_relation_ids(self) -> Collection[int]:
+        """Get the set of relation identifiers."""
+        raise NotImplementedError
+
     def extra_repr(self) -> str:
         """Extra representation string."""
         d = [
@@ -785,6 +793,14 @@ class TriplesFactory(CoreTriplesFactory):
     def relation_id_to_label(self) -> Mapping[int, str]:
         """Return the mapping from relations IDs to labels."""
         return self.relation_labeling.id_to_label
+
+    def get_entity_ids(self) -> Collection[int]:
+        """Get the set of entity identifiers."""
+        return self.entity_to_id.values()
+
+    def get_relation_ids(self) -> Collection[int]:
+        """Get the set of relation identifiers."""
+        return self.relation_to_id.values()
 
     @property
     def triples(self) -> np.ndarray:  # noqa: D401

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -517,7 +517,7 @@ class CoreTriplesFactory:
         rv = pd.DataFrame(data=data)
 
         # Re-order columns
-        columns = list(TRIPLES_DF_COLUMNS[:3]) + sorted(set(rv.columns).difference(TRIPLES_DF_COLUMNS))
+        columns = list(TRIPLES_DF_COLUMNS[::2]) + sorted(set(rv.columns).difference(TRIPLES_DF_COLUMNS))
         return rv.loc[:, columns]
 
     def new_with_restriction(
@@ -929,7 +929,7 @@ class TriplesFactory(CoreTriplesFactory):
             )
 
         # Re-order columns
-        columns = old_col[:3] + list(TRIPLES_DF_COLUMNS[3:]) + old_col[3:]
+        columns = list(TRIPLES_DF_COLUMNS) + old_col[3:]
         return data.loc[:, columns]
 
     def new_with_restriction(
@@ -939,6 +939,8 @@ class TriplesFactory(CoreTriplesFactory):
         invert_entity_selection: bool = False,
         invert_relation_selection: bool = False,
     ) -> 'TriplesFactory':  # noqa: D102
+        if entities is None and relations is None:
+            return self
         if entities is not None:
             entities = self.entities_to_ids(entities=entities)
         if relations is not None:

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -20,6 +20,7 @@ from ..typing import EntityMapping, LabeledTriples, MappedTriples, RelationMappi
 from ..utils import compact_mapping, format_relative_comparison, invert_mapping, torch_is_in_1d
 
 __all__ = [
+    'CoreTriplesFactory',
     'TriplesFactory',
     'create_entity_mapping',
     'create_relation_mapping',

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -415,6 +415,24 @@ class TriplesFactory:
             },
         )
 
+    def with_labels(
+        self,
+        entity_to_id: Mapping[str, int],
+        relation_to_id: Mapping[str, int],
+    ) -> "TriplesFactory":
+        """Adds labeling to the TriplesFactory."""
+        if self.entity_to_id is not None or self.relation_to_id is not None:
+            raise ValueError("TriplesFactory already has a labeling.")
+        return TriplesFactory(
+            mapped_triples=self.mapped_triples,
+            entity_to_id=entity_to_id,
+            _num_entities=None,
+            relation_to_id=relation_to_id,
+            _num_relations=None,
+            create_inverse_triples=self.create_inverse_triples,
+            metadata=self.metadata,
+        )
+
     @property
     def num_entities(self) -> int:  # noqa: D401
         """The number of unique entities."""

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -197,6 +197,7 @@ class CoreTriplesFactory:
         metadata: Optional[Mapping[str, Any]] = None,
     ):
         """
+        Create the triples factory.
 
         :param mapped_triples: shape: (n, 3)
             A three-column matrix where each row are the head identifier, relation identifier, then tail identifier.
@@ -233,6 +234,7 @@ class TriplesFactory(CoreTriplesFactory):
         metadata: Optional[Mapping[str, Any]] = None,
     ):
         """
+        Create the triples factory.
 
         :param mapped_triples: shape: (n, 3)
             A three-column matrix where each row are the head identifier, relation identifier, then tail identifier.

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -260,7 +260,7 @@ class CoreTriplesFactory:
     @property
     def num_entities(self) -> int:  # noqa: D401
         """The number of unique entities."""
-        return self.num_entities
+        return self._num_entities
 
     @property
     def num_relations(self) -> int:  # noqa: D401

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -301,7 +301,15 @@ class CoreTriplesFactory:
         relation_to_id: Mapping[str, int],
     ) -> "TriplesFactory":
         """Add labeling to the TriplesFactory."""
-        # TODO: Check labelings
+        # check new label to ID mappings
+        for name, columns, new_labeling in (
+            ("entity", [0, 2], entity_to_id),
+            ("relation", 1, relation_to_id),
+        ):
+            existing_ids = set(self.mapped_triples[:, columns].unique().tolist())
+            if not existing_ids.issubset(new_labeling.values()):
+                diff = existing_ids.difference(new_labeling.values())
+                raise ValueError(f"Some existing IDs do not occur in the new {name} labeling: {diff}")
         return TriplesFactory(
             mapped_triples=self.mapped_triples,
             entity_to_id=entity_to_id,

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -287,8 +287,8 @@ class CoreTriplesFactory:
     def get_most_frequent_relations(self, n: Union[int, float]) -> Set[int]:
         """Get the IDs of the n most frequent relations.
 
-        :param n: Either the (integer) number of top relations to keep or the (float) percentage of top relationships
-         to keep
+        :param n:
+            Either the (integer) number of top relations to keep or the (float) percentage of top relationships to keep.
         """
         logger.info(f'applying cutoff of {n} to {self}')
         if isinstance(n, float):

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -469,40 +469,49 @@ class TriplesFactory(CoreTriplesFactory):
 
     @property
     def entity_to_id(self) -> Mapping[str, int]:
+        """Return the mapping from entity labels to IDs."""
         assert self.entity_labeling is not None
         return self.entity_labeling.label_to_id
 
     @property
     def entity_id_to_label(self) -> Mapping[int, str]:
+        """Return the mapping from entity IDs to labels."""
         assert self.entity_labeling is not None
         return self.entity_labeling.id_to_label
 
     @property
     def _vectorized_entity_mapper(self) -> Callable[..., np.ndarray]:
+        """Return the vectorized mapping from entity labels to IDs."""
         assert self.entity_labeling is not None
         return self.entity_labeling._vectorized_mapper
 
     @property
     def _vectorized_entity_labeler(self) -> Callable[..., np.ndarray]:
+        """Return the vectorized mapping from entity IDs to labels."""
         assert self.entity_labeling is not None
         return self.entity_labeling._vectorized_labeler
 
     @property
     def relation_to_id(self) -> Mapping[str, int]:
+        """Return the mapping from relations labels to IDs."""
+        assert self.relation_labeling is not None
         return self.relation_labeling.label_to_id
 
     @property
     def relation_id_to_label(self) -> Mapping[int, str]:
+        """Return the mapping from relations IDs to labels."""
         assert self.relation_labeling is not None
         return self.relation_labeling.id_to_label
 
     @property
     def _vectorized_relation_mapper(self) -> Callable[..., np.ndarray]:
+        """Return the vectorized mapping from relations labels to IDs."""
         assert self.relation_labeling is not None
         return self.relation_labeling._vectorized_mapper
 
     @property
     def _vectorized_relation_labeler(self) -> Callable[..., np.ndarray]:
+        """Return the vectorized mapping from relations IDs to labels."""
         assert self.relation_labeling is not None
         return self.relation_labeling._vectorized_labeler
 

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -85,6 +85,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         elif path_to_numeric_triples is not None:
             numeric_triples = load_triples(path_to_numeric_triples)
 
+        assert self.entity_to_id is not None
         self.numeric_literals, self.literals_to_id = create_matrix_of_literals(
             numeric_triples=numeric_triples,
             entity_to_id=self.entity_to_id,

--- a/tests/test_model_mode.py
+++ b/tests/test_model_mode.py
@@ -192,3 +192,11 @@ class MinimalTriplesFactory:
     }
     num_entities = 2
     num_relations = 2
+
+    @classmethod
+    def get_entity_ids(cls):  # noqa:D102
+        return cls.entity_to_id.values()
+
+    @classmethod
+    def get_relation_ids(cls):  # noqa:D102
+        return cls.relation_to_id.values()

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -447,22 +447,24 @@ class TestLiterals(unittest.TestCase):
 
         entities = ['poland', 'ussr']
         x = t.new_with_restriction(entities=entities)
+        entities_ids = t.entities_to_ids(entities=entities)
         self.assertEqual(NATIONS_TRAIN_PATH, x.metadata['path'])
         self.assertEqual(
             (
                 f'TriplesFactory(num_entities=14, num_relations=55, num_triples=37,'
-                f' inverse_triples=False, entity_restriction={repr(entities)}, path="{NATIONS_TRAIN_PATH}")'
+                f' inverse_triples=False, entity_restriction={repr(entities_ids)}, path="{NATIONS_TRAIN_PATH}")'
             ),
             repr(x),
         )
 
         relations = ['negativebehavior']
         v = t.new_with_restriction(relations=relations)
+        relations_ids = t.relations_to_ids(relations=relations)
         self.assertEqual(NATIONS_TRAIN_PATH, x.metadata['path'])
         self.assertEqual(
             (
                 f'TriplesFactory(num_entities=14, num_relations=55, num_triples=29,'
-                f' inverse_triples=False, path="{NATIONS_TRAIN_PATH}", relation_restriction={repr(relations)})'
+                f' inverse_triples=False, path="{NATIONS_TRAIN_PATH}", relation_restriction={repr(relations_ids)})'
             ),
             repr(v),
         )


### PR DESCRIPTION
This PR implements parts of #57 

In particular it adds a new constructor to `TriplesFactory.create_without_labels`, and makes passing label-to-id mappings to the base constructor of `TriplesFactory` optional. When accessing methods / attributes which require labels, an exception is raised.