### PR TITLE
Extend normalization to other p norms

### DIFF
--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -125,11 +125,11 @@ def _get_expected_norm(
     """
     if isinstance(p, str) or not math.isfinite(p):
         raise NotImplementedError(f"{p} norm not implemented")
-    # https://en.wikipedia.org/wiki/Half-normal_distribution
     # cf. https://math.stackexchange.com/questions/229033/lp-norm-of-multivariate-standard-normal-random-variable
     # we have E[|x|_p] = E[|x|^p]^(1/p) * d^(1/p)
-    # assuming x ~ N(0, 1), E[|x|^p] = 2^(p/2) * Gamma(p/2 + 1/2) / sqrt(pi)
-    exp_abs_norm_p = math.pow(2, p / 2) * math.gamma(p / 2 + 1 / 2) / math.sqrt(math.pi)
+    # cf. https://www.wolframalpha.com/input/?i=expected+value+of+%7Cx%7C%5Ep
+    # assuming x ~ N(0, 1), E[|x|^p] = 2^(p/2) * Gamma((p+1)/2) / sqrt(pi)
+    exp_abs_norm_p = math.pow(2, p / 2) * math.gamma((p + 1) / 2) / math.sqrt(math.pi)
     return math.pow(exp_abs_norm_p * d, 1 / p)
 
 

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -9,6 +9,7 @@ from typing import Any, ClassVar, Collection, Iterable, Mapping, Optional, Type,
 import torch
 from torch import nn
 from torch.nn import functional
+import scipy.stats
 
 from .utils import get_cls, normalize_string
 
@@ -132,11 +133,20 @@ def _get_expected_norm(
         https://math.stackexchange.com/questions/229033/lp-norm-of-multivariate-standard-normal-random-variable
         https://www.wolframalpha.com/input/?i=expected+value+of+%7Cx%7C%5Ep
     """
-    if isinstance(p, str) or not math.isfinite(p):
-        # TODO: Use https://en.wikipedia.org/wiki/Generalized_extreme_value_distribution for p = +inf
+    if isinstance(p, str):
+        p = float(p)
+    if math.isinf(p) and p > 0:  # max norm
+        # TODO: this only works for x ~ N(0, 1), but not for |x|
+        raise NotImplementedError("Normalization for inf norm is not implemented")
+        # cf. https://en.wikipedia.org/wiki/Generalized_extreme_value_distribution
+        # mean = scipy.stats.norm.ppf(1 - 1/d)
+        # scale = scipy.stats.norm.ppf(1 - 1/d * 1/math.e) - mean
+        # return scipy.stats.gumbel_r.mean(loc=mean, scale=scale)
+    elif math.isfinite(p):
+        exp_abs_norm_p = math.pow(2, p / 2) * math.gamma((p + 1) / 2) / math.sqrt(math.pi)
+        return math.pow(exp_abs_norm_p * d, 1 / p)
+    else:
         raise NotImplementedError(f"{p} norm not implemented")
-    exp_abs_norm_p = math.pow(2, p / 2) * math.gamma((p + 1) / 2) / math.sqrt(math.pi)
-    return math.pow(exp_abs_norm_p * d, 1 / p)
 
 
 class LpRegularizer(Regularizer):

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -133,6 +133,7 @@ def _get_expected_norm(
         https://www.wolframalpha.com/input/?i=expected+value+of+%7Cx%7C%5Ep
     """
     if isinstance(p, str) or not math.isfinite(p):
+        # TODO: Use https://en.wikipedia.org/wiki/Gumbel_distribution for p = +inf
         raise NotImplementedError(f"{p} norm not implemented")
     exp_abs_norm_p = math.pow(2, p / 2) * math.gamma((p + 1) / 2) / math.sqrt(math.pi)
     return math.pow(exp_abs_norm_p * d, 1 / p)

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Regularization in PyKEEN."""
+import functools
 import math
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Collection, Iterable, Mapping, Optional, Type, Union
@@ -103,6 +104,7 @@ class NoRegularizer(Regularizer):
         return torch.zeros(1, dtype=x.dtype, device=x.device)
 
 
+@functools.lru_cache(maxsize=1)
 def _get_expected_norm(
     p: Union[int, float, str],
     d: int,

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -111,9 +111,12 @@ def _get_expected_norm(
     Compute the expected value of the L_p norm.
 
     .. math ::
-        E[\|x\|_p] = d^{-1/p} E[|x_1|^p]^{1/p}
+        E[\|x\|_p] = d^{1/p} E[|x_1|^p]^{1/p}
 
-    under the assumption that :math:`x_i \sim N(0, 1)`.
+    under the assumption that :math:`x_i \sim N(0, 1)`, i.e.
+
+    .. math ::
+        E[|x_1|^p] = 2^{p/2} \cdot \Gamma(\frac{p+1}{2} \cdot \pi^{-1/2}
 
     :param p:
         The parameter p of the norm.
@@ -122,13 +125,13 @@ def _get_expected_norm(
 
     :return:
         The expected value.
+
+    .. seealso ::
+        https://math.stackexchange.com/questions/229033/lp-norm-of-multivariate-standard-normal-random-variable
+        https://www.wolframalpha.com/input/?i=expected+value+of+%7Cx%7C%5Ep
     """
     if isinstance(p, str) or not math.isfinite(p):
         raise NotImplementedError(f"{p} norm not implemented")
-    # cf. https://math.stackexchange.com/questions/229033/lp-norm-of-multivariate-standard-normal-random-variable
-    # we have E[|x|_p] = E[|x|^p]^(1/p) * d^(1/p)
-    # cf. https://www.wolframalpha.com/input/?i=expected+value+of+%7Cx%7C%5Ep
-    # assuming x ~ N(0, 1), E[|x|^p] = 2^(p/2) * Gamma((p+1)/2) / sqrt(pi)
     exp_abs_norm_p = math.pow(2, p / 2) * math.gamma((p + 1) / 2) / math.sqrt(math.pi)
     return math.pow(exp_abs_norm_p * d, 1 / p)
 

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -133,7 +133,7 @@ def _get_expected_norm(
         https://www.wolframalpha.com/input/?i=expected+value+of+%7Cx%7C%5Ep
     """
     if isinstance(p, str) or not math.isfinite(p):
-        # TODO: Use https://en.wikipedia.org/wiki/Gumbel_distribution for p = +inf
+        # TODO: Use https://en.wikipedia.org/wiki/Generalized_extreme_value_distribution for p = +inf
         raise NotImplementedError(f"{p} norm not implemented")
     exp_abs_norm_p = math.pow(2, p / 2) * math.gamma((p + 1) / 2) / math.sqrt(math.pi)
     return math.pow(exp_abs_norm_p * d, 1 / p)

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -9,7 +9,6 @@ from typing import Any, ClassVar, Collection, Iterable, Mapping, Optional, Type,
 import torch
 from torch import nn
 from torch.nn import functional
-import scipy.stats
 
 from .utils import get_cls, normalize_string
 

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -166,14 +166,18 @@ class NormedL2RegularizerTest(_LpRegularizerTest, unittest.TestCase):
     def test_expected_norm(self):
         """Numerically check expected norm."""
         n = 100
-        for p in (1, 2):
-            for d in (2, 4, 8, 16):
+        for p in (1, 2, 3):
+            for d in (2, 8, 64):
                 e_norm = _get_expected_norm(p=p, d=d)
                 norm = torch.randn(n, d).norm(p=p, dim=-1).numpy()
                 norm_mean = norm.mean()
                 norm_std = norm.std()
                 # check if within 0.5 std of observed
                 assert (abs(norm_mean - e_norm) / norm_std) < 0.5
+
+        # test error is raised
+        with pytest.raises(NotImplementedError):
+            _get_expected_norm(p=float('inf'), d=d)
 
 
 class CombinedRegularizerTest(_RegularizerTestCase, unittest.TestCase):

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -6,6 +6,8 @@ import logging
 import unittest
 from typing import Any, ClassVar, Dict, Optional, Type
 
+import pytest
+import scipy.stats
 import torch
 from torch.nn import functional
 
@@ -13,7 +15,7 @@ from pykeen.datasets import Nations
 from pykeen.models import ConvKB, RESCAL, TransH
 from pykeen.regularizers import (
     CombinedRegularizer, LpRegularizer, NoRegularizer, PowerSumRegularizer, Regularizer,
-    TransHRegularizer,
+    TransHRegularizer, _get_expected_norm,
 )
 from pykeen.triples import TriplesFactory
 from pykeen.typing import MappedTriples
@@ -160,6 +162,18 @@ class NormedL2RegularizerTest(_LpRegularizerTest, unittest.TestCase):
     """Test an L_2 normed regularizer."""
 
     regularizer_kwargs = {'normalize': True, 'p': 2}
+
+    @pytest.mark.slow
+    def test_expected_norm(self):
+        n = 100
+        for p in (1, 2):
+            for d in (2, 4, 8, 16):
+                e_norm = _get_expected_norm(p=p, d=d)
+                norm = torch.randn(n, d).norm(p=p, dim=-1).numpy()
+                norm_mean = norm.mean()
+                norm_std = norm.std()
+                # check if within 0.5 std of observed
+                assert (abs(norm_mean - e_norm) / norm_std) < 0.5
 
 
 class CombinedRegularizerTest(_RegularizerTestCase, unittest.TestCase):

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -7,7 +7,6 @@ import unittest
 from typing import Any, ClassVar, Dict, Optional, Type
 
 import pytest
-import scipy.stats
 import torch
 from torch.nn import functional
 

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -164,6 +164,7 @@ class NormedL2RegularizerTest(_LpRegularizerTest, unittest.TestCase):
 
     @pytest.mark.slow
     def test_expected_norm(self):
+        """Numerically check expected norm."""
         n = 100
         for p in (1, 2):
             for d in (2, 4, 8, 16):


### PR DESCRIPTION
When choosing `normalize=True` for `LpRegularizer`, the term is normalized by the expected norm value to isolate the regularization  weight effects from the embedding dimension. Before, only `p=1` and `p=2` were supported. This PR extends this to any `p != inf`.