### PR TITLE
🍇 🙏 Stop storing the training_instances as an instance variable

### DIFF
--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -110,6 +110,7 @@ class LCWATrainingLoop(TrainingLoop):
         self,
         *,
         triples_factory: CoreTriplesFactory,
+        training_instances: Instances,
         batch_size: int,
         sub_batch_size: int,
         supports_sub_batching: bool,
@@ -126,6 +127,7 @@ class LCWATrainingLoop(TrainingLoop):
                 logger.debug(f'Trying slice size {slice_size} now.')
                 self._train(
                     triples_factory=triples_factory,
+                    training_instances=training_instances,
                     num_epochs=1,
                     batch_size=batch_size,
                     sub_batch_size=sub_batch_size,

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -172,6 +172,7 @@ class SLCWATrainingLoop(TrainingLoop):
         self,
         *,
         triples_factory: CoreTriplesFactory,
+        training_instances: Instances,
         batch_size: int,
         sub_batch_size: int,
         supports_sub_batching: bool,

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -81,7 +81,6 @@ def _get_optimizer_kwargs(optimizer: Optimizer) -> Mapping[str, Any]:
 class TrainingLoop(ABC):
     """A training loop."""
 
-    training_instances: Optional[Instances]
     losses_per_epochs: List[float]
     loss_blacklist: Optional[List[Type[Loss]]] = None
 
@@ -108,7 +107,6 @@ class TrainingLoop(ABC):
         """
         self.model = model
         self.optimizer = optimizer
-        self.training_instances = None
         self.losses_per_epochs = []
         self.automatic_memory_optimization = automatic_memory_optimization
 
@@ -232,7 +230,7 @@ class TrainingLoop(ABC):
         """
         # Create training instances. Use the _create_instances function to allow subclasses
         # to modify this behavior
-        self.training_instances = self._create_instances(triples_factory)
+        training_instances = self._create_instances(triples_factory)
 
         # In some cases, e.g. using Optuna for HPO, the cuda cache from a previous run is not cleared
         torch.cuda.empty_cache()
@@ -307,6 +305,7 @@ class TrainingLoop(ABC):
                 checkpoint_on_failure_file_path=checkpoint_on_failure_file_path,
                 drop_last=drop_last,
                 triples_factory=triples_factory,
+                training_instances=training_instances,
             )
 
         # Ensure the release of memory
@@ -321,6 +320,7 @@ class TrainingLoop(ABC):
     def _train(  # noqa: C901
         self,
         triples_factory: CoreTriplesFactory,
+        training_instances: Instances,
         num_epochs: int = 1,
         batch_size: Optional[int] = None,
         slice_size: Optional[int] = None,
@@ -389,8 +389,6 @@ class TrainingLoop(ABC):
         :return:
             The losses per epoch.
         """
-        if self.training_instances is None:
-            raise ValueError('must set training instances before running _train()')
         if self.optimizer is None:
             raise ValueError('optimizer must be set before running _train()')
 
@@ -413,7 +411,10 @@ class TrainingLoop(ABC):
                         "Therefore, the batch_size will be set to the default value '{batch_size}'",
                     )
                 else:
-                    batch_size, batch_size_sufficient = self.batch_size_search(triples_factory=triples_factory)
+                    batch_size, batch_size_sufficient = self.batch_size_search(
+                        triples_factory=triples_factory,
+                        training_instances=training_instances,
+                    )
             else:
                 batch_size = 256
                 logger.info(f"No batch_size provided. Setting batch_size to '{batch_size}'.")
@@ -427,7 +428,10 @@ class TrainingLoop(ABC):
         ):
             # return the relevant parameters slice_size and batch_size
             sub_batch_size, slice_size = self.sub_batch_and_slice(
-                batch_size=batch_size, sampler=sampler, triples_factory=triples_factory,
+                batch_size=batch_size,
+                sampler=sampler,
+                triples_factory=triples_factory,
+                training_instances=training_instances,
             )
 
         # Create dummy result tracker
@@ -447,7 +451,7 @@ class TrainingLoop(ABC):
             if drop_last and not only_size_probing:
                 logger.info(
                     "Dropping last (incomplete) batch each epoch (%s batches).",
-                    format_relative_comparison(part=1, total=len(self.training_instances)),
+                    format_relative_comparison(part=1, total=len(training_instances)),
                 )
 
         # Sanity check
@@ -485,7 +489,7 @@ class TrainingLoop(ABC):
             num_workers = 0
 
         # Bind
-        num_training_instances = len(self.training_instances)
+        num_training_instances = len(training_instances)
 
         _use_outer_tqdm = not only_size_probing and use_tqdm
         _use_inner_tqdm = _use_outer_tqdm and use_tqdm_batch
@@ -506,7 +510,7 @@ class TrainingLoop(ABC):
 
         train_data_loader = DataLoader(
             sampler=sampler,
-            dataset=self.training_instances,
+            dataset=training_instances,
             batch_size=batch_size,
             shuffle=shuffle,
             num_workers=num_workers,
@@ -691,6 +695,7 @@ class TrainingLoop(ABC):
         self,
         *,
         triples_factory: CoreTriplesFactory,
+        training_instances: Instances,
         batch_size: Optional[int] = None,
     ) -> Tuple[int, bool]:
         """Find the maximum batch size for training with the current setting.
@@ -728,6 +733,7 @@ class TrainingLoop(ABC):
                     sub_batch_size=None,
                     only_size_probing=True,
                     triples_factory=triples_factory,
+                    training_instances=training_instances,
                 )
             except RuntimeError as runtime_error:
                 self._free_graph_and_cache()
