### PR TITLE
✂️ 🏭 Excise the triples factory from the model

### DIFF
--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -30,20 +30,20 @@ model:
 
 >>> from pykeen.pipeline import pipeline
 >>> # Run the pipeline
->>> pipeline_result = pipeline(dataset='Nations', model='RotatE')
->>> model = pipeline_result.model
+>>> result = pipeline(dataset='Nations', model='RotatE')
+>>> model = result.model
 >>> # Predict tails
->>> predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs')
+>>> predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs', triples_factory=result.training)
 >>> # Predict relations
->>> predicted_relations_df = model.get_relation_prediction_df('brazil', 'uk')
+>>> predicted_relations_df = model.get_relation_prediction_df('brazil', 'uk', triples_factory=result.training)
 >>> # Predict heads
->>> predicted_heads_df = model.get_head_prediction_df('conferences', 'brazil')
+>>> predicted_heads_df = model.get_head_prediction_df('conferences', 'brazil', triples_factory=result.training)
 >>> # Score all triples (memory intensive)
->>> predictions_df = model.get_all_prediction_df()
+>>> predictions_df = model.get_all_prediction_df(triples_factory=result.training)
 >>> # Score top K triples
->>> top_k_predictions_df = model.get_all_prediction_df(k=150)
+>>> top_k_predictions_df = model.get_all_prediction_df(k=150, triples_factory=result.training)
 >>> # save the model
->>> pipeline_result.save_to_directory('doctests/nations_rotate')
+>>> result.save_to_directory('doctests/nations_rotate')
 
 Loading a Model
 ~~~~~~~~~~~~~~~
@@ -52,11 +52,13 @@ This example shows how to reload a previously trained model. The
 a file named ``trained_model.pkl``, so we will use the one from the
 previous example.
 
->>> import torch
->>> model = torch.load('doctests/nations_rotate/trained_model.pkl')
->>> # Predict tails
->>> predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs')
->>> # everything else is the same as above
+.. code-block:: python
+
+    import torch
+
+    model = torch.load('doctests/nations_rotate_1/trained_model.pkl')
+    training = ...  # load some other way
+    predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs')
 
 There's an example model available at
 https://github.com/pykeen/pykeen/blob/master/notebooks/hello_world/nations_transe/trained_model.pkl

--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -55,7 +55,7 @@ previous example.
 >>> import torch
 >>> from pykeen.datasets import get_dataset
 >>> model = torch.load('doctests/nations_rotate/trained_model.pkl')
->>> training = get_dataset("nations").training
+>>> training = get_dataset(dataset="nations").training
 >>> # Predict tails
 >>> predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs', triples_factory=training)
 >>> # everything else is the same as above

--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -57,8 +57,8 @@ previous example.
     import torch
 
     model = torch.load('doctests/nations_rotate_1/trained_model.pkl')
-    training = ...  # load some other way
-    predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs')
+    training = get_dataset("nations").training
+    predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs', triples_factory=training)
 
 There's an example model available at
 https://github.com/pykeen/pykeen/blob/master/notebooks/hello_world/nations_transe/trained_model.pkl

--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -52,13 +52,13 @@ This example shows how to reload a previously trained model. The
 a file named ``trained_model.pkl``, so we will use the one from the
 previous example.
 
-.. code-block:: python
-
-    import torch
-
-    model = torch.load('doctests/nations_rotate_1/trained_model.pkl')
-    training = get_dataset("nations").training
-    predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs', triples_factory=training)
+>>> import torch
+>>> from pykeen.datasets import get_dataset
+>>> model = torch.load('doctests/nations_rotate/trained_model.pkl')
+>>> training = get_dataset("nations").training
+>>> # Predict tails
+>>> predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs', triples_factory=training)
+>>> # everything else is the same as above
 
 There's an example model available at
 https://github.com/pykeen/pykeen/blob/master/notebooks/hello_world/nations_transe/trained_model.pkl

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -17,6 +17,7 @@ from dataclasses_json import DataClassJsonMixin
 from tqdm.autonotebook import tqdm
 
 from ..models import Model
+from ..triples import TriplesFactory
 from ..triples.utils import get_entities
 from ..typing import MappedTriples
 from ..utils import (
@@ -139,7 +140,7 @@ class Evaluator(ABC):
         tqdm_kwargs: Optional[Mapping[str, str]] = None,
         restrict_entities_to: Optional[torch.LongTensor] = None,
         do_time_consuming_checks: bool = True,
-        training_mapped_triples: Optional[MappedTriples] = None,
+        training_triples_factory: Optional[TriplesFactory] = None,
     ) -> MetricResults:
         """Run :func:`pykeen.evaluation.evaluate` with this evaluator."""
         if batch_size is None and self.automatic_memory_optimization:
@@ -153,7 +154,7 @@ class Evaluator(ABC):
                 batch_size, slice_size = self.batch_and_slice(
                     model=model,
                     mapped_triples=mapped_triples,
-                    training_mapped_triples=training_mapped_triples,
+                    training_triples_factory=training_triples_factory,
                     batch_size=batch_size,
                     device=device,
                     use_tqdm=False,
@@ -169,7 +170,7 @@ class Evaluator(ABC):
 
         rv = evaluate(
             model=model,
-            training_mapped_triples=training_mapped_triples,
+            training_triples_factory=training_triples_factory,
             mapped_triples=mapped_triples,
             evaluators=self,
             batch_size=batch_size,
@@ -193,7 +194,7 @@ class Evaluator(ABC):
         use_tqdm: bool = False,
         restrict_entities_to: Optional[torch.LongTensor] = None,
         do_time_consuming_checks: bool = True,
-        training_mapped_triples: Optional[MappedTriples] = None,
+        training_triples_factory: Optional[TriplesFactory] = None,
     ) -> Tuple[int, Optional[int]]:
         """Find the maximum possible batch_size and slice_size for evaluation with the current setting.
 
@@ -217,6 +218,8 @@ class Evaluator(ABC):
             Should a progress bar be displayed?
         :param restrict_entities_to:
             Whether to restrict the evaluation to certain entities of interest.
+        :param training_triples_factory:
+            Only needed if the evaluator is in filtered mode
 
         :return:
             Maximum possible batch size and, if necessary, the slice_size, which defaults to None.
@@ -228,7 +231,7 @@ class Evaluator(ABC):
             key='batch_size',
             start_value=batch_size,
             model=model,
-            training_mapped_triples=training_mapped_triples,
+            training_triples_factory=training_triples_factory,
             mapped_triples=mapped_triples,
             device=device,
             use_tqdm=use_tqdm,
@@ -246,7 +249,7 @@ class Evaluator(ABC):
             # must have failed to start slice_size search, we start with trying half the entities.
             start_value=ceil(model.num_entities / 2),
             model=model,
-            training_mapped_triples=training_mapped_triples,
+            training_triples_factory=training_triples_factory,
             mapped_triples=mapped_triples,
             device=device,
             use_tqdm=use_tqdm,
@@ -268,7 +271,7 @@ class Evaluator(ABC):
         use_tqdm: bool = False,
         restrict_entities_to: Optional[torch.LongTensor] = None,
         do_time_consuming_checks: bool = True,
-        training_mapped_triples: Optional[MappedTriples] = None,
+        training_triples_factory: Optional[TriplesFactory] = None,
     ) -> Tuple[int, bool]:
         values_dict = {}
         maximum_triples = mapped_triples.shape[0]
@@ -299,7 +302,7 @@ class Evaluator(ABC):
                 torch.cuda.empty_cache()
                 evaluate(
                     model=model,
-                    training_mapped_triples=training_mapped_triples,
+                    training_triples_factory=training_triples_factory,
                     mapped_triples=mapped_triples,
                     evaluators=self,
                     only_size_probing=True,
@@ -478,7 +481,7 @@ def evaluate(
     tqdm_kwargs: Optional[Mapping[str, str]] = None,
     restrict_entities_to: Optional[torch.LongTensor] = None,
     do_time_consuming_checks: bool = True,
-    training_mapped_triples: Optional[MappedTriples] = None,
+    training_triples_factory: Optional[TriplesFactory] = None,
 ) -> Union[MetricResults, List[MetricResults]]:
     """Evaluate metrics for model on mapped triples.
 
@@ -518,7 +521,7 @@ def evaluate(
         Whether to perform some time consuming checks on the provided arguments. Currently, this encompasses:
         - If restrict_entities_to is not None, check whether the triples have been filtered.
         Disabling this option can accelerate the method.
-    :param training_mapped_triples:
+    :param training_triples_factory:
         Only needed if the evaluator is in filtered mode
     """
     if isinstance(evaluators, Evaluator):  # upgrade a single evaluator to a list
@@ -555,9 +558,9 @@ def evaluate(
 
     # Prepare for result filtering
     if filtering_necessary or positive_masks_required:
-        if training_mapped_triples is None:
+        if training_triples_factory is None:
             raise ValueError
-        all_pos_triples = torch.cat([training_mapped_triples, mapped_triples], dim=0)
+        all_pos_triples = torch.cat([training_triples_factory.mapped_triples, mapped_triples], dim=0)
         all_pos_triples = all_pos_triples.to(device=device)
     else:
         all_pos_triples = None

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -558,8 +558,13 @@ def evaluate(
     # Prepare for result filtering
     if filtering_necessary or positive_masks_required:
         if additional_filtered_triples is None:
-            raise ValueError('should at least pass mapped training triples if filtering')
-        all_pos_triples = torch.cat([additional_filtered_triples, mapped_triples], dim=0)
+            logger.warning(
+                'filtered setting was enabled, but there were no `additional_filtered_triples`.'
+                ' This means you probably forgot to pass the training triples.',
+            )
+            all_pos_triples = mapped_triples
+        else:
+            all_pos_triples = torch.cat([additional_filtered_triples, mapped_triples], dim=0)
         all_pos_triples = all_pos_triples.to(device=device)
     else:
         all_pos_triples = None

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -355,7 +355,7 @@ class Evaluator(ABC):
     @staticmethod
     def _check_slicing_availability(model: Model, batch_size: int) -> None:
         # Test if slicing is implemented for the required functions of this model
-        if model.create_inverse_triples:
+        if model.use_inverse_triples:
             if not model.can_slice_t:
                 raise MemoryError(f"The current model can't be evaluated on this hardware with these parameters, as "
                                   f"evaluation batch_size={batch_size} is too big and slicing is not implemented for "

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -102,9 +102,9 @@ class Model(nn.Module, ABC):
         else:
             self.loss = loss
 
-        self._use_inverse_triples = triples_factory.create_inverse_triples
-        self._num_entities = triples_factory.num_entities
-        self._num_relations = triples_factory.num_relations
+        self.use_inverse_triples = triples_factory.create_inverse_triples
+        self.num_entities = triples_factory.num_entities
+        self.num_relations = triples_factory.num_relations
 
         '''
         When predict_with_sigmoid is set to True, the sigmoid function is applied to the logits during evaluation and
@@ -141,21 +141,6 @@ class Model(nn.Module, ABC):
         self.to_device_()
         self.post_parameter_update()
         return self
-
-    @property
-    def num_entities(self) -> int:  # noqa: D401
-        """The number of entities in the knowledge graph."""
-        return self._num_entities
-
-    @property
-    def num_relations(self) -> int:  # noqa: D401
-        """The number of unique relation types in the knowledge graph."""
-        return self._num_relations
-
-    @property
-    def use_inverse_triples(self) -> bool:  # noqa: D401,D400
-        """Should triples be modeled with their inverses?"""
-        return self._use_inverse_triples
 
     """Base methods"""
 

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -48,9 +48,6 @@ class Model(nn.Module, ABC):
     #: The default strategy for optimizing the model's hyper-parameters
     hpo_default: ClassVar[Mapping[str, Any]]
 
-    #: A triples factory with the training triples
-    triples_factory: TriplesFactory
-
     #: The device on which this model and its submodules are stored
     device: torch.device
 
@@ -85,8 +82,6 @@ class Model(nn.Module, ABC):
             The preferred device for model training and inference.
         :param random_seed:
             A random seed to use for initialising the model's weights. **Should** be set when aiming at reproducibility.
-        :param regularizer:
-            A regularizer to use for training.
         """
         super().__init__()
 
@@ -107,8 +102,6 @@ class Model(nn.Module, ABC):
         else:
             self.loss = loss
 
-        # The triples factory facilitates access to the dataset.
-        self.triples_factory = triples_factory
         self._create_inverse_triples = triples_factory.create_inverse_triples
         self._num_entities = triples_factory.num_entities
         self._num_relations = triples_factory.num_relations
@@ -459,7 +452,7 @@ class Model(nn.Module, ABC):
         ...     dataset='Nations',
         ...     model='RotatE',
         ... )
-        >>> df = result.model.get_head_prediction_df('accusation', 'brazil')
+        >>> df = result.model.get_head_prediction_df('accusation', 'brazil', triples_factory=result.training)
         """
         from .predict import get_head_prediction_df
         warnings.warn('Use pykeen.models.predict.get_head_prediction_df', DeprecationWarning)
@@ -501,7 +494,7 @@ class Model(nn.Module, ABC):
         ...     dataset='Nations',
         ...     model='RotatE',
         ... )
-        >>> df = result.model.get_tail_prediction_df('brazil', 'accusation')
+        >>> df = result.model.get_tail_prediction_df('brazil', 'accusation', triples_factory=result.training)
         """
         from .predict import get_tail_prediction_df
         warnings.warn('Use pykeen.models.predict.get_tail_prediction_df', DeprecationWarning)

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -102,7 +102,7 @@ class Model(nn.Module, ABC):
         else:
             self.loss = loss
 
-        self._create_inverse_triples = triples_factory.create_inverse_triples
+        self._use_inverse_triples = triples_factory.create_inverse_triples
         self._num_entities = triples_factory.num_entities
         self._num_relations = triples_factory.num_relations
 
@@ -153,9 +153,9 @@ class Model(nn.Module, ABC):
         return self._num_relations
 
     @property
-    def create_inverse_triples(self) -> bool:  # noqa: D401,D400
+    def use_inverse_triples(self) -> bool:  # noqa: D401,D400
         """Should triples be modeled with their inverses?"""
-        return self._create_inverse_triples
+        return self._use_inverse_triples
 
     """Base methods"""
 
@@ -333,7 +333,7 @@ class Model(nn.Module, ABC):
             For each r-t pair, the scores for all possible heads.
         """
         self.eval()  # Enforce evaluation mode
-        if self.create_inverse_triples:
+        if self.use_inverse_triples:
             scores = self.score_h_inverse(rt_batch=rt_batch, slice_size=slice_size)
         elif slice_size is None:
             scores = self.score_h(rt_batch)
@@ -503,7 +503,7 @@ class Model(nn.Module, ABC):
     """Inverse scoring"""
 
     def _prepare_inverse_batch(self, batch: torch.LongTensor, index_relation: int) -> torch.LongTensor:
-        if not self.create_inverse_triples:
+        if not self.use_inverse_triples:
             raise ValueError(
                 "Your model is not configured to predict with inverse relations."
                 " Set ``create_inverse_triples=True`` when creating the dataset/triples factory"

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -609,8 +609,8 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
         else:
             self.regularizer = NoRegularizer()
 
-        self._entity_ids = triples_factory.get_entity_ids()
-        self._relation_ids = triples_factory.get_relation_ids()
+        self._entity_ids = sorted(triples_factory.get_entity_ids())
+        self._relation_ids = sorted(triples_factory.get_relation_ids())
 
     def post_parameter_update(self) -> None:
         """Has to be called after each parameter update."""

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -602,8 +602,8 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
         else:
             self.regularizer = NoRegularizer()
 
-        self._entity_ids = sorted(triples_factory.get_entity_ids())
-        self._relation_ids = sorted(triples_factory.get_relation_ids())
+        self._entity_ids = triples_factory.entity_ids
+        self._relation_ids = triples_factory.relation_ids
 
     def post_parameter_update(self) -> None:
         """Has to be called after each parameter update."""

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -226,6 +226,8 @@ class PipelineResult(Result):
     #: The model trained by the pipeline
     model: Model
 
+    training: TriplesFactory
+
     #: The training loop used by the pipeline
     training_loop: TrainingLoop
 
@@ -856,7 +858,6 @@ def pipeline(  # noqa: C901
         model_instance = model
         # TODO should training be reset?
         # TODO should kwargs for loss and regularizer be checked and raised for?
-        model_instance.triples_factory = training
     else:
         model_instance = _build_model_helper(
             model=model,
@@ -894,6 +895,7 @@ def pipeline(  # noqa: C901
         negative_sampler_cls = None
         training_loop_instance = training_loop_cls(
             model=model_instance,
+            triples_factory=training,
             optimizer=optimizer_instance,
             **training_loop_kwargs,
         )
@@ -907,6 +909,7 @@ def pipeline(  # noqa: C901
         )
         training_loop_instance = SLCWATrainingLoop(
             model=model_instance,
+            triples_factory=training,
             optimizer=optimizer_instance,
             negative_sampler_cls=negative_sampler_cls,
             negative_sampler_kwargs=negative_sampler_kwargs,
@@ -944,6 +947,7 @@ def pipeline(  # noqa: C901
         stopper,
         model=model_instance,
         evaluator=evaluator_instance,
+        training_triples_factory=training,
         evaluation_triples_factory=validation,
         result_tracker=_result_tracker,
         **stopper_kwargs,
@@ -1010,6 +1014,7 @@ def pipeline(  # noqa: C901
     evaluate_start_time = time.time()
     metric_results: MetricResults = _safe_evaluate(
         model=model_instance,
+        training_mapped_triples=training.mapped_triples,
         mapped_triples=mapped_triples,
         evaluator=evaluator_instance,
         evaluation_kwargs=evaluation_kwargs,
@@ -1025,6 +1030,7 @@ def pipeline(  # noqa: C901
     return PipelineResult(
         random_seed=_random_seed,
         model=model_instance,
+        training=training,
         training_loop=training_loop_instance,
         losses=losses,
         stopper=stopper_instance,
@@ -1037,6 +1043,7 @@ def pipeline(  # noqa: C901
 
 def _safe_evaluate(
     model: Model,
+    training_mapped_triples: MappedTriples,
     mapped_triples: MappedTriples,
     evaluator: Evaluator,
     evaluation_kwargs: Dict[str, Any],
@@ -1045,7 +1052,8 @@ def _safe_evaluate(
     """Evaluate with a potentially safe fallback to CPU.
 
     :param model: The model
-    :param mapped_triples: Mapped triples
+    :param training_mapped_triples: Mapped triples from the training set
+    :param mapped_triples: Mapped triples from the evaluation set (test or valid)
     :param evaluator: An evaluator
     :param evaluation_kwargs: Kwargs for the evaluator (might get modified in place)
     :param evaluation_fallback:
@@ -1063,6 +1071,7 @@ def _safe_evaluate(
             metric_results: MetricResults = evaluator.evaluate(
                 model=model,
                 mapped_triples=mapped_triples,
+                training_mapped_triples=training_mapped_triples,
                 **evaluation_kwargs,
             )
         except (MemoryError, RuntimeError) as e:

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1014,7 +1014,7 @@ def pipeline(  # noqa: C901
     evaluate_start_time = time.time()
     metric_results: MetricResults = _safe_evaluate(
         model=model_instance,
-        training_mapped_triples=training.mapped_triples,
+        training_triples_factory=training,
         mapped_triples=mapped_triples,
         evaluator=evaluator_instance,
         evaluation_kwargs=evaluation_kwargs,
@@ -1043,7 +1043,7 @@ def pipeline(  # noqa: C901
 
 def _safe_evaluate(
     model: Model,
-    training_mapped_triples: MappedTriples,
+    training_triples_factory: TriplesFactory,
     mapped_triples: MappedTriples,
     evaluator: Evaluator,
     evaluation_kwargs: Dict[str, Any],
@@ -1052,7 +1052,7 @@ def _safe_evaluate(
     """Evaluate with a potentially safe fallback to CPU.
 
     :param model: The model
-    :param training_mapped_triples: Mapped triples from the training set
+    :param training_triples_factory: Training triples factory
     :param mapped_triples: Mapped triples from the evaluation set (test or valid)
     :param evaluator: An evaluator
     :param evaluation_kwargs: Kwargs for the evaluator (might get modified in place)
@@ -1071,7 +1071,7 @@ def _safe_evaluate(
             metric_results: MetricResults = evaluator.evaluate(
                 model=model,
                 mapped_triples=mapped_triples,
-                training_mapped_triples=training_mapped_triples,
+                training_triples_factory=training_triples_factory,
                 **evaluation_kwargs,
             )
         except (MemoryError, RuntimeError) as e:

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1071,7 +1071,7 @@ def _safe_evaluate(
             metric_results: MetricResults = evaluator.evaluate(
                 model=model,
                 mapped_triples=mapped_triples,
-                training_triples_factory=training_triples_factory,
+                additional_filter_triples=training_triples_factory.mapped_triples,
                 **evaluation_kwargs,
             )
         except (MemoryError, RuntimeError) as e:

--- a/src/pykeen/pipeline/plot_utils.py
+++ b/src/pykeen/pipeline/plot_utils.py
@@ -178,7 +178,7 @@ def plot_er(  # noqa: C901
         subtitle = f' using {reducer_cls.__name__}'
 
     if plot_entities:
-        entity_id_to_label = pipeline_result.model.triples_factory.entity_id_to_label
+        entity_id_to_label = pipeline_result.training.entity_id_to_label
         for entity_id, entity_reduced_embedding in enumerate(e_embeddings):
             entity_label = entity_id_to_label[entity_id]
             if entities and entity_label not in entities:
@@ -188,7 +188,7 @@ def plot_er(  # noqa: C901
             ax.annotate(entity_label, (x + annotation_x_offset, y + annotation_y_offset))
 
     if plot_relations:
-        relation_id_to_label = pipeline_result.model.triples_factory.relation_id_to_label
+        relation_id_to_label = pipeline_result.training.relation_id_to_label
         for relation_id, relation_reduced_embedding in enumerate(r_embeddings):
             relation_label = relation_id_to_label[relation_id]
             if relations and relation_label not in relations:

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -122,7 +122,7 @@ class EarlyStopper(Stopper):
         # Evaluate
         metric_results = self.evaluator.evaluate(
             model=self.model,
-            training_mapped_triples=self.training_triples_factory.mapped_triples,
+            training_triples_factory=self.training_triples_factory,
             mapped_triples=self.evaluation_triples_factory.mapped_triples,
             use_tqdm=False,
             batch_size=self.evaluation_batch_size,

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -122,7 +122,7 @@ class EarlyStopper(Stopper):
         # Evaluate
         metric_results = self.evaluator.evaluate(
             model=self.model,
-            training_triples_factory=self.training_triples_factory,
+            additional_filter_triples=self.training_triples_factory.mapped_triples,
             mapped_triples=self.evaluation_triples_factory.mapped_triples,
             use_tqdm=False,
             batch_size=self.evaluation_batch_size,

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -62,6 +62,8 @@ class EarlyStopper(Stopper):
     model: Model = dataclasses.field(repr=False)
     #: The evaluator
     evaluator: Evaluator
+    #: The triples to use for training (to be used during filtered evaluation)
+    training_triples_factory: TriplesFactory
     #: The triples to use for evaluation
     evaluation_triples_factory: TriplesFactory
     #: Size of the evaluation batches
@@ -120,6 +122,7 @@ class EarlyStopper(Stopper):
         # Evaluate
         metric_results = self.evaluator.evaluate(
             model=self.model,
+            training_mapped_triples=self.training_triples_factory.mapped_triples,
             mapped_triples=self.evaluation_triples_factory.mapped_triples,
             use_tqdm=False,
             batch_size=self.evaluation_batch_size,

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -13,7 +13,7 @@ from .utils import apply_label_smoothing
 from ..losses import CrossEntropyLoss
 from ..models import Model
 from ..sampling import BasicNegativeSampler, NegativeSampler
-from ..triples import Instances
+from ..triples import Instances, TriplesFactory
 from ..typing import MappedTriples
 
 __all__ = [
@@ -32,6 +32,7 @@ class SLCWATrainingLoop(TrainingLoop):
     def __init__(
         self,
         model: Model,
+        triples_factory: TriplesFactory,
         optimizer: Optional[Optimizer] = None,
         negative_sampler_cls: Optional[Type[NegativeSampler]] = None,
         negative_sampler_kwargs: Optional[Mapping[str, Any]] = None,
@@ -50,6 +51,7 @@ class SLCWATrainingLoop(TrainingLoop):
         """
         super().__init__(
             model=model,
+            triples_factory=triples_factory,
             optimizer=optimizer,
             automatic_memory_optimization=automatic_memory_optimization,
         )

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -93,18 +93,21 @@ class TrainingLoop(ABC):
     def __init__(
         self,
         model: Model,
+        triples_factory: TriplesFactory,
         optimizer: Optional[Optimizer] = None,
         automatic_memory_optimization: bool = True,
     ) -> None:
         """Initialize the training loop.
 
         :param model: The model to train
+        :param triples_factory: The training triples factory
         :param optimizer: The optimizer to use while training the model
         :param automatic_memory_optimization: bool
             Whether to automatically optimize the sub-batch size during
             training and batch size during evaluation with regards to the hardware at hand.
         """
         self.model = model
+        self.triples_factory = triples_factory
         self.optimizer = optimizer
         self.training_instances = None
         self.losses_per_epochs = []
@@ -131,11 +134,6 @@ class TrainingLoop(ABC):
     def get_normalized_name(cls) -> str:
         """Get the normalized name of the training loop."""
         return normalize_string(cls.__name__, suffix=TrainingLoop.__name__)
-
-    @property
-    def triples_factory(self) -> TriplesFactory:  # noqa: D401
-        """The triples factory in the model."""
-        return self.model.triples_factory
 
     @property
     def device(self):  # noqa: D401

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -15,7 +15,7 @@ import torch
 
 from .instances import Instances, LCWAInstances, SLCWAInstances
 from .splitting import split
-from .utils import load_triples
+from .utils import get_entities, get_relations, load_triples
 from ..typing import EntityMapping, LabeledTriples, MappedTriples, RelationMapping, TorchRandomHint
 from ..utils import compact_mapping, format_relative_comparison, invert_mapping, torch_is_in_1d
 
@@ -196,6 +196,8 @@ class CoreTriplesFactory:
         mapped_triples: MappedTriples,
         num_entities: int,
         num_relations: int,
+        entity_ids: Collection[int],
+        relation_ids: Collection[int],
         create_inverse_triples: bool = False,
         metadata: Optional[Mapping[str, Any]] = None,
     ):
@@ -217,6 +219,8 @@ class CoreTriplesFactory:
         self.mapped_triples = mapped_triples
         self._num_entities = num_entities
         self._num_relations = num_relations
+        self.entity_ids = entity_ids
+        self.relation_ids = relation_ids
         self.create_inverse_triples = create_inverse_triples
         if metadata is None:
             metadata = dict()
@@ -228,6 +232,8 @@ class CoreTriplesFactory:
         mapped_triples: MappedTriples,
         num_entities: Optional[int] = None,
         num_relations: Optional[int] = None,
+        entity_ids: Collection[int] = None,
+        relation_ids: Collection[int] = None,
         create_inverse_triples: bool = False,
         metadata: Optional[Mapping[str, Any]] = None,
     ) -> "CoreTriplesFactory":
@@ -252,10 +258,16 @@ class CoreTriplesFactory:
             num_entities = mapped_triples[:, [0, 2]].max().item() + 1
         if num_relations is None:
             num_relations = mapped_triples[:, 1].max().item() + 1
+        if entity_ids is None:
+            entity_ids = get_entities(mapped_triples)
+        if relation_ids is None:
+            relation_ids = get_relations(mapped_triples)
         return CoreTriplesFactory(
             mapped_triples=mapped_triples,
             num_entities=num_entities,
             num_relations=num_relations,
+            entity_ids=entity_ids,
+            relation_ids=relation_ids,
             create_inverse_triples=create_inverse_triples,
             metadata=metadata,
         )
@@ -281,14 +293,6 @@ class CoreTriplesFactory:
     def num_triples(self) -> int:  # noqa: D401
         """The number of triples."""
         return self.mapped_triples.shape[0]
-
-    def get_entity_ids(self) -> Collection[int]:
-        """Get the set of entity identifiers."""
-        return list(range(self.num_entities))
-
-    def get_relation_ids(self) -> Collection[int]:
-        """Get the set of relation identifiers."""
-        return list(range(self.num_relations))
 
     def extra_repr(self) -> str:
         """Extra representation string."""
@@ -413,6 +417,8 @@ class CoreTriplesFactory:
             mapped_triples=mapped_triples,
             num_entities=self.num_entities,
             num_relations=self.real_num_relations,
+            entity_ids=self.entity_ids,
+            relation_ids=self.relation_ids,
             create_inverse_triples=create_inverse_triples,
             metadata={
                 **(extra_metadata or {}),
@@ -630,6 +636,8 @@ class TriplesFactory(CoreTriplesFactory):
             mapped_triples=mapped_triples,
             num_entities=len(entity_to_id),
             num_relations=len(relation_to_id),
+            entity_ids=sorted(entity_to_id.values()),
+            relation_ids=sorted(relation_to_id.values()),
             create_inverse_triples=create_inverse_triples,
             metadata=metadata,
         )
@@ -811,14 +819,6 @@ class TriplesFactory(CoreTriplesFactory):
     def relation_id_to_label(self) -> Mapping[int, str]:
         """Return the mapping from relations IDs to labels."""
         return self.relation_labeling.id_to_label
-
-    def get_entity_ids(self) -> Collection[int]:
-        """Get the set of entity identifiers."""
-        return self.entity_to_id.values()
-
-    def get_relation_ids(self) -> Collection[int]:
-        """Get the set of relation identifiers."""
-        return self.relation_to_id.values()
 
     @property
     def triples(self) -> np.ndarray:  # noqa: D401

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import os
 import re
+from functools import lru_cache
 from typing import Any, Callable, Collection, Dict, List, Mapping, Optional, Sequence, Set, TextIO, Union
 
 import numpy as np
@@ -284,11 +285,11 @@ class CoreTriplesFactory:
 
     def get_entity_ids(self) -> Collection[int]:
         """Get the set of entity identifiers."""
-        raise NotImplementedError  # TODO @mberr should these be pre-cached on __init__?
+        return list(range(self.num_entities))
 
     def get_relation_ids(self) -> Collection[int]:
         """Get the set of relation identifiers."""
-        raise NotImplementedError
+        return list(range(self.num_relations))
 
     def extra_repr(self) -> str:
         """Extra representation string."""

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -7,7 +7,6 @@ import itertools
 import logging
 import os
 import re
-from functools import lru_cache
 from typing import Any, Callable, Collection, Dict, List, Mapping, Optional, Sequence, Set, TextIO, Union
 
 import numpy as np

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -846,6 +846,7 @@ class ModelTestCase(unittest_templates.GenericTestCase[Model]):
         """Test that sLCWA training does not fail."""
         loop = SLCWATrainingLoop(
             model=self.instance,
+            triples_factory=self.factory,
             optimizer=Adagrad(params=self.instance.get_grad_params(), lr=0.001),
             **(self.training_loop_kwargs or {}),
         )
@@ -862,6 +863,7 @@ class ModelTestCase(unittest_templates.GenericTestCase[Model]):
         """Test that LCWA training does not fail."""
         loop = LCWATrainingLoop(
             model=self.instance,
+            triples_factory=self.factory,
             optimizer=Adagrad(params=self.instance.get_grad_params(), lr=0.001),
             **(self.training_loop_kwargs or {}),
         )

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -20,6 +20,11 @@ from pykeen.training import SLCWATrainingLoop
 from pykeen.typing import MappedTriples
 from tests.mocks import MockModel
 
+try:
+    import mlflow
+except ImportError:
+    mlflow = None
+
 
 class TestRandom(unittest.TestCase):
     """Random tests for early stopper."""
@@ -203,6 +208,7 @@ class TestEarlyStopping(unittest.TestCase):
             self.assertFalse(self.stopper.should_stop(epoch=epoch))
         self.assertTrue(self.stopper.should_stop(epoch=epoch))
 
+    @unittest.skipUnless(mlflow is not None, reason='MLFlow not installed')
     def test_result_logging_with_mlflow(self):
         """Test whether the MLFLow result logger works."""
         self.stopper.result_tracker = MLFlowResultTracker()

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -170,6 +170,7 @@ class TestEarlyStopping(unittest.TestCase):
         self.stopper = EarlyStopper(
             model=self.model,
             evaluator=self.mock_evaluator,
+            training_triples_factory=nations.training,
             evaluation_triples_factory=nations.validation,
             patience=self.patience,
             relative_delta=self.delta,
@@ -255,6 +256,7 @@ class TestEarlyStoppingRealWorld(unittest.TestCase):
         stopper = EarlyStopper(
             model=model,
             evaluator=evaluator,
+            training_triples_factory=nations.training,
             evaluation_triples_factory=nations.validation,
             patience=self.patience,
             relative_delta=self.relative_delta,

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -270,6 +270,7 @@ class TestEarlyStoppingRealWorld(unittest.TestCase):
         )
         training_loop = SLCWATrainingLoop(
             model=model,
+            triples_factory=nations.training,
             optimizer=Adam(params=model.get_grad_params()),
             automatic_memory_optimization=False,
         )

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -469,14 +469,15 @@ class TestEvaluationStructure(unittest.TestCase):
         """Prepare for testing the evaluation structure."""
         self.counter = 1337
         self.evaluator = DummyEvaluator(counter=self.counter, filtered=True, automatic_memory_optimization=False)
-        self.triples_factory = Nations().training
-        self.model = MockModel(triples_factory=self.triples_factory)
+        self.dataset = Nations()
+        self.model = MockModel(triples_factory=self.dataset.training)
 
     def test_evaluation_structure(self):
         """Test if the evaluator has a balanced call of head and tail processors."""
         eval_results = self.evaluator.evaluate(
             model=self.model,
-            mapped_triples=self.triples_factory.mapped_triples,
+            training_mapped_triples=self.dataset.training.mapped_triples,
+            mapped_triples=self.dataset.testing.mapped_triples,
             batch_size=1,
             use_tqdm=False,
         )

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -476,7 +476,7 @@ class TestEvaluationStructure(unittest.TestCase):
         """Test if the evaluator has a balanced call of head and tail processors."""
         eval_results = self.evaluator.evaluate(
             model=self.model,
-            training_triples_factory=self.dataset.training,
+            additional_filter_triples=self.dataset.training.mapped_triples,
             mapped_triples=self.dataset.testing.mapped_triples,
             batch_size=1,
             use_tqdm=False,

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -476,7 +476,7 @@ class TestEvaluationStructure(unittest.TestCase):
         """Test if the evaluator has a balanced call of head and tail processors."""
         eval_results = self.evaluator.evaluate(
             model=self.model,
-            training_mapped_triples=self.dataset.training.mapped_triples,
+            training_triples_factory=self.dataset.training,
             mapped_triples=self.dataset.testing.mapped_triples,
             batch_size=1,
             use_tqdm=False,

--- a/tests/test_model_mode.py
+++ b/tests/test_model_mode.py
@@ -196,12 +196,6 @@ class MinimalTriplesFactory:
     }
     num_entities = 2
     num_relations = 2
+    entity_ids = list(range(num_entities))
+    relation_ids = list(range(num_relations))
     create_inverse_triples: bool = False
-
-    @classmethod
-    def get_entity_ids(cls):  # noqa:D102
-        return cls.entity_to_id.values()
-
-    @classmethod
-    def get_relation_ids(cls):  # noqa:D102
-        return cls.relation_to_id.values()

--- a/tests/test_model_mode.py
+++ b/tests/test_model_mode.py
@@ -186,14 +186,6 @@ class SimpleInteractionModel(EntityRelationEmbeddingModel):
 class MinimalTriplesFactory:
     """A triples factory with minial attributes to allow the model to initiate."""
 
-    relation_to_id = {
-        "0": 0,
-        "1": 1,
-    }
-    entity_to_id = {
-        "0": 0,
-        "1": 1,
-    }
     num_entities = 2
     num_relations = 2
     entity_ids = list(range(num_entities))

--- a/tests/test_model_mode.py
+++ b/tests/test_model_mode.py
@@ -196,6 +196,7 @@ class MinimalTriplesFactory:
     }
     num_entities = 2
     num_relations = 2
+    create_inverse_triples: bool = False
 
     @classmethod
     def get_entity_ids(cls):  # noqa:D102

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -47,6 +47,7 @@ class TestPipeline(unittest.TestCase):
         tails_df = get_tail_prediction_df(
             self.model,
             'brazil', 'intergovorgs', testing=self.testing_mapped_triples,
+            triples_factory=self.dataset.training,
             add_novelties=False,
         )
         self.assertEqual(['tail_id', 'tail_label', 'score'], list(tails_df.columns))
@@ -58,13 +59,18 @@ class TestPipeline(unittest.TestCase):
             self.model,
             'brazil', 'intergovorgs', testing=self.testing_mapped_triples,
             remove_known=True,
+            triples_factory=self.dataset.training,
         )
         self.assertEqual(['tail_id', 'tail_label', 'score'], list(tails_df.columns))
         self.assertEqual({'jordan', 'brazil', 'ussr', 'burma', 'china'}, set(tails_df['tail_label']))
 
     def test_predict_tails_with_novelties(self):
         """Test scoring tails with labeling as novel w.r.t. training and testing."""
-        tails_df = get_tail_prediction_df(self.model, 'brazil', 'intergovorgs', testing=self.testing_mapped_triples)
+        tails_df = get_tail_prediction_df(
+            self.model, 'brazil', 'intergovorgs',
+            triples_factory=self.dataset.training,
+            testing=self.testing_mapped_triples,
+        )
         self.assertEqual(['tail_id', 'tail_label', 'score', 'in_training', 'in_testing'], list(tails_df.columns))
         self.assertEqual(self.model.num_entities, len(tails_df.index))
         training_tails = set(tails_df.loc[tails_df['in_training'], 'tail_label'])
@@ -74,7 +80,11 @@ class TestPipeline(unittest.TestCase):
 
     def test_predict_relations_with_novelties(self):
         """Test scoring relations with labeling as novel w.r.t. training and testing."""
-        rel_df = get_relation_prediction_df(self.model, 'brazil', 'uk', testing=self.testing_mapped_triples)
+        rel_df = get_relation_prediction_df(
+            self.model, 'brazil', 'uk',
+            triples_factory=self.dataset.training,
+            testing=self.testing_mapped_triples,
+        )
         self.assertEqual(['relation_id', 'relation_label', 'score', 'in_training', 'in_testing'], list(rel_df.columns))
         self.assertEqual(self.model.num_relations, len(rel_df.index))
         training_rels = set(rel_df.loc[rel_df['in_training'], 'relation_label'])
@@ -91,7 +101,12 @@ class TestPipeline(unittest.TestCase):
 
     def test_predict_heads_with_novelties(self):
         """Test scoring heads with labeling as novel w.r.t. training and testing."""
-        heads_df = get_head_prediction_df(self.model, 'conferences', 'brazil', testing=self.testing_mapped_triples)
+        heads_df = get_head_prediction_df(
+            self.model,
+            'conferences', 'brazil',
+            triples_factory=self.dataset.training,
+            testing=self.testing_mapped_triples,
+        )
         self.assertEqual(['head_id', 'head_label', 'score', 'in_training', 'in_testing'], list(heads_df.columns))
         self.assertEqual(self.model.num_entities, len(heads_df.index))
         training_heads = set(heads_df.loc[heads_df['in_training'], 'head_label'])
@@ -101,7 +116,12 @@ class TestPipeline(unittest.TestCase):
 
     def test_predict_all_no_novelties(self):
         """Test scoring all triples without labeling as novel w.r.t. training and testing."""
-        all_df = get_all_prediction_df(model=self.model, testing=self.testing_mapped_triples, add_novelties=False)
+        all_df = get_all_prediction_df(
+            model=self.model,
+            triples_factory=self.dataset.training,
+            testing=self.testing_mapped_triples,
+            add_novelties=False,
+        )
         self.assertIsInstance(all_df, pd.DataFrame)
         self.assertEqual(
             ['head_id', 'head_label', 'relation_id', 'relation_label', 'tail_id', 'tail_label', 'score'],
@@ -112,7 +132,12 @@ class TestPipeline(unittest.TestCase):
 
     def test_predict_all_remove_known(self):
         """Test scoring all triples while removing non-novel triples w.r.t. training and testing."""
-        all_df = get_all_prediction_df(model=self.model, testing=self.testing_mapped_triples, remove_known=True)
+        all_df = get_all_prediction_df(
+            model=self.model,
+            triples_factory=self.dataset.training,
+            testing=self.testing_mapped_triples,
+            remove_known=True,
+        )
         self.assertIsInstance(all_df, pd.DataFrame)
         self.assertEqual(
             ['head_id', 'head_label', 'relation_id', 'relation_label', 'tail_id', 'tail_label', 'score'],
@@ -125,7 +150,11 @@ class TestPipeline(unittest.TestCase):
 
     def test_predict_all_with_novelties(self):
         """Test scoring all triples with labeling as novel w.r.t. training and testing."""
-        all_df = get_all_prediction_df(model=self.model, testing=self.testing_mapped_triples)
+        all_df = get_all_prediction_df(
+            model=self.model,
+            triples_factory=self.dataset.training,
+            testing=self.testing_mapped_triples,
+        )
         self.assertIsInstance(all_df, pd.DataFrame)
         self.assertEqual(
             [

--- a/tests/training/test_utils.py
+++ b/tests/training/test_utils.py
@@ -61,7 +61,7 @@ class LossTensorTest(unittest.TestCase):
             loss=loss_cls,
         )
 
-        loop = LCWATrainingLoop(model=model)
+        loop = LCWATrainingLoop(model=model, triples_factory=factory)
         loss = loop._mr_loss_helper(predictions=self.predictions, labels=self.labels)
         self.assertEqual(14, loss)
 
@@ -77,7 +77,7 @@ class LossTensorTest(unittest.TestCase):
             loss=loss_cls,
         )
 
-        loop = LCWATrainingLoop(model=model)
+        loop = LCWATrainingLoop(model=model, triples_factory=factory)
         loss = loop._mr_loss_helper(predictions=self.predictions, labels=self.labels)
         self.assertEqual(1, loss)
 


### PR DESCRIPTION
After a discussion with @migalkin related to the HF Accelerate PR (#393), he was a bit concerned that the `pykeen.models.Model` class actually holds the instance of the training `pykeen.triples.TriplesFactory`. This PR is a concept for how the triples factory could actually be removed from the model. The interface remains the same, since the various different deriving classes use the training triples factory to prepare various things that they will need (e.g., # triples, # entities, # relations, create inverse triples)

Note - the TrainingLoop class used to have access to the triples factory via its reference to a Model. Now it's storing its on reference to them. Will this cause the same issues as before, just delayed until later?