### PR TITLE
🏳️‍🌈 ⸸ Save primitive result values

### DIFF
--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -431,11 +431,11 @@ class RankBasedEvaluator(Evaluator):
             if len(ranks) < 1:
                 continue
             hits_at_k[side][rank_type] = {
-                k: np.mean(ranks <= (k if isinstance(k, int) else int(self.num_entities * k)))
+                k: np.mean(ranks <= (k if isinstance(k, int) else int(self.num_entities * k))).item()
                 for k in self.ks
             }
             for metric_name, metric_func in all_type_funcs.items():
-                asr[metric_name][side][rank_type] = metric_func(ranks)
+                asr[metric_name][side][rank_type] = metric_func(ranks).item()
 
             expected_rank_type = EXPECTED_RANKS.get(rank_type)
             if expected_rank_type:


### PR DESCRIPTION
Closes #426 

Behold, massive code changes ahead ;)

Saving result dicts to yaml now look like this:

```
(...)
  geometric_mean_rank:
    both:
      optimistic: 330.52384119431156
      pessimistic: 330.52440842233455
      realistic: 330.5241248745452
    head:
      optimistic: 3045.295410650859
      pessimistic: 3045.304775759256
      realistic: 3045.300094254297
    tail:
      optimistic: 35.87369856328443
      pessimistic: 35.87371137120324
      realistic: 35.87370496924207
  harmonic_mean_rank:
    both:
      optimistic: 10.289360973581202
      pessimistic: 10.289361141043626
      realistic: 10.28936105737086
    head:
      optimistic: 222.2969110999365
      pessimistic: 222.29704540160677
      realistic: 222.2969782967548
    tail:
      optimistic: 5.266566120829129
      pessimistic: 5.266566133192489
      realistic: 5.266566127015612
  hits_at_k:
    both:
      optimistic:
        1: 0.0476745032389548
        3: 0.12027804061430963
        5: 0.15295873062086032
        10: 0.19164422447048549
(...)
```
