### PR TITLE
🥝 🏭 Update type annotations to CoreTriplesFactory where possible

### DIFF
--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -87,9 +87,9 @@ def get_dataset(
     *,
     dataset: Union[None, str, Dataset, Type[Dataset]] = None,
     dataset_kwargs: Optional[Mapping[str, Any]] = None,
-    training: Union[None, str, TriplesFactory] = None,
-    testing: Union[None, str, TriplesFactory] = None,
-    validation: Union[None, str, TriplesFactory] = None,
+    training: Union[None, str, CoreTriplesFactory] = None,
+    testing: Union[None, str, CoreTriplesFactory] = None,
+    validation: Union[None, str, CoreTriplesFactory] = None,
 ) -> Dataset:
     """Get the dataset.
 

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -34,7 +34,7 @@ from .openbiolink import OpenBioLink, OpenBioLinkF1, OpenBioLinkF2, OpenBioLinkL
 from .umls import UMLS
 from .wordnet import WN18, WN18RR
 from .yago import YAGO310
-from ..triples import CoreTriplesFactory, TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..utils import normalize_string
 
 __all__ = [

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -32,7 +32,7 @@ from ..sampling import NegativeSampler, negative_sampler_resolver
 from ..stoppers import EarlyStopper, Stopper, stopper_resolver
 from ..trackers import ResultTracker, tracker_resolver
 from ..training import SLCWATrainingLoop, TrainingLoop, training_loop_resolver
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..typing import Hint, HintType
 from ..utils import Result, ensure_ftp_directory, fix_dataclass_init_docs, get_df_io, get_json_bytes_io
 from ..version import get_git_hash, get_version
@@ -65,9 +65,9 @@ class Objective:
 
     # 1. Dataset
     dataset_kwargs: Optional[Mapping[str, Any]] = None
-    training: Hint[TriplesFactory] = None
-    testing: Hint[TriplesFactory] = None
-    validation: Hint[TriplesFactory] = None
+    training: Hint[CoreTriplesFactory] = None
+    testing: Hint[CoreTriplesFactory] = None
+    validation: Hint[CoreTriplesFactory] = None
     evaluation_entity_whitelist: Optional[Collection[str]] = None
     evaluation_relation_whitelist: Optional[Collection[str]] = None
     # 2. Model
@@ -421,9 +421,9 @@ def hpo_pipeline(
     # 1. Dataset
     dataset: Union[None, str, Dataset, Type[Dataset]] = None,
     dataset_kwargs: Optional[Mapping[str, Any]] = None,
-    training: Hint[TriplesFactory] = None,
-    testing: Hint[TriplesFactory] = None,
-    validation: Hint[TriplesFactory] = None,
+    training: Hint[CoreTriplesFactory] = None,
+    testing: Hint[CoreTriplesFactory] = None,
+    validation: Hint[CoreTriplesFactory] = None,
     evaluation_entity_whitelist: Optional[Collection[str]] = None,
     evaluation_relation_whitelist: Optional[Collection[str]] = None,
     # 2. Model
@@ -813,9 +813,9 @@ def _set_study_dataset(
     study: Study,
     *,
     dataset: Union[None, str, Dataset, Type[Dataset]] = None,
-    training: Union[None, str, TriplesFactory] = None,
-    testing: Union[None, str, TriplesFactory] = None,
-    validation: Union[None, str, TriplesFactory] = None,
+    training: Union[None, str, CoreTriplesFactory] = None,
+    testing: Union[None, str, CoreTriplesFactory] = None,
+    validation: Union[None, str, CoreTriplesFactory] = None,
 ):
     if dataset is not None:
         if training is not None or testing is not None or validation is not None:

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -19,7 +19,7 @@ from torch import nn
 from ..losses import Loss, MarginRankingLoss
 from ..nn.emb import Embedding, EmbeddingSpecification
 from ..regularizers import NoRegularizer, Regularizer
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory, TriplesFactory
 from ..typing import DeviceHint, ScorePack
 from ..utils import NoRandomSeedNecessary, _can_slice, extend_batch, resolve_device, set_random_seed
 
@@ -62,7 +62,7 @@ class Model(nn.Module, ABC):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         loss: Optional[Loss] = None,
         predict_with_sigmoid: bool = False,
         preferred_device: DeviceHint = None,
@@ -546,7 +546,7 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         loss: Optional[Loss] = None,
         predict_with_sigmoid: bool = False,
         preferred_device: DeviceHint = None,
@@ -704,7 +704,7 @@ class EntityEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         entity_representations: EmbeddingSpecification,
         loss: Optional[Loss] = None,
         predict_with_sigmoid: bool = False,
@@ -753,7 +753,7 @@ class EntityRelationEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         entity_representations: EmbeddingSpecification,
         relation_representations: EmbeddingSpecification,
         loss: Optional[Loss] = None,

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -19,7 +19,7 @@ from torch import nn
 from ..losses import Loss, MarginRankingLoss
 from ..nn.emb import Embedding, EmbeddingSpecification
 from ..regularizers import NoRegularizer, Regularizer
-from ..triples import CoreTriplesFactory, TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..typing import DeviceHint, ScorePack
 from ..utils import NoRandomSeedNecessary, _can_slice, extend_batch, resolve_device, set_random_seed
 

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -19,7 +19,7 @@ from ..losses import Loss
 from ..nn.emb import EmbeddingSpecification, RepresentationModule
 from ..nn.modules import Interaction, interaction_resolver
 from ..regularizers import Regularizer
-from ..triples import CoreTriplesFactory, TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..typing import DeviceHint, HeadRepresentation, RelationRepresentation, TailRepresentation
 from ..utils import check_shapes
 

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -19,7 +19,7 @@ from ..losses import Loss
 from ..nn.emb import EmbeddingSpecification, RepresentationModule
 from ..nn.modules import Interaction, interaction_resolver
 from ..regularizers import Regularizer
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory, TriplesFactory
 from ..typing import DeviceHint, HeadRepresentation, RelationRepresentation, TailRepresentation
 from ..utils import check_shapes
 
@@ -327,7 +327,7 @@ class ERModel(
     def __init__(
         self,
         *,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         interaction: Hint[Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation]],
         interaction_kwargs: Optional[Mapping[str, Any]] = None,
         entity_representations: EmbeddingSpecificationHint = None,

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -11,7 +11,7 @@ import pandas as pd
 import torch
 
 from .base import Model
-from ..triples import CoreTriplesFactory
+from ..triples import CoreTriplesFactory, TriplesFactory
 from ..typing import MappedTriples, ScorePack
 
 __all__ = [
@@ -30,7 +30,7 @@ def get_head_prediction_df(
     relation_label: str,
     tail_label: str,
     *,
-    triples_factory: CoreTriplesFactory,
+    triples_factory: TriplesFactory,
     add_novelties: bool = True,
     remove_known: bool = False,
     testing: Optional[torch.LongTensor] = None,
@@ -94,7 +94,7 @@ def get_tail_prediction_df(
     head_label: str,
     relation_label: str,
     *,
-    triples_factory: CoreTriplesFactory,
+    triples_factory: TriplesFactory,
     add_novelties: bool = True,
     remove_known: bool = False,
     testing: Optional[torch.LongTensor] = None,
@@ -158,7 +158,7 @@ def get_relation_prediction_df(
     head_label: str,
     tail_label: str,
     *,
-    triples_factory: CoreTriplesFactory,
+    triples_factory: TriplesFactory,
     add_novelties: bool = True,
     remove_known: bool = False,
     testing: Optional[torch.LongTensor] = None,

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -11,7 +11,7 @@ import pandas as pd
 import torch
 
 from .base import Model
-from ..triples import CoreTriplesFactory, TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..typing import MappedTriples, ScorePack
 
 __all__ = [

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -11,7 +11,7 @@ import pandas as pd
 import torch
 
 from .base import Model
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory, TriplesFactory
 from ..typing import MappedTriples, ScorePack
 
 __all__ = [
@@ -30,7 +30,7 @@ def get_head_prediction_df(
     relation_label: str,
     tail_label: str,
     *,
-    triples_factory: TriplesFactory,
+    triples_factory: CoreTriplesFactory,
     add_novelties: bool = True,
     remove_known: bool = False,
     testing: Optional[torch.LongTensor] = None,
@@ -94,7 +94,7 @@ def get_tail_prediction_df(
     head_label: str,
     relation_label: str,
     *,
-    triples_factory: TriplesFactory,
+    triples_factory: CoreTriplesFactory,
     add_novelties: bool = True,
     remove_known: bool = False,
     testing: Optional[torch.LongTensor] = None,
@@ -158,7 +158,7 @@ def get_relation_prediction_df(
     head_label: str,
     tail_label: str,
     *,
-    triples_factory: TriplesFactory,
+    triples_factory: CoreTriplesFactory,
     add_novelties: bool = True,
     remove_known: bool = False,
     testing: Optional[torch.LongTensor] = None,
@@ -220,7 +220,7 @@ def get_relation_prediction_df(
 def get_all_prediction_df(
     model: Model,
     *,
-    triples_factory: TriplesFactory,
+    triples_factory: CoreTriplesFactory,
     k: Optional[int] = None,
     batch_size: int = 1,
     return_tensors: bool = False,

--- a/src/pykeen/models/unimodal/compgcn.py
+++ b/src/pykeen/models/unimodal/compgcn.py
@@ -10,7 +10,7 @@ from class_resolver import Hint
 from ..nbase import ERModel
 from ...nn.emb import CombinedCompGCNRepresentations, EmbeddingSpecification
 from ...nn.modules import DistMultInteraction, Interaction
-from ...triples import CoreTriplesFactory, TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import RelationRepresentation
 
 __all__ = [

--- a/src/pykeen/models/unimodal/compgcn.py
+++ b/src/pykeen/models/unimodal/compgcn.py
@@ -10,7 +10,7 @@ from class_resolver import Hint
 from ..nbase import ERModel
 from ...nn.emb import CombinedCompGCNRepresentations, EmbeddingSpecification
 from ...nn.modules import DistMultInteraction, Interaction
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory, TriplesFactory
 from ...typing import RelationRepresentation
 
 __all__ = [
@@ -39,7 +39,7 @@ class CompGCN(ERModel[torch.FloatTensor, RelationRepresentation, torch.FloatTens
     def __init__(
         self,
         *,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 64,
         encoder_kwargs: Optional[Mapping[str, Any]] = None,
         interaction: Hint[Interaction[torch.FloatTensor, RelationRepresentation, torch.FloatTensor]] = None,

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -12,7 +12,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import CoreTriplesFactory, TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 from ...utils import split_complex
 

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -12,7 +12,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory, TriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 from ...utils import split_complex
 
@@ -76,7 +76,7 @@ class ComplEx(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 200,
         loss: Optional[Loss] = None,
         regularizer: Optional[Regularizer] = None,

--- a/src/pykeen/models/unimodal/conv_e.py
+++ b/src/pykeen/models/unimodal/conv_e.py
@@ -17,7 +17,7 @@ from ...nn.emb import Embedding, EmbeddingSpecification
 from ...nn.init import xavier_normal_
 from ...nn.modules import _calculate_missing_shape_information
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 from ...utils import is_cudnn_error
 
@@ -122,7 +122,7 @@ class ConvE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         input_channels: Optional[int] = None,
         output_channels: int = 32,
         embedding_height: Optional[int] = None,

--- a/src/pykeen/models/unimodal/conv_kb.py
+++ b/src/pykeen/models/unimodal/conv_kb.py
@@ -15,7 +15,7 @@ from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDD
 from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -82,7 +82,7 @@ class ConvKB(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         hidden_dropout_rate: float = 0.,
         embedding_dim: int = 200,
         loss: Optional[Loss] = None,

--- a/src/pykeen/models/unimodal/distmult.py
+++ b/src/pykeen/models/unimodal/distmult.py
@@ -14,7 +14,7 @@ from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_normal_norm_, xavier_uniform_
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -75,7 +75,7 @@ class DistMult(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,

--- a/src/pykeen/models/unimodal/ermlp.py
+++ b/src/pykeen/models/unimodal/ermlp.py
@@ -14,7 +14,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -51,7 +51,7 @@ class ERMLP(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,

--- a/src/pykeen/models/unimodal/ermlpe.py
+++ b/src/pykeen/models/unimodal/ermlpe.py
@@ -13,7 +13,7 @@ from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDD
 from ...losses import BCEAfterSigmoidLoss, Loss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -63,7 +63,7 @@ class ERMLPE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         hidden_dim: int = 300,
         input_dropout: float = 0.2,
         hidden_dropout: float = 0.3,

--- a/src/pykeen/models/unimodal/hole.py
+++ b/src/pykeen/models/unimodal/hole.py
@@ -13,7 +13,7 @@ from ...moves import irfft, rfft
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_uniform_
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 from ...utils import clamp_norm
 
@@ -66,7 +66,7 @@ class HolE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 200,
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -14,7 +14,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 from ...utils import clamp_norm
 
@@ -69,7 +69,7 @@ class KG2E(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,

--- a/src/pykeen/models/unimodal/ntn.py
+++ b/src/pykeen/models/unimodal/ntn.py
@@ -12,7 +12,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -61,7 +61,7 @@ class NTN(EntityEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 100,
         num_slices: int = 4,
         loss: Optional[Loss] = None,

--- a/src/pykeen/models/unimodal/proj_e.py
+++ b/src/pykeen/models/unimodal/proj_e.py
@@ -15,7 +15,7 @@ from ...losses import BCEWithLogitsLoss, Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_uniform_
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -65,7 +65,7 @@ class ProjE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,

--- a/src/pykeen/models/unimodal/rescal.py
+++ b/src/pykeen/models/unimodal/rescal.py
@@ -12,7 +12,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -60,7 +60,7 @@ class RESCAL(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -13,7 +13,7 @@ from ...nn.emb import EmbeddingSpecification, RGCNRepresentations
 from ...nn.message_passing import Decomposition
 from ...nn.modules import Interaction, interaction_resolver
 from ...nn.weighting import EdgeWeighting
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Initializer, RelationRepresentation
 
 __all__ = [
@@ -61,7 +61,7 @@ class RGCN(
     def __init__(
         self,
         *,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 500,
         num_layers: int = 2,
         # https://github.com/MichSchli/RelationPrediction/blob/c77b094fe5c17685ed138dae9ae49b304e0d8d89/code/encoders/affine_transform.py#L24-L28

--- a/src/pykeen/models/unimodal/rotate.py
+++ b/src/pykeen/models/unimodal/rotate.py
@@ -12,7 +12,7 @@ from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import init_phases, xavier_uniform_
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 from ...utils import complex_normalize
 
@@ -59,7 +59,7 @@ class RotatE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 200,
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,

--- a/src/pykeen/models/unimodal/simple.py
+++ b/src/pykeen/models/unimodal/simple.py
@@ -11,7 +11,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...regularizers import PowerSumRegularizer, Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -71,7 +71,7 @@ class SimplE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 200,
         loss: Optional[Loss] = None,
         preferred_device: DeviceHint = None,

--- a/src/pykeen/models/unimodal/structured_embedding.py
+++ b/src/pykeen/models/unimodal/structured_embedding.py
@@ -17,7 +17,7 @@ from ...losses import Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...nn.init import xavier_uniform_
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 from ...utils import compose
 
@@ -55,7 +55,7 @@ class StructuredEmbedding(EntityEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         scoring_fct_norm: int = 1,
         loss: Optional[Loss] = None,

--- a/src/pykeen/models/unimodal/trans_d.py
+++ b/src/pykeen/models/unimodal/trans_d.py
@@ -13,7 +13,7 @@ from ...losses import Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...nn.init import xavier_normal_, xavier_uniform_, xavier_uniform_norm_
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory, TriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 from ...utils import clamp_norm
 
@@ -119,7 +119,7 @@ class TransD(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         relation_dim: int = 30,
         loss: Optional[Loss] = None,

--- a/src/pykeen/models/unimodal/trans_d.py
+++ b/src/pykeen/models/unimodal/trans_d.py
@@ -13,7 +13,7 @@ from ...losses import Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...nn.init import xavier_normal_, xavier_uniform_, xavier_uniform_norm_
 from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory, TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 from ...utils import clamp_norm
 

--- a/src/pykeen/models/unimodal/trans_e.py
+++ b/src/pykeen/models/unimodal/trans_e.py
@@ -14,7 +14,7 @@ from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_uniform_, xavier_uniform_norm_
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -57,7 +57,7 @@ class TransE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         scoring_fct_norm: int = 1,
         loss: Optional[Loss] = None,

--- a/src/pykeen/models/unimodal/trans_h.py
+++ b/src/pykeen/models/unimodal/trans_h.py
@@ -13,7 +13,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...regularizers import Regularizer, TransHRegularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -71,7 +71,7 @@ class TransH(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         scoring_fct_norm: int = 2,
         loss: Optional[Loss] = None,

--- a/src/pykeen/models/unimodal/trans_r.py
+++ b/src/pykeen/models/unimodal/trans_r.py
@@ -15,7 +15,7 @@ from ...losses import Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...nn.init import xavier_uniform_, xavier_uniform_norm_
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import Constrainer, DeviceHint, Hint, Initializer
 from ...utils import clamp_norm
 
@@ -79,7 +79,7 @@ class TransR(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 50,
         relation_dim: int = 30,
         scoring_fct_norm: int = 1,

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -14,7 +14,7 @@ from ...losses import BCEAfterSigmoidLoss, Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_normal_
 from ...regularizers import Regularizer
-from ...triples import TriplesFactory
+from ...triples import CoreTriplesFactory
 from ...typing import DeviceHint, Hint, Initializer
 
 __all__ = [
@@ -86,7 +86,7 @@ class TuckER(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_dim: int = 200,
         relation_dim: Optional[int] = None,
         loss: Optional[Loss] = None,

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -23,7 +23,7 @@ from .init import init_phases, xavier_normal_, xavier_normal_norm_, xavier_unifo
 from .message_passing import Decomposition, decomposition_resolver
 from .weighting import EdgeWeighting, SymmetricEdgeWeighting, edge_weight_resolver
 from ..regularizers import Regularizer
-from ..triples import CoreTriplesFactory, TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..typing import Constrainer, Hint, HintType, Initializer, Normalizer
 from ..utils import Bias, activation_resolver, clamp_norm, complex_normalize, convert_to_canonical_shape
 
@@ -469,7 +469,7 @@ class RGCNRepresentations(RepresentationModule):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         embedding_specification: EmbeddingSpecification,
         num_layers: int = 2,
         use_bias: bool = True,
@@ -763,10 +763,10 @@ class CompGCNLayer(nn.Module):
         edge_type = 2 * edge_type
         # update entity representations: mean over self-loops / forward edges / backward edges
         x_e = (
-            self.composition(x_e, self.self_loop) @ self.w_loop
-            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
-            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
-        ) / 3
+                  self.composition(x_e, self.self_loop) @ self.w_loop
+                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
+                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
+              ) / 3
 
         if self.bias:
             x_e = self.bias(x_e)

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -763,10 +763,10 @@ class CompGCNLayer(nn.Module):
         edge_type = 2 * edge_type
         # update entity representations: mean over self-loops / forward edges / backward edges
         x_e = (
-                  self.composition(x_e, self.self_loop) @ self.w_loop
-                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
-                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
-              ) / 3
+            self.composition(x_e, self.self_loop) @ self.w_loop
+            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
+            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
+        ) / 3
 
         if self.bias:
             x_e = self.bias(x_e)

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -195,7 +195,7 @@ from ..sampling import NegativeSampler, negative_sampler_resolver
 from ..stoppers import EarlyStopper, Stopper, stopper_resolver
 from ..trackers import ResultTracker, tracker_resolver
 from ..training import SLCWATrainingLoop, TrainingLoop, training_loop_resolver
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..typing import Hint, HintType, MappedTriples
 from ..utils import (
     Result, ensure_ftp_directory, fix_dataclass_init_docs, get_json_bytes_io, get_model_io, random_non_negative_int,
@@ -226,7 +226,8 @@ class PipelineResult(Result):
     #: The model trained by the pipeline
     model: Model
 
-    training: TriplesFactory
+    #: The training triples
+    training: CoreTriplesFactory
 
     #: The training loop used by the pipeline
     training_loop: TrainingLoop
@@ -621,9 +622,9 @@ def pipeline(  # noqa: C901
     # 1. Dataset
     dataset: Union[None, str, Dataset, Type[Dataset]] = None,
     dataset_kwargs: Optional[Mapping[str, Any]] = None,
-    training: Hint[TriplesFactory] = None,
-    testing: Hint[TriplesFactory] = None,
-    validation: Hint[TriplesFactory] = None,
+    training: Hint[CoreTriplesFactory] = None,
+    testing: Hint[CoreTriplesFactory] = None,
+    validation: Hint[CoreTriplesFactory] = None,
     evaluation_entity_whitelist: Optional[Collection[str]] = None,
     evaluation_relation_whitelist: Optional[Collection[str]] = None,
     # 2. Model
@@ -1044,7 +1045,7 @@ def pipeline(  # noqa: C901
 
 def _safe_evaluate(
     model: Model,
-    training_triples_factory: TriplesFactory,
+    training_triples_factory: CoreTriplesFactory,
     mapped_triples: MappedTriples,
     evaluator: Evaluator,
     evaluation_kwargs: Dict[str, Any],

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -9,7 +9,7 @@ from class_resolver import HintOrType
 
 from .filtering import Filterer
 from .negative_sampler import NegativeSampler
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory
 
 __all__ = [
     'BasicNegativeSampler',
@@ -45,7 +45,7 @@ class BasicNegativeSampler(NegativeSampler):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         num_negs_per_pos: Optional[int] = None,
         filtered: bool = False,
         filterer: HintOrType[Filterer] = None,

--- a/src/pykeen/sampling/bernoulli_negative_sampler.py
+++ b/src/pykeen/sampling/bernoulli_negative_sampler.py
@@ -9,7 +9,7 @@ from class_resolver import HintOrType
 
 from .filtering import Filterer
 from .negative_sampler import NegativeSampler
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory
 
 __all__ = [
     'BernoulliNegativeSampler',
@@ -45,7 +45,7 @@ class BernoulliNegativeSampler(NegativeSampler):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         num_negs_per_pos: Optional[int] = None,
         filtered: bool = False,
         filterer: HintOrType[Filterer] = None,

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -9,7 +9,7 @@ import torch
 from class_resolver import HintOrType
 
 from .filtering import Filterer, filterer_resolver
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..utils import normalize_string
 
 __all__ = [
@@ -28,7 +28,7 @@ class NegativeSampler(ABC):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         num_negs_per_pos: Optional[int] = None,
         filtered: bool = False,
         filterer: HintOrType[Filterer] = None,

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -11,7 +11,7 @@ from .stopper import Stopper
 from ..evaluation import Evaluator
 from ..models import Model
 from ..trackers import ResultTracker
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory
 from ..utils import fix_dataclass_init_docs
 
 __all__ = [
@@ -63,9 +63,9 @@ class EarlyStopper(Stopper):
     #: The evaluator
     evaluator: Evaluator
     #: The triples to use for training (to be used during filtered evaluation)
-    training_triples_factory: TriplesFactory
+    training_triples_factory: CoreTriplesFactory
     #: The triples to use for evaluation
-    evaluation_triples_factory: TriplesFactory
+    evaluation_triples_factory: CoreTriplesFactory
     #: Size of the evaluation batches
     evaluation_batch_size: Optional[int] = None
     #: Slice size of the evaluation batches

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -10,7 +10,7 @@ import torch
 
 from .training_loop import TrainingLoop
 from .utils import apply_label_smoothing
-from ..triples import Instances, TriplesFactory
+from ..triples import CoreTriplesFactory, Instances
 from ..typing import MappedTriples
 
 __all__ = [
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 class LCWATrainingLoop(TrainingLoop):
     """A training loop that uses the local closed world assumption training approach."""
 
-    def _create_instances(self, triples_factory: TriplesFactory) -> Instances:  # noqa: D102
+    def _create_instances(self, triples_factory: CoreTriplesFactory) -> Instances:  # noqa: D102
         return triples_factory.create_lcwa_instances()
 
     @staticmethod
@@ -109,7 +109,7 @@ class LCWATrainingLoop(TrainingLoop):
     def _slice_size_search(
         self,
         *,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         batch_size: int,
         sub_batch_size: int,
         supports_sub_batching: bool,

--- a/src/pykeen/training/schlichtkrull_sampler.py
+++ b/src/pykeen/training/schlichtkrull_sampler.py
@@ -8,11 +8,11 @@ from typing import List, Optional, Tuple
 import torch
 from torch.utils.data.sampler import Sampler
 
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory
 
 
 def _compute_compressed_adjacency_list(
-    triples_factory: TriplesFactory,
+    triples_factory: CoreTriplesFactory,
 ) -> Tuple[torch.LongTensor, torch.LongTensor, torch.LongTensor]:
     """Compute compressed undirected adjacency list representation for efficient sampling.
 
