### PR TITLE
Add --version option to make issues easier

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ Steps to reproduce the behavior:
 
 **Environment:**
 
-Please copy the output of `pykeen --version` here (and delete this text).
+Please copy the table output by `pykeen --version` here (and delete this text).
 This includes information about your system and installation of PyKEEN.
 
 **Additional information**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,20 +20,10 @@ Steps to reproduce the behavior:
 **Expected behavior**
 [A clear and concise description of what you expected to happen.]
 
-**Environment (please complete the following information):**
- - OS: [e.g. macOS]
- - Python version: [e.g. 3.8.1]
- - Version of this software: [e.g. 0.0.1-dev] # run ``pip list | grep -Eiw 'pykeen'`` in your environment shell
- - Versions of required Python packages: # run pip list | grep -Eiw 'torch|numpy|Click|click-default-group|tqdm'
-   - Torch: [e.g. 1.1.0]
-   - Numpy: [e.g. 1.13.3]
-   - Click: [e.g. 7.0]
-   - Click_default_group: [e.g. 1.2]
-   - Tqdm: [e.g. 4.31.1]
+**Environment:**
 
-Note: To obtain the relevant package versions you can run
-``pip list | grep -Eiw 'pykeen|torch|numpy|Click|click-default-group|tqdm'`` in your environment shell. To obtain the
-python version simply execute ``python --version`` in your shell.
+Please copy the output of `pykeen --version` here (and delete this text).
+This includes information about your system and installation of PyKEEN.
 
 **Additional information**
 [Add any other information about the problem here.]

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -59,7 +59,7 @@ def _version_callback(ctx, _param, _value):
         ('cuda', torch.version.cuda),
         ('cudnn', torch.backends.cudnn.version()),
     ]
-    click.echo(tabulate(t1, tablefmt='github'))
+    click.echo(tabulate(t1, tablefmt='github', headers=['Key', 'Value']))
     ctx.exit()
 
 

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -48,25 +48,20 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 def _version_callback(ctx, _param, _value):
-    version = get_version(with_git_hash=True)
+    import torch
     t1 = [
         ('os.name', os.name),
         ('platform.system()', platform.system()),
         ('platform.release()', platform.release()),
         ('python', f'{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}'),
-        ('PyKEEN', version),
+        ('pykeen', get_version(with_git_hash=True)),
+        ('torch', torch.__version__),
+        ('has gpu', torch.cuda.is_available()),
+        ('cuda', torch.version.cuda),
+        ('cudnn', torch.backends.cudnn.version()),
     ]
 
-    git_hash = get_git_hash()
-    development = git_hash and git_hash != 'UNHASHED'
-    t3 = [
-        ('version', get_version()),
-        ('development', str(development).lower()),
-    ]
-    if development:
-        t3.append(('hash', git_hash))
-
-    others = ['torch', 'numpy', 'pandas', 'click', 'click-default-group', 'tqdm']
+    others = ['numpy', 'pandas', 'click', 'click-default-group', 'tqdm']
     t2 = [
         (other, importlib.metadata.version(other))
         for other in others
@@ -74,9 +69,7 @@ def _version_callback(ctx, _param, _value):
 
     click.echo('#### System Configuration\n')
     click.echo(tabulate(t1, tablefmt='github'))
-    click.echo('\n#### PyKEEN Configuration\n')
-    click.echo(tabulate(t3, tablefmt='github'))
-    click.echo('\n#### Installed Packages\n')
+    click.echo('\n#### Dependencies\n')
     click.echo(tabulate(t2, tablefmt='github', headers=['Package', 'Version']))
     ctx.exit()
 

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -42,7 +42,7 @@ from .trackers import trackers as trackers_dict
 from .training import training_loops as training_dict
 from .triples.utils import EXTENSION_IMPORTERS, PREFIX_IMPORTERS
 from .utils import get_until_first_blank
-from .version import get_version
+from .version import get_git_hash, get_version
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -53,17 +53,30 @@ def _version_callback(ctx, _param, _value):
         ('os.name', os.name),
         ('platform.system()', platform.system()),
         ('platform.release()', platform.release()),
-        ('Python', ".".join(map(str, sys.version_info))),
-        ('PyKEEN', version)
+        ('python', f'{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}'),
+        ('PyKEEN', version),
     ]
 
