### PR TITLE
🐐 😉 Add monotonic affine transformation of scores

### DIFF
--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1155,6 +1155,14 @@ class MonotonicAffineTransformationInteraction(Interaction[HeadRepresentation, R
 
     Monotonicity is required to preserve the ordering of the original scoring function, and thus ensures that more
     plausible triples are still more plausible after the transformation.
+
+    For example, we can add a bias to a distance-based interaction function to enable positive values:
+
+    >>> base = TransEInteraction(p=2)
+    >>> interaction = MonotonicAffineTransformationInteraction(base=base, trainable_bias=True, trainable_scale=False)
+
+    When combined with BCE loss, we can geometrically think about predicting a (soft) sphere at :math:`h + r` with
+    radius equal to the bias of the transformation.
     """
 
     def __init__(

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1162,7 +1162,8 @@ class MonotonicAffineTransformationInteraction(Interaction[HeadRepresentation, R
     >>> interaction = MonotonicAffineTransformationInteraction(base=base, trainable_bias=True, trainable_scale=False)
 
     When combined with BCE loss, we can geometrically think about predicting a (soft) sphere at :math:`h + r` with
-    radius equal to the bias of the transformation.
+    radius equal to the bias of the transformation. When we add a trainable scale, the model can control the "softness"
+    of the decision boundary itself.
     """
 
     def __init__(

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1175,6 +1175,10 @@ class MonotoneAffineTransformationInteraction(Interaction[HeadRepresentation, Re
 
         # the base interaction
         self.base = base
+        # forward entity/relation shapes
+        self.entity_shape = base.entity_shape
+        self.relation_shape = base.relation_shape
+        self.tail_entity_shape = base.tail_entity_shape
 
         # store initial values for reset_parameters
         self.initial_bias = initial_bias

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -24,6 +24,8 @@ __all__ = [
     'Interaction',
     'FunctionalInteraction',
     'TranslationalInteraction',
+    # Adapter classes
+    'MonotonicAffineTransformationInteraction',
     # Concrete Classes
     'ComplExInteraction',
     'ConvEInteraction',

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1141,7 +1141,13 @@ class PairREInteraction(TranslationalInteraction[FloatTensor, Tuple[FloatTensor,
         return dict(h=h, r_h=r[0], r_t=r[1], t=t)
 
 
-class MonotonicAffineTransformationInteraction(Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation]):
+class MonotonicAffineTransformationInteraction(
+    Interaction[
+        HeadRepresentation,
+        RelationRepresentation,
+        TailRepresentation
+    ],
+):
     r"""
     An adapter of interaction functions which adds a scalar (trainable) monotonic affine transformation of the score.
 

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1147,6 +1147,11 @@ class MonotoneAffineTransformationInteraction(Interaction[HeadRepresentation, Re
 
     .. math ::
         score(h, r, t) = \alpha \cdot score'(h, r, t) + \beta
+
+    This adapter is useful for losses such as BCE, where there is a fixed decision threshold, or margin-based losses,
+    where the margin is not be treated as hyper-parameter, but rather a trainable parameter. This is particulary useful,
+    if the value range of the score function is not known in advance, and thus choosing an appropriate margin becomes
+    difficult.
     """
 
     def __init__(

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1181,16 +1181,16 @@ class MonotoneAffineTransformationInteraction(Interaction[HeadRepresentation, Re
         self.tail_entity_shape = base.tail_entity_shape
 
         # store initial values for reset_parameters
-        self.initial_bias = initial_bias
-        self.initial_log_scale = math.log(initial_scale)
+        self.initial_bias = torch.as_tensor(data=[initial_bias], dtype=torch.get_default_dtype())
+        self.initial_log_scale = torch.as_tensor(data=[math.log(initial_scale)], dtype=torch.get_default_dtype())
 
         # The parameters of the affine transformation
         self.bias = nn.Parameter(torch.empty(size=tuple()), requires_grad=trainable_bias)
         self.log_scale = nn.Parameter(torch.empty(size=tuple()), requires_grad=trainable_scale)
 
     def reset_parameters(self):  # noqa: D102
-        self.bias.data = self.initial_bias
-        self.log_scale.data = self.initial_log_scale
+        self.bias.data = self.initial_bias.to(device=self.bias.device)
+        self.log_scale.data = self.initial_log_scale.to(device=self.bias.device)
 
     def forward(
         self,

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1145,7 +1145,7 @@ class MonotonicAffineTransformationInteraction(
     Interaction[
         HeadRepresentation,
         RelationRepresentation,
-        TailRepresentation
+        TailRepresentation,
     ],
 ):
     r"""

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -4,6 +4,7 @@
 
 import logging
 from typing import Tuple
+from unittest import SkipTest
 
 import numpy
 import torch
@@ -388,6 +389,35 @@ class MuRETests(cases.TranslationalInteractionTests):
     def _additional_score_checks(self, scores):
         # Since MuRE has offsets, the scores do not need to negative
         pass
+
+
+class MonotoneAffineTransformationInteraction(cases.InteractionTestCase):
+    """Tests for monotone affine transformation interaction adapter."""
+
+    cls = pykeen.nn.modules.MonotoneAffineTransformationInteraction
+    kwargs = dict(
+        base=pykeen.nn.modules.TransEInteraction(p=2),
+    )
+
+    def test_forward_consistency_with_functional(self):  # noqa: D102
+        raise SkipTest("Not a functional interaction.")
+
+    def test_scores(self):  # noqa: D102
+        raise SkipTest("Not a functional interaction.")
+
+    def _exp_score(self, **kwargs) -> torch.FloatTensor:
+        raise NotImplementedError
+
+    def test_monotonicity(self):
+        """Verify monotonicity."""
+        for hs, rs, ts in self._get_test_shapes():
+            h, r, t = self._get_hrt(hs, rs, ts)
+            s_t = self.instance(h=h, r=r, t=t).view(-1)
+            s_o = self.instance.base(h=h, r=r, t=t).view(-1)
+            # intra-interaction comparison
+            c_t = (s_t.unsqueeze(dim=0) > s_t.unsqueeze(dim=1))
+            c_o = (s_o.unsqueeze(dim=0) > s_o.unsqueeze(dim=1))
+            assert (c_t == c_o).all()
 
 
 class InteractionTestsTestCase(cases.TestsTestCase[Interaction]):

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -391,10 +391,10 @@ class MuRETests(cases.TranslationalInteractionTests):
         pass
 
 
-class MonotoneAffineTransformationInteraction(cases.InteractionTestCase):
-    """Tests for monotone affine transformation interaction adapter."""
+class MonotonicAffineTransformationInteractionTests(cases.InteractionTestCase):
+    """Tests for monotonic affine transformation interaction adapter."""
 
-    cls = pykeen.nn.modules.MonotoneAffineTransformationInteraction
+    cls = pykeen.nn.modules.MonotonicAffineTransformationInteraction
     kwargs = dict(
         base=pykeen.nn.modules.TransEInteraction(p=2),
     )
@@ -405,7 +405,8 @@ class MonotoneAffineTransformationInteraction(cases.InteractionTestCase):
     def test_scores(self):  # noqa: D102
         raise SkipTest("Not a functional interaction.")
 
-    def _exp_score(self, **kwargs) -> torch.FloatTensor:
+    def _exp_score(self, **kwargs) -> torch.FloatTensor:  # noqa: D102
+        # We do not need this, since we do not check for functional consistency anyway
         raise NotImplementedError
 
     def test_monotonicity(self):


### PR DESCRIPTION
This PR adds a modular adapter to add a (trainable) monotonic affine transformation to any interaction function.