### PR TITLE
🛠️ 🥰 Fix regularizer passing

### DIFF
--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -615,7 +615,7 @@ def hpo_pipeline(
     regularizer_cls: Optional[Type[Regularizer]]
     if regularizer is not None:
         regularizer_cls = regularizer_resolver.lookup(regularizer)
-    elif hasattr(model_cls, 'regularizer_default'):
+    elif getattr(model_cls, 'regularizer_default', None):
         regularizer_cls = model_cls.regularizer_default
     else:
         regularizer_cls = None

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -553,7 +553,7 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
     """A base module for PyKEEN 1.0-style KGE models."""
 
     #: The default regularizer class
-    regularizer_default: ClassVar[Type[Regularizer]] = NoRegularizer  # type: ignore
+    regularizer_default: ClassVar[Optional[Type[Regularizer]]] = None
     #: The default parameters for the default regularizer class
     regularizer_default_kwargs: ClassVar[Optional[Mapping[str, Any]]] = None
     #: The instance of the regularizer
@@ -593,11 +593,14 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
             random_seed=random_seed,
         )
         # Regularizer
-        if regularizer is None:
-            regularizer = self.regularizer_default(
+        if regularizer is not None:
+            self.regularizer = regularizer
+        elif self.regularizer_default is not None:
+            self.regularizer = self.regularizer_default(
                 **(self.regularizer_default_kwargs or {}),
             )
-        self.regularizer = regularizer
+        else:
+            self.regularizer = NoRegularizer()
 
     def post_parameter_update(self) -> None:
         """Has to be called after each parameter update."""

--- a/src/pykeen/models/multimodal/complex_literal.py
+++ b/src/pykeen/models/multimodal/complex_literal.py
@@ -13,6 +13,7 @@ from ..unimodal.complex import ComplEx
 from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import BCEWithLogitsLoss, Loss
 from ...nn import Embedding
+from ...regularizers import Regularizer
 from ...triples import TriplesNumericLiteralsFactory
 from ...typing import DeviceHint
 from ...utils import split_complex
@@ -46,6 +47,7 @@ class ComplExLiteral(ComplEx, MultimodalModel):
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,
         random_seed: Optional[int] = None,
+        regularizer: Optional[Regularizer] = None,
     ) -> None:
         """Initialize the model."""
         super().__init__(
@@ -54,6 +56,7 @@ class ComplExLiteral(ComplEx, MultimodalModel):
             loss=loss,
             preferred_device=preferred_device,
             random_seed=random_seed,
+            regularizer=regularizer,
             entity_initializer=xavier_normal_,
             relation_initializer=xavier_normal_,
         )

--- a/src/pykeen/models/multimodal/distmult_literal.py
+++ b/src/pykeen/models/multimodal/distmult_literal.py
@@ -12,6 +12,7 @@ from ..unimodal.distmult import DistMult
 from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss
 from ...nn import Embedding
+from ...regularizers import Regularizer
 from ...triples import TriplesNumericLiteralsFactory
 from ...typing import DeviceHint
 
@@ -42,6 +43,7 @@ class DistMultLiteral(DistMult, MultimodalModel):
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,
         random_seed: Optional[int] = None,
+        regularizer: Optional[Regularizer] = None,
     ) -> None:
         super().__init__(
             triples_factory=triples_factory,
@@ -49,6 +51,7 @@ class DistMultLiteral(DistMult, MultimodalModel):
             loss=loss,
             preferred_device=preferred_device,
             random_seed=random_seed,
+            regularizer=regularizer,
         )
 
         # Literal

--- a/tests/test_hpo.py
+++ b/tests/test_hpo.py
@@ -8,7 +8,7 @@ import unittest
 import optuna
 import pytest
 
-from pykeen.datasets.nations import NATIONS_TRAIN_PATH
+from pykeen.datasets.nations import NATIONS_TRAIN_PATH, NationsLiteral
 from pykeen.hpo import hpo_pipeline
 from pykeen.hpo.hpo import suggest_kwargs
 from pykeen.triples import TriplesFactory
@@ -163,3 +163,23 @@ class TestHyperparameterOptimization(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as directory:
             hpo_pipeline_result.save_to_directory(directory)
+
+
+@pytest.mark.slow
+class TestHyperparameterOptimizationLiterals(unittest.TestCase):
+    """Test hyper-parameter optimization."""
+
+    def test_run(self):
+        """Test simply making a study."""
+        hpo_pipeline_result = hpo_pipeline(
+            dataset=NationsLiteral,
+            model='DistMultLiteral',
+            training_kwargs=dict(num_epochs=5, use_tqdm=False),
+            n_trials=2,
+        )
+        df = hpo_pipeline_result.study.trials_dataframe(multi_index=True)
+        # Check a model param is optimized
+        self.assertIn(('params', 'model.embedding_dim'), df.columns)
+        # Check a loss param is optimized
+        self.assertIn(('params', 'loss.margin'), df.columns)
+        self.assertNotIn(('params', 'training.num_epochs'), df.columns)


### PR DESCRIPTION
Closes #344 

The actual solution to #344 was just to add the regularizer argument to the ComplexLiteral and DistmultLiteral classes since they both inherit from ComplEx and DistMult, respectively, which both have default regularizers and take regularizers.

However, this PR also includes changes to more explicitly handle when `None` is passed as a regularizer to the pipeline or to the HPO pipeline. Now, it checks in the following order:

1. Regularizer is not None
2. Model has a regularizer_default
3. Leave it as None


