### PR TITLE
💃 🧪 Update model tests to unittest template

### DIFF
--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1003,7 +1003,8 @@ Traceback
         self.instance.post_parameter_update()
 
         # assert that the regularization term has been reset
-        assert self.instance.regularizer.regularization_term == torch.zeros(1, dtype=torch.float, device=self.instance.device)
+        expected_term = torch.zeros(1, dtype=torch.float, device=self.instance.device)
+        assert self.instance.regularizer.regularization_term == expected_term
 
     def test_post_parameter_update(self):
         """Test whether post_parameter_update correctly enforces model constraints."""

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -677,23 +677,14 @@ class LpRegularizerTest(RegularizerTestCase):
         return value
 
 
-class ModelTestCase(unittest.TestCase):
+class ModelTestCase(unittest_templates.GenericTestCase[Model]):
     """A test case for quickly defining common tests for KGE models."""
-
-    #: The class of the model to test
-    model_cls: ClassVar[Type[Model]]
-
-    #: Additional arguments passed to the model's constructor method
-    model_kwargs: ClassVar[Optional[Mapping[str, Any]]] = None
 
     #: Additional arguments passed to the training loop's constructor method
     training_loop_kwargs: ClassVar[Optional[Mapping[str, Any]]] = None
 
     #: The triples factory instance
     factory: TriplesFactory
-
-    #: The model instance
-    model: Model
 
     #: The batch size for use for forward_* tests
     batch_size: int = 20
@@ -720,45 +711,50 @@ class ModelTestCase(unittest.TestCase):
     # initialization
     num_constant_init: int = 0
 
-    def setUp(self) -> None:
-        """Set up the test case with a triples factory and model."""
+    def pre_setup_hook(self) -> None:  # noqa: D102
+        # for reproducible testing
         _, self.generator, _ = set_random_seed(42)
 
+    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
+        kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
         dataset = Nations(create_inverse_triples=self.create_inverse_triples)
         self.factory = dataset.training
-        self.model = self.model_cls(
-            triples_factory=self.factory,
-            embedding_dim=self.embedding_dim,
-            **(self.model_kwargs or {}),
-        ).to_device_()
+        # insert shared parameters
+        kwargs["triples_factory"] = self.factory
+        kwargs["embedding_dim"] = self.embedding_dim
+        return kwargs
+
+    def post_instantiation_hook(self) -> None:  # noqa: D102
+        # move model to correct device
+        self.instance = self.instance.to_device_()
 
     def test_get_grad_parameters(self):
         """Test the model's ``get_grad_params()`` method."""
         # assert there is at least one trainable parameter
-        assert len(list(self.model.get_grad_params())) > 0
+        assert len(list(self.instance.get_grad_params())) > 0
 
         # Check that all the parameters actually require a gradient
-        for parameter in self.model.get_grad_params():
+        for parameter in self.instance.get_grad_params():
             assert parameter.requires_grad
 
         # Try to initialize an optimizer
-        optimizer = SGD(params=self.model.get_grad_params(), lr=1.0)
+        optimizer = SGD(params=self.instance.get_grad_params(), lr=1.0)
         assert optimizer is not None
 
     def test_reset_parameters_(self):
         """Test :func:`Model.reset_parameters_`."""
         # get model parameters
-        params = list(self.model.parameters())
+        params = list(self.instance.parameters())
         old_content = {
             id(p): p.data.detach().clone()
             for p in params
         }
 
         # re-initialize
-        self.model.reset_parameters_()
+        self.instance.reset_parameters_()
 
         # check that the operation works in-place
-        new_params = list(self.model.parameters())
+        new_params = list(self.instance.parameters())
         assert set(id(np) for np in new_params) == set(id(p) for p in params)
 
         # check that the parameters where modified
@@ -782,13 +778,13 @@ class ModelTestCase(unittest.TestCase):
     def test_save(self) -> None:
         """Test that the model can be saved properly."""
         with tempfile.TemporaryDirectory() as temp_directory:
-            torch.save(self.model, os.path.join(temp_directory, 'model.pickle'))
+            torch.save(self.instance, os.path.join(temp_directory, 'model.pickle'))
 
     def test_score_hrt(self) -> None:
         """Test the model's ``score_hrt()`` function."""
-        batch = self.factory.mapped_triples[:self.batch_size, :].to(self.model.device)
+        batch = self.factory.mapped_triples[:self.batch_size, :].to(self.instance.device)
         try:
-            scores = self.model.score_hrt(batch)
+            scores = self.instance.score_hrt(batch)
         except RuntimeError as e:
             if str(e) == 'fft: ATen not compiled with MKL support':
                 self.skipTest(str(e))
@@ -799,13 +795,13 @@ class ModelTestCase(unittest.TestCase):
 
     def test_score_t(self) -> None:
         """Test the model's ``score_t()`` function."""
-        batch = self.factory.mapped_triples[:self.batch_size, :2].to(self.model.device)
+        batch = self.factory.mapped_triples[:self.batch_size, :2].to(self.instance.device)
         # assert batch comprises (head, relation) pairs
         assert batch.shape == (self.batch_size, 2)
         assert (batch[:, 0] < self.factory.num_entities).all()
         assert (batch[:, 1] < self.factory.num_relations).all()
         try:
-            scores = self.model.score_t(batch)
+            scores = self.instance.score_t(batch)
         except NotImplementedError:
             self.fail(msg='Score_o not yet implemented')
         except RuntimeError as e:
@@ -813,18 +809,18 @@ class ModelTestCase(unittest.TestCase):
                 self.skipTest(str(e))
             else:
                 raise e
-        assert scores.shape == (self.batch_size, self.model.num_entities)
+        assert scores.shape == (self.batch_size, self.instance.num_entities)
         self._check_scores(batch, scores)
 
     def test_score_h(self) -> None:
         """Test the model's ``score_h()`` function."""
