### PR TITLE
🙀 💾 Remove unavailable dataset variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 <p align="center">
   <a href="#installation">Installation</a> •
   <a href="#quickstart">Quickstart</a> •
-  <a href="#datasets-28">Datasets</a> •
+  <a href="#datasets-26">Datasets</a> •
   <a href="#models-27">Models</a> •
   <a href="#supporters">Support</a> •
   <a href="#citation">Citation</a>
@@ -96,7 +96,7 @@ The full documentation can be found at https://pykeen.readthedocs.io.
 Below are the models, datasets, training modes, evaluators, and metrics implemented
 in ``pykeen``.
 
-### Datasets (28)
+### Datasets (26)
 
 The citation for each dataset corresponds to either the paper describing the dataset,
 the first paper published using the dataset with knowledge graph embedding models,
@@ -123,8 +123,6 @@ or the URL for the dataset if neither of the first two are available.
 | OGB BioKG                          | [`pykeen.datasets.OGBBioKG`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OGBBioKG.html)           | [Hu *et al*., 2020](https://arxiv.org/abs/2005.00687)                                                                   |      45085 |          51 |   5088433 |
 | OGB WikiKG                         | [`pykeen.datasets.OGBWikiKG`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OGBWikiKG.html)         | [Hu *et al*., 2020](https://arxiv.org/abs/2005.00687)                                                                   |    2500604 |         535 |  17137181 |
 | OpenBioLink                        | [`pykeen.datasets.OpenBioLink`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OpenBioLink.html)     | [Breit *et al*., 2020](https://doi.org/10.1093/bioinformatics/btaa274)                                                  |     180992 |          28 |   4563407 |
-| OpenBioLink (F1)                   | [`pykeen.datasets.OpenBioLinkF1`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OpenBioLinkF1.html) | [`PyKEEN/pykeen-openbiolink-benchmark`](https://github.com/PyKEEN/pykeen-openbiolink-benchmark)                         |     116425 |          19 |   1716703 |
-| OpenBioLink (F2)                   | [`pykeen.datasets.OpenBioLinkF2`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OpenBioLinkF2.html) | [`PyKEEN/pykeen-openbiolink-benchmark`](https://github.com/PyKEEN/pykeen-openbiolink-benchmark)                         |     110628 |          17 |    734925 |
 | OpenBioLink                        | [`pykeen.datasets.OpenBioLinkLQ`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OpenBioLinkLQ.html) | [Breit *et al*., 2020](https://doi.org/10.1093/bioinformatics/btaa274)                                                  |     480876 |          32 |  27320889 |
 | Unified Medical Language System    | [`pykeen.datasets.UMLS`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.UMLS.html)                   | [`ZhenfengLei/KGDatasets`](https://github.com/ZhenfengLei/KGDatasets)                                                   |        135 |          46 |      6529 |
 | WK3l-120k Family                   | [`pykeen.datasets.WK3l120k`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.WK3l120k.html)           | [Chen *et al*., 2017](https://www.ijcai.org/Proceedings/2017/0209.pdf)                                                  |     119748 |        3109 |   1375406 |

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -30,7 +30,7 @@ from .hetionet import Hetionet
 from .kinships import Kinships
 from .nations import Nations
 from .ogb import OGBBioKG, OGBWikiKG
-from .openbiolink import OpenBioLink, OpenBioLinkF1, OpenBioLinkF2, OpenBioLinkLQ
+from .openbiolink import OpenBioLink, OpenBioLinkLQ
 from .umls import UMLS
 from .wk3l import WK3l15k
 from .wordnet import WN18, WN18RR
@@ -43,8 +43,6 @@ __all__ = [
     'Kinships',
     'Nations',
     'OpenBioLink',
-    'OpenBioLinkF1',
-    'OpenBioLinkF2',
     'OpenBioLinkLQ',
     'CoDExSmall',
     'CoDExMedium',
@@ -71,10 +69,24 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-_DATASETS: Set[Type[Dataset]] = {
-    entry.load()
-    for entry in iter_entry_points(group='pykeen.datasets')
-}
+
+def _load_datasets() -> Set[Type[Dataset]]:
+    rv = set()
+    for entry in iter_entry_points(group='pykeen.datasets'):
+        try:
+            cls = entry.load()
+        except ImportError:
+            logger.warning(
+                'PyKEEN was unable to load dataset %s. Try uninstalling PyKEEN with ``pip uninstall pykeen`` '
+                'then reinstalling', entry.name,
+            )
+            continue
+        else:
+            rv.add(cls)
+    return rv
+
+
+_DATASETS = _load_datasets()
 if not _DATASETS:
     raise RuntimeError('Datasets have been loaded with entrypoints since PyKEEN v1.0.5. Please reinstall.')
 

--- a/src/pykeen/datasets/openbiolink.py
+++ b/src/pykeen/datasets/openbiolink.py
@@ -13,14 +13,10 @@ from .base import PackedZipRemoteDataset
 
 __all__ = [
     'OpenBioLink',
-    'OpenBioLinkF1',
-    'OpenBioLinkF2',
     'OpenBioLinkLQ',
 ]
 
 HQ_URL = 'https://samwald.info/res/OpenBioLink_2020_final/HQ_DIR.zip'
-F1_URL = 'https://github.com/PyKEEN/pykeen-openbiolink-benchmark/raw/master/filter_1/openbiolink_f1.zip'
-F2_URL = 'https://github.com/PyKEEN/pykeen-openbiolink-benchmark/raw/master/filter_2/openbiolink_f2.zip'
 LQ_URL = 'https://samwald.info/res/OpenBioLink_2020_final/ALL_DIR.zip'
 
 
@@ -67,78 +63,6 @@ class OpenBioLink(PackedZipRemoteDataset):
 
 
 @parse_docdata
-class OpenBioLinkF1(PackedZipRemoteDataset):
-    """The PyKEEN First Filtered OpenBioLink 2020 Dataset.
-
-    ---
-    name: OpenBioLink (F1)
-    citation:
-        author: Mubeen
-        year: 2020
-        github: PyKEEN/pykeen-openbiolink-benchmark
-    statistics:
-        entities: 116425
-        relations: 19
-        training: 1616040
-        testing: 45026
-        validation: 55637
-        triples: 1716703
-    """
-
-    def __init__(self, create_inverse_triples: bool = False, **kwargs):
-        """Initialize the OpenBioLink (Filter-1) dataset.
-
-        :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.PackedZipRemoteDataset`.
-        """
-        super().__init__(
-            url=F1_URL,
-            name='openbiolink_f1.zip',
-            relative_training_path='train.tsv',
-            relative_testing_path='test.tsv',
-            relative_validation_path='val.tsv',
-            create_inverse_triples=create_inverse_triples,
-            **kwargs,
-        )
-
-
-@parse_docdata
-class OpenBioLinkF2(PackedZipRemoteDataset):
-    """The PyKEEN Second Filtered OpenBioLink 2020 Dataset.
-
-    ---
-    name: OpenBioLink (F2)
-    citation:
-        author: Mubeen
-        year: 2020
-        github: PyKEEN/pykeen-openbiolink-benchmark
-    statistics:
-        entities: 110628
-        relations: 17
-        training: 676156
-        testing: 30075
-        validation: 28694
-        triples: 734925
-    """
-
-    def __init__(self, create_inverse_triples: bool = False, **kwargs):
-        """Initialize the OpenBioLink (Filter-2) dataset.
-
-        :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.PackedZipRemoteDataset`.
-        """
-        super().__init__(
-            url=F2_URL,
-            name='openbiolink_f2.zip',
-            relative_training_path='train.tsv',
-            relative_testing_path='test.tsv',
-            relative_validation_path='val.tsv',
-            create_inverse_triples=create_inverse_triples,
-            **kwargs,
-        )
-
-
-@parse_docdata
 class OpenBioLinkLQ(PackedZipRemoteDataset):
     """The low-quality variant of the OpenBioLink dataset.
 
@@ -178,7 +102,7 @@ class OpenBioLinkLQ(PackedZipRemoteDataset):
 @click.command()
 @verbose_option
 def _main():
-    for cls in [OpenBioLink, OpenBioLinkF1, OpenBioLinkF2, OpenBioLinkLQ]:
+    for cls in [OpenBioLink, OpenBioLinkLQ]:
         cls().summarize()
 
 


### PR DESCRIPTION
This PR removes the unavailable OpenBioLink variants F1 & F2. They may be re-added when they become available.