@@ -762,12 +768,14 @@ class TrainingLoop(ABC):
         batch_size: int,
         sampler: Optional[str],
         triples_factory: CoreTriplesFactory,
+        training_instances: Instances,
     ) -> Tuple[int, Optional[int]]:
         """Check if sub-batching and/or slicing is necessary to train the model on the hardware at hand."""
         sub_batch_size, finished_search, supports_sub_batching = self._sub_batch_size_search(
             batch_size=batch_size,
             sampler=sampler,
             triples_factory=triples_factory,
+            training_instances=training_instances,
         )
         # If the sub_batch_size did not finish search with a possibility that fits the hardware, we have to try slicing
         if finished_search:
@@ -817,6 +825,7 @@ class TrainingLoop(ABC):
         batch_size: int,
         sampler: Optional[str],
         triples_factory: CoreTriplesFactory,
+        training_instances: Instances,
     ) -> Tuple[int, bool, bool]:
         """Find the allowable sub batch size for training with the current setting.
 
@@ -841,6 +850,7 @@ class TrainingLoop(ABC):
             logger.debug(f'Trying batch_size {batch_size} for training now.')
             self._train(
                 triples_factory=triples_factory,
+                training_instances=training_instances,
                 num_epochs=1,
                 batch_size=batch_size,
                 sub_batch_size=sub_batch_size,
@@ -875,6 +885,7 @@ class TrainingLoop(ABC):
                             sampler=sampler,
                             only_size_probing=True,
                             triples_factory=triples_factory,
+                            training_instances=training_instances,
                         )
                     except RuntimeError as runtime_error:
                         self._free_graph_and_cache()

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -173,6 +173,8 @@ class TrainingLoop(ABC):
     ) -> Optional[List[float]]:
         """Train the KGE model.
 
+        :param triples_factory:
+            The training triples factory
         :param num_epochs:
             The number of epochs to train the model.
         :param batch_size:
@@ -343,6 +345,8 @@ class TrainingLoop(ABC):
     ) -> Optional[List[float]]:
         """Train the KGE model.
 
+        :param triples_factory:
+            The training triples factory
         :param num_epochs:
             The number of epochs to train the model.
         :param batch_size:
@@ -707,6 +711,8 @@ class TrainingLoop(ABC):
 
         :param triples_factory:
             The triples factory over which search is run
+        :param training_instances:
+            The training instances generated from the triples factory
         :param batch_size:
             The batch size to start the search with. If None, set batch_size=num_triples (i.e. full batch training).
 
@@ -783,6 +789,7 @@ class TrainingLoop(ABC):
 
         slice_size = self._slice_size_search(
             triples_factory=triples_factory,
+            training_instances=training_instances,
             batch_size=batch_size,
             sub_batch_size=sub_batch_size,
             supports_sub_batching=supports_sub_batching,
@@ -794,6 +801,7 @@ class TrainingLoop(ABC):
         self,
         *,
         triples_factory: CoreTriplesFactory,
+        training_instances: Instances,
         batch_size: int,
         sub_batch_size: int,
         supports_sub_batching: bool,


### PR DESCRIPTION
This PR will simplify #417 by removing yet another unnecessary instance variable from the `TrainingLoop` class. The `training_instances` do not actually need to be stored in state, since they only have to get passed around after calling `TrainingLoop.train()`

This PR might also allow us to remove the triples_factory itself from many of these inner calls. This probably not the case, since the triples factor is used for two things: getting the number of triples (which isn't stored in the LCWA instances) and getting the mapped triples for graph sampling (which again isn't stored in the LCWA instances)