### PR TITLE
🔧🕗 Update model initialization

### DIFF
--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -87,6 +87,10 @@ model_resolver = Resolver.from_subclasses(
     base=Model,
     skip={
         _NewAbstractModel,
+        # We might be able to relax this later
+        ERModel,
+        LiteralModel,
+        # Old style models should never be looked up
         _OldAbstractModel,
         EntityEmbeddingModel,
         EntityRelationEmbeddingModel,

--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -6,9 +6,7 @@ entities and relations. In general, a larger score indicates a higher plausibili
 score value is model-dependent, and usually it cannot be directly interpreted as a probability.
 """  # noqa: D205, D400
 
-from typing import Set, Type
-
-from class_resolver import Resolver, get_subclasses
+from class_resolver import Resolver
 
 from .base import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, _OldAbstractModel
 from .multimodal import ComplExLiteral, DistMultLiteral, LiteralModel
@@ -85,9 +83,12 @@ __all__ = [
     'make_model_cls',
 ]
 
-_MODELS: Set[Type[Model]] = {
-    subcls
-    for subcls in get_subclasses(Model)  # type: ignore
-    if not subcls._is_base_model
-}
-model_resolver = Resolver(classes=_MODELS, base=Model)  # type: ignore
+model_resolver = Resolver.from_subclasses(
+    base=Model,
+    skip={
+        _NewAbstractModel,
+        _OldAbstractModel,
+        EntityEmbeddingModel,
+        EntityRelationEmbeddingModel,
+    },
+)

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -43,9 +43,6 @@ class Model(nn.Module, ABC):
     and relation representations in the form of :class:`pykeen.nn.Embedding`.
     """
 
-    #: Keep track of if this is a base model
-    _is_base_model: ClassVar[bool]
-
     #: The default strategy for optimizing the model's hyper-parameters
     hpo_default: ClassVar[Mapping[str, Any]]
 
@@ -598,7 +595,6 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
 
     def __init_subclass__(cls, autoreset: bool = True, **kwargs):  # noqa:D105
         super().__init_subclass__(**kwargs)
-        cls._is_base_model = not autoreset
         if autoreset:
             _add_post_reset_parameters(cls)
 

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -591,7 +591,8 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
 
     def __init_subclass__(cls, autoreset: bool = True, **kwargs):  # noqa:D105
         super().__init_subclass__(**kwargs)
-        if not inspect.isabstract(cls):
+        cls._is_base_model = not autoreset
+        if not cls._is_base_model:
             _add_post_reset_parameters(cls)
 
     def post_parameter_update(self) -> None:

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -110,7 +110,7 @@ class Model(nn.Module, ABC):
         '''
         self.predict_with_sigmoid = predict_with_sigmoid
 
-    def __init_subclass__(cls, **kwargs):  # noqa:D105
+    def __init_subclass__(cls, **kwargs):
         """Initialize the subclass.
 
         This checks for all subclasses if they are tagged with :class:`abc.ABC` with :func:`inspect.isabstract`.

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import logging
 import pickle
 import warnings
@@ -111,6 +112,10 @@ class Model(nn.Module, ABC):
         also for predictions after training, but has no effect on the training.
         '''
         self.predict_with_sigmoid = predict_with_sigmoid
+
+    def __init_subclass__(cls, **kwargs):  # noqa:D105
+        if not inspect.isabstract(cls):
+            parse_docdata(cls)
 
     """Properties"""
 
@@ -585,10 +590,9 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
         self._relation_ids = triples_factory.relation_ids
 
     def __init_subclass__(cls, autoreset: bool = True, **kwargs):  # noqa:D105
-        cls._is_base_model = not autoreset
-        if not cls._is_base_model:
+        super().__init_subclass__(**kwargs)
+        if not inspect.isabstract(cls):
             _add_post_reset_parameters(cls)
-            parse_docdata(cls)
 
     def post_parameter_update(self) -> None:
         """Has to be called after each parameter update."""

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -112,12 +112,6 @@ class Model(nn.Module, ABC):
         '''
         self.predict_with_sigmoid = predict_with_sigmoid
 
-    def __init_subclass__(cls, autoreset: bool = True, **kwargs):  # noqa:D105
-        cls._is_base_model = not autoreset
-        if not cls._is_base_model:
-            _add_post_reset_parameters(cls)
-            parse_docdata(cls)
-
     """Properties"""
 
     @property
@@ -589,6 +583,12 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
 
         self._entity_ids = triples_factory.entity_ids
         self._relation_ids = triples_factory.relation_ids
+
+    def __init_subclass__(cls, autoreset: bool = True, **kwargs):  # noqa:D105
+        cls._is_base_model = not autoreset
+        if not cls._is_base_model:
+            _add_post_reset_parameters(cls)
+            parse_docdata(cls)
 
     def post_parameter_update(self) -> None:
         """Has to be called after each parameter update."""

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -114,6 +114,13 @@ class Model(nn.Module, ABC):
         self.predict_with_sigmoid = predict_with_sigmoid
 
     def __init_subclass__(cls, **kwargs):  # noqa:D105
+        """Initialize the subclass.
+
+        This checks for all subclasses if they are tagged with :class:`abc.ABC` with :func:`inspect.isabstract`.
+        All non-abstract deriving models should have citation information. Subclasses can further override
+        ``__init_subclass__``, but need to remember to call ``super().__init_subclass__`` as well so this
+        gets run.
+        """
         if not inspect.isabstract(cls):
             parse_docdata(cls)
 
@@ -592,7 +599,7 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
     def __init_subclass__(cls, autoreset: bool = True, **kwargs):  # noqa:D105
         super().__init_subclass__(**kwargs)
         cls._is_base_model = not autoreset
-        if not cls._is_base_model:
+        if autoreset:
             _add_post_reset_parameters(cls)
 
     def post_parameter_update(self) -> None:

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -365,20 +365,20 @@ class ERModel(
             random_seed=random_seed,
             predict_with_sigmoid=predict_with_sigmoid,
         )
+        self.interaction = interaction_resolver.make(interaction, pos_kwargs=interaction_kwargs)
         self.entity_representations = _prepare_representation_module_list(
             representations=entity_representations,
             num_embeddings=triples_factory.num_entities,
-            shapes=interaction.entity_shape,
+            shapes=self.interaction.entity_shape,
             label="entity",
-            skip_checks=interaction.tail_entity_shape is not None,
+            skip_checks=self.interaction.tail_entity_shape is not None,
         )
         self.relation_representations = _prepare_representation_module_list(
             representations=relation_representations,
             num_embeddings=triples_factory.num_relations,
-            shapes=interaction.relation_shape,
+            shapes=self.interaction.relation_shape,
             label="relation",
         )
-        self.interaction = interaction_resolver.make(interaction, pos_kwargs=interaction_kwargs)
         # Comment: it is important that the regularizers are stored in a module list, in order to appear in
         # model.modules(). Thereby, we can collect them automatically.
         self.weight_regularizers = nn.ModuleList()

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -313,7 +313,14 @@ class ERModel(
     _NewAbstractModel,
     autoreset=False,
 ):
-    """A commonly useful base for KGEMs using embeddings and interaction modules."""
+    """A commonly useful base for KGEMs using embeddings and interaction modules.
+
+    .. warning::
+
+        If you directly instantiate :class:`ERModel`, you must also call :func:`ERModel.reset_parameters_`
+        explicitly. This is because any subclasses use the :func:`ERModel.__init_subclasses__` function to
+        automatically register a post-``__init__()`` call, but the base class does not.
+    """
 
     #: The entity representations
     entity_representations: Sequence[RepresentationModule]

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -11,7 +11,6 @@ from operator import itemgetter
 from typing import Any, ClassVar, Generic, Iterable, List, Mapping, Optional, Sequence, Tuple, Type, Union, cast
 
 import torch
-from class_resolver import Hint
 from torch import nn
 
 from .base import Model
@@ -342,7 +341,11 @@ class ERModel(
         self,
         *,
         triples_factory: CoreTriplesFactory,
-        interaction: Hint[Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation]],
+        interaction: Union[
+            str,
+            Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation],
+            Type[Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation]],
+        ],
         interaction_kwargs: Optional[Mapping[str, Any]] = None,
         entity_representations: EmbeddingSpecificationHint = None,
         relation_representations: EmbeddingSpecificationHint = None,

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -314,11 +314,6 @@ class ERModel(
 ):
     """A commonly useful base for KGEMs using embeddings and interaction modules.
 
-    .. warning::
-
-        If you directly instantiate :class:`ERModel`, you must also call :func:`ERModel.reset_parameters_`
-        explicitly. This is because any subclasses use the :func:`ERModel.__init_subclasses__` function to
-        automatically register a post-``__init__()`` call, but the base class does not.
     ---
     citation:
         author: Ali

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -38,7 +38,7 @@ EmbeddingSpecificationHint = Union[
 ]
 
 
-class _NewAbstractModel(Model, ABC, autoreset=False):
+class _NewAbstractModel(Model, ABC):
     """An abstract class for knowledge graph embedding models (KGEMs).
 
     The only function that needs to be implemented for a given subclass is
@@ -311,7 +311,6 @@ def _prepare_representation_module_list(
 class ERModel(
     Generic[HeadRepresentation, RelationRepresentation, TailRepresentation],
     _NewAbstractModel,
-    autoreset=False,
 ):
     """A commonly useful base for KGEMs using embeddings and interaction modules.
 
@@ -389,6 +388,8 @@ class ERModel(
         # Comment: it is important that the regularizers are stored in a module list, in order to appear in
         # model.modules(). Thereby, we can collect them automatically.
         self.weight_regularizers = nn.ModuleList()
+        # Explicitly call reset_parameters to trigger initialization
+        self.reset_parameters_()
 
     def append_weight_regularizer(
         self,

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -314,6 +314,13 @@ class ERModel(
 ):
     """A commonly useful base for KGEMs using embeddings and interaction modules.
 
+    This model does not use post-init hooks to automatically initialize all of its
+    parameters. Rather, the call to :func:`Model.reset_parameters_` happens at the end of
+    ``ERModel.__init__``. This is possible because all trainable parameters should necessarily
+    be passed through the ``super().__init__()`` in subclasses of :class:`ERModel`.
+
+    Other code can still be put after the call to ``super().__init__()`` in subclasses, such as
+    registering regularizers (as done in :class:`pykeen.models.ConvKB` and :class:`pykeen.models.TransH`).
     ---
     citation:
         author: Ali

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -319,6 +319,12 @@ class ERModel(
         If you directly instantiate :class:`ERModel`, you must also call :func:`ERModel.reset_parameters_`
         explicitly. This is because any subclasses use the :func:`ERModel.__init_subclasses__` function to
         automatically register a post-``__init__()`` call, but the base class does not.
+    ---
+    citation:
+        author: Ali
+        year: 2021
+        link: https://jmlr.org/papers/v22/20-825.html
+        github: pykeen/pykeen
     """
 
     #: The entity representations

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -966,7 +966,7 @@ class ModelTestCase(unittest_templates.GenericTestCase[Model]):
 
     def _help_test_cli(self, args):
         """Test running the pipeline on all models."""
-        if issubclass(self.cls, (pykeen.models.RGCN, pykeen.models.ERModel)):
+        if issubclass(self.cls, pykeen.models.RGCN) or self.cls is pykeen.models.ERModel:
             self.skipTest(f"Cannot choose interaction via CLI for {self.cls}.")
         runner = CliRunner()
         cli = build_cli_from_cls(self.cls)

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -966,7 +966,7 @@ class ModelTestCase(unittest_templates.GenericTestCase[Model]):
 
     def _help_test_cli(self, args):
         """Test running the pipeline on all models."""
-        if issubclass(self.cls, pykeen.models.RGCN):
+        if issubclass(self.cls, (pykeen.models.RGCN, pykeen.models.ERModel)):
             self.skipTest(f"Cannot choose interaction via CLI for {self.cls}.")
         runner = CliRunner()
         cli = build_cli_from_cls(self.cls)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,7 +14,7 @@ import unittest_templates
 import pykeen.experiments
 import pykeen.models
 from pykeen.models import (
-    ERModel, EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, _MODELS,
+    ERModel, EntityEmbeddingModel, EntityRelationEmbeddingModel, Model,
     _NewAbstractModel, _OldAbstractModel, model_resolver,
 )
 from pykeen.models.multimodal.base import LiteralModel
@@ -705,7 +705,7 @@ class TestModelUtilities(unittest.TestCase):
         """Test that classes are checked as abstract properly."""
         self.assertTrue(EntityEmbeddingModel._is_base_model)
         self.assertTrue(EntityRelationEmbeddingModel._is_base_model)
-        for cls in _MODELS:
+        for cls in model_resolver.lookup_dict:
             self.assertFalse(
                 cls._is_base_model,
                 msg=f'{cls.__name__} should not be marked as a a base model',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,17 +29,18 @@ from tests.mocks import MockModel
 from tests.test_model_mode import SimpleInteractionModel
 
 SKIP_MODULES = {
-                   Model,
-                   _OldAbstractModel,
-                   _NewAbstractModel,
-                   # DummyModel,
-                   LiteralModel,
-                   EntityEmbeddingModel,
-                   EntityRelationEmbeddingModel,
-                   ERModel,
-                   MockModel,
-                   SimpleInteractionModel,
-               } | set(LiteralModel.__subclasses__())
+    Model,
+    _OldAbstractModel,
+    _NewAbstractModel,
+    # DummyModel,
+    LiteralModel,
+    EntityEmbeddingModel,
+    EntityRelationEmbeddingModel,
+    ERModel,
+    MockModel,
+    SimpleInteractionModel,
+}
+SKIP_MODULES.update(LiteralModel.__subclasses__())
 
 
 class TestCompGCN(cases.ModelTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -760,15 +760,5 @@ class ERModelTests(cases.ModelTestCase):
         kwargs["relation_representations"] = EmbeddingSpecification(embedding_dim=embedding_dim)
         return kwargs
 
-    def post_instantiation_hook(self) -> None:
-        """Move the model to the correct device (from super()) and explicitly reset the parameters.
-
-        This is necessary only for the test on :class:`ERModel` directly since the ``autoreset``
-        parameter is set to false on base classes. This means that users must explicitly call
-        :func:`ERModel.reset_parameters_` if they directly instantiate the base class.
-        """
-        super().post_instantiation_hook()
-        self.instance.reset_parameters_()
-
     def test_has_hpo_defaults(self):  # noqa: D102
         raise unittest.SkipTest(f"Base class {self.cls} does not provide HPO defaults.")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -752,3 +752,26 @@ class TestModelUtilities(unittest.TestCase):
                     exp_content.add(tuple(c))
 
             assert actual_content == exp_content
+
+
+class ERModelTests(cases.ModelTestCase):
+    """Tests for the general ER-Model."""
+
+    cls = pykeen.models.ERModel
+    kwargs = dict(
+        interaction="distmult",  # use name to test interaction resolution
+    )
+
+    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
+        kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
+        embedding_dim = kwargs.pop("embedding_dim")
+        kwargs["entity_representations"] = EmbeddingSpecification(embedding_dim=embedding_dim)
+        kwargs["relation_representations"] = EmbeddingSpecification(embedding_dim=embedding_dim)
+        return kwargs
+
+    def test_has_hpo_defaults(self):  # noqa: D102
+        raise unittest.SkipTest(f"Base class {self.cls} does not provide HPO defaults.")
+
+    def test_reset_parameters_constructor_call(self):  # noqa: D102
+        # TODO: Do we really want this?
+        raise unittest.SkipTest(f"Base class {self.cls} does not call reset_parameters in the constructor.")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -701,16 +701,6 @@ def _remove_non_models(elements):
 class TestModelUtilities(unittest.TestCase):
     """Extra tests for utility functions."""
 
-    def test_abstract(self):
-        """Test that classes are checked as abstract properly."""
-        self.assertTrue(EntityEmbeddingModel._is_base_model)
-        self.assertTrue(EntityRelationEmbeddingModel._is_base_model)
-        for cls in model_resolver.lookup_dict:
-            self.assertFalse(
-                cls._is_base_model,
-                msg=f'{cls.__name__} should not be marked as a a base model',
-            )
-
     def test_get_novelty_mask(self):
         """Test `get_novelty_mask()`."""
         num_triples = 7

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -769,5 +769,15 @@ class ERModelTests(cases.ModelTestCase):
         kwargs["relation_representations"] = EmbeddingSpecification(embedding_dim=embedding_dim)
         return kwargs
 
+    def post_instantiation_hook(self) -> None:
+        """Move the model to the correct device (from super()) and explicitly reset the parameters.
+
+        This is necessary only for the test on :class:`ERModel` directly since the ``autoreset``
+        parameter is set to false on base classes. This means that users must explicitly call
+        :func:`ERModel.reset_parameters_` if they directly instantiate the base class.
+        """
+        super().post_instantiation_hook()
+        self.instance.reset_parameters_()
+
     def test_has_hpo_defaults(self):  # noqa: D102
         raise unittest.SkipTest(f"Base class {self.cls} does not provide HPO defaults.")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,17 +29,17 @@ from tests.mocks import MockModel
 from tests.test_model_mode import SimpleInteractionModel
 
 SKIP_MODULES = {
-    Model,
-    _OldAbstractModel,
-    _NewAbstractModel,
-    # DummyModel,
-    LiteralModel,
-    EntityEmbeddingModel,
-    EntityRelationEmbeddingModel,
-    ERModel,
-    MockModel,
-    SimpleInteractionModel,
-} | set(LiteralModel.__subclasses__())
+                   Model,
+                   _OldAbstractModel,
+                   _NewAbstractModel,
+                   # DummyModel,
+                   LiteralModel,
+                   EntityEmbeddingModel,
+                   EntityRelationEmbeddingModel,
+                   ERModel,
+                   MockModel,
+                   SimpleInteractionModel,
+               } | set(LiteralModel.__subclasses__())
 
 
 class TestCompGCN(cases.ModelTestCase):
@@ -771,7 +771,3 @@ class ERModelTests(cases.ModelTestCase):
 
     def test_has_hpo_defaults(self):  # noqa: D102
         raise unittest.SkipTest(f"Base class {self.cls} does not provide HPO defaults.")
-
-    def test_reset_parameters_constructor_call(self):  # noqa: D102
-        # TODO: Do we really want this?
-        raise unittest.SkipTest(f"Base class {self.cls} does not call reset_parameters in the constructor.")


### PR DESCRIPTION
This PR makes two updates to model initialization:

1. It fixes the interaction resolution order within the ERModel. In particular it makes sure to resolve the interaction before accessing its attributes.
2. It updates the post-init hooks

This PR also updates the magical usage of `__init_subclass__` that hacked in post-init hooks which included resetting (initializing) the model parameters. It's now much less hacky since this is only necessary for old-style models. New-style models (i.e., subclasses of `pykeen.models.ERModel`) necessarily have to set all initializable parameters inside the `super().__init__()` call to `pykeen.models.ERModel`, so it's possible to explicitly code the call to reset the parameters at the end of  `pykeen.models.ERModel.__init__()`. This is not the case for old-style models, so we keep the magic there (just call us Santa Claus).

@cthoyt brought up the concern that in the new-style implementation of the ConvKB and TransH models in #107, there is some stuff going on after the call to `super().__init__()`, specifically these two models both register regularizers after the fact. It is necessarily the case that these should not have trainable parameters, so this is okay. For more information, see #424.