### PR TITLE
🤝 ❤️ Add dataset similarity calculation

### DIFF
--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -130,7 +130,8 @@ class Dataset:
         :param other: The other shuffling of the dataset
         :return: A float of the similarity
 
-        .. seealso:: :func:`pykeen.triples.triples_factory.splits_similarity`."""
+        .. seealso:: :func:`pykeen.triples.triples_factory.splits_similarity`.
+        """
         from ..triples.triples_factory import splits_similarity
         return splits_similarity(self._tup(), other._tup())
 

--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -2,6 +2,8 @@
 
 """Utility classes for constructing datasets."""
 
+from __future__ import annotations
+
 import logging
 import os
 import pathlib
@@ -121,6 +123,21 @@ class Dataset:
     def get_normalized_name(cls) -> str:
         """Get the normalized name of the dataset."""
         return normalize_string(cls.__name__)
+
+    def similarity(self, other: Dataset) -> float:
+        """Compute the similarity between two shuffles of the same dataset.
+
+        :param other: The other shuffling of the dataset
+        :return: A float of the similarity
+
+        .. seealso:: :func:`pykeen.triples.triples_factory.splits_similarity`."""
+        from ..triples.triples_factory import splits_similarity
+        return splits_similarity(self._tup(), other._tup())
+
+    def _tup(self):
+        if self.validation is None:
+            return self.training, self.testing
+        return self.training, self.testing, self.validation
 
 
 class EagerDataset(Dataset):

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -991,3 +991,34 @@ class TriplesFactory(CoreTriplesFactory):
             invert_entity_selection=invert_entity_selection,
             invert_relation_selection=invert_relation_selection,
         ).with_labels(entity_to_id=self.entity_to_id, relation_to_id=self.relation_to_id)
+
+
+def splits_steps(a: Sequence[CoreTriplesFactory], b: Sequence[CoreTriplesFactory]) -> int:
+    """Compute the number of moves to go from the first sequence of triples factories to the second.
+
+    :return: The number of triples present in the training sets in both
+    """
+    if len(a) != len(b):
+        raise ValueError('Must have same number of triples factories')
+
+    train_1 = _smt(a[0].mapped_triples)
+    train_2 = _smt(b[0].mapped_triples)
+
+    # FIXME currently the implementation does not consider the non-training (i.e., second-last entries)
+    #  for the number of steps. Consider more interesting way to discuss splits w/ valid
+
+    return len(train_1.symmetric_difference(train_2))
+
+
+def splits_similarity(a: Sequence[CoreTriplesFactory], b: Sequence[CoreTriplesFactory]) -> float:
+    """Compute the similarity between two datasets' splits.
+
+    :return: The number of triples present in the training sets in both
+    """
+    steps = splits_steps(a, b)
+    n = sum(tf.num_triples for tf in a)
+    return 1 - steps / n
+
+
+def _smt(x):
+    return set(tuple(xx.detach().numpy().tolist()) for xx in x)

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -25,6 +25,8 @@ __all__ = [
     'create_entity_mapping',
     'create_relation_mapping',
     'INVERSE_SUFFIX',
+    'splits_steps',
+    'splits_similarity',
 ]
 
 logger = logging.getLogger(__name__)

--- a/tests/test_dataset_similarity.py
+++ b/tests/test_dataset_similarity.py
@@ -13,8 +13,8 @@ from pykeen.triples.triples_factory import splits_similarity, splits_steps
 class TestRemix(unittest.TestCase):
     """Tests for remix functions."""
 
-    def test_splits_distance(self):
-        """Test the distance calculation."""
+    def test_splits_similarity(self):
+        """Test the similarity calculation."""
         a_train = torch.as_tensor([
             [1, 1, 2],
             [2, 1, 3],

--- a/tests/test_dataset_similarity.py
+++ b/tests/test_dataset_similarity.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for remixing and other triples reorganization."""
+
+import unittest
+
+import torch
+
+from pykeen.triples import CoreTriplesFactory
+from pykeen.triples.triples_factory import splits_similarity, splits_steps
+
+
+class TestRemix(unittest.TestCase):
+    """Tests for remix functions."""
+
+    def test_splits_distance(self):
+        """Test the distance calculation."""
+        a_train = torch.as_tensor([
+            [1, 1, 2],
+            [2, 1, 3],
+            [1, 2, 3],
+            [4, 1, 5],
+            [5, 1, 6],
+        ])
+        a_test = torch.as_tensor([
+            [4, 2, 6],
+        ])
+        b_train = torch.as_tensor([
+            [1, 1, 2],
+            [2, 1, 3],
+            [1, 2, 3],
+            [4, 1, 5],
+            [4, 2, 6],
+        ])
+        b_test = torch.as_tensor([
+            [5, 1, 6],
+        ])
+
+        a_train_tf = CoreTriplesFactory.create(a_train)
+        a_test_tf = CoreTriplesFactory.create(a_test)
+        b_train_tf = CoreTriplesFactory.create(b_train)
+        b_test_tf = CoreTriplesFactory.create(b_test)
+
+        steps = splits_steps([a_train_tf, a_test_tf], [b_train_tf, b_test_tf])
+        self.assertEqual(2, steps)
+
+        similarity = splits_similarity([a_train_tf, a_test_tf], [b_train_tf, b_test_tf])
+        self.assertEqual(1 - steps / 6, similarity)


### PR DESCRIPTION
This PR is part of a breakdown of #126. It adds a function for calculating the similarity between two re-shuffling of the same dataset. This will support investigation of robustness of a given split.

The first generation of the algorithm calculates the number of triples that need to be moved in and out of the training set, then normalizes by the number of total triples. Effectively, this is a tanimoto similarity of the triples in the training set.

Future directions:

1. A “deterioration” workflow in which triples are randomly removed from the training set. This will enable investigation of how much training data is really needed to perform well, and when you’re removing it, when does performance start to take a hit
2. A “remixing” workflow, which shuffles the training/testing/validation split to enable us to look into robustness of the splits themselves
3. If we want to go outside of modifying a single dataset, we can talk about application specific dataset similarity which could let us look into the construction of the KG itself. For example, a biological KG that has 5 databases vs leaving one of those databases out