### PR TITLE
🌼 🔍 Add filterer for negative samples based on Bloom Filter

### DIFF
--- a/docs/source/reference/negative_sampling.rst
+++ b/docs/source/reference/negative_sampling.rst
@@ -2,10 +2,10 @@ Negative Sampling
 =================
 .. automodapi:: pykeen.sampling
     :no-heading:
-    :headings: --
+    :headings: ~~
 
 Filtering
----------
+=========
 .. automodapi:: pykeen.sampling.filtering
     :no-heading:
-    :headings: --
+    :headings: ~~

--- a/docs/source/reference/negative_sampling.rst
+++ b/docs/source/reference/negative_sampling.rst
@@ -2,10 +2,10 @@ Negative Sampling
 =================
 .. automodapi:: pykeen.sampling
     :no-heading:
-    :headings: ~~
+    :headings: --
 
 Filtering
 =========
 .. automodapi:: pykeen.sampling.filtering
     :no-heading:
-    :headings: ~~
+    :headings: --

--- a/docs/source/tutorial/understanding_evaluation.rst
+++ b/docs/source/tutorial/understanding_evaluation.rst
@@ -172,13 +172,12 @@ incapability to solve of one the tasks.
 
 Filtering
 ~~~~~~~~~
-The rank-based evaluation allows using the "filtered setting" motivated by [bordes2013]_, which is enabled by default.
-When evaluating the tail prediction for a triple :math:`(h, r, t)`, i.e. scoring all triples :math:`(h, r, e)`, there
-may be additional known triples :math:`(h, r, t')` for :math:`t \neq t'`. If the model predicts a higher score for
-:math:`(h, r, t')`, the rank will increase, and hence the measured model performance will decrease. However, giving
-:math:`(h, r, t')` a high score (and thus a low rank) is desirable since it is a true triple as well. Thus, the
-filtered evaluation setting ignores for a given triple :math:`(h, r, t)` the scores of all other *known* true triples
-:math:`(h, r, t')`.
+The formulation of standard negative sampling algorithms leads to the generation of known false negatives, which will
+have low ranks and therefore worsen the metrics reported during rank-based evaluation. The "filtered setting" proposed
+by [bordes2013]_ can remove known false negatives, but it comes with a large performance cost. Since the number of
+false negatives is effectively small, this correction can be reasonably omitted. By default, PyKEEN does *not*
+enable the "filtered setting", but it does implement several variants that are described in detail in
+:mod:`pykeen.sampling.filtering`.
 
 Entity and Relation Restriction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorial/understanding_evaluation.rst
+++ b/docs/source/tutorial/understanding_evaluation.rst
@@ -172,9 +172,9 @@ incapability to solve of one the tasks.
 
 Filtering
 ~~~~~~~~~
-The rank-based evaluation allows using the "filtered setting", which is enabled by default. When evaluating
-the tail prediction for a triple :math:`(h, r, t)`, i.e. scoring all triples :math:`(h, r, e)`, there may be
-additional known triples :math:`(h, r, t')` for :math:`t \neq t'`. If the model predicts a higher score for
+The rank-based evaluation allows using the "filtered setting" motivated by [bordes2013]_, which is enabled by default.
+When evaluating the tail prediction for a triple :math:`(h, r, t)`, i.e. scoring all triples :math:`(h, r, e)`, there
+may be additional known triples :math:`(h, r, t')` for :math:`t \neq t'`. If the model predicts a higher score for
 :math:`(h, r, t')`, the rank will increase, and hence the measured model performance will decrease. However, giving
 :math:`(h, r, t')` a high score (and thus a low rank) is desirable since it is a true triple as well. Thus, the
 filtered evaluation setting ignores for a given triple :math:`(h, r, t)` the scores of all other *known* true triples

--- a/docs/source/tutorial/understanding_evaluation.rst
+++ b/docs/source/tutorial/understanding_evaluation.rst
@@ -172,12 +172,13 @@ incapability to solve of one the tasks.
 
 Filtering
 ~~~~~~~~~
-The formulation of standard negative sampling algorithms leads to the generation of known false negatives, which will
-have low ranks and therefore worsen the metrics reported during rank-based evaluation. The "filtered setting" proposed
-by [bordes2013]_ can remove known false negatives, but it comes with a large performance cost. Since the number of
-false negatives is effectively small, this correction can be reasonably omitted. By default, PyKEEN does *not*
-enable the "filtered setting", but it does implement several variants that are described in detail in
-:mod:`pykeen.sampling.filtering`.
+The rank-based evaluation allows using the "filtered setting", proposed by [bordes2013]_, which is enabled by default.
+When evaluating the tail prediction for a triple :math:`(h, r, t)`, i.e. scoring all triples :math:`(h, r, e)`, there
+may be additional known triples :math:`(h, r, t')` for :math:`t \neq t'`. If the model predicts a higher score for
+:math:`(h, r, t')`, the rank will increase, and hence the measured model performance will decrease. However, giving
+:math:`(h, r, t')` a high score (and thus a low rank) is desirable since it is a true triple as well. Thus, the
+filtered evaluation setting ignores for a given triple :math:`(h, r, t)` the scores of all other *known* true triples
+:math:`(h, r, t')`.
 
 Entity and Relation Restriction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ install_requires =
     more_click
     pystow>=0.0.3
     docdata
-    class_resolver
+    class_resolver>=0.0.7
 
 zip_safe = false
 include_package_data = True

--- a/src/pykeen/sampling/__init__.py
+++ b/src/pykeen/sampling/__init__.py
@@ -1,34 +1,112 @@
 # -*- coding: utf-8 -*-
 
-r"""Because most knowledge graphs are generated under the open world assumption, knowledge
-graph embedding models must be trained involving techniques such as negative sampling to
-avoid over-generalization.
+r"""For entities $\mathcal{E}$ and relations $\mathcal{R}$, the set of all possible triples $\mathcal{T}$ is 
+constructed through their cartesian product $\mathcal{T} = \mathcal{E} \times \mathcal{R} \times \mathcal{E}$.
+A given knowledge graph $\mathcal{K}$ is a subset of all possible triples $\mathcal{K} \subseteq \mathcal{T}$.
 
-Two common approaches for generating negative samples are :class:`pykeen.sampling.BasicNegativeSampler`
-and :class:`pykeen.sampling.BernoulliBasicSampler` in which negative triples are created by corrupting
-a positive triple $(h,r,t) \in \mathcal{K}$ by replacing either $h$ or $t$.
-We denote with $\mathcal{N}$ the set of all potential negative triples:
+Construction of Knowledge Graphs
+--------------------------------
+When constructing a knowledge graph $\mathcal{K}_{\text{closed}}$ under the closed world assumption, the labels of the 
+remaining triples $(h,r,t) \in \mathcal{T} \setminus \mathcal{K}_{\text{closed}}$ are defined as negative. 
+When constructing a knowledge graph $\mathcal{K}_{\text{open}}$ under the open world assumption, the labels of the
+remaining triples $(h,r,t) \in \mathcal{T} \setminus \mathcal{K}_{\text{open}}$ are unknown.
+
+Becuase most knowledge graphs are generated under the open world assumption, negative sampling techniques
+must be employed during the training of knowledge graph embedding models to avoid over-generalization.
+
+Corruption
+----------
+Negative sampling techniques often generate negative triples by corrupting a known positive triple
+$(h,r,t) \in \mathcal{K}$ by replacing either $h$, $r$, or $t$ with one of the following operations:
+
+=================  =====================================================================================
+Corrupt heads      :math:`\mathcal{H}(h, r, t) = \{(h', r, t) \mid h' \in \mathcal{E} \land h' \neq h\}`
+Corrupt relations  :math:`\mathcal{R}(h, r, t) = \{(h, r', t) \mid r' \in \mathcal{E} \land r' \neq r\}`
+Corrupt tails      :math:`\mathcal{T}(h, r, t) = \{(h, r, t') \mid t' \in \mathcal{E} \land t' \neq t\}`
+=================  =====================================================================================
+
+Typically, the corrupt relations operation $\mathcal{R}(h, r, t)$ is omitted becuase the evaluation of knowledge
+graph embedding models on the link prediction task only consideres the goodness of head prediction and tail
+prediction, but not relation prediction. Therefore, the set of candidate negative triples $\mathcal{N}(h, r, t)$ for
+a given known positive triple $(h,r,t) \in \mathcal{K}$ is given by:
 
 .. math::
