### PR TITLE
🌻 ❄️ Add dtype annotation to pykeen.nn.Embedding

### DIFF
--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -103,12 +103,12 @@ class ComplEx(EntityRelationEmbeddingModel):
             # initialize with entity and relation embeddings with standard normal distribution, cf.
             # https://github.com/ttrouill/complex/blob/dc4eb93408d9a5288c986695b58488ac80b1cc17/efe/models.py#L481-L487
             entity_representations=EmbeddingSpecification(
-                embedding_dim=2 * embedding_dim,  # complex embeddings
+                embedding_dim=embedding_dim,
                 initializer=entity_initializer,
                 dtype=torch.complex64,
             ),
             relation_representations=EmbeddingSpecification(
-                embedding_dim=2 * embedding_dim,  # complex embeddings
+                embedding_dim=embedding_dim,
                 initializer=relation_initializer,
                 dtype=torch.complex64,
             ),

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -105,10 +105,12 @@ class ComplEx(EntityRelationEmbeddingModel):
             entity_representations=EmbeddingSpecification(
                 embedding_dim=2 * embedding_dim,  # complex embeddings
                 initializer=entity_initializer,
+                dtype=torch.complex64,
             ),
             relation_representations=EmbeddingSpecification(
                 embedding_dim=2 * embedding_dim,  # complex embeddings
                 initializer=relation_initializer,
+                dtype=torch.complex64,
             ),
         )
 

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -105,12 +105,12 @@ class ComplEx(EntityRelationEmbeddingModel):
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
-                dtype=torch.complex64,
+                dtype=torch.cfloat,
             ),
             relation_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
-                dtype=torch.complex64,
+                dtype=torch.cfloat,
             ),
         )
 

--- a/src/pykeen/models/unimodal/rotate.py
+++ b/src/pykeen/models/unimodal/rotate.py
@@ -91,13 +91,15 @@ class RotatE(EntityRelationEmbeddingModel):
             random_seed=random_seed,
             regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
-                embedding_dim=2 * embedding_dim,  # complex embeddings
+                embedding_dim=embedding_dim,
                 initializer=xavier_uniform_,
+                dtype=torch.complex64,
             ),
             relation_representations=EmbeddingSpecification(
-                embedding_dim=2 * embedding_dim,  # complex embeddings
+                embedding_dim=embedding_dim,
                 initializer=init_phases,
                 constrainer=complex_normalize,
+                dtype=torch.complex64,
             ),
         )
         self.real_embedding_dim = embedding_dim

--- a/src/pykeen/models/unimodal/rotate.py
+++ b/src/pykeen/models/unimodal/rotate.py
@@ -93,13 +93,13 @@ class RotatE(EntityRelationEmbeddingModel):
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=xavier_uniform_,
-                dtype=torch.complex64,
+                dtype=torch.cfloat,
             ),
             relation_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=init_phases,
                 constrainer=complex_normalize,
-                dtype=torch.complex64,
+                dtype=torch.cfloat,
             ),
         )
         self.real_embedding_dim = embedding_dim

--- a/src/pykeen/models/unimodal/rotate.py
+++ b/src/pykeen/models/unimodal/rotate.py
@@ -71,13 +71,13 @@ class RotatE(EntityRelationEmbeddingModel):
             regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
-                initializer=xavier_uniform_,
+                initializer=entity_initializer,
                 dtype=torch.cfloat,
             ),
             relation_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
-                initializer=init_phases,
-                constrainer=complex_normalize,
+                initializer=relation_initializer,
+                constrainer=relation_constrainer,
                 dtype=torch.cfloat,
             ),
         )

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -2,8 +2,17 @@
 
 """Test embeddings."""
 
-from pykeen.nn import Embedding
-from tests import cases
+import unittest
+from typing import Any, MutableMapping
+from unittest.mock import Mock
+
+import numpy
+import torch
+
+from pykeen.models.unimodal.rgcn import RGCNRepresentations
+from pykeen.nn import Embedding, EmbeddingSpecification, RepresentationModule
+from pykeen.triples import TriplesFactory
+from tests import cases, mocks
 
 
 class EmbeddingTests(cases.RepresentationTestCase):
