### PR TITLE
🏫 🍂 Add optional embedding dropout

### DIFF
--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -200,9 +200,9 @@ class Embedding(RepresentationModule):
     update (using the post_parameter_update hook), i.e., outside of the automatic gradient computation.
 
     The optional dropout can be used as a regularization technique. Moreover, it enables to obtain uncertainty estimates
-    via techniques such as Monte-Carlo dropout. The following simple example shows how to obtain different scores
-    for a single triple from an (untrained) model. These scores can be considered as samples from a distribution over
-    the scores.
+    via techniques such as `Monte-Carlo dropout <https://arxiv.org/abs/1506.02142>`_. The following simple example shows
+    how to obtain different scores for a single triple from an (untrained) model. These scores can be considered as
+    samples from a distribution over the scores.
 
     >>> from pykeen.datasets.nations import Nations
     >>> dataset = Nations()
@@ -800,10 +800,10 @@ class CompGCNLayer(nn.Module):
         edge_type = 2 * edge_type
         # update entity representations: mean over self-loops / forward edges / backward edges
         x_e = (
-            self.composition(x_e, self.self_loop) @ self.w_loop
-            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
-            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
-        ) / 3
+                  self.composition(x_e, self.self_loop) @ self.w_loop
+                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
+                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
+              ) / 3
 
         if self.bias:
             x_e = self.bias(x_e)

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -771,10 +771,10 @@ class CompGCNLayer(nn.Module):
         edge_type = 2 * edge_type
         # update entity representations: mean over self-loops / forward edges / backward edges
         x_e = (
-                  self.composition(x_e, self.self_loop) @ self.w_loop
-                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
-                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
-              ) / 3
+            self.composition(x_e, self.self_loop) @ self.w_loop
+            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
+            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
+        ) / 3
 
         if self.bias:
             x_e = self.bias(x_e)

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -807,10 +807,10 @@ class CompGCNLayer(nn.Module):
         edge_type = 2 * edge_type
         # update entity representations: mean over self-loops / forward edges / backward edges
         x_e = (
-                  self.composition(x_e, self.self_loop) @ self.w_loop
-                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
-                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
-              ) / 3
+            self.composition(x_e, self.self_loop) @ self.w_loop
+            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
+            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
+        ) / 3
 
         if self.bias:
             x_e = self.bias(x_e)

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -206,15 +206,12 @@ class Embedding(RepresentationModule):
 
     >>> from pykeen.datasets.nations import Nations
     >>> dataset = Nations()
-    # TODO: Move resolution to ERModel, once https://github.com/pykeen/pykeen/pull/411 is solved
-    >>> from pykeen.nn.modules import interaction_resolver
-    >>> interaction = interaction_resolver.make("distmult")
     >>> from pykeen.nn.emb import EmbeddingSpecification
     >>> spec = EmbeddingSpecification(embedding_dim=3, dropout=0.1)
     >>> from pykeen.models import ERModel
     >>> model = ERModel(
     ...     triples_factory=dataset.training,
-    ...     interaction=interaction,
+    ...     interaction='distmult',
     ...     entity_representations=spec,
     ...     relation_representations=spec,
     ... )

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -393,6 +393,7 @@ class EmbeddingSpecification:
     regularizer: Optional['Regularizer'] = None
 
     dtype: Optional[torch.dtype] = None
+    dropout: Optional[float] = None
 
     def make(self, *, num_embeddings: int, device: Optional[torch.device] = None) -> Embedding:
         """Create an embedding with this specification."""
@@ -408,6 +409,7 @@ class EmbeddingSpecification:
             constrainer_kwargs=self.constrainer_kwargs,
             regularizer=self.regularizer,
             dtype=self.dtype,
+            dropout=self.dropout,
         )
         if device is not None:
             rv = rv.to(device)

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -199,10 +199,10 @@ class Embedding(RepresentationModule):
     embedding vectors are of unit length. A *constrainer* can be used similarly, but it is applied after each parameter
     update (using the post_parameter_update hook), i.e., outside of the automatic gradient computation.
 
-    The optional dropout can be used as a regularization technique. Moreover, it enables to obtain uncertainty estimates
-    via techniques such as `Monte-Carlo dropout <https://arxiv.org/abs/1506.02142>`_. The following simple example shows
-    how to obtain different scores for a single triple from an (untrained) model. These scores can be considered as
-    samples from a distribution over the scores.
+    The optional dropout can also be used as a regularization technique. Moreover, it enables to obtain uncertainty
+    estimates via techniques such as `Monte-Carlo dropout <https://arxiv.org/abs/1506.02142>`_. The following simple
+    example shows how to obtain different scores for a single triple from an (untrained) model. These scores can be
+    considered as samples from a distribution over the scores.
 
     >>> from pykeen.datasets.nations import Nations
     >>> dataset = Nations()

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -800,10 +800,10 @@ class CompGCNLayer(nn.Module):
         edge_type = 2 * edge_type
         # update entity representations: mean over self-loops / forward edges / backward edges
         x_e = (
-                  self.composition(x_e, self.self_loop) @ self.w_loop
-                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
-                  + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
-              ) / 3
+            self.composition(x_e, self.self_loop) @ self.w_loop
+            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index, edge_type=edge_type, weight=self.w_fwd)
+            + self.message(x_e=x_e, x_r=x_r, edge_index=edge_index.flip(0), edge_type=edge_type + 1, weight=self.w_bwd)
+        ) / 3
 
         if self.bias:
             x_e = self.bias(x_e)

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -226,6 +226,7 @@ class Embedding(RepresentationModule):
     normalizer: Optional[Normalizer]
     constrainer: Optional[Constrainer]
     regularizer: Optional['Regularizer']
+    dropout: Optional[nn.Dropout]
 
     def __init__(
         self,

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -32,6 +32,20 @@ class EmbeddingTests(cases.RepresentationTestCase):
         embedding_dim = int(numpy.prod(self.instance.shape))
         assert self.instance.shape == (embedding_dim,)
 
+    def test_dropout(self):
+        """Test dropout layer."""
+        # create a new instance with guaranteed dropout
+        kwargs = self.instance_kwargs
+        kwargs.pop("dropout", None)
+        dropout_instance = self.cls(**kwargs, dropout=0.1)
+        # set to training mode
+        dropout_instance.train()
+        # check for different output
+        indices = torch.arange(2)
+        first = dropout_instance(indices)
+        second = dropout_instance(indices)
+        assert not torch.allclose(first, second)
+
 
 class LiteralEmbeddingTests(cases.RepresentationTestCase):
     """Tests for literal embeddings."""


### PR DESCRIPTION
This PR adds an optional embedding dropout to the Embedding class. Enabling it can serve as a regularizer, but also enables obtaining uncertainty estimates via techniques such as Monte-Carlo Dropout.

As a side note:
Some of the parts currently implemented for Embedding could be pulled up to the general `Representation` class (or in a new intermediate `AbstractRepresentation` class). From my point of view, this applies for the `normalizer`, and the newly introducted `dropout`.

#### Dependencies:
* [x] #411 - for simplification of the docstring example.