### PR TITLE
💃 💫 Abstract the base model

### DIFF
--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -8,7 +8,7 @@ score value is model-dependent, and usually it cannot be directly interpreted as
 
 from typing import Mapping, Set, Type, Union
 
-from .base import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, MultimodalModel, OModel
+from .base import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, MultimodalModel, _OldAbstractModel
 from .multimodal import ComplExLiteral, DistMultLiteral
 from .unimodal import (
     ComplEx,
@@ -38,7 +38,7 @@ from ..utils import get_cls, get_subclasses, normalize_string
 __all__ = [
     # Base Models
     'Model',
-    'OModel',
+    '_OldAbstractModel',
     'EntityEmbeddingModel',
     'EntityRelationEmbeddingModel',
     'MultimodalModel',

--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -8,7 +8,7 @@ score value is model-dependent, and usually it cannot be directly interpreted as
 
 from typing import Mapping, Set, Type, Union
 
-from .base import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, MultimodalModel  # noqa:F401
+from .base import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, MultimodalModel, OModel
 from .multimodal import ComplExLiteral, DistMultLiteral
 from .unimodal import (
     ComplEx,
@@ -38,6 +38,7 @@ from ..utils import get_cls, get_subclasses, normalize_string
 __all__ = [
     # Base Models
     'Model',
+    'OModel',
     'EntityEmbeddingModel',
     'EntityRelationEmbeddingModel',
     'MultimodalModel',

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -91,7 +91,7 @@ class Model(nn.Module, ABC):
         super().__init__()
 
         # Initialize the device
-        self._set_device(preferred_device)
+        self.device = resolve_device(device=preferred_device)
 
         # Random seeds have to set before the embeddings are initialized
         if random_seed is None:
@@ -285,20 +285,6 @@ class Model(nn.Module, ABC):
         self.to(self.device)
         torch.cuda.empty_cache()
         return self
-
-    def _set_device(self, device: DeviceHint = None) -> None:
-        """Set the Torch device to use."""
-        self.device = resolve_device(device=device)
-
-    def to_cpu_(self) -> Model:
-        """Transfer the entire model to CPU."""
-        self._set_device('cpu')
-        return self.to_device_()
-
-    def to_gpu_(self) -> Model:
-        """Transfer the entire model to GPU."""
-        self._set_device('cuda')
-        return self.to_device_()
 
     def reset_parameters_(self):  # noqa: D401
         """Reset all parameters of the model and enforce model constraints."""

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -142,6 +142,13 @@ class Model(nn.Module, ABC):
         """Whether score_t supports slicing."""
         return _can_slice(self.score_t)
 
+    def reset_parameters_(self):  # noqa: D401
+        """Reset all parameters of the model and enforce model constraints."""
+        self._reset_parameters_()
+        self.to_device_()
+        self.post_parameter_update()
+        return self
+
     @property
     def num_entities(self) -> int:  # noqa: D401
         """The number of entities in the knowledge graph."""
@@ -284,13 +291,6 @@ class Model(nn.Module, ABC):
         """Transfer model to device."""
         self.to(self.device)
         torch.cuda.empty_cache()
-        return self
-
-    def reset_parameters_(self):  # noqa: D401
-        """Reset all parameters of the model and enforce model constraints."""
-        self._reset_parameters_()
-        self.to_device_()
-        self.post_parameter_update()
         return self
 
     def get_grad_params(self) -> Iterable[nn.Parameter]:

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -23,7 +23,7 @@ from ..utils import NoRandomSeedNecessary, _can_slice, extend_batch, resolve_dev
 
 __all__ = [
     'Model',
-    'OModel',
+    '_OldAbstractModel',
     'EntityEmbeddingModel',
     'EntityRelationEmbeddingModel',
     'MultimodalModel',
@@ -585,7 +585,7 @@ class Model(nn.Module, ABC):
             return self.score_t(hr_batch=t_r_inv, slice_size=slice_size)  # type: ignore
 
 
-class OModel(Model, ABC, autoreset=False):
+class _OldAbstractModel(Model, ABC, autoreset=False):
     """A base module for PyKEEN 1.0-style KGE models."""
 
     #: The default regularizer class
@@ -812,7 +812,7 @@ class OModel(Model, ABC, autoreset=False):
         self.regularizer.reset()
 
 
-class EntityEmbeddingModel(OModel, ABC, autoreset=False):
+class EntityEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):
     """A base module for most KGE models that have one embedding for entities."""
 
     def __init__(
@@ -872,7 +872,7 @@ class EntityEmbeddingModel(OModel, ABC, autoreset=False):
         self.entity_embeddings.post_parameter_update()
 
 
-class EntityRelationEmbeddingModel(OModel, ABC, autoreset=False):
+class EntityRelationEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):
     """A base module for KGE models that have different embeddings for entities and relations."""
 
     def __init__(
@@ -964,7 +964,7 @@ class EntityRelationEmbeddingModel(OModel, ABC, autoreset=False):
         self.relation_embeddings.post_parameter_update()
 
 
-class MultimodalModel(OModel, ABC, autoreset=False):
+class MultimodalModel(_OldAbstractModel, ABC, autoreset=False):
     """A base module for multimodal KGE models."""
 
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -167,11 +167,6 @@ class Model(nn.Module, ABC):
         """Reset all parameters of the model in-place."""
         raise NotImplementedError
 
-    @abstractmethod
-    def to_device_(self) -> Model:
-        """Transfer model to device."""
-        raise NotImplementedError
-
     """Abstract methods - Scoring"""
 
     @abstractmethod
@@ -284,6 +279,12 @@ class Model(nn.Module, ABC):
         """
 
     """Concrete methods"""
+
+    def to_device_(self):
+        """Transfer model to device."""
+        self.to(self.device)
+        torch.cuda.empty_cache()
+        return self
 
     def _set_device(self, device: DeviceHint = None) -> None:
         """Set the Torch device to use."""
@@ -648,13 +649,6 @@ class OModel(Model, ABC, autoreset=False):
                 **(self.regularizer_default_kwargs or {}),
             )
         self.regularizer = regularizer
-
-    def to_device_(self):
-        """Transfer model to device."""
-        self.to(self.device)
-        self.regularizer.to(self.device)  # TODO is this not automatic? it would be great if we could remove this line
-        torch.cuda.empty_cache()
-        return self
 
     def post_parameter_update(self) -> None:
         """Has to be called after each parameter update."""

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -12,7 +12,7 @@ from torch.nn import functional
 
 from . import ComplEx, DistMult, ERMLP
 from .. import EntityEmbeddingModel
-from ..base import Model
+from ..base import OModel
 from ...constants import DEFAULT_DROPOUT_HPO_RANGE
 from ...losses import Loss
 from ...nn import Embedding, RepresentationModule
@@ -425,7 +425,7 @@ class Decoder(nn.Module):
         return (h * r * t).sum(dim=-1)
 
 
-class RGCN(Model):
+class RGCN(OModel):
     """An implementation of R-GCN from [schlichtkrull2018]_.
 
     This model uses graph convolutions with relation-specific weights.

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -12,7 +12,7 @@ from torch.nn import functional
 
 from . import ComplEx, DistMult, ERMLP
 from .. import EntityEmbeddingModel
-from ..base import OModel
+from ..base import _OldAbstractModel
 from ...constants import DEFAULT_DROPOUT_HPO_RANGE
 from ...losses import Loss
 from ...nn import Embedding, RepresentationModule
@@ -425,7 +425,7 @@ class Decoder(nn.Module):
         return (h * r * t).sum(dim=-1)
 
 
-class RGCN(OModel):
+class RGCN(_OldAbstractModel):
     """An implementation of R-GCN from [schlichtkrull2018]_.
 
     This model uses graph convolutions with relation-specific weights.

--- a/src/pykeen/pipeline.py
+++ b/src/pykeen/pipeline.py
@@ -627,7 +627,8 @@ def replicate_pipeline_from_config(
 
 def _iterate_moved(pipeline_results: Iterable[PipelineResult]):
     for pipeline_result in pipeline_results:
-        pipeline_result.model.to_cpu_()
+        pipeline_result.model.device = resolve_device('cpu')
+        pipeline_result.model.to_device_()
         yield pipeline_result
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,15 +22,7 @@ import pykeen.experiments
 import pykeen.models
 from pykeen.datasets.kinships import KINSHIPS_TRAIN_PATH
 from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH, Nations
-from pykeen.models import _MODELS
-from pykeen.models.base import (
-    EntityEmbeddingModel,
-    EntityRelationEmbeddingModel,
-    Model,
-    MultimodalModel,
-    OModel,
-    _extend_batch,
-)
+from pykeen.models import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, MultimodalModel, OModel, _MODELS
 from pykeen.models.cli import build_cli_from_cls
 from pykeen.models.predict import get_novelty_mask, predict
 from pykeen.models.unimodal.rgcn import (
@@ -42,7 +34,7 @@ from pykeen.models.unimodal.trans_d import _project_entity
 from pykeen.nn import Embedding, RepresentationModule
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop, TrainingLoop
 from pykeen.triples import TriplesFactory
-from pykeen.utils import all_in_bounds, clamp_norm, set_random_seed
+from pykeen.utils import all_in_bounds, clamp_norm, extend_batch, set_random_seed
 
 SKIP_MODULES = {
     Model.__name__,
@@ -1276,7 +1268,7 @@ class TestModelUtilities(unittest.TestCase):
         num_choices = len(all_ids)
 
         for dim in range(3):
-            h_ext_batch = _extend_batch(batch=batch, all_ids=all_ids, dim=dim)
+            h_ext_batch = extend_batch(batch=batch, all_ids=all_ids, dim=dim)
 
             # check shape
             assert h_ext_batch.shape == (batch_size * num_choices, 3)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,10 @@ import pykeen.experiments
 import pykeen.models
 from pykeen.datasets.kinships import KINSHIPS_TRAIN_PATH
 from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH, Nations
-from pykeen.models import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, MultimodalModel, OModel, _MODELS
+from pykeen.models import (
+    EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, MultimodalModel, _MODELS,
+    _OldAbstractModel,
+)
 from pykeen.models.cli import build_cli_from_cls
 from pykeen.models.predict import get_novelty_mask, predict
 from pykeen.models.unimodal.rgcn import (
@@ -38,7 +41,7 @@ from pykeen.utils import all_in_bounds, clamp_norm, extend_batch, set_random_see
 
 SKIP_MODULES = {
     Model.__name__,
-    OModel.__name__,
+    _OldAbstractModel.__name__,
     'DummyModel',
     MultimodalModel.__name__,
     EntityEmbeddingModel.__name__,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,6 +28,7 @@ from pykeen.models.base import (
     EntityRelationEmbeddingModel,
     Model,
     MultimodalModel,
+    OModel,
     _extend_batch,
 )
 from pykeen.models.cli import build_cli_from_cls
@@ -45,6 +46,7 @@ from pykeen.utils import all_in_bounds, clamp_norm, set_random_seed
 
 SKIP_MODULES = {
     Model.__name__,
+    OModel.__name__,
     'DummyModel',
     MultimodalModel.__name__,
     EntityEmbeddingModel.__name__,

--- a/tests/training/test_utils.py
+++ b/tests/training/test_utils.py
@@ -9,8 +9,7 @@ import numpy as np
 import torch
 
 from pykeen.losses import MarginRankingLoss
-from pykeen.models import TransE
-from pykeen.models.base import Model
+from pykeen.models import Model, TransE
 from pykeen.training.lcwa import LCWATrainingLoop
 from pykeen.training.utils import apply_label_smoothing, lazy_compile_random_batches
 from pykeen.triples import TriplesFactory


### PR DESCRIPTION
As a follow up to several PRs preparing the code for type checking and abstraction, this PR finally excises an even *base*-r model from the `Model` class that contains only the interface and most commonly used functions for the model class. I then renamed the old model to `OModel` to cut down on the diff, since most code consuming models should assume only the top-evel `Model` interface. As we port the first new model, what lives in the base-st model can also change.