@@ -19,3 +28,104 @@ class EmbeddingTests(cases.RepresentationTestCase):
         """Test shape and num_embeddings."""
         assert self.instance.max_id == self.instance.num_embeddings
         assert self.instance.shape == (self.instance.embedding_dim,)
+
+
+class TensorEmbeddingTests(cases.RepresentationTestCase):
+    """Tests for Embedding with 2-dimensional shape."""
+
+    cls = Embedding
+    exp_shape = (3, 7)
+    kwargs = dict(
+        num_embeddings=10,
+        shape=(3, 7),
+    )
+
+
+class RGCNRepresentationTests(cases.RepresentationTestCase):
+    """Test RGCN representations."""
+
+    cls = RGCNRepresentations
+    num = 8
+    kwargs = dict(
+        num_bases_or_blocks=2,
+        embedding_dim=num,
+    )
+    num_relations: int = 7
+    num_triples: int = 31
+    num_bases: int = 2
+
+    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
+        kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
+        # TODO: use triple generation
+        # generate random triples
+        mapped_triples = numpy.stack([
+            numpy.random.randint(max_id, size=(self.num_triples,))
+            for max_id in (self.num, self.num_relations, self.num)
+        ], axis=-1)
+        entity_names = [f"e_{i}" for i in range(self.num)]
+        relation_names = [f"r_{i}" for i in range(self.num_relations)]
+        triples = numpy.stack([
+            [names[i] for i in col.tolist()]
+            for col, names in zip(
+                mapped_triples.T,
+                (entity_names, relation_names, entity_names),
+            )
+        ])
+        kwargs["triples_factory"] = TriplesFactory.from_labeled_triples(triples=triples)
+        return kwargs
+
+
+class RepresentationModuleTestsTestCase(cases.TestsTestCase[RepresentationModule]):
+    """Test that there are tests for all representation modules."""
+
+    base_cls = RepresentationModule
+    base_test = cases.RepresentationTestCase
+    skip_cls = {mocks.CustomRepresentations}
+
+
+class EmbeddingSpecificationTests(unittest.TestCase):
+    """Tests for EmbeddingSpecification."""
+
+    #: The number of embeddings
+    num: int = 3
+
+    def test_make(self):
+        """Test make."""
+        initializer = Mock()
+        normalizer = Mock()
+        constrainer = Mock()
+        regularizer = Mock()
+        for embedding_dim, shape in [
+            (None, (3,)),
+            (None, (3, 5)),
+            (3, None),
+        ]:
+            spec = EmbeddingSpecification(
+                embedding_dim=embedding_dim,
+                shape=shape,
+                initializer=initializer,
+                normalizer=normalizer,
+                constrainer=constrainer,
+                regularizer=regularizer,
+            )
+            emb = spec.make(num_embeddings=self.num)
+
+            # check shape
+            self.assertEqual(emb.embedding_dim, (embedding_dim or int(numpy.prod(shape))))
+            self.assertEqual(emb.shape, (shape or (embedding_dim,)))
+            self.assertEqual(emb.num_embeddings, self.num)
+
+            # check attributes
+            self.assertIs(emb.initializer, initializer)
+            self.assertIs(emb.normalizer, normalizer)
+            self.assertIs(emb.constrainer, constrainer)
+            self.assertIs(emb.regularizer, regularizer)
+
+    def test_make_complex(self):
+        """Test making a complex embedding."""
+        s = EmbeddingSpecification(
+            shape=(5, 5),
+            dtype=torch.cfloat,
+        )
+        e = s.make(num_embeddings=100)
+        self.assertEqual((5, 10), e.shape)


### PR DESCRIPTION
This PR is the next step after #287 in bringing the embeddings and embedding specifications into the future. It adds the ability to annotate the data inside the embedding. Unfortunately, embeddings do not yet support native complex tensors (see #134) so this is a nice abstraction in the mean time. Futher, it is the final abstraction on the embeddings/representations necessary for #260. Luckily, very little code needed to be changed.

All credit goes to @mberr since this code was originally in #107 and later #260.

Tasks:

- [x] Add dtype to embedding (@cthoyt)
- [x] Add dtype to embedding specification (@cthoyt)
- [x] Add tests (@mberr) 