### PR TITLE
✅ 🛑 Add correct early stopper epoch handling within the training loop

### DIFF
--- a/src/pykeen/stoppers/stopper.py
+++ b/src/pykeen/stoppers/stopper.py
@@ -21,6 +21,7 @@ class Stopper(ABC):
     """A harness for stopping training."""
 
     def __init__(self, *args, **kwargs):
+        # To make MyPy happy
         self.best_epoch = None
 
     def should_evaluate(self, epoch: int) -> bool:

--- a/src/pykeen/stoppers/stopper.py
+++ b/src/pykeen/stoppers/stopper.py
@@ -21,7 +21,7 @@ class Stopper(ABC):
     """A harness for stopping training."""
 
     def __init__(self, *args, **kwargs):
-        pass
+        self.best_epoch = None
 
     def should_evaluate(self, epoch: int) -> bool:
         """Check if the stopper should be evaluated on the given epoch."""

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -647,6 +647,8 @@ class TrainingLoop(ABC):
 
         # If the early stopper never stopped the training loop, the temporary file path needs to be terminated
         if stopper is not None:
+            if last_best_stopper_model_epoch is not None:
+                self._load_state(path=best_epoch_model_path.name)
             best_epoch_model_path.close()
 
         return self.losses_per_epochs

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -396,7 +396,7 @@ class TrainingLoop(ABC):
             raise ValueError('optimizer must be set before running _train()')
         # When using early stopping models have to be saved separately at the best epoch, since the training loop will
         # due to the patience continue to train after the best epoch and thus alter the model
