### PR TITLE
Add drop_last option to data loader in training loop

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -8,7 +8,7 @@ import itertools as itt
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, ClassVar, Collection, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -20,7 +20,7 @@ from ..nn import Embedding
 from ..regularizers import NoRegularizer, Regularizer
 from ..triples import TriplesFactory
 from ..typing import Constrainer, DeviceHint, Initializer, MappedTriples, Normalizer
-from ..utils import NoRandomSeedNecessary, empty, get_batchnorm_modules, resolve_device, set_random_seed
+from ..utils import NoRandomSeedNecessary, get_batchnorm_modules, resolve_device, set_random_seed
 
 __all__ = [
     'Model',
@@ -312,14 +312,9 @@ class Model(nn.Module, ABC):
         return _can_slice(self.score_t)
 
     @property
-    def modules_not_supporting_sub_batching(self) -> Iterable[nn.Module]:
+    def modules_not_supporting_sub_batching(self) -> List[nn.Module]:
         """Return all modules not supporting sub-batching."""
-        return get_batchnorm_modules(base=self)
-
-    @property
-    def supports_subbatching(self) -> bool:  # noqa: D400, D401
-        """Does this model support sub-batching?"""
-        return empty(self.modules_not_supporting_sub_batching)
+        return get_batchnorm_modules(module=self)
 
     @abstractmethod
     def _reset_parameters_(self):  # noqa: D401

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -8,7 +8,7 @@ import itertools as itt
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, ClassVar, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, ClassVar, Collection, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -312,7 +312,7 @@ class Model(nn.Module, ABC):
         return _can_slice(self.score_t)
 
     @property
-    def modules_not_supporting_sub_batching(self) -> List[nn.Module]:
+    def modules_not_supporting_sub_batching(self) -> Collection[nn.Module]:
         """Return all modules not supporting sub-batching."""
         return get_batchnorm_modules(module=self)
 

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -63,7 +63,7 @@ class SubBatchingNotSupportedError(NotImplementedError):
     def __str__(self):  # noqa: D105
         return (
             f'No sub-batching support for {self.model.__class__.__name__} due to modules '
-            f'{list(self.model.modules_not_supporting_sub_batching)}.'
+            f'{self.model.modules_not_supporting_sub_batching}.'
         )
 
 

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -418,12 +418,12 @@ class TrainingLoop(ABC):
         if batch_size == 1 and model_contains_batch_norm:
             raise ValueError("Cannot train a model with batch_size=1 containing BatchNorm layers.")
         if drop_last is None:
-            if not only_size_probing:
+            drop_last = model_contains_batch_norm
+            if drop_last and not only_size_probing:
                 logger.info(
                     f"Dropping last (incomplete) batch each epoch "
                     f"({format_relative_comparison(part=1, total=len(self.training_instances))} batches)."
                 )
-            drop_last = model_contains_batch_norm
 
         # Sanity check
         if self.model.is_mr_loss and label_smoothing > 0.:

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -27,7 +27,7 @@ from ..trackers import ResultTracker
 from ..training.schlichtkrull_sampler import GraphSampler
 from ..triples import Instances, TriplesFactory
 from ..typing import MappedTriples
-from ..utils import is_cuda_oom_error, is_cudnn_error, normalize_string
+from ..utils import format_relative_comparison, is_cuda_oom_error, is_cudnn_error, normalize_string
 
 __all__ = [
     'TrainingLoop',
@@ -418,6 +418,11 @@ class TrainingLoop(ABC):
         if batch_size == 1 and model_contains_batch_norm:
             raise ValueError("Cannot train a model with batch_size=1 containing BatchNorm layers.")
         if drop_last is None:
+            if not only_size_probing:
+                logger.info(
+                    f"Dropping last (incomplete) batch each epoch "
+                    f"({format_relative_comparison(part=1, total=len(self.training_instances))} batches)."
+                )
             drop_last = model_contains_batch_norm
 
         # Sanity check

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -413,7 +413,7 @@ class TrainingLoop(ABC):
         elif self.model.modules_not_supporting_sub_batching:
             raise SubBatchingNotSupportedError(self.model)
 
-        model_contains_batch_norm = get_batchnorm_modules(self.model)
+        model_contains_batch_norm = bool(get_batchnorm_modules(self.model))
         if batch_size == 1 and model_contains_batch_norm:
             raise ValueError("Cannot train a model with batch_size=1 containing BatchNorm layers.")
         if drop_last is None:

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -60,7 +60,7 @@ class SubBatchingNotSupportedError(NotImplementedError):
     def __str__(self):  # noqa: D105
         return (
             f'No sub-batching support for {self.model.__class__.__name__} due to modules '
-            f'{self.model.modules_not_supporting_sub_batching}.'
+            f'{list(self.model.modules_not_supporting_sub_batching)}.'
         )
 
 

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -519,3 +519,25 @@ def format_relative_comparison(
 ) -> str:
     """Format a relative comparison."""
     return f"{part}/{total} ({part / total:2.2%})"
+
+
+BATCH_NORM_MODULES = (  # must be a tuple
+    torch.nn.BatchNorm1d,
+    torch.nn.BatchNorm2d,
+    torch.nn.BatchNorm3d,
+    torch.nn.SyncBatchNorm,
+)
+
+
+def get_batchnorm_modules(base: torch.nn.Module) -> Iterable[torch.nn.Module]:
+    """Return all submodules which are batch normalization layers."""
+    return (
+        module
+        for module in base.modules()
+        if isinstance(module, BATCH_NORM_MODULES)
+    )
+
+
+def empty(iterable: Iterable) -> bool:
+    """Check whether an iterable is non empty."""
+    return not any(True for _ in iterable)

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 import torch
 import torch.nn
+import torch.nn.modules.batchnorm
 
 from .constants import PYKEEN_BENCHMARKS
 from .typing import DeviceHint, RandomHint, TorchRandomHint
@@ -521,18 +522,10 @@ def format_relative_comparison(
     return f"{part}/{total} ({part / total:2.2%})"
 
 
-BATCH_NORM_MODULES = (  # must be a tuple
-    torch.nn.BatchNorm1d,
-    torch.nn.BatchNorm2d,
-    torch.nn.BatchNorm3d,
-    torch.nn.SyncBatchNorm,
-)
-
-
 def get_batchnorm_modules(module: torch.nn.Module) -> List[torch.nn.Module]:
     """Return all submodules which are batch normalization layers."""
     return [
         submodule
         for submodule in module.modules()
-        if isinstance(submodule, BATCH_NORM_MODULES)
+        if isinstance(submodule, torch.nn.modules.batchnorm._BatchNorm)
     ]

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -529,15 +529,10 @@ BATCH_NORM_MODULES = (  # must be a tuple
 )
 
 
-def get_batchnorm_modules(base: torch.nn.Module) -> Iterable[torch.nn.Module]:
+def get_batchnorm_modules(module: torch.nn.Module) -> List[torch.nn.Module]:
     """Return all submodules which are batch normalization layers."""
-    return (
-        module
-        for module in base.modules()
-        if isinstance(module, BATCH_NORM_MODULES)
-    )
-
-
-def empty(iterable: Iterable) -> bool:
-    """Check whether an iterable is non empty."""
-    return not any(True for _ in iterable)
+    return [
+        submodule
+        for submodule in module.modules()
+        if isinstance(submodule, BATCH_NORM_MODULES)
+    ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Unittest for for global utilities."""
-
 import itertools
 import string
 import unittest
@@ -11,8 +10,7 @@ import torch
 
 from pykeen.nn import Embedding
 from pykeen.utils import (
-    clamp_norm, compact_mapping, compose, flatten_dictionary, get_until_first_blank, l2_regularization,
-    torch_is_in_1d,
+    clamp_norm, compact_mapping, compose, flatten_dictionary, get_until_first_blank, l2_regularization, torch_is_in_1d,
 )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Unittest for for global utilities."""
+
 import itertools
 import string
 import unittest
@@ -10,7 +11,8 @@ import torch
 
 from pykeen.nn import Embedding
 from pykeen.utils import (
-    clamp_norm, compact_mapping, compose, flatten_dictionary, get_until_first_blank, l2_regularization, torch_is_in_1d,
+    clamp_norm, compact_mapping, compose, empty, flatten_dictionary, get_until_first_blank, l2_regularization,
+    torch_is_in_1d,
 )
 
 
@@ -268,3 +270,12 @@ def test_torch_is_in_1d():
                 invert=invert,
             )
             assert (result == expected_result).all()
+
+
+class TestOther(unittest.TestCase):
+    """Test remaining functions."""
+
+    def test_empty(self):
+        """Test the :func:`empty` function."""
+        self.assertTrue(empty(iter([])))
+        self.assertFalse(empty(iter([1])))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ import torch
 
 from pykeen.nn import Embedding
 from pykeen.utils import (
-    clamp_norm, compact_mapping, compose, empty, flatten_dictionary, get_until_first_blank, l2_regularization,
+    clamp_norm, compact_mapping, compose, flatten_dictionary, get_until_first_blank, l2_regularization,
     torch_is_in_1d,
 )
 
@@ -270,12 +270,3 @@ def test_torch_is_in_1d():
                 invert=invert,
             )
             assert (result == expected_result).all()
-
-
-class TestOther(unittest.TestCase):
-    """Test remaining functions."""
-
-    def test_empty(self):
-        """Test the :func:`empty` function."""
-        self.assertTrue(empty(iter([])))
-        self.assertFalse(empty(iter([1])))


### PR DESCRIPTION
This PR supersedes #113.

It adds the `drop_last` option to `TrainingLoop.train`. When `None`, `drop_last=True` if and only if the model contains any `BatchNorm` layers. It can also be provided explicitly to override this default. Moreover, when `batch_size=1` the training loop will raise an error if the model contains any batch norm layers.