### PR TITLE
Add CPU handling for automatic memory optimization

### DIFF
--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -137,7 +137,8 @@ class Evaluator(ABC):
         if mapped_triples is None:
             mapped_triples = model.triples_factory.mapped_triples
 
-        if batch_size is None and self.automatic_memory_optimization:
+        # On CPU memory optimization doesn't work, since OOM on RAM will crash the entire host machine.
+        if batch_size is None and self.automatic_memory_optimization and not model.device.type == 'cpu':
             batch_size, slice_size = self.batch_and_slice(
                 model=model,
                 mapped_triples=mapped_triples,
@@ -531,7 +532,8 @@ def evaluate(
 
     # Prepare batches
     if batch_size is None:
-        batch_size = 1
+        # This should be a reasonable default size that works on most setups while being faster than batch_size=1
+        batch_size = 32
     batches = split_list_in_batches_iter(input_list=mapped_triples, batch_size=batch_size)
 
     # Show progressbar

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -137,23 +137,29 @@ class Evaluator(ABC):
         if mapped_triples is None:
             mapped_triples = model.triples_factory.mapped_triples
 
-        # Using automatic memory optimization on CPU may result in undocumented crashes due to OS' OOM killer.
-        if batch_size is None and self.automatic_memory_optimization and model.device.type != 'cpu':
-            batch_size, slice_size = self.batch_and_slice(
-                model=model,
-                mapped_triples=mapped_triples,
-                batch_size=batch_size,
-                device=device,
-                use_tqdm=False,
-                restrict_entities_to=restrict_entities_to,
-                do_time_consuming_checks=do_time_consuming_checks,
-            )
-            # The batch_size and slice_size should be accessible to outside objects for re-use, e.g. early stoppers.
-            self.batch_size = batch_size
-            self.slice_size = slice_size
+        if batch_size is None and self.automatic_memory_optimization:
+            # Using automatic memory optimization on CPU may result in undocumented crashes due to OS' OOM killer.
+            if model.device.type == 'cpu':
+                logger.info(
+                    "Currently automatic memory optimization only supports GPUs, but you're using a CPU. "
+                    "Therefore, the batch_size will be set to the default value.",
+                )
+            else:
+                batch_size, slice_size = self.batch_and_slice(
+                    model=model,
+                    mapped_triples=mapped_triples,
+                    batch_size=batch_size,
+                    device=device,
+                    use_tqdm=False,
+                    restrict_entities_to=restrict_entities_to,
+                    do_time_consuming_checks=do_time_consuming_checks,
+                )
+                # The batch_size and slice_size should be accessible to outside objects for re-use, e.g. early stoppers.
+                self.batch_size = batch_size
+                self.slice_size = slice_size
 
-            # Clear the ranks from the current evaluator
-            self.finalize()
+                # Clear the ranks from the current evaluator
+                self.finalize()
 
         return evaluate(
             model=model,

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -137,7 +137,7 @@ class Evaluator(ABC):
         if mapped_triples is None:
             mapped_triples = model.triples_factory.mapped_triples
 
-        # On CPU memory optimization doesn't work, since OOM on RAM will crash the entire host machine.
+        # Using automatic memory optimization on CPU may result in undocumented crashes due to OS' OOM killer.
         if batch_size is None and self.automatic_memory_optimization and model.device.type != 'cpu':
             batch_size, slice_size = self.batch_and_slice(
                 model=model,

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -138,7 +138,7 @@ class Evaluator(ABC):
             mapped_triples = model.triples_factory.mapped_triples
 
         # On CPU memory optimization doesn't work, since OOM on RAM will crash the entire host machine.
-        if batch_size is None and self.automatic_memory_optimization and not model.device.type == 'cpu':
+        if batch_size is None and self.automatic_memory_optimization and model.device.type != 'cpu':
             batch_size, slice_size = self.batch_and_slice(
                 model=model,
                 mapped_triples=mapped_triples,

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -534,6 +534,7 @@ def evaluate(
     if batch_size is None:
         # This should be a reasonable default size that works on most setups while being faster than batch_size=1
         batch_size = 32
+        logger.info(f"No evaluation batch_size provided. Setting batch_size to '{batch_size}'.")
     batches = split_list_in_batches_iter(input_list=mapped_triples, batch_size=batch_size)
 
     # Show progressbar

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -393,10 +393,12 @@ class TrainingLoop(ABC):
             if self.model.device.type == 'cpu':
                 batch_size = 256
                 batch_size_sufficient = True
+                logger.info(f"No batch_size provided. Setting batch_size to '{batch_size}'.")
             elif self.automatic_memory_optimization:
                 batch_size, batch_size_sufficient = self.batch_size_search()
             else:
                 batch_size = 256
+                logger.info(f"No batch_size provided. Setting batch_size to '{batch_size}'.")
 
         # This will find necessary parameters to optimize the use of the hardware at hand
         if (

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -389,7 +389,7 @@ class TrainingLoop(ABC):
         # Take the biggest possible training batch_size, if batch_size not set
         batch_size_sufficient = False
         if batch_size is None:
-            # On CPU memory optimization doesn't work, since OOM on RAM will crash the entire host machine.
+            # Using automatic memory optimization on CPU may result in undocumented crashes due to OS' OOM killer.
             if self.model.device.type == 'cpu':
                 batch_size = 256
                 batch_size_sufficient = True

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -389,13 +389,17 @@ class TrainingLoop(ABC):
         # Take the biggest possible training batch_size, if batch_size not set
         batch_size_sufficient = False
         if batch_size is None:
-            # Using automatic memory optimization on CPU may result in undocumented crashes due to OS' OOM killer.
-            if self.model.device.type == 'cpu':
-                batch_size = 256
-                batch_size_sufficient = True
-                logger.info(f"No batch_size provided. Setting batch_size to '{batch_size}'.")
-            elif self.automatic_memory_optimization:
-                batch_size, batch_size_sufficient = self.batch_size_search()
+            if self.automatic_memory_optimization:
+                # Using automatic memory optimization on CPU may result in undocumented crashes due to OS' OOM killer.
+                if self.model.device.type == 'cpu':
+                    batch_size = 256
+                    batch_size_sufficient = True
+                    logger.info(
+                        "Currently automatic memory optimization only supports GPUs, but you're using a CPU. "
+                        "Therefore, the batch_size will be set to the default value '{batch_size}'",
+                    )
+                else:
+                    batch_size, batch_size_sufficient = self.batch_size_search()
             else:
                 batch_size = 256
                 logger.info(f"No batch_size provided. Setting batch_size to '{batch_size}'.")

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -389,7 +389,11 @@ class TrainingLoop(ABC):
         # Take the biggest possible training batch_size, if batch_size not set
         batch_size_sufficient = False
         if batch_size is None:
-            if self.automatic_memory_optimization:
+            # On CPU memory optimization doesn't work, since OOM on RAM will crash the entire host machine.
+            if self.model.device.type == 'cpu':
+                batch_size = 256
+                batch_size_sufficient = True
+            elif self.automatic_memory_optimization:
                 batch_size, batch_size_sufficient = self.batch_size_search()
             else:
                 batch_size = 256


### PR DESCRIPTION
This PR fixes the issue where `automatic_memory_optimization` is activated when using a CPU only setup.
Because increasing the batch_size until an OOM Error occurs on a CPU means that the entire host system crashes, the technique used in `automatic_memory_optimization` is not applicable for CPUs.

Imo the "smartest" way of handling this case is to use a sensible default value for CPU setups, like shown in the proposed code.