-        if stopper is not None:
+        if stopper is not None and not only_size_probing:
             last_best_stopper_model_epoch = None
             best_epoch_model_path = tempfile.NamedTemporaryFile()
 

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -976,10 +976,10 @@ class TrainingLoop(ABC):
         torch.cuda.empty_cache()
 
     def _save_state(
-            self,
-            path: Union[str, pathlib.Path],
-            stopper: Optional[Stopper] = None,
-            best_epoch_model_checkpoint_path: Optional[Union[str, pathlib.Path]] = None,
+        self,
+        path: Union[str, pathlib.Path],
+        stopper: Optional[Stopper] = None,
+        best_epoch_model_checkpoint_path: Optional[Union[str, pathlib.Path]] = None,
     ) -> None:
         """Save the state of the training loop.
 

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -1107,7 +1107,7 @@ class TrainingLoop(ABC):
         # If the checkpoint was saved with a best epoch model from the early stopper, this model has to be retrieved
         best_epoch_model_file_path = None
         best_epoch = None
-        if checkpoint['best_epoch_model_checkpoint'] is not None:
+        if checkpoint.get('best_epoch_model_checkpoint'):
             best_epoch_model_file_path = pathlib.Path(NamedTemporaryFile().name)
             best_epoch = checkpoint['best_epoch_model_checkpoint']['epoch']
             torch.save(

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -248,6 +248,8 @@ class TrainingLoop(ABC):
         # If a checkpoint file is given, it must be loaded if it exists already
         save_checkpoints = False
         checkpoint_path = None
+        best_epoch_model_path = None
+        last_best_epoch = None
         if checkpoint_name:
             checkpoint_path = checkpoint_directory.joinpath(checkpoint_name)
             if checkpoint_path.is_file():
@@ -1007,6 +1009,11 @@ class TrainingLoop(ABC):
         else:
             torch_cuda_random_state = None
 
+        if best_epoch_model_checkpoint_path is not None:
+            best_epoch_model_checkpoint = torch.load(best_epoch_model_checkpoint_path)
+        else:
+            best_epoch_model_checkpoint = None
+
         torch.save(
             {
                 'epoch': self._epoch,
@@ -1021,7 +1028,7 @@ class TrainingLoop(ABC):
                 'torch_random_state': torch.random.get_rng_state(),
                 'torch_cuda_random_state': torch_cuda_random_state,
                 # This is an entire checkpoint for the optional best model when using early stopping
-                'best_epoch_model_checkpoint_path': torch.load(best_epoch_model_checkpoint_path),
+                'best_epoch_model_checkpoint': best_epoch_model_checkpoint,
             },
             path,
             pickle_protocol=pickle.HIGHEST_PROTOCOL,

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from hashlib import md5
 from tempfile import NamedTemporaryFile
-from typing import Any, List, IO, Mapping, Optional, Tuple, Type, Union
+from typing import Any, IO, List, Mapping, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch
@@ -1085,7 +1085,7 @@ class TrainingLoop(ABC):
             )
 
         # If the checkpoint was saved with a best epoch model from the early stopper, this model has to be retrieved
-        best_epoch_model_path = None
+        best_epoch_model_file = None
         best_epoch = None
         if checkpoint['best_epoch_model_checkpoint'] is not None:
             best_epoch_model_file = NamedTemporaryFile()

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -417,6 +417,7 @@ class TrainingLoop(ABC):
         ):
             # Create a path
             best_epoch_model_file_path = pathlib.Path(NamedTemporaryFile().name)
+        best_epoch_model_checkpoint_file_path: Optional[pathlib.Path] = None
 
         if isinstance(self.model, RGCN) and sampler != 'schlichtkrull':
             logger.warning(

--- a/src/pykeen/typing.py
+++ b/src/pykeen/typing.py
@@ -23,7 +23,6 @@ __all__ = [
     # Others
     'DeviceHint',
     'TorchRandomHint',
-    'TemporaryFile',
     # Tensor Functions
     'Initializer',
     'Normalizer',
@@ -90,13 +89,3 @@ class ScorePack(NamedTuple):
 
     result: torch.LongTensor
     scores: torch.FloatTensor
-
-
-class TemporaryFile(IO[bytes]):
-    """Temporary file wrapper
-
-    This class provides a wrapper around files opened for
-    temporary use.  In particular, it seeks to automatically
-    remove the file when it is no longer needed.
-    """
-    name: str

--- a/src/pykeen/typing.py
+++ b/src/pykeen/typing.py
@@ -2,7 +2,7 @@
 
 """Type hints for PyKEEN."""
 
-from typing import Callable, Mapping, NamedTuple, Sequence, TypeVar, Union, cast
+from typing import Callable, IO, Mapping, NamedTuple, Sequence, TypeVar, Union, cast
 
 import numpy as np
 import torch
@@ -23,6 +23,7 @@ __all__ = [
     # Others
     'DeviceHint',
     'TorchRandomHint',
+    'TemporaryFile',
     # Tensor Functions
     'Initializer',
     'Normalizer',
@@ -89,3 +90,13 @@ class ScorePack(NamedTuple):
 
     result: torch.LongTensor
     scores: torch.FloatTensor
+
+
+class TemporaryFile(IO[bytes]):
+    """Temporary file wrapper
+
+    This class provides a wrapper around files opened for
+    temporary use.  In particular, it seeks to automatically
+    remove the file when it is no longer needed.
+    """
+    name: str

--- a/src/pykeen/typing.py
+++ b/src/pykeen/typing.py
@@ -2,7 +2,7 @@
 
 """Type hints for PyKEEN."""
 
-from typing import Callable, IO, Mapping, NamedTuple, Sequence, TypeVar, Union, cast
+from typing import Callable, Mapping, NamedTuple, Sequence, TypeVar, Union, cast
 
 import numpy as np
 import torch

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -62,7 +62,7 @@ class MockModel(EntityRelationEmbeddingModel):
         return self._generate_fake_scores(batch=rt_batch)
 
     def reset_parameters_(self) -> Model:  # noqa: D102
-        self.num_backward_propagations += 1
+        pass  # Not needed for unittest
 
 
 class MockEvaluator(Evaluator):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -2,14 +2,17 @@
 
 """Mocks for tests."""
 
-from typing import Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 import torch
 from torch import nn
 
+from pykeen.evaluation import Evaluator, MetricResults, RankBasedMetricResults
+from pykeen.evaluation.rank_based_evaluator import RANK_REALISTIC, RANK_TYPES, SIDES
 from pykeen.models import EntityRelationEmbeddingModel, Model
 from pykeen.nn.emb import EmbeddingSpecification, RepresentationModule
 from pykeen.triples import CoreTriplesFactory
+from pykeen.typing import MappedTriples
 
 __all__ = [
     'CustomRepresentations',
@@ -59,3 +62,78 @@ class MockModel(EntityRelationEmbeddingModel):
 
     def reset_parameters_(self) -> Model:  # noqa: D102
         pass  # Not needed for unittest
+
+
+class MockEvaluator(Evaluator):
+    """A mock evaluator for testing early stopping."""
+
+    def __init__(self, losses: Iterable[float], automatic_memory_optimization: bool = True) -> None:
+        super().__init__(automatic_memory_optimization=automatic_memory_optimization)
+        self.losses = tuple(losses)
+        self.losses_iter = iter(self.losses)
+
+    def process_tail_scores_(
+        self,
+        hrt_batch: MappedTriples,
+        true_scores: torch.FloatTensor,
+        scores: torch.FloatTensor,
+        dense_positive_mask: Optional[torch.FloatTensor] = None,
+    ) -> None:  # noqa: D102
+        pass
+
+    def process_head_scores_(
+        self,
+        hrt_batch: MappedTriples,
+        true_scores: torch.FloatTensor,
+        scores: torch.FloatTensor,
+        dense_positive_mask: Optional[torch.FloatTensor] = None,
+    ) -> None:  # noqa: D102
+        pass
+
+    def finalize(self) -> MetricResults:  # noqa: D102
+        hits = next(self.losses_iter)
+        dummy_1 = {
+            side: {
+                rank_type: 10
+                for rank_type in RANK_TYPES
+            }
+            for side in SIDES
+        }
+        dummy_2 = {
+            side: {
+                rank_type: 1.0
+                for rank_type in RANK_TYPES
+            }
+            for side in SIDES
+        }
+        return RankBasedMetricResults(
+            arithmetic_mean_rank=dummy_1,
+            geometric_mean_rank=dummy_1,
+            harmonic_mean_rank=dummy_1,
+            median_rank=dummy_1,
+            inverse_arithmetic_mean_rank=dummy_2,
+            inverse_harmonic_mean_rank=dummy_2,
+            inverse_geometric_mean_rank=dummy_2,
+            inverse_median_rank=dummy_2,
+            adjusted_arithmetic_mean_rank=dummy_2,
+            adjusted_arithmetic_mean_rank_index={
+                side: {
+                    RANK_REALISTIC: 0.0,
+                }
+                for side in SIDES
+            },
+            rank_std=dummy_1,
+            rank_var=dummy_1,
+            rank_mad=dummy_1,
+            hits_at_k={
+                side: {
+                    rank_type: {
+                        10: hits,
+                    } for rank_type in RANK_TYPES
+                }
+                for side in SIDES
+            },
+        )
+
+    def __repr__(self):  # noqa: D105
+        return f'{self.__class__.__name__}(losses={self.losses})'

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -42,7 +42,8 @@ class MockModel(EntityRelationEmbeddingModel):
             relation_representations=EmbeddingSpecification(embedding_dim=50),
         )
         num_entities = self.num_entities
-        self.scores = torch.arange(num_entities, dtype=torch.float)
+        self.scores = torch.arange(num_entities, dtype=torch.float, requires_grad=True)
+        self.num_backward_propagations = 0
 
     def _generate_fake_scores(self, batch: torch.LongTensor) -> torch.FloatTensor:
         """Generate fake scores s[b, i] = i of size (batch_size, num_entities)."""
@@ -61,7 +62,7 @@ class MockModel(EntityRelationEmbeddingModel):
         return self._generate_fake_scores(batch=rt_batch)
 
     def reset_parameters_(self) -> Model:  # noqa: D102
-        pass  # Not needed for unittest
+        self.num_backward_propagations += 1
 
 
 class MockEvaluator(Evaluator):

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -204,7 +204,7 @@ class TestEarlyStoppingRealWorld(unittest.TestCase):
             stopper=stopper,
             use_tqdm=False,
         )
-        self.assertEqual(stopper.number_results, (len(losses) + 2 * stopper.frequency) // stopper.frequency)
+        self.assertEqual(stopper.number_results, (len(losses) + self.patience * stopper.frequency) // stopper.frequency)
         self.assertEqual(
             self.stop_epoch,
             (len(losses) + 2 * stopper.frequency),

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -204,5 +204,9 @@ class TestEarlyStoppingRealWorld(unittest.TestCase):
             stopper=stopper,
             use_tqdm=False,
         )
-        self.assertEqual(stopper.number_results, len(losses) // stopper.frequency)
-        self.assertEqual(self.stop_epoch, len(losses), msg='Did not stop early like it should have')
+        self.assertEqual(stopper.number_results, (len(losses) + 2 * stopper.frequency) // stopper.frequency)
+        self.assertEqual(
+            self.stop_epoch,
+            (len(losses) + 2 * stopper.frequency),
+            msg='Did not stop early like it should have',
+        )

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -16,7 +16,7 @@ from pykeen.models import Model, TransE
 from pykeen.stoppers.early_stopping import EarlyStopper, is_improvement
 from pykeen.trackers import MLFlowResultTracker
 from pykeen.training import SLCWATrainingLoop
-from tests.mocks import MockModel, MockEvaluator
+from tests.mocks import MockEvaluator, MockModel
 
 try:
     import mlflow

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -3,7 +3,7 @@
 """Tests of early stopping."""
 
 import unittest
-from typing import Iterable, List, Optional
+from typing import List
 
 import numpy
 import pytest

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -11,14 +11,12 @@ import torch
 from torch.optim import Adam
 
 from pykeen.datasets import Nations
-from pykeen.evaluation import Evaluator, MetricResults, RankBasedEvaluator, RankBasedMetricResults
-from pykeen.evaluation.rank_based_evaluator import RANK_REALISTIC, RANK_TYPES, SIDES
+from pykeen.evaluation import RankBasedEvaluator
 from pykeen.models import Model, TransE
 from pykeen.stoppers.early_stopping import EarlyStopper, is_improvement
 from pykeen.trackers import MLFlowResultTracker
 from pykeen.training import SLCWATrainingLoop
-from pykeen.typing import MappedTriples
-from tests.mocks import MockModel
+from tests.mocks import MockModel, MockEvaluator
 
 try:
     import mlflow
@@ -54,81 +52,6 @@ class TestRandom(unittest.TestCase):
                     larger_is_better=larger_is_better,
                     relative_delta=relative_delta,
                 ))
-
-
-class MockEvaluator(Evaluator):
-    """A mock evaluator for testing early stopping."""
-
-    def __init__(self, losses: Iterable[float], automatic_memory_optimization: bool = True) -> None:
-        super().__init__(automatic_memory_optimization=automatic_memory_optimization)
-        self.losses = tuple(losses)
-        self.losses_iter = iter(self.losses)
-
-    def process_tail_scores_(
-        self,
-        hrt_batch: MappedTriples,
-        true_scores: torch.FloatTensor,
-        scores: torch.FloatTensor,
-        dense_positive_mask: Optional[torch.FloatTensor] = None,
-    ) -> None:  # noqa: D102
-        pass
-
-    def process_head_scores_(
-        self,
-        hrt_batch: MappedTriples,
-        true_scores: torch.FloatTensor,
-        scores: torch.FloatTensor,
-        dense_positive_mask: Optional[torch.FloatTensor] = None,
-    ) -> None:  # noqa: D102
-        pass
-
-    def finalize(self) -> MetricResults:  # noqa: D102
-        hits = next(self.losses_iter)
-        dummy_1 = {
-            side: {
-                rank_type: 10
-                for rank_type in RANK_TYPES
-            }
-            for side in SIDES
-        }
-        dummy_2 = {
-            side: {
-                rank_type: 1.0
-                for rank_type in RANK_TYPES
-            }
-            for side in SIDES
-        }
-        return RankBasedMetricResults(
-            arithmetic_mean_rank=dummy_1,
-            geometric_mean_rank=dummy_1,
-            harmonic_mean_rank=dummy_1,
-            median_rank=dummy_1,
-            inverse_arithmetic_mean_rank=dummy_2,
-            inverse_harmonic_mean_rank=dummy_2,
-            inverse_geometric_mean_rank=dummy_2,
-            inverse_median_rank=dummy_2,
-            adjusted_arithmetic_mean_rank=dummy_2,
-            adjusted_arithmetic_mean_rank_index={
-                side: {
-                    RANK_REALISTIC: 0.0,
-                }
-                for side in SIDES
-            },
-            rank_std=dummy_1,
-            rank_var=dummy_1,
-            rank_mad=dummy_1,
-            hits_at_k={
-                side: {
-                    rank_type: {
-                        10: hits,
-                    } for rank_type in RANK_TYPES
-                }
-                for side in SIDES
-            },
-        )
-
-    def __repr__(self):  # noqa: D105
-        return f'{self.__class__.__name__}(losses={self.losses})'
 
 
 class LogCallWrapper:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -11,7 +11,7 @@ from torch import optim
 
 from pykeen.datasets import Nations
 from pykeen.losses import CrossEntropyLoss
-from pykeen.models import ConvE, Model, TransE, UnstructuredModel
+from pykeen.models import ConvE, Model, TransE
 from pykeen.optimizers import optimizer_resolver
 from pykeen.stoppers.early_stopping import EarlyStopper
 from pykeen.training import SLCWATrainingLoop, training_loop_resolver
@@ -294,7 +294,11 @@ class TestTrainingEarlyStopping(unittest.TestCase):
 
     def test_early_stopper_best_epoch_model_retrieval(self):
         """Test if the best epoch model is returned when using the early stopper."""
-        training_loop = DummyTrainingLoop(model=self.model, triples_factory=self.triples_factory.training, sub_batch_size=self.batch_size)
+        training_loop = DummyTrainingLoop(
+            model=self.model,
+            triples_factory=self.triples_factory.training,
+            sub_batch_size=self.batch_size,
+        )
 
         _ = training_loop.train(
             triples_factory=self.triples_factory.training,

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -4,19 +4,21 @@
 
 import tempfile
 import unittest
-from typing import Optional
+from typing import List, Optional
 
 import torch
 from torch import optim
 
 from pykeen.datasets import Nations
 from pykeen.losses import CrossEntropyLoss
-from pykeen.models import ConvE, Model, TransE
+from pykeen.models import ConvE, Model, TransE, UnstructuredModel
 from pykeen.optimizers import optimizer_resolver
+from pykeen.stoppers.early_stopping import EarlyStopper
 from pykeen.training import SLCWATrainingLoop, training_loop_resolver
 from pykeen.training.training_loop import NonFiniteLossError, TrainingApproachLossMismatchError
 from pykeen.triples import TriplesFactory
 from pykeen.typing import MappedTriples
+from tests.mocks import MockEvaluator, MockModel
 
 
 class DummyTrainingLoop(SLCWATrainingLoop):
@@ -256,3 +258,48 @@ class TrainingLoopTests(unittest.TestCase):
         )
 
         self.assertEqual(losses, losses_2)
+
+
+class TestTrainingEarlyStopping(unittest.TestCase):
+    """Tests for early stopping during training."""
+
+    batch_size: int = 128
+    #: The window size used by the early stopper
+    patience: int = 2
+    #: The mock losses the mock evaluator will return
+    mock_losses: List[float] = [10.0, 9.0, 8.0, 8.0, 8.0, 8.0]
+    #: The (zeroed) index  - 1 at which stopping will occur
+    stop_constant: int = 4
+    #: The minimum improvement
+    delta: float = 0.0
+    #: The best results
+    best_results: List[float] = [10.0, 9.0, 8.0, 8.0, 8.0]
+
+    def setUp(self):
+        """Prepare for testing the early stopper."""
+        # Set automatic_memory_optimization to false for tests
+        self.mock_evaluator = MockEvaluator(self.mock_losses, automatic_memory_optimization=False)
+        self.triples_factory = Nations()
+        self.model = MockModel(triples_factory=self.triples_factory.training)
+        self.stopper = EarlyStopper(
+            model=self.model,
+            evaluator=self.mock_evaluator,
+            training_triples_factory=self.triples_factory.training,
+            evaluation_triples_factory=self.triples_factory.validation,
+            patience=self.patience,
+            relative_delta=self.delta,
+            larger_is_better=False,
+            frequency=1,
+        )
+
+    def test_early_stopper_best_epoch_model_retrieval(self):
+        """Test if the best epoch model is returned when using the early stopper."""
+        training_loop = DummyTrainingLoop(model=self.model, triples_factory=self.triples_factory.training, sub_batch_size=self.batch_size)
+
+        _ = training_loop.train(
+            triples_factory=self.triples_factory.training,
+            num_epochs=10,
+            batch_size=self.batch_size,
+            stopper=self.stopper,
+        )
+        self.assertEqual(training_loop.model.num_backward_propagations, self.patience)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -306,4 +306,4 @@ class TestTrainingEarlyStopping(unittest.TestCase):
             batch_size=self.batch_size,
             stopper=self.stopper,
         )
-        self.assertEqual(training_loop.model.num_backward_propagations, self.patience)
+        self.assertEqual(training_loop._epoch, len(self.stopper.results) - self.patience)


### PR DESCRIPTION
When using the early stopper with patience, the model will continue training after the _best epoch_ and thus deviate. Once the training loop finishes, this altered model will be passed back from the training loop even though it is different from the _best model_ at the time of the _best epoch_, which is what the early stopper reports. This becomes especially problematic when the model is used for the final evaluation afterwards.

This PR overcomes this problem by always saving the best epoch state of the model and reconstructing this state when the early stopper concludes the training loop, such that the training loop will pass the actual _best model_ back. To make this as simple and resource friendly as possible, those files are saved in temporary paths during the training loop, which are automatically removed once they served their purpose.