-    others = ['torch', 'numpy', 'pandas']
+    git_hash = get_git_hash()
+    development = git_hash and git_hash != 'UNHASHED'
+    t3 = [
+        ('version', get_version()),
+        ('development', str(development).lower()),
+    ]
+    if development:
+        t3.append(('hash', git_hash))
+
+    others = ['torch', 'numpy', 'pandas', 'click', 'click-default-group', 'tqdm']
     t2 = [
         (other, importlib.metadata.version(other))
         for other in others
     ]
 
+    click.echo('#### System Configuration\n')
     click.echo(tabulate(t1, tablefmt='github'))
+    click.echo('\n#### PyKEEN Configuration\n')
+    click.echo(tabulate(t3, tablefmt='github'))
+    click.echo('\n#### Installed Packages\n')
     click.echo(tabulate(t2, tablefmt='github', headers=['Package', 'Version']))
     ctx.exit()
 

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -49,9 +49,9 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 def _version_callback(ctx, _param, _value):
     import torch
     t1 = [
-        ('os.name', os.name),
-        ('platform.system()', platform.system()),
-        ('platform.release()', platform.release()),
+        ('`os.name`', os.name),
+        ('`platform.system()`', platform.system()),
+        ('`platform.release()`', platform.release()),
         ('python', f'{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}'),
         ('pykeen', get_version(with_git_hash=True)),
         ('torch', torch.__version__),

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -13,7 +13,6 @@ later, but that will cause problems - the code will get executed twice:
 .. seealso:: http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
 
-import importlib.metadata
 import inspect
 import os
 import platform
@@ -42,7 +41,7 @@ from .trackers import trackers as trackers_dict
 from .training import training_loops as training_dict
 from .triples.utils import EXTENSION_IMPORTERS, PREFIX_IMPORTERS
 from .utils import get_until_first_blank
-from .version import get_git_hash, get_version
+from .version import get_version
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -56,21 +55,11 @@ def _version_callback(ctx, _param, _value):
         ('python', f'{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}'),
         ('pykeen', get_version(with_git_hash=True)),
         ('torch', torch.__version__),
-        ('has gpu', torch.cuda.is_available()),
+        ('cuda available', str(torch.cuda.is_available()).lower()),
         ('cuda', torch.version.cuda),
         ('cudnn', torch.backends.cudnn.version()),
     ]
-
-    others = ['numpy', 'pandas', 'click', 'click-default-group', 'tqdm']
-    t2 = [
-        (other, importlib.metadata.version(other))
-        for other in others
-    ]
-
-    click.echo('#### System Configuration\n')
     click.echo(tabulate(t1, tablefmt='github'))
-    click.echo('\n#### Dependencies\n')
-    click.echo(tabulate(t2, tablefmt='github', headers=['Package', 'Version']))
     ctx.exit()
 
 

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -14,7 +14,6 @@ from typing import (
     Union,
 )
 
-import click
 import numpy as np
 import pandas as pd
 import torch

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -14,6 +14,7 @@ from typing import (
     Union,
 )
 
+import click
 import numpy as np
 import pandas as pd
 import torch


### PR DESCRIPTION
Closes #233

Usage:

```shell
$ pykeen --version
| Key                  | Value              |
|----------------------|--------------------|
| `os.name`            | posix              |
| `platform.system()`  | Darwin             |
| `platform.release()` | 20.2.0             |
| python               | 3.8.6              |
| pykeen               | 1.0.6-dev-01b7861c |
| torch                | 1.7.0              |
| cuda available       | false              |
| cuda                 |                    |
| cudnn                |                    |
```

When you paste it in github, this gets rendered like this:

| Key                | Value              |
|--------------------|--------------------|
| `os.name`            | posix              |
| `platform.system()`  | Darwin             |
| `platform.release()` | 20.2.0             |
| python             | 3.8.6              |
| pykeen             | 1.0.6-dev-01b7861c |
| torch              | 1.7.0              |
| cuda available     | false              |
| cuda               |                    |
| cudnn              |                    |