### PR TITLE
Hotfix noqa flake8 errors in CI pipeline

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ deps =
     flake8
     flake8-bandit
     flake8-colors
-    flake8-docstrings
+    flake8-docstrings<1.6
     flake8-import-order
     flake8-bugbear
     flake8-commas


### PR DESCRIPTION
Add `flake8-docstring<1.6` constraint until noqa error is fixed.

The difference in versions between the last build without these errors is
```diff
-flake8==3.8.4
+flake8==3.9.0
-flake8-docstrings==1.5.0
+flake8-docstrings==1.6.0
-pycodestyle==2.6.0
+pycodestyle==2.7.0
-pydocstyle==5.1.1
+pydocstyle==6.0.0
```

Adding the `flake8-docstrings` constraint seems to be sufficient.