### PR TITLE
Fix saving results from training multimodal models

### DIFF
--- a/src/pykeen/models/multimodal/complex_literal.py
+++ b/src/pykeen/models/multimodal/complex_literal.py
@@ -66,8 +66,10 @@ class ComplExLiteral(ComplEx, MultimodalModel):
         self.numeric_literals = Embedding(
             num_embeddings=triples_factory.num_entities,
             embedding_dim=triples_factory.numeric_literals.shape[-1],
-            initializer=triples_factory._get_numeric_literals,
+            initializer=triples_factory.initializer,
         )
+        # explicitly reset to load the triples in
+        self.numeric_literals.reset_parameters()
         # Number of columns corresponds to number of literals
         self.num_of_literals = self.numeric_literals.embedding_dim
 

--- a/src/pykeen/models/multimodal/complex_literal.py
+++ b/src/pykeen/models/multimodal/complex_literal.py
@@ -66,7 +66,7 @@ class ComplExLiteral(ComplEx, MultimodalModel):
         self.numeric_literals = Embedding(
             num_embeddings=triples_factory.num_entities,
             embedding_dim=triples_factory.numeric_literals.shape[-1],
-            initializer=lambda x: triples_factory.numeric_literals,
+            initializer=triples_factory._get_numeric_literals,
         )
         # Number of columns corresponds to number of literals
         self.num_of_literals = self.numeric_literals.embedding_dim

--- a/src/pykeen/models/multimodal/complex_literal.py
+++ b/src/pykeen/models/multimodal/complex_literal.py
@@ -66,7 +66,7 @@ class ComplExLiteral(ComplEx, MultimodalModel):
         self.numeric_literals = Embedding(
             num_embeddings=triples_factory.num_entities,
             embedding_dim=triples_factory.numeric_literals.shape[-1],
-            initializer=triples_factory.initializer,
+            initializer=triples_factory.literal_initializer,
         )
         # explicitly reset to load the triples in
         self.numeric_literals.reset_parameters()

--- a/src/pykeen/models/multimodal/distmult_literal.py
+++ b/src/pykeen/models/multimodal/distmult_literal.py
@@ -59,7 +59,7 @@ class DistMultLiteral(DistMult, MultimodalModel):
         self.numeric_literals = Embedding(
             num_embeddings=triples_factory.num_entities,
             embedding_dim=triples_factory.numeric_literals.shape[-1],
-            initializer=triples_factory.initializer,
+            initializer=triples_factory.literal_initializer,
         )
         # explicitly reset to load the triples in
         self.numeric_literals.reset_parameters()

--- a/src/pykeen/models/multimodal/distmult_literal.py
+++ b/src/pykeen/models/multimodal/distmult_literal.py
@@ -59,8 +59,10 @@ class DistMultLiteral(DistMult, MultimodalModel):
         self.numeric_literals = Embedding(
             num_embeddings=triples_factory.num_entities,
             embedding_dim=triples_factory.numeric_literals.shape[-1],
-            initializer=triples_factory._get_numeric_literals,
+            initializer=triples_factory.initializer,
         )
+        # explicitly reset to load the triples in
+        self.numeric_literals.reset_parameters()
         # Number of columns corresponds to number of literals
         self.num_of_literals = self.numeric_literals.embedding_dim
         self.linear_transformation = nn.Linear(self.embedding_dim + self.num_of_literals, self.embedding_dim)

--- a/src/pykeen/models/multimodal/distmult_literal.py
+++ b/src/pykeen/models/multimodal/distmult_literal.py
@@ -59,7 +59,7 @@ class DistMultLiteral(DistMult, MultimodalModel):
         self.numeric_literals = Embedding(
             num_embeddings=triples_factory.num_entities,
             embedding_dim=triples_factory.numeric_literals.shape[-1],
-            initializer=lambda x: triples_factory.numeric_literals,
+            initializer=triples_factory._get_numeric_literals,
         )
         # Number of columns corresponds to number of literals
         self.num_of_literals = self.numeric_literals.embedding_dim

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -114,3 +114,6 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
             numeric_literals=self.numeric_literals,
             literals_to_id=self.literals_to_id,
         )
+
+    def _get_numeric_literals(self):
+        return self.numeric_literals

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -116,6 +116,6 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
             literals_to_id=self.literals_to_id,
         )
 
-    def initializer(self, _) -> torch.FloatTensor:
+    def literal_initializer(self, _) -> torch.FloatTensor:
         """Initialize an embedding, for use as the ``initializer`` kwarg for :class:`pykeen.nn.Embedding`."""
         return torch.as_tensor(self.numeric_literals, dtype=torch.float)

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -6,6 +6,7 @@ import logging
 from typing import Dict, Optional, TextIO, Tuple, Union
 
 import numpy as np
+import torch
 
 from .instances import MultimodalLCWAInstances, MultimodalSLCWAInstances
 from .triples_factory import TriplesFactory
@@ -115,5 +116,6 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
             literals_to_id=self.literals_to_id,
         )
 
-    def _get_numeric_literals(self):
-        return self.numeric_literals
+    def initializer(self, _) -> torch.FloatTensor:
+        """Initialize an embedding, for use as the ``initializer`` kwarg for :class:`pykeen.nn.Embedding`."""
+        return torch.as_tensor(self.numeric_literals, dtype=torch.float)

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -2,6 +2,7 @@
 
 """Tests for literal models."""
 
+import tempfile
 import unittest
 
 from pykeen.datasets.nations import NationsLiteral
@@ -12,18 +13,21 @@ class TestLiteralModel(unittest.TestCase):
     """Test that the pipeline can be run on literal datasets."""
 
     def _help(self, model):
-        return pipeline(
+        rv = pipeline(
             dataset=NationsLiteral,
             model=model,
             training_kwargs=dict(num_epochs=5, use_tqdm=False),
             evaluation_kwargs=dict(use_tqdm=False),
             training_loop='lcwa',
         )
+        self.assertIsNotNone(rv)
+        with tempfile.TemporaryDirectory() as d:
+            rv.save_to_directory(d)
 
     def test_complex(self):
         """Test running on ComplEx."""
-        _ = self._help('ComplExLiteral')
+        self._help('ComplExLiteral')
 
     def test_distmult(self):
         """Test running on DistMult."""
-        _ = self._help('DistMultLiteral')
+        self._help('DistMultLiteral')


### PR DESCRIPTION
Closes #348, pointed out by @GenetAsefa.

The issue was that a lambda was constructed to act as an initializer, so I reorganized it.

However, I think in the process I realized that this initializer is never actually called, so there's something else going on here that needs fixing. This was solved by explicitly calling `self.numeric_literals.reset_parameters()` directly after instantiation of `self.numeric_literals = Embedding(...)`. However, this solution will be overwritten by #245, where this harness has already been rewritten.