### PR TITLE
👽 🇪🇺 The shape of embeddings to come

### DIFF
--- a/docs/source/reference/nn/index.rst
+++ b/docs/source/reference/nn/index.rst
@@ -9,4 +9,5 @@
    functional
    modules
    similarity
+   representation
    init

--- a/docs/source/reference/nn/representation.rst
+++ b/docs/source/reference/nn/representation.rst
@@ -1,0 +1,4 @@
+Representation
+==============
+.. automodule:: pykeen.nn.emb
+    :members:

--- a/src/pykeen/models/unimodal/rescal.py
+++ b/src/pykeen/models/unimodal/rescal.py
@@ -101,9 +101,9 @@ class RESCAL(EntityRelationEmbeddingModel):
         return scores[:, :, 0]
 
     def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        h = self.entity_embeddings(indices=hr_batch[:, 0]).view(-1, 1, self.embedding_dim)
-        r = self.relation_embeddings(indices=hr_batch[:, 1]).view(-1, self.embedding_dim, self.embedding_dim)
-        t = self.entity_embeddings(indices=None).transpose(0, 1).view(1, self.embedding_dim, self.num_entities)
+        h = self.entity_embeddings(indices=hr_batch[:, 0]).unsqueeze(dim=1)
+        r = self.relation_embeddings(indices=hr_batch[:, 1])
+        t = self.entity_embeddings(indices=None).unsqueeze(dim=0).transpose(-1, -2)
 
         # Compute scores
         scores = h @ r @ t
@@ -116,9 +116,9 @@ class RESCAL(EntityRelationEmbeddingModel):
     def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         """Forward pass using left side (head) prediction."""
         # Get embeddings
-        h = self.entity_embeddings(indices=None).view(1, self.num_entities, self.embedding_dim)
-        r = self.relation_embeddings(indices=rt_batch[:, 0]).view(-1, self.embedding_dim, self.embedding_dim)
-        t = self.entity_embeddings(indices=rt_batch[:, 1]).view(-1, self.embedding_dim, 1)
+        h = self.entity_embeddings(indices=None).unsqueeze(dim=0)
+        r = self.relation_embeddings(indices=rt_batch[:, 0])
+        t = self.entity_embeddings(indices=rt_batch[:, 1]).unsqueeze(dim=-1)
 
         # Compute scores
         scores = h @ r @ t

--- a/src/pykeen/models/unimodal/rescal.py
+++ b/src/pykeen/models/unimodal/rescal.py
@@ -79,18 +79,18 @@ class RESCAL(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
             ),
             relation_representations=EmbeddingSpecification(
-                embedding_dim=embedding_dim ** 2,  # d x d matrices
+                shape=(embedding_dim, embedding_dim),  # d x d matrices
             ),
         )
 
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         # shape: (b, d)
-        h = self.entity_embeddings(indices=hrt_batch[:, 0]).view(-1, 1, self.embedding_dim)
+        h = self.entity_embeddings(indices=hrt_batch[:, 0]).unsqueeze(dim=1)
         # shape: (b, d, d)
-        r = self.relation_embeddings(indices=hrt_batch[:, 1]).view(-1, self.embedding_dim, self.embedding_dim)
+        r = self.relation_embeddings(indices=hrt_batch[:, 1])
         # shape: (b, d)
-        t = self.entity_embeddings(indices=hrt_batch[:, 2]).view(-1, self.embedding_dim, 1)
+        t = self.entity_embeddings(indices=hrt_batch[:, 2]).unsqueeze(dim=-1)
 
         # Compute scores
         scores = h @ r @ t

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -134,7 +134,7 @@ class RGCNRepresentations(RepresentationModule):
     ):
         super().__init__(
             max_id=triples_factory.num_entities,
-            shape=(self.embedding_dim,),
+            shape=(embedding_dim,),
         )
 
         self.triples_factory = triples_factory
@@ -148,7 +148,6 @@ class RGCNRepresentations(RepresentationModule):
                 initializer=nn.init.xavier_uniform_,
             )
         self.base_embeddings = base_representations
-        self.embedding_dim = embedding_dim
 
         # check decomposition
         self.decomposition = decomposition
@@ -207,8 +206,8 @@ class RGCNRepresentations(RepresentationModule):
                 self.bases.append(nn.Parameter(
                     data=torch.empty(
                         self.num_bases,
-                        self.embedding_dim,
-                        self.embedding_dim,
+                        embedding_dim,
+                        embedding_dim,
                     ),
                     requires_grad=True,
                 ))