-    \mathcal{N} &=& \bigcup_{(h,r,t) \in \mathcal{K}} \mathcal{N}(h, r, t)\\
-    \mathcal{N}(h, r, t) &=& \mathcal{T}(h, r) \cup \mathcal{H}(r, t)\\
-    \mathcal{T}(h, r) &=& \{(h, r, t') \mid t' \in \mathcal{E} \land t' \neq t\}\\
-    \mathcal{H}(r, t) &=& \{(h', r, t) \mid h' \in \mathcal{E} \land h' \neq h\}
 
-In theory, all positive triples in $\mathcal{K}$ should be excluded from this set of candidate negative
-triples $\mathcal{N}$ such that $\mathcal{N}^- = \mathcal{N} \setminus \mathcal{K}$. If these false
-negatives are ranked higher than testing triples during evaluation, the resulting metrics become less
-accurate.
+    \mathcal{N}(h, r, t) = \mathcal{T}(h, r, t) \cup \mathcal{H}(h, r, t)
 
-An algorithm for removing these false negatives was proposed in [bordes2013]_.
-In practice, however, since usually $|\mathcal{N}| \gg |\mathcal{K}|$, the likelihood of generating a false
-negative is rather low. Therefore, the additional filter step is often omitted to lower computational cost.
+Generally, the set of potential negative triples $\mathcal{N}$ over all positive triples $(h,r,t) \in \mathcal{K}$
+is defined as:
 
-.. warning:: 
+.. math::
 
-    It should be taken into account that a corrupted triple that is *not part*
-    of the knowledge graph can represent a true fact. These false negatives can
-    not be removed *a priori* in the filtered setting because they are unknown.
+    \mathcal{N} = \bigcup_{(h,r,t) \in \mathcal{K}} \mathcal{N}(h, r, t)
+
+Uniform Negative Sampling
+~~~~~~~~~~~~~~~~~~~~~~~~~
+The default negative sampler :class:`pykeen.sampling.BasicNegativeSampler` generates corrupted triples from
+a known positive triple $(h,r,t) \in \mathcal{K}$ by uniformly randomly either using the corrupt heads operation
+or the corrupt tails operation. The default negative sampler is automatically used in the following code:
+
+.. code-block:: python
+
+    from pykeen.pipeline import pipeline
+
+    results = pipeline(
+        dataset='YAGO3-10',
+        model='PairRE',
+        training_loop='sLCWA',
+    )
+
+
+It can be set explicitly with:
+
+.. code-block:: python
+
+    from pykeen.pipeline import pipeline
+
+    results = pipeline(
+        dataset='YAGO3-10',
+        model='PairRE',
+        training_loop='sLCWA',
+        negative_sampler='basic',
+    )
+    
+In general, the behavior of the negative sampler can be modified when using the :func:`pykeen.pipeline.pipeline` by
+passing the ``negative_sampler_kwargs`` argument. In order to explicitly specifiy which of the head, relation, and
+tail corruption methods are used, the ``corruption_schema`` argument can be used. For example, to use all three,
+the collection ``('h', 'r', 't')`` can be passed as in the following:
+
+.. code-block:: python
+
+    from pykeen.pipeline import pipeline
+
+    results = pipeline(
+        dataset='YAGO3-10',
+        model='PairRE',
+        training_loop='sLCWA',
+        negative_sampler='basic',
+        negative_sampler_kwargs=dict(
+            corruption_scheme=('h', 'r', 't'),
+        ),
+    )
+
+Bernoulli Negative Sampling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Bernoulli negative sampler :class:`pykeen.sampling.BernoulliNegativeSampler` generates corrupted triples from
+a known positive triple $(h,r,t) \in \mathcal{K}$ similarly to the uniform negative sampler, but it pre-computes
+a probability $p_r$ for each relation $r$ to weight whether the head corruption is used with probability $p_r$ or
+if tail corruption is used with probability $1 - p_r$.
+
+.. code-block:: python
+
+    from pykeen.pipeline import pipeline
+
+    results = pipeline(
+        dataset='YAGO3-10',
+        model='PairRE',
+        training_loop='sLCWA',
+        negative_sampler='bernoulli',
+    )
 """  # noqa
 
 from typing import Set, Type

--- a/src/pykeen/sampling/__init__.py
+++ b/src/pykeen/sampling/__init__.py
@@ -16,10 +16,19 @@ We denote with $\mathcal{N}$ the set of all potential negative triples:
     \mathcal{H}(r, t) &=& \{(h', r, t) \mid h' \in \mathcal{E} \land h' \neq h\}
 
 In theory, all positive triples in $\mathcal{K}$ should be excluded from this set of candidate negative
-triples $\mathcal{N}$ such that $\mathcal{N}^- = \mathcal{N} \setminus \mathcal{K}$. In practice, however,
-since usually $|\mathcal{N}| \gg |\mathcal{K}|$, the likelihood of generating a false negative is rather low.
-Therefore, the additional filter step is often omitted to lower computational cost. It should be taken
-into account that a corrupted triple that is *not part* of the knowledge graph can represent a true fact.
+triples $\mathcal{N}$ such that $\mathcal{N}^- = \mathcal{N} \setminus \mathcal{K}$. If these false
+negatives are ranked higher than testing triples during evaluation, the resulting metrics become less
+accurate.
+
+An algorithm for removing these false negatives was proposed in [bordes2013]_.
+In practice, however, since usually $|\mathcal{N}| \gg |\mathcal{K}|$, the likelihood of generating a false
+negative is rather low. Therefore, the additional filter step is often omitted to lower computational cost.
+
+.. warning:: 
+
+    It should be taken into account that a corrupted triple that is *not part*
+    of the knowledge graph can represent a true fact. These false negatives can
+    not be removed *a priori* in the filtered setting because they are unknown.
 """  # noqa
 
 from typing import Set, Type

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -96,15 +96,15 @@ class BasicNegativeSampler(NegativeSampler):
             # To make sure we don't replace the {head, relation, tail} by the
             # original value we shift all values greater or equal than the original value by one up
             # for that reason we choose the random value from [0, num_{heads, relations, tails} -1]
-            if not self.filtered:
+            if self.filterer is None:
                 negative_batch[start:stop, index] += (
                     negative_batch[start:stop, index] >= positive_batch[start:stop, index]
                 ).long()
 
         # If filtering is activated, all negative triples that are positive in the training dataset will be removed
-        if self.filtered:
-            negative_batch, batch_filter = self.filter_negative_triples(negative_batch=negative_batch)
-        else:
+        if self.filterer is None:
             batch_filter = None
+        else:
+            negative_batch, batch_filter = self.filterer(negative_batch=negative_batch)
 
         return negative_batch, batch_filter

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -95,7 +95,11 @@ class BasicNegativeSampler(NegativeSampler):
             stop = min(start + split_idx, num_negs)
 
             # Relations have a different index maximum than entities
-            index_max = self.num_relations - 1 if index == 1 else self.num_entities - 1
+            index_max = self.num_relations if index == 1 else self.num_entities
+
+            # If we do not use a filterer, we at least make sure to not replace the triples by the original value
+            if self.filterer is None:
+                index_max -= 1
 
             negative_batch[start:stop, index] = torch.randint(
                 high=index_max,

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -2,10 +2,12 @@
 
 """Negative sampling algorithm based on the work of of Bordes *et al.*."""
 
-from typing import Collection, Optional, Tuple
+from typing import Any, Collection, Mapping, Optional, Tuple
 
 import torch
+from class_resolver import HintOrType
 
+from .filtering import Filterer
 from .negative_sampler import NegativeSampler
 from ..triples import TriplesFactory
 
@@ -46,21 +48,29 @@ class BasicNegativeSampler(NegativeSampler):
         triples_factory: TriplesFactory,
         num_negs_per_pos: Optional[int] = None,
         filtered: bool = False,
+        filterer: HintOrType[Filterer] = None,
+        filterer_kwargs: Optional[Mapping[str, Any]] = None,
         corruption_scheme: Optional[Collection[str]] = None,
     ) -> None:
-        """Initialize the negative sampler with the given entities.
+        """Initialize the basic negative sampler with the given entities.
 
         :param triples_factory: The factory holding the triples to sample from
         :param num_negs_per_pos: Number of negative samples to make per positive triple. Defaults to 1.
         :param filtered: Whether proposed corrupted triples that are in the training data should be filtered.
             Defaults to False. See explanation in :func:`filter_negative_triples` for why this is
             a reasonable default.
+        :param filterer: If filtered is set to True, this can be used to choose which filter module from
+            :mod:`pykeen.sampling.filtering` is used.
+        :param filterer_kwargs:
+            Additional keyword-based arguments passed to the filterer upon construction.
         :param corruption_scheme: What sides ('h', 'r', 't') should be corrupted. Defaults to head and tail ('h', 't').
         """
         super().__init__(
             triples_factory=triples_factory,
             num_negs_per_pos=num_negs_per_pos,
             filtered=filtered,
+            filterer=filterer,
+            filterer_kwargs=filterer_kwargs,
         )
         self.corruption_scheme = corruption_scheme or ('h', 't')
         # Set the indices

--- a/src/pykeen/sampling/bernoulli_negative_sampler.py
+++ b/src/pykeen/sampling/bernoulli_negative_sampler.py
@@ -109,14 +109,14 @@ class BernoulliNegativeSampler(NegativeSampler):
         negative_batch[tail_mask, 2] = negative_entities[tail_mask]
 
         # If filtering is activated, all negative triples that are positive in the training dataset will be removed
-        if self.filtered:
-            negative_batch, batch_filter = self.filter_negative_triples(negative_batch=negative_batch)
-        else:
+        if self.filterer is None:
             # To make sure we don't replace the head by the original value
             # we shift all values greater or equal than the original value by one up
             # for that reason we choose the random value from [0, num_entities -1]
             negative_batch[head_mask, 0] += (negative_batch[head_mask, 0] >= positive_batch[head_mask, 0]).long()
             negative_batch[tail_mask, 2] += (negative_batch[tail_mask, 2] >= positive_batch[tail_mask, 2]).long()
             batch_filter = None
+        else:
+            negative_batch, batch_filter = self.filterer(negative_batch=negative_batch)
 
         return negative_batch, batch_filter

--- a/src/pykeen/sampling/bernoulli_negative_sampler.py
+++ b/src/pykeen/sampling/bernoulli_negative_sampler.py
@@ -112,10 +112,15 @@ class BernoulliNegativeSampler(NegativeSampler):
         # Tails are corrupted if heads are not corrupted
         tail_mask = ~head_mask
 
-        # Randomly sample corruption. See below for explanation of
-        # why this is on a range of [0, num_entities - 1]
+        index_max = self.triples_factory.num_entities
+        # If we do not use a filterer, we at least make sure to not replace the triples by the original value
+        # See below for explanation of why this is on a range of [0, num_entities - 1]
+        if self.filterer is None:
+            index_max -= 1
+
+        # Randomly sample corruption.
         negative_entities = torch.randint(
-            self.triples_factory.num_entities - 1,
+            index_max,
             size=(num_negs,),
             device=positive_batch.device,
         )

--- a/src/pykeen/sampling/bernoulli_negative_sampler.py
+++ b/src/pykeen/sampling/bernoulli_negative_sampler.py
@@ -2,10 +2,12 @@
 
 """Negative sampling algorithm based on the work of [wang2014]_."""
 
-from typing import Optional, Tuple
+from typing import Any, Mapping, Optional, Tuple
 
 import torch
+from class_resolver import HintOrType
 
+from .filtering import Filterer
 from .negative_sampler import NegativeSampler
 from ..triples import TriplesFactory
 
@@ -46,11 +48,27 @@ class BernoulliNegativeSampler(NegativeSampler):
         triples_factory: TriplesFactory,
         num_negs_per_pos: Optional[int] = None,
         filtered: bool = False,
+        filterer: HintOrType[Filterer] = None,
+        filterer_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> None:
+        """Initialize the bernoulli negative sampler with the given entities.
+
+        :param triples_factory: The factory holding the triples to sample from
+        :param num_negs_per_pos: Number of negative samples to make per positive triple. Defaults to 1.
+        :param filtered: Whether proposed corrupted triples that are in the training data should be filtered.
+            Defaults to False. See explanation in :func:`filter_negative_triples` for why this is
+            a reasonable default.
+        :param filterer: If filtered is set to True, this can be used to choose which filter module from
+            :mod:`pykeen.sampling.filtering` is used.
+        :param filterer_kwargs:
+            Additional keyword-based arguments passed to the filterer upon construction.
+        """
         super().__init__(
             triples_factory=triples_factory,
             num_negs_per_pos=num_negs_per_pos,
             filtered=filtered,
+            filterer=filterer,
+            filterer_kwargs=filterer_kwargs,
         )
         # Preprocessing: Compute corruption probabilities
         triples = self.triples_factory.mapped_triples

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -86,7 +86,6 @@ from ..triples import CoreTriplesFactory
 __all__ = [
     "filterer_resolver",
     "Filterer",
-    "OldFilterer",
     "BloomFilterer",
     "PythonSetFilterer",
 ]
@@ -120,53 +119,6 @@ class Filterer(nn.Module):
             A pair (filtered_negative_batch, keep_mask) of shape ???
         """
         raise NotImplementedError
-
-
-class OldFilterer(Filterer):
-    """The default filterer.
-
-    .. warning:: This filterer may contain a correctness error, cf. https://github.com/pykeen/pykeen/issues/272
-    """
-
-    def __init__(self, triples_factory: CoreTriplesFactory):
-        """Initialize the filterer.
-
-        :param triples_factory:
-            The triples factory.
-        """
-        super().__init__()
-        # Make sure the mapped triples are initiated
-        # Copy the mapped triples to the device for efficient filtering
-        self.register_buffer(name="mapped_triples", tensor=triples_factory.mapped_triples)
-
-    def forward(
-        self,
-        negative_batch: torch.LongTensor,
-    ) -> Tuple[torch.LongTensor, Optional[torch.BoolTensor]]:  # noqa: D102
-        try:
-            # Check which heads of the mapped triples are also in the negative triples
-            head_filter = (
-                self.mapped_triples[:, 0:1].view(1, -1) == negative_batch[:, 0:1]  # type: ignore
-            ).max(axis=0)[0]
-            # Reduce the search space by only using possible matches that at least contain the head we look for
-            sub_mapped_triples = self.mapped_triples[head_filter]  # type: ignore
-            # Check in this subspace which relations of the mapped triples are also in the negative triples
-            relation_filter = (sub_mapped_triples[:, 1:2].view(1, -1) == negative_batch[:, 1:2]).max(axis=0)[0]
-            # Reduce the search space by only using possible matches that at least contain head and relation we look for
-            sub_mapped_triples = sub_mapped_triples[relation_filter]
-            # Create a filter indicating which of the proposed negative triples are positive in the training dataset
-            final_filter = (sub_mapped_triples[:, 2:3].view(1, -1) == negative_batch[:, 2:3]).max(axis=1)[0]
-        except RuntimeError as e:
-            # In cases where no triples should be filtered, the subspace reduction technique above will fail
-            if str(e) == (
-                'cannot perform reduction function max on tensor with no elements because the operation does not '
-                'have an identity'
-            ):
-                final_filter = torch.zeros(negative_batch.shape[0], dtype=torch.bool, device=negative_batch.device)
-            else:
-                raise e
-        # Return only those proposed negative triples that are not positive in the training dataset
-        return negative_batch[~final_filter], ~final_filter
 
 
 class PythonSetFilterer(Filterer):

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -13,10 +13,11 @@ from torch import nn
 from ..triples import CoreTriplesFactory
 
 __all__ = [
-    'filterer_resolver',
-    'Filterer',
-    'DefaultFilterer',
-    'BloomFilterer',
+    "filterer_resolver",
+    "Filterer",
+    "DefaultFilterer",
+    "BloomFilterer",
+    "PythonSetFilterer",
 ]
 
 

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -42,16 +42,6 @@ class Filterer(nn.Module):
         raise NotImplementedError
 
 
-class NoFilterer(Filterer):
-    """Dummy filterer which just forwards the batch."""
-
-    def forward(
-        self,
-        negative_batch: torch.LongTensor,
-    ) -> Tuple[torch.LongTensor, Optional[torch.BoolTensor]]:  # noqa: D102
-        return negative_batch, None
-
-
 class DefaultFilterer(Filterer):
     """The default filterer."""
 

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -16,25 +16,25 @@ If no relations in $\mathcal{K}$ satisfy any of the relevant properties for the 
 sampling, then there is guaranteed to be no overlap between $\mathcal{N}$ and $\mathcal{K}$ such that 
 $\mathcal{N} \cap \mathcal{K} \neq \emptyset$. However, this scenario is very unlikely for real-world knowledge graphs.
 
-The known positive triples that appear in $\mathcal{N}$ are known false negatives. This is problematic because they
-will be scored well by the knowledge graph embedding model during evaluation, have lower ranks, and ultimately lead to
-worse performance on rank-based evaluation metrics such as the (arithmetic) mean rank.
+The known positive triples that appear in $\mathcal{N}$ are known false negatives. Hence, we know that these are 
+incorrect (negative) training examples, and might want to exclude them to reduce the training noise.
 
 .. warning:: 
 
-    It should be taken into account that a corrupted triple that is *not part*
+    It should be taken into account that also a corrupted triple that is *not part*
     of the knowledge graph can represent a true fact. These "unknown" false negatives can
     not be removed *a priori* in the filtered setting. The philosophy of the methodology again relies
     on the low number of unknown false negatives such that learning can take place.
 
+
+However, in practice, $|\mathcal{N}| \gg |\mathcal{K}|$, so the likelihood of generating a false negative is rather low. 
+Therefore, the additional filter step is often omitted to lower computational cost. This general observation might not 
+hold for all entities; e.g., for a hub entity which is connected to many other entities, there may be a considerable 
+number of false negatives without filtering.
+ 
+
 Identifying False Negatives
 ---------------------------
-[bordes2013]_ proposed an exact algorithm in which all known positive triples in $\mathcal{K}$ are excluded from
-the set of candidate negative triples $\mathcal{N}$ such that $\mathcal{N}^- = \mathcal{N} \setminus \mathcal{K}$
-in order to yield more accurate evaluations. However, in practice, $|\mathcal{N}| \gg |\mathcal{K}|$, so the
-likelihood of generating a false negative is rather low. Therefore, the additional filter step is often omitted
-to lower computational cost.
-
 By default, PyKEEN does *not* filter false negatives from $\mathcal{N}$. To enable the "filtered setting", the
 ``filtered`` keyword can be given to ``negative_sampler_kwargs`` like in:
 
@@ -51,11 +51,10 @@ By default, PyKEEN does *not* filter false negatives from $\mathcal{N}$. To enab
     )
 
 PyKEEN implements several algorithms for filtering with different properties that can be chosen using the
-``filterer`` keyword argument in ``negative_sampler_kwargs``. By default, an exact algorithm is used in
-:class:`pykeen.sampling.filtering.DefaultFilterer`. However, a filterer based on
-`bloom filters <https://en.wikipedia.org/wiki/Bloom_filter>`_ is also available in
-:class:`pykeen.sampling.filtering.BloomFilterer` that trades exact correctness for speed and efficiency.
-It can be activated with:
+``filterer`` keyword argument in ``negative_sampler_kwargs``. By default, an fast and approximate algorithm is used in
+:class:`pykeen.sampling.filtering.BloomFilterer`, which is based on 
+`bloom filters <https://en.wikipedia.org/wiki/Bloom_filter>`_. The bloom filterer also has a configurable desired error 
+rate, which can be further lowered at the cost of increase in memory and computation costs. 
 
 .. code-block:: python
 
@@ -68,7 +67,28 @@ It can be activated with:
         negative_sampler='basic',
         negative_sampler_kwargs=dict(
             filtered=True,
-            filterer='bloom',    
+            filterer='bloom',
+            filterer_kwargs=dict(
+                error_rate=0.0001,
+            ),
+        ),
+    )
+
+If you want to have a guarantee that all known false negatives are filtered, you can use a slower implementation based 
+on Python's built-in sets, the :class:`pykeen.sampling.filtering.PythonSetFilterer`. It can be activated with:
+
+.. code-block:: python
+
+    from pykeen.pipeline import pipeline
+
+    results = pipeline(
+        dataset='YAGO3-10',
+        model='PairRE',
+        training_loop='sLCWA',
+        negative_sampler='basic',
+        negative_sampler_kwargs=dict(
+            filtered=True,
+            filterer='python-set',    
         ),
     )
 """  # noqa

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -86,7 +86,7 @@ from ..triples import CoreTriplesFactory
 __all__ = [
     "filterer_resolver",
     "Filterer",
-    "DefaultFilterer",
+    "OldFilterer",
     "BloomFilterer",
     "PythonSetFilterer",
 ]
@@ -122,7 +122,7 @@ class Filterer(nn.Module):
         raise NotImplementedError
 
 
-class DefaultFilterer(Filterer):
+class OldFilterer(Filterer):
     """The default filterer.
 
     .. warning:: This filterer may contain a correctness error, cf. https://github.com/pykeen/pykeen/issues/272
@@ -346,5 +346,5 @@ class BloomFilterer(Filterer):
 
 filterer_resolver = Resolver.from_subclasses(
     base=Filterer,
-    default=DefaultFilterer,
+    default=OldFilterer,
 )

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -346,5 +346,5 @@ class BloomFilterer(Filterer):
 
 filterer_resolver = Resolver.from_subclasses(
     base=Filterer,
-    default=OldFilterer,
+    default=BloomFilterer,
 )

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -198,14 +198,14 @@ class BloomFilterer(Filterer):
         """
         # pre-hash
         x = (self.mersenne * batch).sum(dim=-1)
-        for i in range(self.num_probes_k):
+        for i in range(self.rounds):
             # cf. https://github.com/skeeto/hash-prospector#two-round-functions
             x = x ^ (x >> 16)
             x = x * 0x7feb352d
             x = x ^ (x >> 15)
             x = x * 0x846ca68b
             x = x ^ (x >> 16)
-            yield x.sum(dim=-1) % self.num_bits_m
+            yield x.sum(dim=-1) % self.bit_array.shape[0]
 
     def add(self, triples: torch.LongTensor) -> None:
         """

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -3,13 +3,13 @@
 r"""Consider the following properties of relation $r$. Because the corruption operations are applied independently
 of triples, the resulting candidate corrupt triples could overlap with known positive triples in $\mathcal{K}$.
 
-=====================  ============================================  ===============================================================
+=====================  ============================================  ==============================================================
 Property of :math:`r`  Example pair of triples                       Implications
-=====================  ============================================  ===============================================================
+=====================  ============================================  ==============================================================
 one-to-many            :math:`(h,r,t_1), (h,r,t_2) \in \mathcal{K}`  :math:`(h,r,t_2) \in T(h,r,t_1) \cup (h,r,t_1) \in T(h,r,t_2)`
 multiple               :math:`(h,r_1,t), (h,r_2,t) \in \mathcal{K}`  :math:`(h,r_2,t) \in R(h,r_1,t) \cup (h,r_1,t) \in R(h,r_2,t)`
 many-to-one            :math:`(h_1,r,t), (h_2,r,t) \in \mathcal{K}`  :math:`(h_2,r,t) \in H(h_1,r,t) \cup (h_1,r,t) \in H(h_2,r,t)`
-=====================  ============================================  ===============================================================
+=====================  ============================================  ==============================================================
 
 If no relations in $\mathcal{K}$ satisfy any of the relevant properties for the corruption schema chosen in negative
 sampling, then there is guaranteed to be no overlap between $\mathcal{N}$ and $\mathcal{K}$ such that 
@@ -44,7 +44,7 @@ PyKEEN implements several algorithms for filtering with different properties tha
 ``filterer`` keyword argument in ``negative_sampler_kwargs``. By default, an exact algorithm is used in
 :class:`pykeen.sampling.filtering.DefaultFilterer`. However, a filterer based on
 `bloom filters <https://en.wikipedia.org/wiki/Bloom_filter>`_ is also available in
-:class:`pykeen.sampling.filtering.BloomFilterer`that trades exact correctness for speed and efficiency.
+:class:`pykeen.sampling.filtering.BloomFilterer` that trades exact correctness for speed and efficiency.
 It can be activated with:
 
 .. code-block:: python

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -137,7 +137,6 @@ class Filterer(nn.Module):
         :return:
             A pair (filtered_negative_batch, keep_mask) of shape ???
         """
-
         keep_mask = ~self.contains(batch=negative_batch)
         return negative_batch[keep_mask], keep_mask
 

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-r"""Consider the following properties of relation $r$. Because the corruption operations are applied independently
-of triples, the resulting candidate corrupt triples could overlap with known positive triples in $\mathcal{K}$.
+r"""Consider the following properties of relation $r$. Because the corruption operations (see `Corruption`_)
+are applied independently of triples, the resulting candidate corrupt triples could overlap with known positive
+triples in $\mathcal{K}$.
 
 =====================  ============================================  ==============================================================
 Property of :math:`r`  Example pair of triples                       Implications
@@ -19,6 +20,8 @@ The known positive triples that appear in $\mathcal{N}$ are false negatives. Thi
 be scored well by the knowledge graph embedding model during evaluation, have lower ranks, and ultimately lead to
 worse performance on rank-based evaluation metrics such as the (arithmetic) mean rank.
 
+Identifying False Negatives
+---------------------------
 [bordes2013]_ proposed an exact algorithm in which all known positive triples in $\mathcal{K}$ are excluded from
 the set of candidate negative triples $\mathcal{N}$ such that $\mathcal{N}^- = \mathcal{N} \setminus \mathcal{K}$
 in order to yield more accurate evaluations. However, in practice, $|\mathcal{N}| \gg |\mathcal{K}|$, so the

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -179,7 +179,7 @@ class BloomFilterer(Filterer):
         # Store some meta-data
         self.error_rate = error_rate
 
-    def __repr__(self):
+    def __repr__(self):  # noqa:D105
         return (
             f"{self.__class__.__name__}("
             f"error_rate={self.error_rate}, "
@@ -204,7 +204,7 @@ class BloomFilterer(Filterer):
         """
         # pre-hash
         x = (self.mersenne * batch).sum(dim=-1)
-        for i in range(self.rounds):
+        for _ in range(self.rounds):
             # cf. https://github.com/skeeto/hash-prospector#two-round-functions
             x = x ^ (x >> 16)
             x = x * 0x7feb352d

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -59,6 +59,12 @@ class DefaultFilterer(Filterer):
     """
 
     def __init__(self, triples_factory: CoreTriplesFactory):
+        """
+        Initialize the filterer.
+
+        :param triples_factory:
+            The triples factory.
+        """
         super().__init__()
         # Make sure the mapped triples are initiated
         # Copy the mapped triples to the device for efficient filtering

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -1,0 +1,97 @@
+"""Filterer for negative triples."""
+from abc import abstractmethod
+from typing import Optional, Tuple
+
+import torch
+from class_resolver import Resolver
+from torch import nn
+
+from ..triples import CoreTriplesFactory
+
+
+class Filterer(nn.Module):
+    """An interface for filtering methods for negative triples."""
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    @abstractmethod
+    def forward(
+        self,
+        negative_batch: torch.LongTensor,
+    ) -> Tuple[torch.LongTensor, Optional[torch.BoolTensor]]:
+        """Filter all proposed negative samples that are positive in the training dataset.
+
+        Normally there is a low probability that proposed negative samples are positive in the training datasets and
+        thus act as false negatives. This is expected to act as a kind of regularization, since it adds noise signal to
+        the training data. However, the degree of regularization is hard to control since the added noise signal depends
+        on the ratio of true triples for a given entity relation or entity entity pair. Therefore, the effects are hard
+        to control and a researcher might want to exclude the possibility of having false negatives in the proposed
+        negative triples.
+
+        .. note ::
+            Filtering is a very expensive task, since every proposed negative sample has to be checked against the
+            entire training dataset.
+
+        :param negative_batch: shape: ???
+            The batch of negative triples.
+
+        :return:
+            A pair (filtered_negative_batch, keep_mask) of shape ???
+        """
+        raise NotImplementedError
+
+
+class NoFilterer(Filterer):
+    """Dummy filterer which just forwards the batch."""
+
+    def forward(
+        self,
+        negative_batch: torch.LongTensor,
+    ) -> Tuple[torch.LongTensor, Optional[torch.BoolTensor]]:  # noqa: D102
+        return negative_batch, None
+
+
+class DefaultFilterer(Filterer):
+    """The default filterer."""
+
+    def __init__(self, triples_factory: CoreTriplesFactory):
+        super().__init__()
+        # Make sure the mapped triples are initiated
+        # Copy the mapped triples to the device for efficient filtering
+        self.register_buffer(name="mapped_triples", tensor=triples_factory.mapped_triples)
+
+    def forward(
+        self,
+        negative_batch: torch.LongTensor,
+    ) -> Tuple[torch.LongTensor, Optional[torch.BoolTensor]]:  # noqa: D102
+        try:
+            # Check which heads of the mapped triples are also in the negative triples
+            head_filter = (
+                self.mapped_triples[:, 0:1].view(1, -1) == negative_batch[:, 0:1]  # type: ignore
+            ).max(axis=0)[0]
+            # Reduce the search space by only using possible matches that at least contain the head we look for
+            sub_mapped_triples = self.mapped_triples[head_filter]  # type: ignore
+            # Check in this subspace which relations of the mapped triples are also in the negative triples
+            relation_filter = (sub_mapped_triples[:, 1:2].view(1, -1) == negative_batch[:, 1:2]).max(axis=0)[0]
+            # Reduce the search space by only using possible matches that at least contain head and relation we look for
+            sub_mapped_triples = sub_mapped_triples[relation_filter]
+            # Create a filter indicating which of the proposed negative triples are positive in the training dataset
+            final_filter = (sub_mapped_triples[:, 2:3].view(1, -1) == negative_batch[:, 2:3]).max(axis=1)[0]
+        except RuntimeError as e:
+            # In cases where no triples should be filtered, the subspace reduction technique above will fail
+            if str(e) == (
+                'cannot perform reduction function max on tensor with no elements because the operation does not '
+                'have an identity'
+            ):
+                final_filter = torch.zeros(negative_batch.shape[0], dtype=torch.bool, device=negative_batch.device)
+            else:
+                raise e
+        # Return only those proposed negative triples that are not positive in the training dataset
+        return negative_batch[~final_filter], ~final_filter
+
+
+filterer_resolver = Resolver.from_subclasses(
+    base=Filterer,
+    default=DefaultFilterer,
+)

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -211,7 +211,7 @@ class BloomFilterer(Filterer):
             x = x ^ (x >> 15)
             x = x * 0x846ca68b
             x = x ^ (x >> 16)
-            yield x.sum(dim=-1) % self.bit_array.shape[0]
+            yield x % self.bit_array.shape[0]
 
     def add(self, triples: torch.LongTensor) -> None:
         """

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -52,19 +52,15 @@ class Filterer(nn.Module):
 
 
 class DefaultFilterer(Filterer):
-    """
-    The default filterer.
+    """The default filterer.
 
-    .. warning ::
-        This filterer may contain a correctness error, cf. https://github.com/pykeen/pykeen/issues/272
+    .. warning:: This filterer may contain a correctness error, cf. https://github.com/pykeen/pykeen/issues/272
     """
 
     def __init__(self, triples_factory: CoreTriplesFactory):
-        """
-        Initialize the filterer.
+        """Initialize the filterer.
 
-        :param triples_factory:
-            The triples factory.
+        :param triples_factory: The triples factory.
         """
         super().__init__()
         # Make sure the mapped triples are initiated
@@ -102,22 +98,16 @@ class DefaultFilterer(Filterer):
 
 
 class PythonSetFilterer(Filterer):
-    """
-    A filterer using Python sets for filtering.
+    """A filterer using Python sets for filtering.
 
     This filterer is expected to be rather slow due to the conversion from torch long tensors to Python tuples. It can
     still serve as a baseline for performance comparison.
     """
 
-    def __init__(
-        self,
-        triples_factory: CoreTriplesFactory,
-    ):
-        """
-        Initialize the filterer.
+    def __init__(self, triples_factory: CoreTriplesFactory):
+        """Initialize the filterer.
 
-        :param triples_factory:
-            The triples factory.
+        :param triples_factory: The triples factory.
         """
         super().__init__()
         # store set of triples
@@ -135,8 +125,7 @@ class PythonSetFilterer(Filterer):
 
 
 class BloomFilterer(Filterer):
-    """
-    A filterer for negative triples based on the Bloom filter.
+    """A filterer for negative triples based on the Bloom filter.
 
     Pure PyTorch, a proper module which can be moved to GPU, and support batch-wise computation.
 
@@ -151,17 +140,11 @@ class BloomFilterer(Filterer):
     #: The bit-array for the Bloom filter data structure
     bit_array: torch.BoolTensor
 
-    def __init__(
-        self,
-        triples_factory: CoreTriplesFactory,
-        error_rate: float = 0.001,
-    ):
+    def __init__(self, triples_factory: CoreTriplesFactory, error_rate: float = 0.001):
         """Initialize the Bloom filter based filterer.
 
-        :param triples_factory:
-            The triples factory.
-        :param error_rate:
-            The desired error rate.
+        :param triples_factory: The triples factory.
+        :param error_rate: The desired error rate.
         """
         super().__init__()
 

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -16,7 +16,7 @@ If no relations in $\mathcal{K}$ satisfy any of the relevant properties for the 
 sampling, then there is guaranteed to be no overlap between $\mathcal{N}$ and $\mathcal{K}$ such that 
 $\mathcal{N} \cap \mathcal{K} \neq \emptyset$. However, this scenario is very unlikely for real-world knowledge graphs.
 
-The known positive triples that appear in $\mathcal{N}$ are known false negatives. This is problematic becuase they
+The known positive triples that appear in $\mathcal{N}$ are known false negatives. This is problematic because they
 will be scored well by the knowledge graph embedding model during evaluation, have lower ranks, and ultimately lead to
 worse performance on rank-based evaluation metrics such as the (arithmetic) mean rank.
 

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -51,7 +51,12 @@ class Filterer(nn.Module):
 
 
 class DefaultFilterer(Filterer):
-    """The default filterer."""
+    """
+    The default filterer.
+
+    .. warning ::
+        This filterer may contain a correctness error, cf. https://github.com/pykeen/pykeen/issues/272
+    """
 
     def __init__(self, triples_factory: CoreTriplesFactory):
         super().__init__()

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Mapping, Optional, Tuple, Type, Union
 
 import torch
-from class_resolver import Hint
+from class_resolver import Hint, HintOrType
 
 from .filtering import Filterer, filterer_resolver
 from ..triples import TriplesFactory
@@ -31,7 +31,7 @@ class NegativeSampler(ABC):
         triples_factory: TriplesFactory,
         num_negs_per_pos: Optional[int] = None,
         filtered: bool = False,
-        filterer: Hint[Union[Filterer, Type[Filterer]]] = None,
+        filterer: HintOrType[Filterer] = None,
         filterer_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Initialize the negative sampler with the given entities.

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -32,6 +32,7 @@ class NegativeSampler(ABC):
         num_negs_per_pos: Optional[int] = None,
         filtered: bool = False,
         filterer: Hint[Union[Filterer, Type[Filterer]]] = None,
+        filterer_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Initialize the negative sampler with the given entities.
 
@@ -42,11 +43,14 @@ class NegativeSampler(ABC):
             a reasonable default.
         :param filterer: If filtered is set to True, this can be used to choose which filter module from
             :mod:`pykeen.sampling.filtering` is used.
+        :param filterer_kwargs:
+            Additional keyword-based arguments passed to the filterer upon construction.
         """
         self.triples_factory = triples_factory
         self.num_negs_per_pos = num_negs_per_pos if num_negs_per_pos is not None else 1
         self.filterer = filterer_resolver.make(
             filterer,
+            pos_kwargs=filterer_kwargs,
             triples_factory=triples_factory,
         ) if filtered else None
 

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -23,6 +23,7 @@ class NegativeSampler(ABC):
     #: The default strategy for optimizing the negative sampler's hyper-parameters
     hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]]
 
+    #: A filterer for negative batches
     filterer: Optional[Filterer]
 
     def __init__(

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, Mapping, Optional, Tuple
 
 import torch
 
-from .filtering import DefaultFilterer, NoFilterer, filterer_resolver
+from .filtering import filterer_resolver
 from ..triples import TriplesFactory
 from ..utils import normalize_string
 

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Mapping, Optional, Tuple
 
 import torch
 
+from .filtering import DefaultFilterer, NoFilterer, filterer_resolver
 from ..triples import TriplesFactory
 from ..utils import normalize_string
 
@@ -37,9 +38,10 @@ class NegativeSampler(ABC):
         """
         self.triples_factory = triples_factory
         self.num_negs_per_pos = num_negs_per_pos if num_negs_per_pos is not None else 1
-        self.filtered = filtered
-        # Create mapped triples attribute that is required for filtering
-        self.mapped_triples = None
+        self.filterer = filterer_resolver.make(
+            query=DefaultFilterer if filtered else NoFilterer,
+            pos_kwargs=dict(triples_factory=triples_factory),
+        )
 
     @classmethod
     def get_normalized_name(cls) -> str:
@@ -60,47 +62,3 @@ class NegativeSampler(ABC):
     def sample(self, positive_batch: torch.LongTensor) -> Tuple[torch.LongTensor, Optional[torch.Tensor]]:
         """Generate negative samples from the positive batch."""
         raise NotImplementedError
-
-    def filter_negative_triples(self, negative_batch: torch.LongTensor) -> Tuple[torch.LongTensor, torch.Tensor]:
-        """Filter all proposed negative samples that are positive in the training dataset.
-
-        Normally there is a low probability that proposed negative samples are positive in the training datasets and
-        thus act as false negatives. This is expected to act as a kind of regularization, since it adds noise signal to
-        the training data. However, the degree of regularization is hard to control since the added noise signal depends
-        on the ratio of true triples for a given entity relation or entity entity pair. Therefore, the effects are hard
-        to control and a researcher might want to exclude the possibility of having false negatives in the proposed
-        negative triples.
-        Note: Filtering is a very expensive task, since every proposed negative sample has to be checked against the
-        entire training dataset.
-
-        :param negative_batch: The batch of negative triples
-        """
-        # Make sure the mapped triples are initiated
-        if self.mapped_triples is None:
-            # Copy the mapped triples to the device for efficient filtering
-            self.mapped_triples = self.triples_factory.mapped_triples.to(negative_batch.device)
-
-        try:
-            # Check which heads of the mapped triples are also in the negative triples
-            head_filter = (
-                self.mapped_triples[:, 0:1].view(1, -1) == negative_batch[:, 0:1]  # type: ignore
-            ).max(axis=0)[0]
-            # Reduce the search space by only using possible matches that at least contain the head we look for
-            sub_mapped_triples = self.mapped_triples[head_filter]  # type: ignore
-            # Check in this subspace which relations of the mapped triples are also in the negative triples
-            relation_filter = (sub_mapped_triples[:, 1:2].view(1, -1) == negative_batch[:, 1:2]).max(axis=0)[0]
-            # Reduce the search space by only using possible matches that at least contain head and relation we look for
-            sub_mapped_triples = sub_mapped_triples[relation_filter]
-            # Create a filter indicating which of the proposed negative triples are positive in the training dataset
-            final_filter = (sub_mapped_triples[:, 2:3].view(1, -1) == negative_batch[:, 2:3]).max(axis=1)[0]
-        except RuntimeError as e:
-            # In cases where no triples should be filtered, the subspace reduction technique above will fail
-            if str(e) == (
-                'cannot perform reduction function max on tensor with no elements because the operation does not '
-                'have an identity'
-            ):
-                final_filter = torch.zeros(negative_batch.shape[0], dtype=torch.bool, device=negative_batch.device)
-            else:
-                raise e
-        # Return only those proposed negative triples that are not positive in the training dataset
-        return negative_batch[~final_filter], ~final_filter

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -39,9 +39,8 @@ class NegativeSampler(ABC):
         self.triples_factory = triples_factory
         self.num_negs_per_pos = num_negs_per_pos if num_negs_per_pos is not None else 1
         self.filterer = filterer_resolver.make(
-            query=DefaultFilterer if filtered else NoFilterer,
             pos_kwargs=dict(triples_factory=triples_factory),
-        )
+        ) if filtered else None
 
     @classmethod
     def get_normalized_name(cls) -> str:

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -3,10 +3,10 @@
 """Basic structure for a negative sampler."""
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Mapping, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Mapping, Optional, Tuple
 
 import torch
-from class_resolver import Hint, HintOrType
+from class_resolver import HintOrType
 
 from .filtering import Filterer, filterer_resolver
 from ..triples import TriplesFactory

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -4,7 +4,6 @@
 
 import unittest
 from typing import Any, ClassVar, MutableMapping, Type
-from unittest import SkipTest
 
 import numpy
 import torch
@@ -12,7 +11,7 @@ import unittest_templates
 
 from pykeen.datasets import Nations
 from pykeen.sampling import BasicNegativeSampler, BernoulliNegativeSampler, NegativeSampler
-from pykeen.sampling.filtering import DefaultFilterer, Filterer, NoFilterer
+from pykeen.sampling.filtering import DefaultFilterer, Filterer
 from pykeen.training.schlichtkrull_sampler import GraphSampler, _compute_compressed_adjacency_list
 from pykeen.triples import SLCWAInstances, TriplesFactory
 
@@ -237,15 +236,6 @@ class FiltererTest(unittest_templates.GenericTestCase[Filterer]):
         )
         # The filter should not remove any triple
         assert self.positive_batch.size()[0] == batch_filter.sum()
-
-
-class NoFiltererTests(FiltererTest):
-    """Tests for the Nop filterer."""
-
-    cls = NoFilterer
-
-    def test_filter(self):  # noqa: D102
-        raise SkipTest("NoFilterer does not filter all positives.")
 
 
 class DefaultFiltererTests(FiltererTest):

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -3,15 +3,13 @@
 """Test that samplers can be executed."""
 
 import unittest
-from typing import Any, ClassVar, MutableMapping, Type
+from typing import ClassVar, Type
 
 import numpy
 import torch
-import unittest_templates
 
 from pykeen.datasets import Nations
 from pykeen.sampling import BasicNegativeSampler, BernoulliNegativeSampler, NegativeSampler
-from pykeen.sampling.filtering import DefaultFilterer, Filterer
 from pykeen.training.schlichtkrull_sampler import GraphSampler, _compute_compressed_adjacency_list
 from pykeen.triples import SLCWAInstances, TriplesFactory
 
@@ -203,42 +201,3 @@ class AdjacencyListCompressionTest(unittest.TestCase):
                 int(a) for a in ((triples[:, 0] == i) | (triples[:, 2] == i)).nonzero(as_tuple=False).flatten()
             )
             assert adjacent_edges == set(map(int, edge_ids))
-
-
-class FiltererTest(unittest_templates.GenericTestCase[Filterer]):
-    """A basic test for filtering."""
-
-    seed = 42
-    batch_size = 16
-    num_negs_per_pos = 10
-
-    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
-        kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
-        kwargs["triples_factory"] = self.triples_factory = Nations().training
-        return kwargs
-
-    def post_instantiation_hook(self) -> None:  # noqa: D102
-        seed = 42
-        random = numpy.random.RandomState(seed=seed)
-        self.slcwa_instances = self.triples_factory.create_slcwa_instances()
-        batch_indices = random.randint(low=0, high=len(self.slcwa_instances), size=(self.batch_size,))
-        self.positive_batch = self.slcwa_instances.mapped_triples[batch_indices]
-
-    def test_filter(self):
-        # Check whether filtering works correctly
-        # First giving an example where all triples have to be filtered
-        _, batch_filter = self.instance(negative_batch=self.positive_batch)
-        # The filter should remove all triples
-        assert batch_filter.sum() == 0
-        # Create an example where no triples will be filtered
-        _, batch_filter = self.instance(
-            negative_batch=(self.positive_batch + self.triples_factory.num_entities),
-        )
-        # The filter should not remove any triple
-        assert self.positive_batch.size()[0] == batch_filter.sum()
-
-
-class DefaultFiltererTests(FiltererTest):
-    """Tests for the default filterer."""
-
-    cls = DefaultFilterer

--- a/tests/test_sampling/test_filterer.py
+++ b/tests/test_sampling/test_filterer.py
@@ -8,7 +8,7 @@ import torch
 import unittest_templates
 
 from pykeen.datasets import Nations
-from pykeen.sampling.filtering import BloomFilterer, DefaultFilterer, Filterer, PythonSetFilterer
+from pykeen.sampling.filtering import BloomFilterer, OldFilterer, Filterer, PythonSetFilterer
 from pykeen.utils import set_random_seed
 
 
@@ -49,10 +49,10 @@ class FiltererTest(unittest_templates.GenericTestCase[Filterer]):
         assert self.positive_batch.size()[0] == batch_filter.sum()
 
 
-class DefaultFiltererTests(FiltererTest):
-    """Tests for the default filterer."""
+class OldFiltererTests(FiltererTest):
+    """Tests for the old filterer."""
 
-    cls = DefaultFilterer
+    cls = OldFilterer
 
 
 class PythonSetFiltererTest(FiltererTest):

--- a/tests/test_sampling/test_filterer.py
+++ b/tests/test_sampling/test_filterer.py
@@ -8,7 +8,7 @@ import numpy
 import unittest_templates
 
 from pykeen.datasets import Nations
-from pykeen.sampling.filtering import DefaultFilterer, Filterer
+from pykeen.sampling.filtering import BloomFilterer, DefaultFilterer, Filterer
 
 
 class FiltererTest(unittest_templates.GenericTestCase[Filterer]):
@@ -49,3 +49,16 @@ class DefaultFiltererTests(FiltererTest):
     """Tests for the default filterer."""
 
     cls = DefaultFilterer
+
+
+class BloomFiltererTest(FiltererTest):
+    """Tests for the bloom filterer."""
+
+    cls = BloomFilterer
+
+
+class FiltererMetaTestCase(unittest_templates.MetaTestCase[Filterer]):
+    """Test all filterers are tested."""
+
+    base_cls = Filterer
+    base_test = FiltererTest

--- a/tests/test_sampling/test_filterer.py
+++ b/tests/test_sampling/test_filterer.py
@@ -4,11 +4,12 @@
 
 from typing import Any, MutableMapping
 
-import numpy
+import torch
 import unittest_templates
 
 from pykeen.datasets import Nations
 from pykeen.sampling.filtering import BloomFilterer, DefaultFilterer, Filterer, PythonSetFilterer
+from pykeen.utils import set_random_seed
 
 
 class FiltererTest(unittest_templates.GenericTestCase[Filterer]):
@@ -20,15 +21,18 @@ class FiltererTest(unittest_templates.GenericTestCase[Filterer]):
 
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
+        self.generator = set_random_seed(seed=self.seed)[1]
         kwargs["triples_factory"] = self.triples_factory = Nations().training
         return kwargs
 
     def post_instantiation_hook(self) -> None:  # noqa: D102
-        seed = 42
-        random = numpy.random.RandomState(seed=seed)
         self.slcwa_instances = self.triples_factory.create_slcwa_instances()
-        batch_indices = random.randint(low=0, high=len(self.slcwa_instances), size=(self.batch_size,))
-        self.positive_batch = self.slcwa_instances.mapped_triples[batch_indices]
+        self.positive_batch = self.slcwa_instances.mapped_triples[torch.randint(
+            low=0,
+            high=len(self.slcwa_instances),
+            size=(self.batch_size,),
+            generator=self.generator,
+        )]
 
     def test_filter(self):
         """Test the filter method."""

--- a/tests/test_sampling/test_filterer.py
+++ b/tests/test_sampling/test_filterer.py
@@ -8,7 +8,7 @@ import numpy
 import unittest_templates
 
 from pykeen.datasets import Nations
-from pykeen.sampling.filtering import BloomFilterer, DefaultFilterer, Filterer
+from pykeen.sampling.filtering import BloomFilterer, DefaultFilterer, Filterer, PythonSetFilterer
 
 
 class FiltererTest(unittest_templates.GenericTestCase[Filterer]):
@@ -49,6 +49,12 @@ class DefaultFiltererTests(FiltererTest):
     """Tests for the default filterer."""
 
     cls = DefaultFilterer
+
+
+class PythonSetFiltererTest(FiltererTest):
+    """Tests for the Python set-based filterer."""
+
+    cls = PythonSetFilterer
 
 
 class BloomFiltererTest(FiltererTest):

--- a/tests/test_sampling/test_filterer.py
+++ b/tests/test_sampling/test_filterer.py
@@ -8,7 +8,7 @@ import torch
 import unittest_templates
 
 from pykeen.datasets import Nations
-from pykeen.sampling.filtering import BloomFilterer, OldFilterer, Filterer, PythonSetFilterer
+from pykeen.sampling.filtering import BloomFilterer, Filterer, PythonSetFilterer
 from pykeen.utils import set_random_seed
 
 
@@ -47,12 +47,6 @@ class FiltererTest(unittest_templates.GenericTestCase[Filterer]):
         )
         # The filter should not remove any triple
         assert self.positive_batch.size()[0] == batch_filter.sum()
-
-
-class OldFiltererTests(FiltererTest):
-    """Tests for the old filterer."""
-
-    cls = OldFilterer
 
 
 class PythonSetFiltererTest(FiltererTest):


### PR DESCRIPTION
This PR revises the filtering of generated negative samples during training. It removes the old faulty implementation (cf. #272 ), and implements a fast filterer based on Bloom filters, as well as a slower Python set-based variant with guaranteed correctness. It also updates the documentation.

### Bloom Filterer

The Bloom filterer uses an pure PyTorch implementation of a [Bloom Filter](https://en.wikipedia.org/wiki/Bloom_filter) to existence check. 

>  False positive matches are possible, but false negatives are not – in other words, a query returns either "possibly in set" or "definitely not in set".

Thus, it can happen that some negative samples are rejected which *do not* occur in the training triples, however, non-rejection of existing triples is impossible. The implementation allows to specify a desired error rate (defaulting to 0.1%), and derives appropriate data structure parameters based on theoretical results.

Bloom filters scale nicely in time and space complexity.

For implementation I took inspiration from looking at https://github.com/hiway/python-bloom-filter/, and selected hash functions from https://github.com/skeeto/hash-prospector#two-round-functions.


#### Exemplary results

<details>
<summary>YAGO3-10</summary>
Exact results in less than 2MiB index size.

```python
import humanize
from pykeen.datasets import get_dataset
from pykeen.sampling.filtering import BloomFilterer
dataset = get_dataset(dataset="yago310")
f = BloomFilterer(triples_factory=dataset.training, error_rate=0.001)
print(f)
print(humanize.naturalsize(f.bit_array.numel() / 8))
for key, value in dataset.factory_dict.items():
    print(f"{key:20}: {float(f.contains(batch=value.mapped_triples).float().mean()):3.2%}")
```

```
BloomFilterer(error_rate=0.001, size=15513993, rounds=10, ideal_num_elements=1079040, )
1.9 MB
training            : 100.00%
testing             : 0.00%
validation          : 0.00%
```
</details>

See a more thorough benchmarking at https://github.com/pykeen/bloom-filterer-benchmark

### Dependencies
* [x] #400 (this PR contains some commits from #400 )

### Related Issues
Fixes #272 
Fixes #273 