### PR TITLE
Delay interaction function resolution to base class

### DIFF
--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -342,6 +342,9 @@ class ERModel(
         :param triples_factory:
             The triples factory facilitates access to the dataset.
         :param interaction: The interaction module (e.g., TransE)
+        :param interaction_kwargs:
+            Additional key-word based parameters given to the interaction module's constructor, if not already
+            instantiated.
         :param entity_representations: The entity representation or sequence of representations
         :param relation_representations: The relation representation or sequence of representations
         :param loss:

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -11,12 +11,13 @@ from operator import itemgetter
 from typing import Any, ClassVar, Generic, Iterable, List, Mapping, Optional, Sequence, Tuple, Type, Union, cast
 
 import torch
+from class_resolver import Hint
 from torch import nn
 
 from .base import Model
 from ..losses import Loss
 from ..nn.emb import EmbeddingSpecification, RepresentationModule
-from ..nn.modules import Interaction
+from ..nn.modules import Interaction, interaction_resolver
 from ..regularizers import Regularizer
 from ..triples import TriplesFactory
 from ..typing import DeviceHint, HeadRepresentation, RelationRepresentation, TailRepresentation
@@ -327,7 +328,8 @@ class ERModel(
         self,
         *,
         triples_factory: TriplesFactory,
-        interaction: Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation],
+        interaction: Hint[Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation]],
+        interaction_kwargs: Optional[Mapping[str, Any]] = None,
         entity_representations: EmbeddingSpecificationHint = None,
         relation_representations: EmbeddingSpecificationHint = None,
         loss: Optional[Loss] = None,
@@ -373,7 +375,7 @@ class ERModel(
             shapes=interaction.relation_shape,
             label="relation",
         )
-        self.interaction = interaction
+        self.interaction = interaction_resolver.make(interaction, pos_kwargs=interaction_kwargs)
         # Comment: it is important that the regularizers are stored in a module list, in order to appear in
         # model.modules(). Thereby, we can collect them automatically.
         self.weight_regularizers = nn.ModuleList()

--- a/src/pykeen/models/unimodal/quate.py
+++ b/src/pykeen/models/unimodal/quate.py
@@ -111,7 +111,7 @@ class QuatE(ERModel):
         """
         super().__init__(
             triples_factory=triples_factory,
-            interaction=QuatEInteraction(),
+            interaction=QuatEInteraction,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=4 * embedding_dim,
                 initializer=entity_initializer,


### PR DESCRIPTION
Defers the interaction function resolution to the base class, `ERModel`, thus allowing to pass `Hint[Interaction]` instead.

Also updates `QuatE` to pass an interaction hint instead of an instantiated module.