### PR TITLE
❓🧐 Improve automatic memory optimization parameter handling

### DIFF
--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1000,8 +1000,8 @@ def pipeline(  # noqa: C901
         mapped_triples = validation.mapped_triples
 
     # Evaluate
-    # Reuse optimal evaluation parameters from training if available
-    if evaluator_instance.batch_size is not None or evaluator_instance.slice_size is not None:
+    # Reuse optimal evaluation parameters from training if available, only if the validation triples are used again
+    if evaluator_instance.batch_size is not None or evaluator_instance.slice_size is not None and not use_testing_data:
         evaluation_kwargs['batch_size'] = evaluator_instance.batch_size
         evaluation_kwargs['slice_size'] = evaluator_instance.slice_size
     # Add logging about evaluator for debugging


### PR DESCRIPTION
Currently, the pipeline re-uses derived optimal parameter settings from the automatic memory optimization.
This can lead to issues, because these parameters are derived from using the validation dataset. In cases where the test dataset is bigger than the validation dataset, these re-used parameter are overly optimistic and can lead to crashes. Furthermore, in the light of #398 this issue is significantly increased.

Therefore, this PR will mitigate this issue by making the re-usage of the parameters depending on whether the validation dataset is also used for the final evaluation.