@@ -220,7 +219,7 @@ class RGCNRepresentations(RepresentationModule):
                     requires_grad=True,
                 ))
         elif self.decomposition == 'block':
-            block_size = self.embedding_dim // self.num_bases
+            block_size = embedding_dim // self.num_bases
             for _ in range(self.num_layers):
                 self.bases.append(nn.Parameter(
                     data=torch.empty(
@@ -237,14 +236,14 @@ class RGCNRepresentations(RepresentationModule):
             raise NotImplementedError
         if self.use_bias:
             self.biases = nn.ParameterList([
-                nn.Parameter(torch.empty(self.embedding_dim), requires_grad=True)
+                nn.Parameter(torch.empty(embedding_dim), requires_grad=True)
                 for _ in range(self.num_layers)
             ])
         else:
             self.biases = None
         if self.use_batch_norm:
             self.batch_norms = nn.ModuleList([
-                nn.BatchNorm1d(num_features=self.embedding_dim)
+                nn.BatchNorm1d(num_features=embedding_dim)
                 for _ in range(self.num_layers)
             ])
         else:

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -132,7 +132,10 @@ class RGCNRepresentations(RepresentationModule):
         buffer_messages: bool = True,
         base_representations: Optional[RepresentationModule] = None,
     ):
-        super().__init__()
+        super().__init__(
+            max_id=triples_factory.num_entities,
+            shape=(self.embedding_dim,),
+        )
 
         self.triples_factory = triples_factory
 

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -53,10 +53,9 @@ class RepresentationModule(nn.Module, ABC):
     def __init__(
         self,
         max_id: int,
-        shape: Sequence[int]
+        shape: Sequence[int],
     ):
-        """
-        Initialize the representation module.
+        """Initialize the representation module.
 
         :param max_id:
             The maximum ID (exclusively). Valid Ids reach from 0, ..., max_id-1
@@ -105,13 +104,12 @@ class RepresentationModule(nn.Module, ABC):
         x = self(indices=indices)
         if indices is None:
             x = x.unsqueeze(dim=0)
+        elif indices.ndimension() > 2:
+            raise ValueError(
+                f"Undefined canonical shape for more than 2-dimensional index tensors: {indices.shape}",
+            )
         else:
-            if indices.ndimension() == 1:
-                x = x.unsqueeze(dim=1)
-            elif indices.ndimension() > 2:
-                raise ValueError(
-                    f"Undefined canonical shape for more than 2-dimensional index tensors: {indices.shape}"
-                )
+            x = x.unsqueeze(dim=1)
         return x
 
     @property

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -26,40 +26,16 @@ __all__ = [
 class RepresentationModule(nn.Module):
     """A base class for obtaining representations for entities/relations."""
 
-    #: the maximum ID (exclusively)
-    max_id: int
-
-    #: the shape of an individual representation
-    shape: Tuple[int, ...]
-
-    def __init__(
-        self,
-        max_id: int,
-        shape: Tuple[int, ...],
-    ):
-        """
-        Initialize the representation module.
-
-        :param max_id:
-            The maximum ID (exclusively). Valid Ids reach from 0, ..., max_id-1
-        :param shape:
-            The shape of an individual representation.
-        """
-        super().__init__()
-        self.max_id = max_id
-        self.shape = shape
-
     def forward(
         self,
         indices: Optional[torch.LongTensor] = None,
     ) -> torch.FloatTensor:
         """Get representations for indices.
 
-        :param indices: shape: s
-            The indices, or None. If None, this is interpreted as `torch.arange(self.max_id)` (although implemented
-            more efficiently).
+        :param indices: shape: (m,)
+            The indices, or None. If None, return all representations.
 
-        :return: shape: (*s, *self.shape)
+        :return: shape: (m, d)
             The representations.
         """
         raise NotImplementedError

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import functools
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence, Tuple, Union
 
@@ -23,7 +24,7 @@ __all__ = [
 ]
 
 
-class RepresentationModule(nn.Module):
+class RepresentationModule(nn.Module, ABC):
     """
     A base class for obtaining representations for entities/relations.
 
@@ -66,6 +67,7 @@ class RepresentationModule(nn.Module):
         self.max_id = max_id
         self.shape = tuple(shape)
 
+    @abstractmethod
     def forward(
         self,
         indices: Optional[torch.LongTensor] = None,
@@ -79,7 +81,6 @@ class RepresentationModule(nn.Module):
         :return: shape: (*s, *self.shape)
             The representations.
         """
-        raise NotImplementedError
 
     def reset_parameters(self) -> None:
         """Reset the module's parameters."""

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -108,7 +108,7 @@ class RepresentationModule(nn.Module, ABC):
             raise ValueError(
                 f"Undefined canonical shape for more than 2-dimensional index tensors: {indices.shape}",
             )
-        else:
+        elif indices.ndimension() == 1:
             x = x.unsqueeze(dim=1)
         return x
 

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import functools
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence, Tuple, Union
@@ -116,6 +117,7 @@ class RepresentationModule(nn.Module, ABC):
     def embedding_dim(self) -> int:
         """Return the "embedding dimension". Kept for backward compatibility."""
         # TODO: Remove this property and update code to use shape instead
+        warnings.warn("The embedding_dim property is deprecated. Use .shape instead.", DeprecationWarning)
         return int(np.prod(self.shape))
 
 

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -36,7 +36,8 @@ class RepresentationModule(nn.Module, ABC):
     representations could come from somewhere else, e.g. a GNN encoder.
 
     `shape` describes the shape of a single representation. In case of a vector embedding, this is just a single
-    dimension. For others, e.g. RESCAL, we have 2-d representations, and in general it can be any fixed shape.
+    dimension. For others, e.g. :class:`pykeen.models.RESCAL`, we have 2-d representations, and in general it can be
+    any fixed shape.
 
     We can look at all representations as a tensor of shape `(max_id, *shape)`, and this is exactly the result of
     passing `indices=None` to the forward method.
@@ -75,10 +76,10 @@ class RepresentationModule(nn.Module, ABC):
         """Get representations for indices.
 
         :param indices: shape: s
-            The indices, or None. If None, this is interpreted as `torch.arange(self.max_id)` (although implemented
+            The indices, or None. If None, this is interpreted as ``torch.arange(self.max_id)`` (although implemented
             more efficiently).
 
-        :return: shape: (*s, *self.shape)
+        :return: shape: (``*s``, ``*self.shape``)
             The representations.
         """
 

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -87,6 +87,27 @@ class RepresentationModule(nn.Module):
     def post_parameter_update(self):
         """Apply constraints which should not be included in gradients."""
 
+    def get_in_canonical_shape(
+        self,
+        indices: Optional[torch.LongTensor] = None,
+    ) -> torch.FloatTensor:
+        """Get representations in canonical shape.
+
+        :param indices: None, shape: (n,) or (b, n)
+            The indices. If None, return all representations.
+
+        :return: shape: (b?, n?, d)
+        """
+        x = self(indices=indices)
+        if indices is None:
+            x = x.unsqueeze(dim=0)
+        else:
+            if indices.ndimension() == 1:
+                x = x.unsqueeze(dim=1)
+            elif indices.ndimension() > 2:
+                raise ValueError("Canonical shape is not implemented for more than 2-dimensional index tensors")
+        return x
+
 
 class Embedding(RepresentationModule):
     """Trainable embeddings.
@@ -245,26 +266,6 @@ class Embedding(RepresentationModule):
             x = self.normalizer(x)
         if self.regularizer is not None:
             self.regularizer.update(x)
-        return x
-
-    def get_in_canonical_shape(
-        self,
-        indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
-        """Get embedding in canonical shape.
-
-        :param indices: The indices. If None, return all embeddings.
-
-        :return: shape: (batch_size, num_embeddings, d)
-        """
-        x = self(indices=indices)
-        if indices is None:
-            x = x.unsqueeze(dim=0)
-        else:
-            if indices.ndimension() == 1:
-                x = x.unsqueeze(dim=1)
-            elif indices.ndimension() > 2:
-                raise ValueError("Canonical shape is not implemented for more than 2-dimensional index tensors")
         return x
 
 

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -93,10 +93,13 @@ class RepresentationModule(nn.Module):
     ) -> torch.FloatTensor:
         """Get representations in canonical shape.
 
-        :param indices: None, shape: (n,) or (b, n)
+        :param indices: None, shape: (b,) or (b, n)
             The indices. If None, return all representations.
 
         :return: shape: (b?, n?, d)
+            If indices is None, b=1, n=max_id.
+            If indices is 1-dimensional, b=indices.shape[0] and n=1.
+            If indices is 2-dimensional, b, n = indices.shape
         """
         x = self(indices=indices)
         if indices is None:

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -95,6 +95,8 @@ class Embedding(RepresentationModule):
         :param constrainer_kwargs:
             Additional keyword arguments passed to the constrainer
         """
+        super().__init__()
+
         _embedding_dim, self.shape = process_shape(embedding_dim, shape)
 
         if initializer is None:

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -113,6 +113,12 @@ class RepresentationModule(nn.Module):
                 )
         return x
 
+    @property
+    def embedding_dim(self) -> int:
+        """Return the "embedding dimension". Kept for backward compatibility."""
+        # TODO: Remove this property and update code to use shape instead
+        return int(np.prod(self.shape))
+
 
 class Embedding(RepresentationModule):
     """Trainable embeddings.

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -24,7 +24,24 @@ __all__ = [
 
 
 class RepresentationModule(nn.Module):
-    """A base class for obtaining representations for entities/relations."""
+    """
+    A base class for obtaining representations for entities/relations.
+
+    A representation module maps integer IDs to representations, which are tensors of floats.
+
+    `max_id` defines the upper bound of indices we are allowed to request (exclusively). For simple embeddings this is
+    equivalent to num_embeddings, but more a more appropriate word for general non-embedding representations, where the
+    representations could come from somewhere else, e.g. a GNN encoder.
+
+    `shape` describes the shape of a single representation. In case of a vector embedding, this is just a single
+    dimension. For others, e.g. RESCAL, we have 2-d representations, and in general it can be any fixed shape.
+
+    We can look at all representations as a tensor of shape `(max_id, *shape)`, and this is exactly the result of
+    passing `indices=None` to the forward method.
+
+    We can also pass multi-dimensional `indices` to the forward method, in which case the indices' shape becomes the
+    prefix of the result shape: `(*indices.shape, *self.shape)`.
+    """
 
     #: the maximum ID (exclusively)
     max_id: int

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -189,6 +189,7 @@ class Embedding(RepresentationModule):
         if indices is None:
             x = self._embeddings.weight
         else:
+            assert indices.ndimension() == 1
             x = self._embeddings(indices)
         x = x.view(x.shape[0], *self.shape)
         if self.normalizer is not None:

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -105,7 +105,9 @@ class RepresentationModule(nn.Module):
             if indices.ndimension() == 1:
                 x = x.unsqueeze(dim=1)
             elif indices.ndimension() > 2:
-                raise ValueError("Canonical shape is not implemented for more than 2-dimensional index tensors")
+                raise ValueError(
+                    f"Undefined canonical shape for more than 2-dimensional index tensors: {indices.shape}"
+                )
         return x
 
 

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -26,16 +26,40 @@ __all__ = [
 class RepresentationModule(nn.Module):
     """A base class for obtaining representations for entities/relations."""
 
+    #: the maximum ID (exclusively)
+    max_id: int
+
+    #: the shape of an individual representation
+    shape: Tuple[int, ...]
+
+    def __init__(
+        self,
+        max_id: int,
+        shape: Tuple[int, ...],
+    ):
+        """
+        Initialize the representation module.
+
+        :param max_id:
+            The maximum ID (exclusively). Valid Ids reach from 0, ..., max_id-1
+        :param shape:
+            The shape of an individual representation.
+        """
+        super().__init__()
+        self.max_id = max_id
+        self.shape = shape
+
     def forward(
         self,
         indices: Optional[torch.LongTensor] = None,
     ) -> torch.FloatTensor:
         """Get representations for indices.
 
-        :param indices: shape: (m,)
-            The indices, or None. If None, return all representations.
+        :param indices: shape: s
+            The indices, or None. If None, this is interpreted as `torch.arange(self.max_id)` (although implemented
+            more efficiently).
 
-        :return: shape: (m, d)
+        :return: shape: (*s, *self.shape)
             The representations.
         """
         raise NotImplementedError

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -52,7 +52,7 @@ class RepresentationModule(nn.Module):
     def __init__(
         self,
         max_id: int,
-        shape: Sequence[int, ...],
+        shape: Sequence[int]
     ):
         """
         Initialize the representation module.

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -267,6 +267,7 @@ class Embedding(RepresentationModule):
         x = x.view(*prefix_shape, *self.shape)
         # verify that contiguity is preserved
         assert x.is_contiguous()
+        # TODO: move normalizer / regularizer to base class?
         if self.normalizer is not None:
             x = self.normalizer(x)
         if self.regularizer is not None:

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1228,16 +1228,27 @@ class RepresentationTestCase(GenericTestCase[RepresentationModule]):
         expected_shape = prefix_shape + self.instance.shape
         assert representations.shape == expected_shape
 
-    def test_forward_no_indices(self):
-        """Test forward without indices."""
-        self._test_forward(indices=None)
+    def _test_canonical_shape(self, indices: Optional[torch.LongTensor]):
+        """Test canonical shape."""
+        x = self.instance.get_in_canonical_shape(indices=indices)
 
-    def test_forward_1d_indices(self):
-        """Test forward with 1-dimensional indices."""
-        indices = torch.randint(self.instance.max_id, size=(self.batch_size,))
+    def _test_indices(self, indices: Optional[torch.LongTensor]):
+        """Test forward and canonical shape for indices."""
         self._test_forward(indices=indices)
+        self._test_canonical_shape(indices=indices)
 
-    def test_forward_2d_indices(self):
-        """Test forward with 1-dimensional indices."""
-        indices = torch.randint(self.instance.max_id, size=(self.batch_size, self.num_negatives,))
-        self._test_forward(indices=indices)
+    def test_no_indices(self):
+        """Test without indices."""
+        self._test_indices(indices=None)
+
+    def test_1d_indices(self):
+        """Test with 1-dimensional indices."""
+        self._test_indices(indices=torch.randint(self.instance.max_id, size=(self.batch_size,)))
+
+    def test_2d_indices(self):
+        """Test with 1-dimensional indices."""
+        self._test_indices(indices=(torch.randint(self.instance.max_id, size=(self.batch_size, self.num_negatives,))))
+
+    def test_all_indices(self):
+        """Test with all indices."""
+        self._test_indices(indices=torch.arange(self.instance.max_id))

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1133,7 +1133,7 @@ Traceback
             old_embeddings = self.model.entity_embeddings
             self.model.entity_embeddings = CustomRepresentations(
                 num_entities=self.factory.num_entities,
-                embedding_dim=old_embeddings.embedding_dim,
+                shape=old_embeddings.shape,
             )
             # call some functions
             self.model.reset_parameters_()
@@ -1145,7 +1145,7 @@ Traceback
             old_embeddings = self.model.relation_embeddings
             self.model.relation_embeddings = CustomRepresentations(
                 num_entities=self.factory.num_relations,
-                embedding_dim=old_embeddings.embedding_dim,
+                shape=old_embeddings.shape,
             )
             # call some functions
             self.model.reset_parameters_()

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1207,3 +1207,37 @@ class BaseRGCNTest(ModelTestCase):
         Enriched embeddings have to be reset.
         """
         assert self.model.entity_representations.enriched_embeddings is None
+
+
+class RepresentationTestCase(GenericTestCase[RepresentationModule]):
+    """Common tests for representation modules."""
+
+    batch_size: int = 2
+    num_negatives: int = 3
+
+    def _test_forward(self, indices: Optional[torch.LongTensor]):
+        """Test forward method."""
+        representations = self.instance.forward(indices=indices)
+
+        # check type
+        assert torch.is_tensor(representations)
+        assert representations.dtype == torch.get_default_dtype()
+
+        # check shape
+        prefix_shape = (self.instance.max_id,) if indices is None else tuple(indices.shape)
+        expected_shape = prefix_shape + self.instance.shape
+        assert representations.shape == expected_shape
+
+    def test_forward_no_indices(self):
+        """Test forward without indices."""
+        self._test_forward(indices=None)
+
+    def test_forward_1d_indices(self):
+        """Test forward with 1-dimensional indices."""
+        indices = torch.randint(self.instance.max_id, size=(self.batch_size,))
+        self._test_forward(indices=indices)
+
+    def test_forward_2d_indices(self):
+        """Test forward with 1-dimensional indices."""
+        indices = torch.randint(self.instance.max_id, size=(self.batch_size, self.num_negatives,))
+        self._test_forward(indices=indices)

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1223,7 +1223,7 @@ class RepresentationTestCase(GenericTestCase[RepresentationModule]):
 
         # check shape
         expected_shape = prefix_shape + self.instance.shape
-        assert x.shape == expected_shape
+        self.assertEqual(x.shape, expected_shape)
 
     def _test_forward(self, indices: Optional[torch.LongTensor]):
         """Test forward method."""
@@ -1259,7 +1259,7 @@ class RepresentationTestCase(GenericTestCase[RepresentationModule]):
 
     def test_2d_indices(self):
         """Test with 1-dimensional indices."""
-        self._test_indices(indices=(torch.randint(self.instance.max_id, size=(self.batch_size, self.num_negatives,))))
+        self._test_indices(indices=(torch.randint(self.instance.max_id, size=(self.batch_size, self.num_negatives))))
 
     def test_all_indices(self):
         """Test with all indices."""

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -2,7 +2,7 @@
 
 """Mocks for tests."""
 
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 from torch import nn
@@ -20,13 +20,13 @@ __all__ = [
 class CustomRepresentations(RepresentationModule):
     """A custom representation module with minimal implementation."""
 
-    def __init__(self, num_entities: int, embedding_dim: int = 2):
-        super().__init__(max_id=num_entities, shape=(embedding_dim,))
-        self.x = nn.Parameter(torch.rand(embedding_dim))
+    def __init__(self, num_entities: int, shape: Tuple[int, ...] = (2,)):
+        super().__init__(max_id=num_entities, shape=shape)
+        self.x = nn.Parameter(torch.rand(*shape))
 
     def forward(self, indices: Optional[torch.LongTensor] = None) -> torch.FloatTensor:  # noqa:D102
         n = self.max_id if indices is None else indices.shape[0]
-        return self.x.unsqueeze(dim=0).repeat(n, 1)
+        return self.x.unsqueeze(dim=0).repeat(n, *(1 for _ in self.shape))
 
 
 class MockModel(EntityRelationEmbeddingModel):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -28,15 +28,6 @@ class CustomRepresentations(RepresentationModule):
         n = self.max_id if indices is None else indices.shape[0]
         return self.x.unsqueeze(dim=0).repeat(n, 1)
 
-    def get_in_canonical_shape(
-        self,
-        indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:  # noqa:D102
-        x = self(indices=indices)
-        if indices is None:
-            return x.unsqueeze(dim=0)
-        return x.unsqueeze(dim=1)
-
 
 class MockModel(EntityRelationEmbeddingModel):
     """A mock model returning fake scores."""

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -21,13 +21,11 @@ class CustomRepresentations(RepresentationModule):
     """A custom representation module with minimal implementation."""
 
     def __init__(self, num_entities: int, embedding_dim: int = 2):
-        super().__init__()
-        self.num_embeddings = num_entities
-        self.embedding_dim = embedding_dim
+        super().__init__(max_id=num_entities, shape=(embedding_dim,))
         self.x = nn.Parameter(torch.rand(embedding_dim))
 
     def forward(self, indices: Optional[torch.LongTensor] = None) -> torch.FloatTensor:  # noqa:D102
-        n = self.num_embeddings if indices is None else indices.shape[0]
+        n = self.max_id if indices is None else indices.shape[0]
         return self.x.unsqueeze(dim=0).repeat(n, 1)
 
     def get_in_canonical_shape(

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -1,0 +1,13 @@
+"""Test embeddings."""
+from pykeen.nn import Embedding
+from tests.cases import RepresentationTestCase
+
+
+class EmbeddingTests(RepresentationTestCase):
+    """Tests for embeddings."""
+
+    cls = Embedding
+    kwargs = dict(
+        num_embeddings=7,
+        embedding_dim=13,
+    )

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -1,4 +1,7 @@
+# -*- coding: utf-8 -*-
+
 """Test embeddings."""
+
 from pykeen.nn import Embedding
 from tests import cases
 

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -11,3 +11,8 @@ class EmbeddingTests(RepresentationTestCase):
         num_embeddings=7,
         embedding_dim=13,
     )
+
+    def test_backwards_compatibility(self):
+        """Test shape and num_embeddings."""
+        assert self.instance.max_id == self.instance.num_embeddings
+        assert self.instance.shape == (self.instance.embedding_dim,)

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -1,9 +1,9 @@
 """Test embeddings."""
 from pykeen.nn import Embedding
-from tests.cases import RepresentationTestCase
+from tests import cases
 
 
-class EmbeddingTests(RepresentationTestCase):
+class EmbeddingTests(cases.RepresentationTestCase):
     """Tests for embeddings."""
 
     cls = Embedding

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -166,7 +166,7 @@ class EmbeddingsInCanonicalShapeTests(unittest.TestCase):
         assert emb.shape == (num_ind, 1, self.embedding_dim)
 
         # check values
-        exp = torch.stack([self.embedding(i) for i in indices], dim=0).view(num_ind, 1, self.embedding_dim)
+        exp = torch.stack([self.embedding(i.view(1)) for i in indices], dim=0).view(num_ind, 1, self.embedding_dim)
         assert torch.allclose(emb, exp)
 
     def test_with_consecutive_indices(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,6 @@ import numpy
 import pytest
 import torch
 
-from pykeen.nn import Embedding
 from pykeen.utils import (
     calculate_broadcasted_elementwise_result_shape, clamp_norm, combine_complex, compact_mapping, compose,
     estimate_cost_of_sequence, flatten_dictionary, get_optimal_sequence, get_until_first_blank, project_entity,
@@ -125,64 +124,6 @@ class TestGetUntilFirstBlank(unittest.TestCase):
         """
         r = get_until_first_blank(s)
         self.assertEqual("Broken line.", r)
-
-
-class EmbeddingsInCanonicalShapeTests(unittest.TestCase):
-    """Test get_embedding_in_canonical_shape()."""
-
-    #: The number of embeddings
-    num_embeddings: int = 3
-
-    #: The embedding dimension
-    embedding_dim: int = 2
-
-    def setUp(self) -> None:
-        """Initialize embedding."""
-        self.embedding = Embedding(num_embeddings=self.num_embeddings, embedding_dim=self.embedding_dim)
-        self.generator = torch.manual_seed(42)
-        self.embedding._embeddings.weight.data = torch.rand(
-            self.num_embeddings,
-            self.embedding_dim,
-            generator=self.generator,
-        )
-
-    def test_no_indices(self):
-        """Test getting all embeddings."""
-        emb = self.embedding.get_in_canonical_shape(indices=None)
-
-        # check shape
-        assert emb.shape == (1, self.num_embeddings, self.embedding_dim)
-
-        # check values
-        exp = self.embedding(indices=None).view(1, self.num_embeddings, self.embedding_dim)
-        assert torch.allclose(emb, exp)
-
-    def _test_with_indices(self, indices: torch.Tensor) -> None:
-        """Help tests with index."""
-        emb = self.embedding.get_in_canonical_shape(indices=indices)
-
-        # check shape
-        num_ind = indices.shape[0]
-        assert emb.shape == (num_ind, 1, self.embedding_dim)
-
-        # check values
-        exp = torch.stack([self.embedding(i.view(1)) for i in indices], dim=0).view(num_ind, 1, self.embedding_dim)
-        assert torch.allclose(emb, exp)
-
-    def test_with_consecutive_indices(self):
-        """Test to retrieve all embeddings with consecutive indices."""
-        indices = torch.arange(self.num_embeddings, dtype=torch.long)
-        self._test_with_indices(indices=indices)
-
-    def test_with_indices_with_duplicates(self):
-        """Test to retrieve embeddings at random positions with duplicate indices."""
-        indices = torch.randint(
-            self.num_embeddings,
-            size=(2 * self.num_embeddings,),
-            dtype=torch.long,
-            generator=self.generator,
-        )
-        self._test_with_indices(indices=indices)
 
 
 def _get_torch_is_in_1d_result_naive(


### PR DESCRIPTION
Closes #281

This PR adds explicit shape information to the `pykeen.nn.Embedding` and corresponding `pykeen.nn.EmbeddingSpecification` classes. It is part of the greater effort to break up #107 as one of the main features is enhanced slicing and matrix operations.

## Tasks

- [x] Add shape information (@cthoyt; 51ac2ee0)

The first commit commit automatically calculates the embedding dimension or the shape based on the data given. Currently, we never give the shape, so it's always considered as a single dimension shape tuple. However, this is extensible so this can be changed later.

- [x] Use the shape for something (@mberr)

This is probably inside the `Embedding.get_in_canonical_shape` function, but could also show up in other places. Will need to check back in on #107 (or, the working prototype in #260)