@@ -54,7 +54,7 @@ class GraphSampler(Sampler):
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         num_samples: Optional[int] = None,
     ):
         mapped_triples = triples_factory.mapped_triples

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -13,7 +13,7 @@ from .utils import apply_label_smoothing
 from ..losses import CrossEntropyLoss
 from ..models import Model
 from ..sampling import BasicNegativeSampler, NegativeSampler
-from ..triples import Instances, TriplesFactory
+from ..triples import CoreTriplesFactory, Instances
 from ..typing import MappedTriples
 
 __all__ = [
@@ -32,7 +32,7 @@ class SLCWATrainingLoop(TrainingLoop):
     def __init__(
         self,
         model: Model,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         optimizer: Optional[Optimizer] = None,
         negative_sampler_cls: Optional[Type[NegativeSampler]] = None,
         negative_sampler_kwargs: Optional[Mapping[str, Any]] = None,

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -73,7 +73,7 @@ class SLCWATrainingLoop(TrainingLoop):
         """
         return self.negative_sampler.num_negs_per_pos
 
-    def _create_instances(self, triples_factory: TriplesFactory) -> Instances:  # noqa: D102
+    def _create_instances(self, triples_factory: CoreTriplesFactory) -> Instances:  # noqa: D102
         return triples_factory.create_slcwa_instances()
 
     @staticmethod
@@ -171,7 +171,7 @@ class SLCWATrainingLoop(TrainingLoop):
     def _slice_size_search(
         self,
         *,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         batch_size: int,
         sub_batch_size: int,
         supports_sub_batching: bool,

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -25,7 +25,7 @@ from ..models import Model, RGCN
 from ..stoppers import Stopper
 from ..trackers import ResultTracker
 from ..training.schlichtkrull_sampler import GraphSampler
-from ..triples import Instances, TriplesFactory
+from ..triples import CoreTriplesFactory, Instances
 from ..typing import MappedTriples
 from ..utils import (
     format_relative_comparison, get_batchnorm_modules, is_cuda_oom_error, is_cudnn_error,
@@ -93,7 +93,7 @@ class TrainingLoop(ABC):
     def __init__(
         self,
         model: Model,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         optimizer: Optional[Optimizer] = None,
         automatic_memory_optimization: bool = True,
     ) -> None:

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -151,7 +151,7 @@ class TrainingLoop(ABC):
 
     def train(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         num_epochs: int = 1,
         batch_size: Optional[int] = None,
         slice_size: Optional[int] = None,
@@ -320,7 +320,7 @@ class TrainingLoop(ABC):
 
     def _train(  # noqa: C901
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         num_epochs: int = 1,
         batch_size: Optional[int] = None,
         slice_size: Optional[int] = None,
@@ -671,7 +671,7 @@ class TrainingLoop(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _create_instances(self, triples_factory: TriplesFactory) -> Instances:
+    def _create_instances(self, triples_factory: CoreTriplesFactory) -> Instances:
         """Create the training instances at the beginning of the training loop."""
         raise NotImplementedError
 
@@ -690,7 +690,7 @@ class TrainingLoop(ABC):
     def batch_size_search(
         self,
         *,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         batch_size: Optional[int] = None,
     ) -> Tuple[int, bool]:
         """Find the maximum batch size for training with the current setting.
@@ -761,7 +761,7 @@ class TrainingLoop(ABC):
         *,
         batch_size: int,
         sampler: Optional[str],
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
     ) -> Tuple[int, Optional[int]]:
         """Check if sub-batching and/or slicing is necessary to train the model on the hardware at hand."""
         sub_batch_size, finished_search, supports_sub_batching = self._sub_batch_size_search(
@@ -785,7 +785,7 @@ class TrainingLoop(ABC):
     def _slice_size_search(
         self,
         *,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         batch_size: int,
         sub_batch_size: int,
         supports_sub_batching: bool,
@@ -816,7 +816,7 @@ class TrainingLoop(ABC):
         *,
         batch_size: int,
         sampler: Optional[str],
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
     ) -> Tuple[int, bool, bool]:
         """Find the allowable sub batch size for training with the current setting.
 

--- a/src/pykeen/triples/leakage.py
+++ b/src/pykeen/triples/leakage.py
@@ -28,8 +28,6 @@ __all__ = [
     'reindex',
 ]
 
-# TODO: Update to CoreTriplesFactory
-
 logger = logging.getLogger(__name__)
 X = TypeVar('X')
 Y = TypeVar('Y')

--- a/src/pykeen/triples/leakage.py
+++ b/src/pykeen/triples/leakage.py
@@ -11,14 +11,14 @@ novel triples.
 
 import logging
 from collections import defaultdict
-from typing import Collection, Dict, Iterable, List, Mapping, Optional, Set, Tuple, TypeVar, Union
+from typing import Collection, Dict, Iterable, List, Mapping, Optional, Set, Tuple, TypeVar, Union, cast
 
 import numpy
 import scipy.sparse
 import torch
 
 from pykeen.datasets.base import EagerDataset
-from pykeen.triples.triples_factory import TriplesFactory, cat_triples
+from pykeen.triples.triples_factory import CoreTriplesFactory, TriplesFactory, cat_triples
 from pykeen.typing import MappedTriples
 from pykeen.utils import compact_mapping
 
@@ -111,7 +111,7 @@ def jaccard_similarity_scipy(
 
 
 def triples_factory_to_sparse_matrices(
-    triples_factory: TriplesFactory,
+    triples_factory: CoreTriplesFactory,
 ) -> Tuple[scipy.sparse.spmatrix, scipy.sparse.spmatrix]:
     """Compute relation representations as sparse matrices of entity pairs.
 
@@ -218,14 +218,14 @@ def get_candidate_pairs(
 class Sealant:
     """Stores inverse frequencies and inverse mappings in a given triples factory."""
 
-    triples_factory: TriplesFactory
+    triples_factory: CoreTriplesFactory
     minimum_frequency: float
     inverses: Mapping[int, int]
     inverse_relations_to_delete: Set[int]
 
     def __init__(
         self,
-        triples_factory: TriplesFactory,
+        triples_factory: CoreTriplesFactory,
         minimum_frequency: Optional[float] = None,
         symmetric: bool = True,
     ):
@@ -268,17 +268,17 @@ class Sealant:
         )
         logger.info(f'identified {len(self.candidates)} from {self.triples_factory} to delete')
 
-    def apply(self, triples_factory: TriplesFactory) -> TriplesFactory:
+    def apply(self, triples_factory: CoreTriplesFactory) -> CoreTriplesFactory:
         """Make a new triples factory containing neither duplicate nor inverse relationships."""
         return triples_factory.new_with_restriction(relations=self.relations_to_delete, invert_relation_selection=True)
 
 
 def unleak(
-    train: TriplesFactory,
-    *triples_factories: TriplesFactory,
+    train: CoreTriplesFactory,
+    *triples_factories: CoreTriplesFactory,
     n: Union[None, int, float] = None,
     minimum_frequency: Optional[float] = None,
-) -> Iterable[TriplesFactory]:
+) -> Iterable[CoreTriplesFactory]:
     """Unleak a train, test, and validate triples factory.
 
     :param train: The target triples factory
@@ -380,10 +380,14 @@ def _translate_triples(
     return triples
 
 
-def reindex(*triples_factories: TriplesFactory) -> List[TriplesFactory]:
+def reindex(*triples_factories: CoreTriplesFactory) -> List[CoreTriplesFactory]:
     """Reindex a set of triples factories."""
     # get entities and relations occurring in triples
     all_triples = cat_triples(*triples_factories)
+
+    if not all(isinstance(f, TriplesFactory) for f in triples_factories):
+        raise NotImplementedError("reindex has not been updated for non-TriplesFactory yet.")
+    triples_factories = cast(Tuple[TriplesFactory, ...], triples_factories)
 
     # generate ID translation and new label to Id mappings
     one_factory = triples_factories[0]

--- a/src/pykeen/triples/leakage.py
+++ b/src/pykeen/triples/leakage.py
@@ -370,9 +370,9 @@ def _translate_triples(
         [
             trans[column]
             for column, trans in zip(
-            triples.t(),
-            (entity_translation, relation_translation, entity_translation),
-        )
+                triples.t(),
+                (entity_translation, relation_translation, entity_translation),
+            )
         ],
         dim=-1,
     )

--- a/src/pykeen/triples/leakage.py
+++ b/src/pykeen/triples/leakage.py
@@ -28,6 +28,8 @@ __all__ = [
     'reindex',
 ]
 
+# TODO: Update to CoreTriplesFactory
+
 logger = logging.getLogger(__name__)
 X = TypeVar('X')
 Y = TypeVar('Y')
@@ -368,9 +370,9 @@ def _translate_triples(
         [
             trans[column]
             for column, trans in zip(
-                triples.t(),
-                (entity_translation, relation_translation, entity_translation),
-            )
+            triples.t(),
+            (entity_translation, relation_translation, entity_translation),
+        )
         ],
         dim=-1,
     )

--- a/src/pykeen/triples/remix.py
+++ b/src/pykeen/triples/remix.py
@@ -13,15 +13,15 @@ relationship between datasets' splits' distances and their maximum performance.
 
 from typing import List, Sequence
 
-from pykeen.triples.splitting import normalize_ratios, split
-from pykeen.triples.triples_factory import TriplesFactory, cat_triples
+from .splitting import normalize_ratios, split
+from .triples_factory import CoreTriplesFactory, cat_triples
 
 __all__ = [
     'remix',
 ]
 
 
-def remix(*triples_factories: TriplesFactory, **kwargs) -> List[TriplesFactory]:
+def remix(*triples_factories: CoreTriplesFactory, **kwargs) -> List[CoreTriplesFactory]:
     """Remix the triples from the training, testing, and validation set.
 
     :param triples_factories: A sequence of triples factories
@@ -43,7 +43,7 @@ def remix(*triples_factories: TriplesFactory, **kwargs) -> List[TriplesFactory]:
     ]
 
 
-def _get_ratios(*triples_factories: TriplesFactory) -> Sequence[float]:
+def _get_ratios(*triples_factories: CoreTriplesFactory) -> Sequence[float]:
     total = sum(tf.num_triples for tf in triples_factories)
     ratios = normalize_ratios([tf.num_triples / total for tf in triples_factories])
     return ratios

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from pykeen.models import EntityRelationEmbeddingModel, Model
 from pykeen.nn.emb import EmbeddingSpecification, RepresentationModule
-from pykeen.triples import TriplesFactory
+from pykeen.triples import CoreTriplesFactory
 
 __all__ = [
     'CustomRepresentations',
@@ -32,7 +32,7 @@ class CustomRepresentations(RepresentationModule):
 class MockModel(EntityRelationEmbeddingModel):
     """A mock model returning fake scores."""
 
-    def __init__(self, triples_factory: TriplesFactory):
+    def __init__(self, triples_factory: CoreTriplesFactory):
         super().__init__(
             triples_factory=triples_factory,
             entity_representations=EmbeddingSpecification(embedding_dim=50),


### PR DESCRIPTION
In many places a `TriplesFactory` is required, while `CoreTriplesFactory` suffices.