### PR TITLE
💃 🔄 Implement interaction module to model converter

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ PyKEEN
    tutorial/making_predictions
    tutorial/performance
    extending/index
+   tutorial/model_from_interaction
 
 .. toctree::
    :caption: Reference

--- a/docs/source/tutorial/model_from_interaction.rst
+++ b/docs/source/tutorial/model_from_interaction.rst
@@ -1,0 +1,3 @@
+*Ad hoc* Models from Interactions
+=================================
+.. automodule:: pykeen.models.resolve

--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -11,6 +11,7 @@ from typing import Set, Type
 from .base import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, MultimodalModel, _OldAbstractModel
 from .multimodal import ComplExLiteral, DistMultLiteral
 from .nbase import ERModel, _NewAbstractModel
+from .resolve import make_model, make_model_cls
 from .unimodal import (
     ComplEx,
     ConvE,
@@ -75,6 +76,8 @@ __all__ = [
     'UnstructuredModel',
     # Utils
     'model_resolver',
+    'make_model',
+    'make_model_cls',
 ]
 
 _MODELS: Set[Type[Model]] = {

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -55,19 +55,14 @@ def model_instance_builder(
     **kwargs,
 ) -> ERModel:
     """Build a model from an interaction class hint (name or class)."""
-    interaction_instance = interaction_resolver.make(interaction, interaction_kwargs)
-    entity_representations, relation_representations = _normalize_entity_representations(
+    model_cls = model_builder(
         dimensions=dimensions,
         interaction=interaction,
+        interaction_kwargs=interaction_kwargs,
         entity_representations=entity_representations,
         relation_representations=relation_representations,
     )
-    return ERModel(
-        interaction=interaction_instance,
-        entity_representations=entity_representations,
-        relation_representations=relation_representations,
-        **kwargs,
-    )
+    return model_cls(**kwargs)
 
 
 def model_builder(

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -79,6 +79,17 @@ def make_model(
     return model_cls(**kwargs)
 
 
+class DimensionError(ValueError):
+    """Raised when the wrong dimensions were supplied."""
+
+    def __init__(self, given, expected):
+        self.given = given
+        self.expected = expected
+
+    def __str__(self):
+        return f'Expected dimensions dictionary with keys {self.expected} but got keys {self.given}'
+
+
 def make_model_cls(
     dimensions: Union[int, Mapping[str, int]],
     interaction: Union[str, Interaction, Type[Interaction]],
@@ -126,6 +137,8 @@ def _normalize_entity_representations(
     if isinstance(dimensions, int):
         dimensions = {'d': dimensions}
     assert isinstance(dimensions, dict)
+    if set(dimensions) < interaction.get_dimensions():
+        raise DimensionError(set(dimensions), interaction.get_dimensions())
     if entity_representations is None:
         # TODO: Does not work for interactions with separate tail_entity_shape (i.e., ConvE)
         if interaction.tail_entity_shape is not None:

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -60,7 +60,7 @@ def model_from_interaction(
 def _resolve_representations(
     num_representations: int,
     shape: Sequence[str],
-    representations: OneOrSequence[Union[None, RepresentationModule, EmbeddingSpecification]],
+    representations: Sequence[Union[None, RepresentationModule, EmbeddingSpecification]],
     dimensions: Mapping[str, int],
 ) -> Sequence[RepresentationModule]:
     """
@@ -85,11 +85,14 @@ def _resolve_representations(
         if isinstance(representations, RepresentationModule):
             # FIXME: Error message; also, why is this a problem.
             raise ValueError
+        # share same embedding specification for all representations
+        # TODO: why? they should usually have different ones
         representations = [representations] * len(shape)
 
     # shallow copy to avoid side-effects
     dimensions = dict(**dimensions)
 
+    # TODO: Start with instantiated representations, then embedding specification and then None
     result = []
     for symbolic_shape, representation in zip(shape, representations):
         if representation is None:

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def model_instance_builder(
+    dimensions: Mapping[str, Any],
     interaction: Hint[Interaction] = None,
     interaction_kwargs: Optional[Mapping[str, Any]] = None,
     entity_representations: EmbeddingSpecificationHint = None,
@@ -32,12 +33,18 @@ def model_instance_builder(
         if interaction.tail_entity_shape is not None:
             raise NotImplementedError
         entity_representations = [
-            EmbeddingSpecification(shape=shape)
+            EmbeddingSpecification(shape=tuple(
+                dimensions[d]
+                for d in shape
+            ))
             for shape in interaction.entity_shape
         ]
-    if relation_representations:
+    if relation_representations is None:
         relation_representations = [
-            EmbeddingSpecification(shape=shape)
+            EmbeddingSpecification(shape=tuple(
+                dimensions[d]
+                for d in shape
+            ))
             for shape in interaction.relation_shape
         ]
     return ERModel(

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -81,11 +81,12 @@ def model_builder(
     interaction_instance = interaction_resolver.make(interaction, interaction_kwargs)
     entity_representations, relation_representations = _normalize_entity_representations(
         dimensions=dimensions,
-        interaction=interaction,
+        interaction=interaction_instance.__class__,
         entity_representations=entity_representations,
         relation_representations=relation_representations,
     )
     return model_from_interaction(
+        dimensions=dimensions,
         interaction=interaction_instance,
         entity_representations=entity_representations,
         relation_representations=relation_representations,
@@ -93,11 +94,18 @@ def model_builder(
 
 
 def model_from_interaction(
+    dimensions: Mapping[str, Any],
     interaction: Interaction,
     entity_representations: EmbeddingSpecificationHint = None,
     relation_representations: EmbeddingSpecificationHint = None,
 ) -> Type[ERModel]:
     """Build a model class from an interaction class instance."""
+    entity_representations, relation_representations = _normalize_entity_representations(
+        dimensions=dimensions,
+        interaction=interaction.__class__,
+        entity_representations=entity_representations,
+        relation_representations=relation_representations,
+    )
 
     class ChildERModel(ERModel):
         def __init__(self, **kwargs) -> None:

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -11,6 +11,7 @@ from ..nn.modules import Interaction, interaction_resolver
 from ..typing import Hint
 
 __all__ = [
+    'model_instance_builder',
     'model_builder',
     'model_from_interaction',
 ]
@@ -46,12 +47,6 @@ def model_builder(
 ) -> Type[ERModel]:
     """Build a model class from an interaction class hint (name or class)."""
     interaction_instance = interaction_resolver.make(interaction, interaction_kwargs)
-    entity_representations, relation_representations = _normalize_entity_representations(
-        dimensions=dimensions,
-        interaction=interaction_instance.__class__,
-        entity_representations=entity_representations,
-        relation_representations=relation_representations,
-    )
     return model_from_interaction(
         dimensions=dimensions,
         interaction=interaction_instance,
@@ -122,74 +117,3 @@ def _normalize_entity_representations(
     elif not isinstance(relation_representations, Sequence):
         relation_representations = [relation_representations]
     return entity_representations, relation_representations
-
-
-# FIXME this function is borrowed from PR #107 and originally implemented by @mberr.
-#  It needs a bit of work
-def _resolve_representations(
-    num_representations: int,
-    shape: Sequence[str],
-    representations: Sequence[Union[None, RepresentationModule, EmbeddingSpecification]],
-    dimensions: Mapping[str, int],
-) -> Sequence[RepresentationModule]:
-    """
-    Resolve representations.
-
-    :param num_representations:
-        The number of representations, e.g., number of entities.
-    :param shape: length: num_representations
-        The symbolic shapes for each individual representation. Each shape is a sequence of characters. Each character
-         is resolved to an integer dimension, either by looking it up in the dimensions dictionary, or by sharing the
-         symbolic shape with any of the other representations with given shape.
-    :param representations:
-        The representation specifications. These are either `EmbeddingSpecification`'s, or instantiated representations.
-        Values of `None` correspond to default `EmbeddingSpecification`s.
-    :param dimensions:
-        A mapping from symbolic shapes to actual dimensions.
-
-    :return:
-        A sequence of representation instances of size `num_representations`.
-    """
-    if not isinstance(representations, Sequence):
-        if isinstance(representations, RepresentationModule):
-            # FIXME: Error message; also, why is this a problem.
-            raise ValueError
-        # share same embedding specification for all representations
-        # TODO: why? they should usually have different ones
-        representations = [representations] * len(shape)
-
-    # shallow copy to avoid side-effects
-    dimensions = dict(**dimensions)
-
-    # TODO: Start with instantiated representations, then embedding specification and then None
-    result = []
-    for symbolic_shape, representation in zip(shape, representations):
-        if representation is None:
-            representation = EmbeddingSpecification()
-        if isinstance(representation, RepresentationModule):
-            if representation.max_id < num_representations:
-                # FIXME: Error message
-                raise ValueError
-            elif representation.max_id > num_representations:
-                logger.warning(
-                    f"{representation} does provide representations for more than the requested {num_representations}."
-                    f"While this is not necessarily an error, be aware that these representations will not be trained.",
-                )
-            for name, size in zip(symbolic_shape, representation.shape):
-                expected_dimension = dimensions.get(name)
-                if expected_dimension is not None and expected_dimension != size:
-                    # FIXME: Error message
-                    raise ValueError
-                dimensions[name] = size
-        elif isinstance(representation, EmbeddingSpecification):
-            # set actual shape
-            actual_shape = tuple([dimensions[name] for name in symbolic_shape])
-            representation.shape = actual_shape
-
-            # create embedding
-            representation = representation.make(num_embeddings=num_representations)
-        else:
-            raise AssertionError
-        result.append(representation)
-
-    return result

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -71,6 +71,7 @@ def model_instance_builder(
 
 
 def model_builder(
+    dimensions: Mapping[str, Any],
     interaction: Hint[Interaction] = None,
     interaction_kwargs: Optional[Mapping[str, Any]] = None,
     entity_representations: EmbeddingSpecificationHint = None,
@@ -78,6 +79,12 @@ def model_builder(
 ) -> Type[ERModel]:
     """Build a model class from an interaction class hint (name or class)."""
     interaction_instance = interaction_resolver.make(interaction, interaction_kwargs)
+    entity_representations, relation_representations = _normalize_entity_representations(
+        dimensions=dimensions,
+        interaction=interaction,
+        entity_representations=entity_representations,
+        relation_representations=relation_representations,
+    )
     return model_from_interaction(
         interaction=interaction_instance,
         entity_representations=entity_representations,

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -18,34 +18,6 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def _normalize_entity_representations(
-    dimensions: Mapping[str, int],
-    interaction: Type[Interaction],
-    entity_representations: EmbeddingSpecificationHint,
-    relation_representations: EmbeddingSpecificationHint,
-) -> Tuple[Sequence, Sequence]:
-    if entity_representations is None:
-        # TODO: Does not work for interactions with separate tail_entity_shape (i.e., ConvE)
-        if interaction.tail_entity_shape is not None:
-            raise NotImplementedError
-        entity_representations = [
-            EmbeddingSpecification(shape=tuple(
-                dimensions[d]
-                for d in shape
-            ))
-            for shape in interaction.entity_shape
-        ]
-    if relation_representations is None:
-        relation_representations = [
-            EmbeddingSpecification(shape=tuple(
-                dimensions[d]
-                for d in shape
-            ))
-            for shape in interaction.relation_shape
-        ]
-    return entity_representations, relation_representations
-
-
 def model_instance_builder(
     dimensions: Mapping[str, Any],
     interaction: Hint[Interaction] = None,
@@ -115,6 +87,41 @@ def model_from_interaction(
     ChildERModel._interaction = interaction
 
     return ChildERModel
+
+
+def _normalize_entity_representations(
+    dimensions: Mapping[str, int],
+    interaction: Type[Interaction],
+    entity_representations: EmbeddingSpecificationHint,
+    relation_representations: EmbeddingSpecificationHint,
+) -> Tuple[
+    Sequence[Union[EmbeddingSpecification, RepresentationModule]],
+    Sequence[Union[EmbeddingSpecification, RepresentationModule]],
+]:
+    if entity_representations is None:
+        # TODO: Does not work for interactions with separate tail_entity_shape (i.e., ConvE)
+        if interaction.tail_entity_shape is not None:
+            raise NotImplementedError
+        entity_representations = [
+            EmbeddingSpecification(shape=tuple(
+                dimensions[d]
+                for d in shape
+            ))
+            for shape in interaction.entity_shape
+        ]
+    elif not isinstance(entity_representations, Sequence):
+        entity_representations = [entity_representations]
+    if relation_representations is None:
+        relation_representations = [
+            EmbeddingSpecification(shape=tuple(
+                dimensions[d]
+                for d in shape
+            ))
+            for shape in interaction.relation_shape
+        ]
+    elif not isinstance(relation_representations, Sequence):
+        relation_representations = [relation_representations]
+    return entity_representations, relation_representations
 
 
 # FIXME this function is borrowed from PR #107 and originally implemented by @mberr.

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+"""Generation of ad-hoc model classes."""
+
+import logging
+from typing import Any, Mapping, Optional, Sequence, Type, Union
+
+from .nbase import ERModel, EmbeddingSpecificationHint
+from ..nn import EmbeddingSpecification, RepresentationModule
+from ..nn.modules import Interaction, interaction_resolver
+from ..typing import Hint, OneOrSequence
+
+__all__ = [
+    'model_builder',
+    'model_from_interaction',
+]
+
+logger = logging.getLogger(__name__)
+
+
+def model_builder(
+    interaction: Hint[Interaction] = None,
+    interaction_kwargs: Optional[Mapping[str, Any]] = None,
+    entity_representations: EmbeddingSpecificationHint = None,
+    relation_representations: EmbeddingSpecificationHint = None,
+) -> Type[ERModel]:
+    """Build a model class from an interaction class hint (name or class)."""
+    interaction_instance = interaction_resolver.make(interaction, interaction_kwargs)
+    return model_from_interaction(
+        interaction=interaction_instance,
+        entity_representations=entity_representations,
+        relation_representations=relation_representations,
+    )
+
+
+def model_from_interaction(
+    interaction: Interaction,
+    entity_representations: EmbeddingSpecificationHint = None,
+    relation_representations: EmbeddingSpecificationHint = None,
+) -> Type[ERModel]:
+    """Build a model class from an interaction class instance."""
+
+    class ChildERModel(ERModel):
+        def __init__(self, **kwargs) -> None:
+            """Initialize the model."""
+            super().__init__(
+                interaction=interaction,
+                entity_representations=entity_representations,
+                relation_representations=relation_representations,
+                **kwargs,
+            )
+
+    ChildERModel._interaction = interaction
+
+    return ChildERModel
+
+
+# FIXME this function is borrowed from PR #107 and originally implemented by @mberr.
+#  It needs a bit of work
+def _resolve_representations(
+    num_representations: int,
+    shape: Sequence[str],
+    representations: OneOrSequence[Union[None, RepresentationModule, EmbeddingSpecification]],
+    dimensions: Mapping[str, int],
+) -> Sequence[RepresentationModule]:
+    if not isinstance(representations, Sequence):
+        if isinstance(representations, RepresentationModule):
+            raise ValueError
+        representations = [representations] * len(shape)
+
+    dimensions = dict(**dimensions)
+    result = []
+    for symbolic_shape, representation in zip(shape, representations):
+        if representation is None:
+            representation = EmbeddingSpecification()
+        if isinstance(representation, RepresentationModule):
+            if representation.max_id < num_representations:
+                raise ValueError
+            elif representation.max_id > num_representations:
+                logger.warning(
+                    f"{representation} does provide representations for more than the requested {num_representations}."
+                    f"While this is not necessarily an error, be aware that these representations will not be trained.",
+                )
+            for name, size in zip(symbolic_shape, representation.shape):
+                expected_dimension = dimensions.get(name)
+                if expected_dimension is not None and expected_dimension != size:
+                    raise ValueError
+                dimensions[name] = size
+        elif isinstance(representation, EmbeddingSpecification):
+            actual_shape = tuple([dimensions[name] for name in symbolic_shape])
+            representation = representation.make(
+                num_embeddings=num_representations,
+                embedding_dim=None,
+                shape=actual_shape,
+            )
+        else:
+            raise AssertionError
+        result.append(representation)
+
+    return result

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -8,7 +8,7 @@ import functools
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, TypeVar, Union, cast
+from typing import Any, Callable, Mapping, Optional, Sequence, TYPE_CHECKING, Tuple, TypeVar, Union, cast
 
 import numpy as np
 import torch
@@ -18,9 +18,11 @@ from torch.nn import functional
 
 from .init import init_phases, xavier_normal_, xavier_normal_norm_, xavier_uniform_, xavier_uniform_norm_
 from .norm import complex_normalize
-from ..regularizers import Regularizer
 from ..typing import Constrainer, Hint, Initializer, Normalizer
 from ..utils import clamp_norm, convert_to_canonical_shape
+
+if TYPE_CHECKING:
+    from ..regularizers import Regularizer
 
 __all__ = [
     'RepresentationModule',
@@ -188,7 +190,7 @@ class Embedding(RepresentationModule):
 
     normalizer: Optional[Normalizer]
     constrainer: Optional[Constrainer]
-    regularizer: Optional[Regularizer]
+    regularizer: Optional['Regularizer']
 
     def __init__(
         self,
@@ -201,7 +203,7 @@ class Embedding(RepresentationModule):
         normalizer_kwargs: Optional[Mapping[str, Any]] = None,
         constrainer: Hint[Constrainer] = None,
         constrainer_kwargs: Optional[Mapping[str, Any]] = None,
-        regularizer: Optional[Regularizer] = None,
+        regularizer: Optional['Regularizer'] = None,
         trainable: bool = True,
         dtype: Optional[torch.dtype] = None,
     ):
@@ -354,7 +356,7 @@ class EmbeddingSpecification:
     constrainer: Hint[Constrainer] = None
     constrainer_kwargs: Optional[Mapping[str, Any]] = None
 
-    regularizer: Optional[Regularizer] = None
+    regularizer: Optional['Regularizer'] = None
 
     dtype: Optional[torch.dtype] = None
 

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -17,9 +17,10 @@ from torch import FloatTensor, nn
 
 from . import functional as pkf
 from ..typing import HeadRepresentation, RelationRepresentation, TailRepresentation
-from ..utils import CANONICAL_DIMENSIONS, convert_to_canonical_shape, ensure_tuple, upgrade_to_sequence
+from ..utils import CANONICAL_DIMENSIONS, Resolver, convert_to_canonical_shape, ensure_tuple, upgrade_to_sequence
 
 __all__ = [
+    'interaction_resolver',
     # Base Classes
     'Interaction',
     'FunctionalInteraction',
@@ -1139,3 +1140,10 @@ class PairREInteraction(TranslationalInteraction[FloatTensor, Tuple[FloatTensor,
         t: TailRepresentation,
     ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
         return dict(h=h, r_h=r[0], r_t=r[1], t=t)
+
+
+interaction_resolver = Resolver.from_subclasses(
+    Interaction,  # type: ignore
+    skip={TranslationalInteraction, FunctionalInteraction},
+    suffix=Interaction.__name__,
+)

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -11,11 +11,12 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, Generic, Mapping, MutableMapping, Optional, Sequence, Set, Tuple, Union, cast
 
 import torch
+from class_resolver import Resolver
 from torch import FloatTensor, nn
 
 from . import functional as pkf
 from ..typing import HeadRepresentation, RelationRepresentation, TailRepresentation
-from ..utils import CANONICAL_DIMENSIONS, Resolver, convert_to_canonical_shape, ensure_tuple, upgrade_to_sequence
+from ..utils import CANONICAL_DIMENSIONS, convert_to_canonical_shape, ensure_tuple, upgrade_to_sequence
 
 __all__ = [
     'interaction_resolver',

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -4,13 +4,11 @@
 
 from __future__ import annotations
 
+import itertools as itt
 import logging
 import math
 from abc import ABC, abstractmethod
-from typing import (
-    Any, Callable, Generic, Mapping, MutableMapping, Optional, Sequence, Tuple, Union,
-    cast,
-)
+from typing import Any, Callable, Generic, Mapping, MutableMapping, Optional, Sequence, Set, Tuple, Union, cast
 
 import torch
 from torch import FloatTensor, nn
@@ -73,6 +71,17 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
 
     #: The symbolic shapes for relation representations
     relation_shape: Sequence[str] = ("d",)
+
+    @classmethod
+    def get_dimensions(cls) -> Set[str]:
+        """Get all of the relevant dimension keys.
+
+        This draws from :data:`Interaction.entity_shape`, :data:`Interaction.relation_shape`, and in the case of
+        :class:`ConvEInteraction`, the :data:`Interaction.tail_entity_shape`.
+
+        :returns: a set of strings representting the dimension keys.
+        """
+        return set(itt.chain(cls.entity_shape, cls.tail_entity_shape or set(), cls.relation_shape))
 
     @abstractmethod
     def forward(

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -190,6 +190,26 @@ class Resolver(Generic[X]):
             for cls in classes
         }
 
+    @classmethod
+    def from_subclasses(cls, base: Type[X], skip: Collection[Type[X]], **kwargs) -> 'Resolver':
+        """Make a resolver from the subclasses of a given class.
+
+        :param base: The base class whose subclasses will be indexed
+        :param skip: Any subclasses to skip (usually good to hardcode intermediate base classes)
+        :param kwargs: remaining keyword arguments to pass to :func:`Resolver.__init__`
+        :return: A resolver instance
+        """
+        skip = set(skip)
+        return Resolver(
+            {
+                subcls
+                for subcls in get_subclasses(base)
+                if subcls not in skip
+            },
+            base=base,
+            **kwargs,
+        )
+
     def normalize_inst(self, x: X) -> str:
         """Normalize the class name of the instance."""
         return self.normalize_cls(x.__class__)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,11 +9,13 @@ import pandas as pd
 
 import pykeen.regularizers
 from pykeen.datasets import EagerDataset, Nations
-from pykeen.models import Model
+from pykeen.models import ERModel, Model
 from pykeen.models.predict import (
     get_all_prediction_df, get_head_prediction_df, get_relation_prediction_df,
     get_tail_prediction_df,
 )
+from pykeen.models.resolve import model_builder, model_from_interaction
+from pykeen.nn.modules import TransEInteraction
 from pykeen.pipeline import PipelineResult, pipeline
 from pykeen.regularizers import NoRegularizer
 from pykeen.triples.generation import generate_triples_factory
@@ -172,6 +174,35 @@ class TestPipelineTriples(unittest.TestCase):
             model='TransE',
             training_kwargs=dict(num_epochs=1, use_tqdm=False),
             evaluation_kwargs=dict(use_tqdm=False),
+        )
+
+    def test_interaction_builder(self):
+        """Test resolving an interaction model."""
+        model_cls = model_from_interaction(TransEInteraction(p=2))
+        self._help_test_interaction_resolver(model_cls)
+
+    def test_interaction_resolver_cls(self):
+        """Test resolving the interaction function."""
+        model_cls = model_builder(TransEInteraction, {'p': 2})
+        self._help_test_interaction_resolver(model_cls)
+
+    def test_interaction_resolver_lookup(self):
+        """Test resolving the interaction function."""
+        model_cls = model_builder('TransE', {'p': 2})
+        self._help_test_interaction_resolver(model_cls)
+
+    def _help_test_interaction_resolver(self, model_cls):
+        self.assertTrue(issubclass(model_cls, ERModel))
+        self.assertIsInstance(model_cls._interaction, TransEInteraction)
+        self.assertEqual(2, model_cls._interaction.p)
+        _ = pipeline(
+            training=self.training,
+            testing=self.testing,
+            validation=self.validation,
+            model=model_cls,
+            training_kwargs=dict(num_epochs=1, use_tqdm=False),
+            evaluation_kwargs=dict(use_tqdm=False),
+            random_seed=0,
         )
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,7 +14,7 @@ from pykeen.models.predict import (
     get_all_prediction_df, get_head_prediction_df, get_relation_prediction_df,
     get_tail_prediction_df,
 )
-from pykeen.models.resolve import model_builder, model_from_interaction
+from pykeen.models.resolve import model_builder, model_from_interaction, model_instance_builder
 from pykeen.nn.modules import TransEInteraction
 from pykeen.pipeline import PipelineResult, pipeline
 from pykeen.regularizers import NoRegularizer
@@ -174,6 +174,29 @@ class TestPipelineTriples(unittest.TestCase):
             model='TransE',
             training_kwargs=dict(num_epochs=1, use_tqdm=False),
             evaluation_kwargs=dict(use_tqdm=False),
+        )
+
+    def test_interaction_instance_builder(self):
+        """Test resolving an interaction model instance."""
+        model = model_instance_builder(
+            dimensions=dict(
+                d=3,
+            ),
+            interaction=TransEInteraction,
+            interaction_kwargs=dict(p=2),
+            triples_factory=self.training,
+        )
+        self.assertIsInstance(model, ERModel)
+        self.assertIsInstance(model.interaction, TransEInteraction)
+        self.assertEqual(2, model.interaction.p)
+        _ = pipeline(
+            training=self.training,
+            testing=self.testing,
+            validation=self.validation,
+            model=model,
+            training_kwargs=dict(num_epochs=1, use_tqdm=False),
+            evaluation_kwargs=dict(use_tqdm=False),
+            random_seed=0,
         )
 
     def test_interaction_builder(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -179,9 +179,7 @@ class TestPipelineTriples(unittest.TestCase):
     def test_interaction_instance_builder(self):
         """Test resolving an interaction model instance."""
         model = model_instance_builder(
-            dimensions=dict(
-                d=3,
-            ),
+            dimensions={"d": 3},
             interaction=TransEInteraction,
             interaction_kwargs=dict(p=2),
             triples_factory=self.training,
@@ -201,7 +199,7 @@ class TestPipelineTriples(unittest.TestCase):
 
     def test_interaction_builder(self):
         """Test resolving an interaction model."""
-        model_cls = model_from_interaction(TransEInteraction(p=2))
+        model_cls = model_from_interaction({"d": 3}, TransEInteraction(p=2))
         self._help_test_interaction_resolver(model_cls)
 
     def test_interaction_resolver_cls(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,7 +14,7 @@ from pykeen.models.predict import (
     get_all_prediction_df, get_head_prediction_df, get_relation_prediction_df,
     get_tail_prediction_df,
 )
-from pykeen.models.resolve import model_builder, model_from_interaction, model_instance_builder
+from pykeen.models.resolve import make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
 from pykeen.pipeline import PipelineResult, pipeline
 from pykeen.regularizers import NoRegularizer
@@ -178,7 +178,7 @@ class TestPipelineTriples(unittest.TestCase):
 
     def test_interaction_instance_builder(self):
         """Test resolving an interaction model instance."""
-        model = model_instance_builder(
+        model = make_model(
             dimensions={"d": 3},
             interaction=TransEInteraction,
             interaction_kwargs=dict(p=2),
@@ -199,17 +199,17 @@ class TestPipelineTriples(unittest.TestCase):
 
     def test_interaction_builder(self):
         """Test resolving an interaction model."""
-        model_cls = model_from_interaction({"d": 3}, TransEInteraction(p=2))
+        model_cls = make_model_cls({"d": 3}, TransEInteraction(p=2))
         self._help_test_interaction_resolver(model_cls)
 
     def test_interaction_resolver_cls(self):
         """Test resolving the interaction function."""
-        model_cls = model_builder({"d": 3}, TransEInteraction, {'p': 2})
+        model_cls = make_model_cls({"d": 3}, TransEInteraction, {'p': 2})
         self._help_test_interaction_resolver(model_cls)
 
     def test_interaction_resolver_lookup(self):
         """Test resolving the interaction function."""
-        model_cls = model_builder({"d": 3}, 'TransE', {'p': 2})
+        model_cls = make_model_cls({"d": 3}, 'TransE', {'p': 2})
         self._help_test_interaction_resolver(model_cls)
 
     def _help_test_interaction_resolver(self, model_cls):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,7 +14,7 @@ from pykeen.models.predict import (
     get_all_prediction_df, get_head_prediction_df, get_relation_prediction_df,
     get_tail_prediction_df,
 )
-from pykeen.models.resolve import make_model, make_model_cls
+from pykeen.models.resolve import DimensionError, make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
 from pykeen.pipeline import PipelineResult, pipeline
 from pykeen.regularizers import NoRegularizer
@@ -175,6 +175,18 @@ class TestPipelineTriples(unittest.TestCase):
             training_kwargs=dict(num_epochs=1, use_tqdm=False),
             evaluation_kwargs=dict(use_tqdm=False),
         )
+
+    def test_interaction_instance_missing_dimensions(self):
+        """Test when a dimension is missing."""
+        with self.assertRaises(DimensionError) as exc:
+            make_model_cls(
+                dimensions={},  # missing "d"
+                interaction=TransEInteraction(p=2),
+            )
+        self.assertIsInstance(exc.exception, DimensionError)
+        self.assertEqual({'d'}, exc.exception.expected)
+        self.assertEqual(set(), exc.exception.given)
+        self.assertEqual("Expected dimensions dictionary with keys {'d'} but got keys set()", str(exc.exception))
 
     def test_interaction_instance_builder(self):
         """Test resolving an interaction model instance."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -206,12 +206,12 @@ class TestPipelineTriples(unittest.TestCase):
 
     def test_interaction_resolver_cls(self):
         """Test resolving the interaction function."""
-        model_cls = model_builder(TransEInteraction, {'p': 2})
+        model_cls = model_builder({"d": 3}, TransEInteraction, {'p': 2})
         self._help_test_interaction_resolver(model_cls)
 
     def test_interaction_resolver_lookup(self):
         """Test resolving the interaction function."""
-        model_cls = model_builder('TransE', {'p': 2})
+        model_cls = model_builder({"d": 3}, 'TransE', {'p': 2})
         self._help_test_interaction_resolver(model_cls)
 
     def _help_test_interaction_resolver(self, model_cls):


### PR DESCRIPTION
Closes #325

Make a model class from lookup of an interaction module class:

```python
>>> from pykeen.nn.modules import TransEInteraction
>>> from pykeen.models import make_model_cls
>>> embedding_dim = 3
>>> model_cls = make_model_cls({"d": embedding_dim}, 'TransE', {'p': 2})
>>> # Implicitly can also be written as:
>>> model_cls_alt = make_model_cls(embedding_dim, 'TransE', {'p': 2})
```

Make a model class from an interaction module class:

```python
>>> from pykeen.nn.modules import TransEInteraction
>>> from pykeen.models import make_model_cls
>>> embedding_dim = 3
>>> model_cls = make_model_cls({"d": embedding_dim}, TransEInteraction, {'p': 2})
```

Make a model class from an instantiated interaction module:

```python
>>> from pykeen.nn.modules import TransEInteraction
>>> from pykeen.models import make_model_cls
>>> embedding_dim = 3
>>> model_cls = make_model_cls({"d": embedding_dim}, TransEInteraction(p=2))
```