-        batch = self.factory.mapped_triples[:self.batch_size, 1:].to(self.model.device)
+        batch = self.factory.mapped_triples[:self.batch_size, 1:].to(self.instance.device)
         # assert batch comprises (relation, tail) pairs
         assert batch.shape == (self.batch_size, 2)
         assert (batch[:, 0] < self.factory.num_relations).all()
         assert (batch[:, 1] < self.factory.num_entities).all()
         try:
-            scores = self.model.score_h(batch)
+            scores = self.instance.score_h(batch)
         except NotImplementedError:
             self.fail(msg='Score_s not yet implemented')
         except RuntimeError as e:
@@ -832,15 +828,15 @@ class ModelTestCase(unittest.TestCase):
                 self.skipTest(str(e))
             else:
                 raise e
-        assert scores.shape == (self.batch_size, self.model.num_entities)
+        assert scores.shape == (self.batch_size, self.instance.num_entities)
         self._check_scores(batch, scores)
 
     @pytest.mark.slow
     def test_train_slcwa(self) -> None:
         """Test that sLCWA training does not fail."""
         loop = SLCWATrainingLoop(
-            model=self.model,
-            optimizer=Adagrad(params=self.model.get_grad_params(), lr=0.001),
+            model=self.instance,
+            optimizer=Adagrad(params=self.instance.get_grad_params(), lr=0.001),
             **(self.training_loop_kwargs or {}),
         )
         losses = self._safe_train_loop(
@@ -855,8 +851,8 @@ class ModelTestCase(unittest.TestCase):
     def test_train_lcwa(self) -> None:
         """Test that LCWA training does not fail."""
         loop = LCWATrainingLoop(
-            model=self.model,
-            optimizer=Adagrad(params=self.model.get_grad_params(), lr=0.001),
+            model=self.instance,
+            optimizer=Adagrad(params=self.instance.get_grad_params(), lr=0.001),
             **(self.training_loop_kwargs or {}),
         )
         losses = self._safe_train_loop(
@@ -880,18 +876,18 @@ class ModelTestCase(unittest.TestCase):
 
     def test_save_load_model_state(self):
         """Test whether a saved model state can be re-loaded."""
-        original_model = self.model_cls(
+        original_model = self.cls(
             triples_factory=self.factory,
             embedding_dim=self.embedding_dim,
             random_seed=42,
-            **(self.model_kwargs or {}),
+            **(self.kwargs or {}),
         ).to_device_()
 
-        loaded_model = self.model_cls(
+        loaded_model = self.cls(
             triples_factory=self.factory,
             embedding_dim=self.embedding_dim,
             random_seed=21,
-            **(self.model_kwargs or {}),
+            **(self.kwargs or {}),
         ).to_device_()
 
         def _equal_embeddings(a: RepresentationModule, b: RepresentationModule) -> bool:
@@ -915,7 +911,7 @@ class ModelTestCase(unittest.TestCase):
     @property
     def cli_extras(self):
         """Return a list of extra flags for the CLI."""
-        kwargs = self.model_kwargs or {}
+        kwargs = self.kwargs or {}
         extras = [
             '--silent',
         ]
@@ -957,10 +953,10 @@ class ModelTestCase(unittest.TestCase):
 
     def _help_test_cli(self, args):
         """Test running the pipeline on all models."""
-        if issubclass(self.model_cls, pykeen.models.RGCN):
-            self.skipTest(f"Cannot choose interaction via CLI for {self.model_cls}.")
+        if issubclass(self.cls, pykeen.models.RGCN):
+            self.skipTest(f"Cannot choose interaction via CLI for {self.cls}.")
         runner = CliRunner()
-        cli = build_cli_from_cls(self.model_cls)
+        cli = build_cli_from_cls(self.cls)
         # TODO: Catch HolE MKL error?
         result: Result = runner.invoke(cli, args)
 
@@ -970,7 +966,7 @@ class ModelTestCase(unittest.TestCase):
             msg=f'''
 Command
 =======
-$ pykeen train {self.model_cls.__name__.lower()} {' '.join(args)}
+$ pykeen train {self.cls.__name__.lower()} {' '.join(args)}
 
 Output
 ======
@@ -989,38 +985,38 @@ Traceback
     def test_has_hpo_defaults(self):
         """Test that there are defaults for HPO."""
         try:
-            d = self.model_cls.hpo_default
+            d = self.cls.hpo_default
         except AttributeError:
-            self.fail(msg=f'{self.model_cls.__name__} is missing hpo_default class attribute')
+            self.fail(msg=f'{self.cls.__name__} is missing hpo_default class attribute')
         else:
             self.assertIsInstance(d, dict)
 
     def test_post_parameter_update_regularizer(self):
         """Test whether post_parameter_update resets the regularization term."""
-        if not hasattr(self.model, 'regularizer'):
+        if not hasattr(self.instance, 'regularizer'):
             self.skipTest('no regularizer')
 
         # set regularizer term to something that isn't zero
-        self.model.regularizer.regularization_term = torch.ones(1, dtype=torch.float, device=self.model.device)
+        self.instance.regularizer.regularization_term = torch.ones(1, dtype=torch.float, device=self.instance.device)
 
         # call post_parameter_update
-        self.model.post_parameter_update()
+        self.instance.post_parameter_update()
 
         # assert that the regularization term has been reset
-        assert self.model.regularizer.regularization_term == torch.zeros(1, dtype=torch.float, device=self.model.device)
+        assert self.instance.regularizer.regularization_term == torch.zeros(1, dtype=torch.float, device=self.instance.device)
 
     def test_post_parameter_update(self):
         """Test whether post_parameter_update correctly enforces model constraints."""
         # do one optimization step
-        opt = optim.SGD(params=self.model.parameters(), lr=1.)
-        batch = self.factory.mapped_triples[:self.batch_size, :].to(self.model.device)
-        scores = self.model.score_hrt(hrt_batch=batch)
+        opt = optim.SGD(params=self.instance.parameters(), lr=1.)
+        batch = self.factory.mapped_triples[:self.batch_size, :].to(self.instance.device)
+        scores = self.instance.score_hrt(hrt_batch=batch)
         fake_loss = scores.mean()
         fake_loss.backward()
         opt.step()
 
         # call post_parameter_update
-        self.model.post_parameter_update()
+        self.instance.post_parameter_update()
 
         # check model constraints
         self._check_constraints()
@@ -1030,15 +1026,15 @@ Traceback
 
     def test_score_h_with_score_hrt_equality(self) -> None:
         """Test the equality of the model's  ``score_h()`` and ``score_hrt()`` function."""
-        batch = self.factory.mapped_triples[:self.batch_size, 1:].to(self.model.device)
-        self.model.eval()
+        batch = self.factory.mapped_triples[:self.batch_size, 1:].to(self.instance.device)
+        self.instance.eval()
         # assert batch comprises (relation, tail) pairs
         assert batch.shape == (self.batch_size, 2)
         assert (batch[:, 0] < self.factory.num_relations).all()
         assert (batch[:, 1] < self.factory.num_entities).all()
         try:
-            scores_h = self.model.score_h(batch)
-            scores_hrt = super(self.model.__class__, self.model).score_h(batch)
+            scores_h = self.instance.score_h(batch)
+            scores_hrt = super(self.instance.__class__, self.instance).score_h(batch)
         except NotImplementedError:
             self.fail(msg='Score_h not yet implemented')
         except RuntimeError as e:
@@ -1051,15 +1047,15 @@ Traceback
 
     def test_score_r_with_score_hrt_equality(self) -> None:
         """Test the equality of the model's  ``score_r()`` and ``score_hrt()`` function."""
-        batch = self.factory.mapped_triples[:self.batch_size, [0, 2]].to(self.model.device)
-        self.model.eval()
+        batch = self.factory.mapped_triples[:self.batch_size, [0, 2]].to(self.instance.device)
+        self.instance.eval()
         # assert batch comprises (relation, tail) pairs
         assert batch.shape == (self.batch_size, 2)
         assert (batch[:, 0] < self.factory.num_entities).all()
         assert (batch[:, 1] < self.factory.num_entities).all()
         try:
-            scores_r = self.model.score_r(batch)
-            scores_hrt = super(self.model.__class__, self.model).score_r(batch)
+            scores_r = self.instance.score_r(batch)
+            scores_hrt = super(self.instance.__class__, self.instance).score_r(batch)
         except NotImplementedError:
             self.fail(msg='Score_h not yet implemented')
         except RuntimeError as e:
@@ -1072,15 +1068,15 @@ Traceback
 
     def test_score_t_with_score_hrt_equality(self) -> None:
         """Test the equality of the model's  ``score_t()`` and ``score_hrt()`` function."""
-        batch = self.factory.mapped_triples[:self.batch_size, :-1].to(self.model.device)
-        self.model.eval()
+        batch = self.factory.mapped_triples[:self.batch_size, :-1].to(self.instance.device)
+        self.instance.eval()
         # assert batch comprises (relation, tail) pairs
         assert batch.shape == (self.batch_size, 2)
         assert (batch[:, 0] < self.factory.num_entities).all()
         assert (batch[:, 1] < self.factory.num_relations).all()
         try:
-            scores_t = self.model.score_t(batch)
-            scores_hrt = super(self.model.__class__, self.model).score_t(batch)
+            scores_t = self.instance.score_t(batch)
+            scores_hrt = super(self.instance.__class__, self.instance).score_t(batch)
         except NotImplementedError:
             self.fail(msg='Score_h not yet implemented')
         except RuntimeError as e:
@@ -1093,12 +1089,12 @@ Traceback
 
     def test_reset_parameters_constructor_call(self):
         """Tests whether reset_parameters is called in the constructor."""
-        with patch.object(self.model_cls, 'reset_parameters_', return_value=None) as mock_method:
+        with patch.object(self.cls, 'reset_parameters_', return_value=None) as mock_method:
             try:
-                self.model_cls(
+                self.cls(
                     triples_factory=self.factory,
                     embedding_dim=self.embedding_dim,
-                    **(self.model_kwargs or {}),
+                    **(self.kwargs or {}),
                 )
             except TypeError as error:
                 assert error.args == ("'NoneType' object is not callable",)
@@ -1106,32 +1102,32 @@ Traceback
 
     def test_custom_representations(self):
         """Tests whether we can provide custom representations."""
-        if isinstance(self.model, EntityEmbeddingModel):
-            old_embeddings = self.model.entity_embeddings
-            self.model.entity_embeddings = CustomRepresentations(
+        if isinstance(self.instance, EntityEmbeddingModel):
+            old_embeddings = self.instance.entity_embeddings
+            self.instance.entity_embeddings = CustomRepresentations(
                 num_entities=self.factory.num_entities,
                 shape=old_embeddings.shape,
             )
             # call some functions
-            self.model.reset_parameters_()
+            self.instance.reset_parameters_()
             self.test_score_hrt()
             self.test_score_t()
             # reset to old state
-            self.model.entity_embeddings = old_embeddings
-        elif isinstance(self.model, EntityRelationEmbeddingModel):
-            old_embeddings = self.model.relation_embeddings
-            self.model.relation_embeddings = CustomRepresentations(
+            self.instance.entity_embeddings = old_embeddings
+        elif isinstance(self.instance, EntityRelationEmbeddingModel):
+            old_embeddings = self.instance.relation_embeddings
+            self.instance.relation_embeddings = CustomRepresentations(
                 num_entities=self.factory.num_relations,
                 shape=old_embeddings.shape,
             )
             # call some functions
-            self.model.reset_parameters_()
+            self.instance.reset_parameters_()
             self.test_score_hrt()
             self.test_score_t()
             # reset to old state
-            self.model.relation_embeddings = old_embeddings
+            self.instance.relation_embeddings = old_embeddings
         else:
-            self.skipTest(f'Not testing custom representations for model: {self.model.__class__.__name__}')
+            self.skipTest(f'Not testing custom representations for model: {self.instance.__class__.__name__}')
 
 
 class DistanceModelTestCase(ModelTestCase):
@@ -1146,7 +1142,7 @@ class DistanceModelTestCase(ModelTestCase):
 class BaseKG2ETest(ModelTestCase):
     """General tests for the KG2E model."""
 
-    model_cls = pykeen.models.KG2E
+    cls = pykeen.models.KG2E
 
     def _check_constraints(self):
         """Check model constraints.
@@ -1154,28 +1150,28 @@ class BaseKG2ETest(ModelTestCase):
         * Entity and relation embeddings have to have at most unit L2 norm.
         * Covariances have to have values between c_min and c_max
         """
-        for embedding in (self.model.entity_embeddings, self.model.relation_embeddings):
+        for embedding in (self.instance.entity_embeddings, self.instance.relation_embeddings):
             assert all_in_bounds(embedding(indices=None).norm(p=2, dim=-1), high=1., a_tol=EPSILON)
-        for cov in (self.model.entity_covariances, self.model.relation_covariances):
-            assert all_in_bounds(cov(indices=None), low=self.model.c_min, high=self.model.c_max)
+        for cov in (self.instance.entity_covariances, self.instance.relation_covariances):
+            assert all_in_bounds(cov(indices=None), low=self.instance.c_min, high=self.instance.c_max)
 
 
 class BaseNTNTest(ModelTestCase):
     """Test the NTN model."""
 
-    model_cls = pykeen.models.NTN
+    cls = pykeen.models.NTN
 
     def test_can_slice(self):
         """Test that the slicing properties are calculated correctly."""
-        self.assertTrue(self.model.can_slice_h)
-        self.assertFalse(self.model.can_slice_r)
-        self.assertTrue(self.model.can_slice_t)
+        self.assertTrue(self.instance.can_slice_h)
+        self.assertFalse(self.instance.can_slice_r)
+        self.assertTrue(self.instance.can_slice_t)
 
 
 class BaseRGCNTest(ModelTestCase):
     """Test the R-GCN model."""
 
-    model_cls = pykeen.models.RGCN
+    cls = pykeen.models.RGCN
     sampler = 'schlichtkrull'
 
     def _check_constraints(self):
@@ -1183,7 +1179,7 @@ class BaseRGCNTest(ModelTestCase):
 
         Enriched embeddings have to be reset.
         """
-        assert self.model.entity_representations[0].enriched_embeddings is None
+        assert self.instance.entity_representations[0].enriched_embeddings is None
 
 
 class RepresentationTestCase(GenericTestCase[RepresentationModule]):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import numpy
 import torch
+import unittest_templates
 
 import pykeen.experiments
 import pykeen.models
@@ -22,21 +23,23 @@ from pykeen.nn.emb import Embedding
 from pykeen.utils import all_in_bounds, clamp_norm, extend_batch
 from tests import cases
 from tests.constants import EPSILON
+from tests.mocks import MockModel
+from tests.test_model_mode import SimpleInteractionModel
 
 SKIP_MODULES = {
-    Model.__name__,
-    _OldAbstractModel.__name__,
-    _NewAbstractModel.__name__,
-    'DummyModel',
-    MultimodalModel.__name__,
-    EntityEmbeddingModel.__name__,
-    EntityRelationEmbeddingModel.__name__,
-    ERModel.__name__,
-    'MockModel',
-    'SimpleInteractionModel',
+    Model,
+    _OldAbstractModel,
+    _NewAbstractModel,
+    # DummyModel,
+    MultimodalModel,
+    EntityEmbeddingModel,
+    EntityRelationEmbeddingModel,
+    ERModel,
+    MockModel,
+    SimpleInteractionModel,
 }
 for cls in MultimodalModel.__subclasses__():
-    SKIP_MODULES.add(cls.__name__)
+    SKIP_MODULES.add(cls)
 
 
 class TestComplex(cases.ModelTestCase):
@@ -581,8 +584,12 @@ class TestUM(cases.DistanceModelTestCase):
     cls = pykeen.models.UnstructuredModel
 
 
-class TestTesting(unittest.TestCase):
+class TestTesting(unittest_templates.MetaTestCase[Model]):
     """Yo dawg, I heard you like testing, so I wrote a test to test the tests so you can test while you're testing."""
+
+    base_test = cases.ModelTestCase
+    base_cls = Model
+    skip_cls = SKIP_MODULES
 
     def test_documentation(self):
         """Test all models have appropriate structured documentation."""
@@ -596,32 +603,6 @@ class TestTesting(unittest.TestCase):
                 self.assertIn('author', docdata['citation'])
                 self.assertIn('link', docdata['citation'])
                 self.assertIn('year', docdata['citation'])
-
-    def test_testing(self):
-        """Check that there's a test for all models.
-
-        For now, this is excluding multimodel models. Not sure how to test those yet.
-        """
-        model_names = {
-            cls.__name__
-            for cls in model_resolver.lookup_dict.values()
-            if not issubclass(cls, ERModel)
-        }
-        model_names -= SKIP_MODULES
-
-        tested_model_names = {
-            value.cls.__name__
-            for name, value in globals().items()
-            if (
-                isinstance(value, type)
-                and issubclass(value, cases.ModelTestCase)
-                and not name.startswith('_')
-                and not issubclass(value.cls, (ERModel, MultimodalModel))
-            )
-        }
-        tested_model_names -= SKIP_MODULES
-
-        self.assertEqual(model_names, tested_model_names, msg='Some models have not been tested')
 
     def test_importing(self):
         """Test that all models are available from :mod:`pykeen.models`."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,16 +42,16 @@ for cls in MultimodalModel.__subclasses__():
 class TestComplex(cases.ModelTestCase):
     """Test the ComplEx model."""
 
-    model_cls = pykeen.models.ComplEx
+    cls = pykeen.models.ComplEx
 
 
 class TestConvE(cases.ModelTestCase):
     """Test the ConvE model."""
 
-    model_cls = pykeen.models.ConvE
+    cls = pykeen.models.ConvE
     embedding_dim = 12
     create_inverse_triples = True
-    model_kwargs = {
+    kwargs = {
         'output_channels': 2,
         'embedding_height': 3,
         'embedding_width': 4,
@@ -66,8 +66,8 @@ class TestConvE(cases.ModelTestCase):
 class TestConvKB(cases.ModelTestCase):
     """Test the ConvKB model."""
 
-    model_cls = pykeen.models.ConvKB
-    model_kwargs = {
+    cls = pykeen.models.ConvKB
+    kwargs = {
         'num_filters': 2,
     }
     # two bias terms, one conv-filter
@@ -77,14 +77,14 @@ class TestConvKB(cases.ModelTestCase):
 class TestDistMult(cases.ModelTestCase):
     """Test the DistMult model."""
 
-    model_cls = pykeen.models.DistMult
+    cls = pykeen.models.DistMult
 
     def _check_constraints(self):
         """Check model constraints.
 
         Entity embeddings have to have unit L2 norm.
         """
-        entity_norms = self.model.entity_embeddings(indices=None).norm(p=2, dim=-1)
+        entity_norms = self.instance.entity_embeddings(indices=None).norm(p=2, dim=-1)
         assert torch.allclose(entity_norms, torch.ones_like(entity_norms))
 
     def _test_score_all_triples(self, k: Optional[int], batch_size: int = 16):
@@ -93,7 +93,7 @@ class TestDistMult(cases.ModelTestCase):
         :param k: The number of triples to return. Set to None, to keep all.
         :param batch_size: The batch size to use for calculating scores.
         """
-        top_triples, top_scores = predict(model=self.model, batch_size=batch_size, k=k)
+        top_triples, top_scores = predict(model=self.instance, batch_size=batch_size, k=k)
 
         # check type
         assert torch.is_tensor(top_triples)
@@ -112,8 +112,8 @@ class TestDistMult(cases.ModelTestCase):
 
         # check ID ranges
         assert (top_triples >= 0).all()
-        assert top_triples[:, [0, 2]].max() < self.model.num_entities
-        assert top_triples[:, 1].max() < self.model.num_relations
+        assert top_triples[:, [0, 2]].max() < self.instance.num_entities
+        assert top_triples[:, 1].max() < self.instance.num_relations
 
     def test_score_all_triples(self):
         """Test score_all_triples with a large batch size."""
@@ -137,8 +137,8 @@ class TestDistMult(cases.ModelTestCase):
 class TestERMLP(cases.ModelTestCase):
     """Test the ERMLP model."""
 
-    model_cls = pykeen.models.ERMLP
-    model_kwargs = {
+    cls = pykeen.models.ERMLP
+    kwargs = {
         'hidden_dim': 4,
     }
     # Two linear layer biases
@@ -148,8 +148,8 @@ class TestERMLP(cases.ModelTestCase):
 class TestERMLPE(cases.ModelTestCase):
     """Test the extended ERMLP model."""
 
-    model_cls = pykeen.models.ERMLPE
-    model_kwargs = {
+    cls = pykeen.models.ERMLPE
+    kwargs = {
         'hidden_dim': 4,
     }
     # Two BN layers, bias & scale
@@ -159,20 +159,20 @@ class TestERMLPE(cases.ModelTestCase):
 class TestHolE(cases.ModelTestCase):
     """Test the HolE model."""
 
-    model_cls = pykeen.models.HolE
+    cls = pykeen.models.HolE
 
     def _check_constraints(self):
         """Check model constraints.
 
         Entity embeddings have to have at most unit L2 norm.
         """
-        assert all_in_bounds(self.model.entity_embeddings(indices=None).norm(p=2, dim=-1), high=1., a_tol=EPSILON)
+        assert all_in_bounds(self.instance.entity_embeddings(indices=None).norm(p=2, dim=-1), high=1., a_tol=EPSILON)
 
 
 class TestKG2EWithKL(cases.BaseKG2ETest):
     """Test the KG2E model with KL similarity."""
 
-    model_kwargs = {
+    kwargs = {
         'dist_similarity': 'KL',
     }
 
@@ -180,14 +180,14 @@ class TestKG2EWithKL(cases.BaseKG2ETest):
 class TestMuRE(cases.ModelTestCase):
     """Test the MuRE model."""
 
-    model_cls = pykeen.models.MuRE
+    cls = pykeen.models.MuRE
     num_constant_init = 2  # biases
 
 
 class TestKG2EWithEL(cases.BaseKG2ETest):
     """Test the KG2E model with EL similarity."""
 
-    model_kwargs = {
+    kwargs = {
         'dist_similarity': 'EL',
     }
 
@@ -195,7 +195,7 @@ class TestKG2EWithEL(cases.BaseKG2ETest):
 class TestNTNLowMemory(cases.BaseNTNTest):
     """Test the NTN model with automatic memory optimization."""
 
-    model_kwargs = {
+    kwargs = {
         'num_slices': 2,
     }
 
@@ -207,7 +207,7 @@ class TestNTNLowMemory(cases.BaseNTNTest):
 class TestNTNHighMemory(cases.BaseNTNTest):
     """Test the NTN model without automatic memory optimization."""
 
-    model_kwargs = {
+    kwargs = {
         'num_slices': 2,
     }
 
@@ -219,13 +219,13 @@ class TestNTNHighMemory(cases.BaseNTNTest):
 class TestProjE(cases.ModelTestCase):
     """Test the ProjE model."""
 
-    model_cls = pykeen.models.ProjE
+    cls = pykeen.models.ProjE
 
 
 class TestQuatE(cases.ModelTestCase):
     """Test the QuatE model."""
 
-    model_cls = pykeen.models.QuatE
+    cls = pykeen.models.QuatE
     # quaternion have four components
     embedding_dim = 4 * cases.ModelTestCase.embedding_dim
 
@@ -233,13 +233,13 @@ class TestQuatE(cases.ModelTestCase):
 class TestRESCAL(cases.ModelTestCase):
     """Test the RESCAL model."""
 
-    model_cls = pykeen.models.RESCAL
+    cls = pykeen.models.RESCAL
 
 
 class TestRGCNBasis(cases.BaseRGCNTest):
     """Test the R-GCN model."""
 
-    model_kwargs = {
+    kwargs = {
         'interaction': "transe",
         'interaction_kwargs': dict(p=1),
         'decomposition': "bases",
@@ -255,7 +255,7 @@ class TestRGCNBlock(cases.BaseRGCNTest):
     """Test the R-GCN model with block decomposition."""
 
     embedding_dim = 6
-    model_kwargs = {
+    kwargs = {
         'interaction': "distmult",
         'decomposition': "block",
         "decomposition_kwargs": dict(
@@ -271,7 +271,7 @@ class TestRGCNBlock(cases.BaseRGCNTest):
 class TestRotatE(cases.ModelTestCase):
     """Test the RotatE model."""
 
-    model_cls = pykeen.models.RotatE
+    cls = pykeen.models.RotatE
 
     def _check_constraints(self):
         """Check model constraints.
@@ -279,7 +279,7 @@ class TestRotatE(cases.ModelTestCase):
         Relation embeddings' entries have to have absolute value 1 (i.e. represent a rotation in complex plane)
         """
         relation_abs = (
-            self.model
+            self.instance
                 .relation_embeddings(indices=None)
                 .view(self.factory.num_relations, -1, 2)
                 .norm(p=2, dim=-1)
@@ -290,20 +290,20 @@ class TestRotatE(cases.ModelTestCase):
 class TestSimplE(cases.ModelTestCase):
     """Test the SimplE model."""
 
-    model_cls = pykeen.models.SimplE
+    cls = pykeen.models.SimplE
 
 
 class _BaseTestSE(cases.ModelTestCase):
     """Test the Structured Embedding model."""
 
-    model_cls = pykeen.models.StructuredEmbedding
+    cls = pykeen.models.StructuredEmbedding
 
     def _check_constraints(self):
         """Check model constraints.
 
         Entity embeddings have to have unit L2 norm.
         """
-        norms = self.model.entity_embeddings(indices=None).norm(p=2, dim=-1)
+        norms = self.instance.entity_embeddings(indices=None).norm(p=2, dim=-1)
         assert torch.allclose(norms, torch.ones_like(norms))
 
 
@@ -326,8 +326,8 @@ class TestSEHighMemory(_BaseTestSE):
 class TestTransD(cases.DistanceModelTestCase):
     """Test the TransD model."""
 
-    model_cls = pykeen.models.TransD
-    model_kwargs = {
+    cls = pykeen.models.TransD
+    kwargs = {
         'relation_dim': 4,
     }
 
@@ -336,7 +336,7 @@ class TestTransD(cases.DistanceModelTestCase):
 
         Entity and relation embeddings have to have at most unit L2 norm.
         """
-        for emb in (self.model.entity_embeddings, self.model.relation_embeddings):
+        for emb in (self.instance.entity_embeddings, self.instance.relation_embeddings):
             assert all_in_bounds(emb(indices=None).norm(p=2, dim=-1), high=1., a_tol=EPSILON)
 
     def test_score_hrt_manual(self):
@@ -348,7 +348,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         entity_embeddings._embeddings.weight.data.copy_(weights)
-        self.model.entity_embeddings = entity_embeddings
+        self.instance.entity_embeddings = entity_embeddings
 
         projection_weights = torch.as_tensor(data=[[3., 3.], [2., 2.]], dtype=torch.float)
         entity_projection_embeddings = Embedding(
@@ -356,7 +356,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         entity_projection_embeddings._embeddings.weight.data.copy_(projection_weights)
-        self.model.entity_projections = entity_projection_embeddings
+        self.instance.entity_projections = entity_projection_embeddings
 
         # relation embeddings
         relation_weights = torch.as_tensor(data=[[4.], [4.]], dtype=torch.float)
@@ -365,7 +365,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=1,
         )
         relation_embeddings._embeddings.weight.data.copy_(relation_weights)
-        self.model.relation_embeddings = relation_embeddings
+        self.instance.relation_embeddings = relation_embeddings
 
         relation_projection_weights = torch.as_tensor(data=[[5.], [3.]], dtype=torch.float)
         relation_projection_embeddings = Embedding(
@@ -373,11 +373,11 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=1,
         )
         relation_projection_embeddings._embeddings.weight.data.copy_(relation_projection_weights)
-        self.model.relation_projections = relation_projection_embeddings
+        self.instance.relation_projections = relation_projection_embeddings
 
         # Compute Scores
         batch = torch.as_tensor(data=[[0, 0, 0], [0, 0, 1]], dtype=torch.long)
-        scores = self.model.score_hrt(hrt_batch=batch)
+        scores = self.instance.score_hrt(hrt_batch=batch)
         self.assertEqual(scores.shape[0], 2)
         self.assertEqual(scores.shape[1], 1)
         first_score = scores[0].item()
@@ -391,7 +391,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=3,
         )
         relation_embeddings._embeddings.weight.data.copy_(relation_weights)
-        self.model.relation_embeddings = relation_embeddings
+        self.instance.relation_embeddings = relation_embeddings
 
         relation_projection_weights = torch.as_tensor(data=[[4., 4., 4.], [4., 4., 4.]], dtype=torch.float)
         relation_projection_embeddings = Embedding(
@@ -399,15 +399,15 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=3,
         )
         relation_projection_embeddings._embeddings.weight.data.copy_(relation_projection_weights)
-        self.model.relation_projections = relation_projection_embeddings
+        self.instance.relation_projections = relation_projection_embeddings
 
         # Compute Scores
         batch = torch.as_tensor(data=[[0, 0, 0]], dtype=torch.long)
-        scores = self.model.score_hrt(hrt_batch=batch)
+        scores = self.instance.score_hrt(hrt_batch=batch)
         self.assertAlmostEqual(scores.item(), -27, delta=0.01)
 
         batch = torch.as_tensor(data=[[0, 0, 0], [0, 0, 0]], dtype=torch.long)
-        scores = self.model.score_hrt(hrt_batch=batch)
+        scores = self.instance.score_hrt(hrt_batch=batch)
         self.assertEqual(scores.shape[0], 2)
         self.assertEqual(scores.shape[1], 1)
         first_score = scores[0].item()
@@ -423,7 +423,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=3,
         )
         entity_embeddings._embeddings.weight.data.copy_(weights)
-        self.model.entity_embeddings = entity_embeddings
+        self.instance.entity_embeddings = entity_embeddings
 
         projection_weights = torch.as_tensor(data=[[2., 2., 2.], [2., 2., 2.]], dtype=torch.float)
         entity_projection_embeddings = Embedding(
@@ -431,7 +431,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=3,
         )
         entity_projection_embeddings._embeddings.weight.data.copy_(projection_weights)
-        self.model.entity_projections = entity_projection_embeddings
+        self.instance.entity_projections = entity_projection_embeddings
 
         # relation embeddings
         relation_weights = torch.as_tensor(data=[[3., 3.], [3., 3.]], dtype=torch.float)
@@ -440,7 +440,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         relation_embeddings._embeddings.weight.data.copy_(relation_weights)
-        self.model.relation_embeddings = relation_embeddings
+        self.instance.relation_embeddings = relation_embeddings
 
         relation_projection_weights = torch.as_tensor(data=[[4., 4.], [4., 4.]], dtype=torch.float)
         relation_projection_embeddings = Embedding(
@@ -448,11 +448,11 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         relation_projection_embeddings._embeddings.weight.data.copy_(relation_projection_weights)
-        self.model.relation_projections = relation_projection_embeddings
+        self.instance.relation_projections = relation_projection_embeddings
 
         # Compute Scores
         batch = torch.as_tensor(data=[[0, 0, 0], [0, 0, 0]], dtype=torch.long)
-        scores = self.model.score_hrt(hrt_batch=batch)
+        scores = self.instance.score_hrt(hrt_batch=batch)
         self.assertEqual(scores.shape[0], 2)
         self.assertEqual(scores.shape[1], 1)
         first_score = scores[0].item()
@@ -463,20 +463,20 @@ class TestTransD(cases.DistanceModelTestCase):
     def test_project_entity(self):
         """Test _project_entity."""
         # random entity embeddings & projections
-        e = torch.rand(1, self.model.num_entities, self.embedding_dim, generator=self.generator)
+        e = torch.rand(1, self.instance.num_entities, self.embedding_dim, generator=self.generator)
         e = clamp_norm(e, maxnorm=1, p=2, dim=-1)
-        e_p = torch.rand(1, self.model.num_entities, self.embedding_dim, generator=self.generator)
+        e_p = torch.rand(1, self.instance.num_entities, self.embedding_dim, generator=self.generator)
 
         # random relation embeddings & projections
-        r = torch.rand(self.batch_size, 1, self.model.relation_dim, generator=self.generator)
+        r = torch.rand(self.batch_size, 1, self.instance.relation_dim, generator=self.generator)
         r = clamp_norm(r, maxnorm=1, p=2, dim=-1)
-        r_p = torch.rand(self.batch_size, 1, self.model.relation_dim, generator=self.generator)
+        r_p = torch.rand(self.batch_size, 1, self.instance.relation_dim, generator=self.generator)
 
         # project
         e_bot = _project_entity(e=e, e_p=e_p, r=r, r_p=r_p)
 
         # check shape:
-        assert e_bot.shape == (self.batch_size, self.model.num_entities, self.model.relation_dim)
+        assert e_bot.shape == (self.batch_size, self.instance.num_entities, self.instance.relation_dim)
 
         # check normalization
         assert (torch.norm(e_bot, dim=-1, p=2) <= 1.0 + 1.0e-06).all()
@@ -485,36 +485,36 @@ class TestTransD(cases.DistanceModelTestCase):
 class TestTransE(cases.DistanceModelTestCase):
     """Test the TransE model."""
 
-    model_cls = pykeen.models.TransE
+    cls = pykeen.models.TransE
 
     def _check_constraints(self):
         """Check model constraints.
 
         Entity embeddings have to have unit L2 norm.
         """
-        entity_norms = self.model.entity_embeddings(indices=None).norm(p=2, dim=-1)
+        entity_norms = self.instance.entity_embeddings(indices=None).norm(p=2, dim=-1)
         assert torch.allclose(entity_norms, torch.ones_like(entity_norms))
 
 
 class TestTransH(cases.DistanceModelTestCase):
     """Test the TransH model."""
 
-    model_cls = pykeen.models.TransH
+    cls = pykeen.models.TransH
 
     def _check_constraints(self):
         """Check model constraints.
 
         Entity embeddings have to have unit L2 norm.
         """
-        entity_norms = self.model.normal_vector_embeddings(indices=None).norm(p=2, dim=-1)
+        entity_norms = self.instance.normal_vector_embeddings(indices=None).norm(p=2, dim=-1)
         assert torch.allclose(entity_norms, torch.ones_like(entity_norms))
 
 
 class TestTransR(cases.DistanceModelTestCase):
     """Test the TransR model."""
 
-    model_cls = pykeen.models.TransR
-    model_kwargs = {
+    cls = pykeen.models.TransR
+    kwargs = {
         'relation_dim': 4,
     }
 
@@ -527,7 +527,7 @@ class TestTransR(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         entity_embeddings._embeddings.weight.data.copy_(weights)
-        self.model.entity_embeddings = entity_embeddings
+        self.instance.entity_embeddings = entity_embeddings
 
         # relation embeddings
         relation_weights = torch.as_tensor(data=[[4., 4], [5., 5.]], dtype=torch.float)
@@ -536,7 +536,7 @@ class TestTransR(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         relation_embeddings._embeddings.weight.data.copy_(relation_weights)
-        self.model.relation_embeddings = relation_embeddings
+        self.instance.relation_embeddings = relation_embeddings
 
         relation_projection_weights = torch.as_tensor(data=[[5., 5., 6., 6.], [7., 7., 8., 8.]], dtype=torch.float)
         relation_projection_embeddings = Embedding(
@@ -544,11 +544,11 @@ class TestTransR(cases.DistanceModelTestCase):
             embedding_dim=4,
         )
         relation_projection_embeddings._embeddings.weight.data.copy_(relation_projection_weights)
-        self.model.relation_projections = relation_projection_embeddings
+        self.instance.relation_projections = relation_projection_embeddings
 
         # Compute Scores
         batch = torch.as_tensor(data=[[0, 0, 0], [0, 0, 1]], dtype=torch.long)
-        scores = self.model.score_hrt(hrt_batch=batch)
+        scores = self.instance.score_hrt(hrt_batch=batch)
         self.assertEqual(scores.shape[0], 2)
         self.assertEqual(scores.shape[1], 1)
         first_score = scores[0].item()
@@ -560,15 +560,15 @@ class TestTransR(cases.DistanceModelTestCase):
 
         Entity and relation embeddings have to have at most unit L2 norm.
         """
-        for emb in (self.model.entity_embeddings, self.model.relation_embeddings):
+        for emb in (self.instance.entity_embeddings, self.instance.relation_embeddings):
             assert all_in_bounds(emb(indices=None).norm(p=2, dim=-1), high=1., a_tol=1.0e-06)
 
 
 class TestTuckEr(cases.ModelTestCase):
     """Test the TuckEr model."""
 
-    model_cls = pykeen.models.TuckER
-    model_kwargs = {
+    cls = pykeen.models.TuckER
+    kwargs = {
         'relation_dim': 4,
     }
     #: 2xBN (bias & scale)
@@ -578,7 +578,7 @@ class TestTuckEr(cases.ModelTestCase):
 class TestUM(cases.DistanceModelTestCase):
     """Test the Unstructured Model."""
 
-    model_cls = pykeen.models.UnstructuredModel
+    cls = pykeen.models.UnstructuredModel
 
 
 class TestTesting(unittest.TestCase):
@@ -586,10 +586,10 @@ class TestTesting(unittest.TestCase):
 
     def test_documentation(self):
         """Test all models have appropriate structured documentation."""
-        for name, model_cls in sorted(model_resolver.lookup_dict.items()):
+        for name, cls in sorted(model_resolver.lookup_dict.items()):
             with self.subTest(name=name):
                 try:
-                    docdata = model_cls.__docdata__
+                    docdata = cls.__docdata__
                 except AttributeError:
                     self.fail('missing __docdata__')
                 self.assertIn('citation', docdata)
@@ -603,20 +603,20 @@ class TestTesting(unittest.TestCase):
         For now, this is excluding multimodel models. Not sure how to test those yet.
         """
         model_names = {
-            model_cls.__name__
-            for model_cls in model_resolver.lookup_dict.values()
-            if not issubclass(model_cls, ERModel)
+            cls.__name__
+            for cls in model_resolver.lookup_dict.values()
+            if not issubclass(cls, ERModel)
         }
         model_names -= SKIP_MODULES
 
         tested_model_names = {
-            value.model_cls.__name__
+            value.cls.__name__
             for name, value in globals().items()
             if (
                 isinstance(value, type)
                 and issubclass(value, cases.ModelTestCase)
                 and not name.startswith('_')
-                and not issubclass(value.model_cls, (ERModel, MultimodalModel))
+                and not issubclass(value.cls, (ERModel, MultimodalModel))
             )
         }
         tested_model_names -= SKIP_MODULES
@@ -699,10 +699,10 @@ class TestModelUtilities(unittest.TestCase):
         self.assertTrue(EntityEmbeddingModel._is_base_model)
         self.assertTrue(EntityRelationEmbeddingModel._is_base_model)
         self.assertTrue(MultimodalModel._is_base_model)
-        for model_cls in _MODELS:
+        for cls in _MODELS:
             self.assertFalse(
-                model_cls._is_base_model,
-                msg=f'{model_cls.__name__} should not be marked as a a base model',
+                cls._is_base_model,
+                msg=f'{cls.__name__} should not be marked as a a base model',
             )
 
     def test_get_novelty_mask(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -219,6 +219,12 @@ class TestNTNHighMemory(cases.BaseNTNTest):
     }
 
 
+class TestPairRE(cases.ModelTestCase):
+    """Test the PairRE model."""
+
+    cls = pykeen.models.PairRE
+
+
 class TestProjE(cases.ModelTestCase):
     """Test the ProjE model."""
 


### PR DESCRIPTION
This PR updates the model tests to use the `unittest_templates` package.

It also adds a missing test for PairRE.


Besides reducing code duplication, it also enables modifying the default kwargs passed to the models, necessary for tests in #382 .