### PR TITLE
🙃 🙃 Do not create inverse triples for validation and testing factory

### DIFF
--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -247,7 +247,8 @@ class PathDataset(LazyDataset):
             path=self.testing_path,
             entity_to_id=self._training.entity_to_id,  # share entity index with training
             relation_to_id=self._training.relation_to_id,  # share relation index with training
-            create_inverse_triples=self.create_inverse_triples,
+            # do not explicitly create inverse triples for testing; this is handled by the evaluation code
+            create_inverse_triples=False,
         )
 
     def _load_validation(self) -> None:
@@ -258,7 +259,8 @@ class PathDataset(LazyDataset):
             path=self.validation_path,
             entity_to_id=self._training.entity_to_id,  # share entity index with training
             relation_to_id=self._training.relation_to_id,  # share relation index with training
-            create_inverse_triples=self.create_inverse_triples,
+            # do not explicitly create inverse triples for testing; this is handled by the evaluation code
+            create_inverse_triples=False,
         )
 
     def __repr__(self) -> str:  # noqa: D105

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -482,7 +482,7 @@ def evaluate(
         The model to evaluate.
     :param mapped_triples:
         The triples on which to evaluate. The mapped triples should never contain inverse triples - these are created by
-         the model class on the fly.
+        the model class on the fly.
     :param evaluators:
         An evaluator or a list of evaluators working on batches of triples and corresponding scores.
     :param only_size_probing:

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -481,7 +481,8 @@ def evaluate(
     :param model:
         The model to evaluate.
     :param mapped_triples:
-        The triples on which to evaluate.
+        The triples on which to evaluate. The mapped triples should never contain inverse triples - these are created by
+         the model class on the fly.
     :param evaluators:
         An evaluator or a list of evaluators working on batches of triples and corresponding scores.
     :param only_size_probing:

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -464,7 +464,7 @@ class CoreTriplesFactory:
         return [
             self.clone_and_exchange_triples(
                 mapped_triples=triples,
-                # do not create inverse triples in evaluation factories
+                # do not explicitly create inverse triples for testing; this is handled by the evaluation code
                 create_inverse_triples=None if i == 0 else False,
             )
             for i, triples in enumerate(split(

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -383,6 +383,7 @@ class CoreTriplesFactory:
         mapped_triples: MappedTriples,
         extra_metadata: Optional[Dict[str, Any]] = None,
         keep_metadata: bool = True,
+        create_inverse_triples: Optional[bool] = None,
     ) -> "CoreTriplesFactory":
         """
         Create a new triples factory sharing everything except the triples.
@@ -397,15 +398,19 @@ class CoreTriplesFactory:
             the dictionaries will be unioned with precedence taken on keys from ``extra_metadata``.
         :param keep_metadata:
             Pass the current factory's metadata to the new triples factory
+        :param create_inverse_triples:
+            Change inverse triple creation flag. If None, use flag from this factory.
 
         :return:
             The new factory.
         """
+        if create_inverse_triples is None:
+            create_inverse_triples = self.create_inverse_triples
         return CoreTriplesFactory(
             mapped_triples=mapped_triples,
             num_entities=self.num_entities,
             num_relations=self.real_num_relations,
-            create_inverse_triples=self.create_inverse_triples,
+            create_inverse_triples=create_inverse_triples,
             metadata={
                 **(extra_metadata or {}),
                 **(self.metadata if keep_metadata else {}),  # type: ignore

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -771,12 +771,15 @@ class TriplesFactory(CoreTriplesFactory):
         mapped_triples: MappedTriples,
         extra_metadata: Optional[Dict[str, Any]] = None,
         keep_metadata: bool = True,
+        create_inverse_triples: Optional[bool] = None,
     ) -> "TriplesFactory":  # noqa: D102
+        if create_inverse_triples is None:
+            create_inverse_triples = self.create_inverse_triples
         return TriplesFactory(
             entity_to_id=self.entity_to_id,
             relation_to_id=self.relation_to_id,
             mapped_triples=mapped_triples,
-            create_inverse_triples=self.create_inverse_triples,
+            create_inverse_triples=create_inverse_triples,
             metadata={
                 **(extra_metadata or {}),
                 **(self.metadata if keep_metadata else {}),  # type: ignore

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -462,14 +462,18 @@ class CoreTriplesFactory:
         """
         # Make new triples factories for each group
         return [
-            self.clone_and_exchange_triples(mapped_triples=triples)
-            for triples in split(
+            self.clone_and_exchange_triples(
+                mapped_triples=triples,
+                # do not create inverse triples in evaluation factories
+                create_inverse_triples=None if i == 0 else False,
+            )
+            for i, triples in enumerate(split(
                 mapped_triples=self.mapped_triples,
                 ratios=ratios,
                 random_state=random_state,
                 randomize_cleanup=randomize_cleanup,
                 method=method,
-            )
+            ))
         ]
 
     def get_mask_for_entities(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -95,6 +95,13 @@ class TestNations(cases.LocalDatasetTestCase):
     exp_num_triples = 1992
     dataset_cls = Nations
 
+    def test_create_inverse_triples(self):
+        """Verify that inverse triples are only created in the training factory."""
+        dataset = Nations(create_inverse_triples=True)
+        assert dataset.training.create_inverse_triples
+        assert not dataset.testing.create_inverse_triples
+        assert not dataset.validation.create_inverse_triples
+
 
 class TestKinships(cases.LocalDatasetTestCase):
     """Test the Nations dataset."""

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -208,6 +208,17 @@ class TestTriplesFactory(unittest.TestCase):
             assert y.shape == (batch_size, factory.num_entities)
             assert y.dtype == torch.get_default_dtype()
 
+    def test_split_inverse_triples(self):
+        """Test whether inverse triples are only created in the training factory."""
+        # set create inverse triple to true
+        self.factory.create_inverse_triples = True
+        # split factory
+        train, *others = self.factory.split()
+        # check that in *training* inverse triple are to be created
+        assert train.create_inverse_triples
+        # check that in all other splits no inverse triples are to be created
+        assert not any(f.create_inverse_triples for f in others)
+
 
 class TestSplit(unittest.TestCase):
     """Test splitting."""


### PR DESCRIPTION
Fixes #261 

Tasks:

check the following:

* do not create inverse triples for testing / validation in
  * [x] dataset + test
  * [x] split + test
* [ ] Check in evaluation code if evaluation factories create inverse triple and warn/fail if they do.
  * We cannot check this for the triples, since we only receive the mapped triples and not the factory. The docstring has been adjusted to make the user aware of it.