### PR TITLE
🧹 📜 Documentation cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,23 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_
 
 `Unreleased <https://github.com/pykeen/pykeen/compare/v1.4.0...HEAD>`_
 -----------------------------------------------------------------------
-Updated
-~~~~~~~
-- Updated interfaces of models and negative samplers to enforce kwargs (https://github.com/pykeen/pykeen/pull/445)
-
 New Metrics
 ~~~~~~~~~~~
 - Adjusted Arithmetic Mean Rank Index (https://github.com/pykeen/pykeen/pull/378)
 - Add harmonic, geometric, and median rankings (https://github.com/pykeen/pykeen/pull/381)
+
+New Trackers
+~~~~~~~~~~~~
+- Console Tracker (https://github.com/pykeen/pykeen/pull/440)
+
+New Models
+~~~~~~~~~~
+- QuatE (https://github.com/pykeen/pykeen/pull/367)
+- CompGCN (https://github.com/pykeen/pykeen/pull/382)
+
+Datasets
+~~~~~~~~
+- Removed invalid datasets (OpenBioLink filtered sets; https://github.com/pykeen/pykeen/pull/#439)
 
 Added
 ~~~~~
@@ -24,10 +33,14 @@ Added
 - Pass custom training loops to pipeline (https://github.com/pykeen/pykeen/pull/334)
 - Compatibility later for the fft module (https://github.com/pykeen/pykeen/pull/288)
 - Official Python 3.9 support, now that PyTorch has it (https://github.com/pykeen/pykeen/pull/223)
-
+- Utilities for dataset analysis (https://github.com/pykeen/pykeen/pull/16, https://github.com/pykeen/pykeen/pull/392)
 Updated
 ~~~~~~~
 - R-GCN implementation now uses new-style models and is super idiomatic (https://github.com/pykeen/pykeen/pull/110)
+
+Changed
+~~~~~~~
+- Updated interfaces of models and negative samplers to enforce kwargs (https://github.com/pykeen/pykeen/pull/445)
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_
 
 `Unreleased <https://github.com/pykeen/pykeen/compare/v1.4.0...HEAD>`_
 -----------------------------------------------------------------------
+Updated
+~~~~~~~
+- Updated interfaces of models and negative samplers to enforce kwargs (https://github.com/pykeen/pykeen/pull/445)
 
 New Metrics
 ~~~~~~~~~~~

--- a/src/pykeen/experiments/validate.py
+++ b/src/pykeen/experiments/validate.py
@@ -30,6 +30,9 @@ _SKIP_ANNOTATIONS = {
     Model, Optional[Model], Type[Model], Optional[Type[Model]],
     Union[str, Callable[[torch.FloatTensor], torch.FloatTensor]],
 }
+_SKIP_EXTRANEOUS = {
+    'predict_with_sigmoid',
+}
 
 
 def iterate_config_paths() -> Iterable[Tuple[str, str, str]]:
@@ -107,7 +110,7 @@ def get_configuration_errors(path: str):  # noqa: C901
         for name in kwargs_value:
             if name == 'self':
                 continue
-            if name not in signature.parameters:
+            if name not in signature.parameters and name not in _SKIP_EXTRANEOUS:
                 extraneous_kwargs.append(name)
         if extraneous_kwargs:
             _x = '\n'.join(

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -58,6 +58,10 @@ class Model(nn.Module, ABC):
     #: The instance of the loss
     loss: Loss
 
+    num_entities: int
+    num_relations: int
+    use_inverse_triples: bool
+
     def __init__(
         self,
         triples_factory: CoreTriplesFactory,

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -716,6 +716,7 @@ class EntityEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):
 
     def __init__(
         self,
+        *,
         triples_factory: CoreTriplesFactory,
         entity_representations: EmbeddingSpecification,
         loss: Optional[Loss] = None,
@@ -765,6 +766,7 @@ class EntityRelationEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):
 
     def __init__(
         self,
+        *,
         triples_factory: CoreTriplesFactory,
         entity_representations: EmbeddingSpecification,
         relation_representations: EmbeddingSpecification,

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -87,6 +87,8 @@ class ComplEx(EntityRelationEmbeddingModel):
 
         :param embedding_dim:
             The embedding dimensionality of the entity embeddings.
+        :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.normal_`
+        :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.normal_`
         :param kwargs:
             Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
         """

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -12,8 +12,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 from ...utils import split_complex
 
 __all__ = [
@@ -76,38 +75,22 @@ class ComplEx(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 200,
-        loss: Optional[Loss] = None,
-        regularizer: Optional[Regularizer] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
         # initialize with entity and relation embeddings with standard normal distribution, cf.
         # https://github.com/ttrouill/complex/blob/dc4eb93408d9a5288c986695b58488ac80b1cc17/efe/models.py#L481-L487
         entity_initializer: Hint[Initializer] = normal_,
         relation_initializer: Hint[Initializer] = normal_,
+        **kwargs,
     ) -> None:
         """Initialize ComplEx.
 
-        :param triples_factory:
-            The triple factory connected to the model.
         :param embedding_dim:
             The embedding dimensionality of the entity embeddings.
-        :param loss:
-            The loss to use. Defaults to SoftplusLoss.
-        :param regularizer:
-            The regularizer to use.
-        :param preferred_device:
-            The default device where to model is located.
-        :param random_seed:
-            An optional random seed to set before the initialization of weights.
+        :param kwargs:
+            Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
         """
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -118,6 +101,7 @@ class ComplEx(EntityRelationEmbeddingModel):
                 initializer=relation_initializer,
                 dtype=torch.cfloat,
             ),
+            **kwargs,
         )
 
     @staticmethod

--- a/src/pykeen/models/unimodal/conv_e.py
+++ b/src/pykeen/models/unimodal/conv_e.py
@@ -16,9 +16,8 @@ from ...losses import BCEAfterSigmoidLoss, Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...nn.init import xavier_normal_
 from ...nn.modules import _calculate_missing_shape_information
-from ...regularizers import Regularizer
 from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 from ...utils import is_cudnn_error
 
 __all__ = [
@@ -138,13 +137,10 @@ class ConvE(EntityRelationEmbeddingModel):
         output_dropout: float = 0.3,
         feature_map_dropout: float = 0.2,
         embedding_dim: int = 200,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         apply_batch_normalization: bool = True,
         entity_initializer: Hint[Initializer] = xavier_normal_,
         relation_initializer: Hint[Initializer] = xavier_normal_,
+        **kwargs,
     ) -> None:
         """Initialize the model."""
         # ConvE should be trained with inverse triples
@@ -157,10 +153,6 @@ class ConvE(EntityRelationEmbeddingModel):
 
         super().__init__(
             triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -169,11 +161,12 @@ class ConvE(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
         # ConvE uses one bias for each entity
         self.bias_term = Embedding.init_with_device(
-            num_embeddings=triples_factory.num_entities,
+            num_embeddings=self.num_entities,
             embedding_dim=1,
             device=self.device,
             initializer=nn.init.zeros_,

--- a/src/pykeen/models/unimodal/conv_kb.py
+++ b/src/pykeen/models/unimodal/conv_kb.py
@@ -3,7 +3,7 @@
 """Implementation of the ConvKB model."""
 
 import logging
-from typing import Any, ClassVar, Mapping, Optional, Type
+from typing import Any, ClassVar, Mapping, Type
 
 import torch
 import torch.autograd
@@ -12,11 +12,9 @@ from torch.nn.init import uniform_
 
 from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 
 __all__ = [
     'ConvKB',
@@ -82,27 +80,19 @@ class ConvKB(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         hidden_dropout_rate: float = 0.,
         embedding_dim: int = 200,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
         num_filters: int = 400,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = uniform_,
         relation_initializer: Hint[Initializer] = uniform_,
+        **kwargs,
     ) -> None:
         """Initialize the model.
 
         To be consistent with the paper, pass entity and relation embeddings pre-trained from TransE.
         """
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -111,6 +101,7 @@ class ConvKB(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
         self.num_filters = num_filters

--- a/src/pykeen/models/unimodal/conv_kb.py
+++ b/src/pykeen/models/unimodal/conv_kb.py
@@ -81,14 +81,22 @@ class ConvKB(EntityRelationEmbeddingModel):
     def __init__(
         self,
         *,
-        hidden_dropout_rate: float = 0.,
         embedding_dim: int = 200,
+        hidden_dropout_rate: float = 0.,
         num_filters: int = 400,
         entity_initializer: Hint[Initializer] = uniform_,
         relation_initializer: Hint[Initializer] = uniform_,
         **kwargs,
     ) -> None:
         """Initialize the model.
+
+        :param embedding_dim: The entity embedding dimension $d$.
+        :param hidden_dropout_rate: The hidden dropout rate
+        :param num_filters: The number of convolutional filters to use
+        :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param kwargs:
+            Remaining keyword arguments passed through to :class:`pykeen.models.EntityRelationEmbeddingModel`.
 
         To be consistent with the paper, pass entity and relation embeddings pre-trained from TransE.
         """

--- a/src/pykeen/models/unimodal/distmult.py
+++ b/src/pykeen/models/unimodal/distmult.py
@@ -2,20 +2,17 @@
 
 """Implementation of DistMult."""
 
-from typing import Any, ClassVar, Mapping, Optional, Type
+from typing import Any, ClassVar, Mapping, Type
 
 import torch
-import torch.autograd
 from torch.nn import functional
 
 from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_normal_norm_, xavier_uniform_
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import Constrainer, DeviceHint, Hint, Initializer
+from ...typing import Constrainer, Hint, Initializer
 
 __all__ = [
     'DistMult',
@@ -75,15 +72,12 @@ class DistMult(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 50,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         entity_constrainer: Hint[Constrainer] = functional.normalize,
         relation_initializer: Hint[Initializer] = xavier_normal_norm_,
+        **kwargs,
     ) -> None:
         r"""Initialize DistMult.
 
@@ -92,13 +86,10 @@ class DistMult(EntityRelationEmbeddingModel):
             https://github.com/thunlp/OpenKE/blob/adeed2c0d2bef939807ed4f69c1ea4db35fd149b/models/DistMult.py#L16-L17
         :param entity_constrainer: Default: constrain entity embeddings to unit length
         :param relation_initializer: Default: relations are initialized to unit length (but not constrained)
+        :param kwargs:
+            Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
         """
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -108,6 +99,7 @@ class DistMult(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
     @staticmethod

--- a/src/pykeen/models/unimodal/ermlp.py
+++ b/src/pykeen/models/unimodal/ermlp.py
@@ -5,17 +5,13 @@
 from typing import Any, ClassVar, Mapping, Optional
 
 import torch
-import torch.autograd
 from torch import nn
 from torch.nn.init import uniform_
 
 from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 
 __all__ = [
     'ERMLP',
@@ -51,23 +47,15 @@ class ERMLP(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 50,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
         hidden_dim: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = uniform_,
         relation_initializer: Hint[Initializer] = uniform_,
+        **kwargs,
     ) -> None:
         """Initialize the model."""
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -76,6 +64,7 @@ class ERMLP(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
         if hidden_dim is None:

--- a/src/pykeen/models/unimodal/ermlpe.py
+++ b/src/pykeen/models/unimodal/ermlpe.py
@@ -2,7 +2,7 @@
 
 """An implementation of the extension to ERMLP."""
 
-from typing import Any, ClassVar, Mapping, Optional, Type
+from typing import Any, ClassVar, Mapping, Type
 
 import torch
 from torch import nn
@@ -12,9 +12,7 @@ from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import BCEAfterSigmoidLoss, Loss
 from ...nn.emb import EmbeddingSpecification
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 
 __all__ = [
     'ERMLPE',
@@ -63,24 +61,16 @@ class ERMLPE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         hidden_dim: int = 300,
         input_dropout: float = 0.2,
         hidden_dropout: float = 0.3,
         embedding_dim: int = 200,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = uniform_,
         relation_initializer: Hint[Initializer] = uniform_,
+        **kwargs,
     ) -> None:
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -89,6 +79,7 @@ class ERMLPE(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
         self.hidden_dim = hidden_dim
 

--- a/src/pykeen/models/unimodal/hole.py
+++ b/src/pykeen/models/unimodal/hole.py
@@ -8,13 +8,10 @@ import torch
 
 from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...moves import irfft, rfft
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_uniform_
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import Constrainer, DeviceHint, Hint, Initializer
+from ...typing import Constrainer, Hint, Initializer
 from ...utils import clamp_norm
 
 __all__ = [
@@ -66,24 +63,16 @@ class HolE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 200,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         entity_constrainer: Hint[Constrainer] = clamp_norm,  # type: ignore
         entity_constrainer_kwargs: Optional[Mapping[str, Any]] = None,
         relation_initializer: Hint[Constrainer] = xavier_uniform_,
+        **kwargs,
     ) -> None:
         """Initialize the model."""
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 # Initialisation, cf. https://github.com/mnick/scikit-kge/blob/master/skge/param.py#L18-L27
@@ -95,6 +84,7 @@ class HolE(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
     @staticmethod

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -11,11 +11,8 @@ from torch.nn.init import uniform_
 
 from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import Constrainer, DeviceHint, Hint, Initializer
+from ...typing import Constrainer, Hint, Initializer
 from ...utils import clamp_norm
 
 __all__ = [
@@ -69,35 +66,37 @@ class KG2E(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 50,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
         dist_similarity: Optional[str] = None,
         c_min: float = 0.05,
         c_max: float = 5.,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = uniform_,
         entity_constrainer: Hint[Constrainer] = clamp_norm,  # type: ignore
         entity_constrainer_kwargs: Optional[Mapping[str, Any]] = None,
         relation_initializer: Hint[Initializer] = uniform_,
         relation_constrainer: Hint[Constrainer] = clamp_norm,  # type: ignore
         relation_constrainer_kwargs: Optional[Mapping[str, Any]] = None,
+        **kwargs,
     ) -> None:
         r"""Initialize KG2E.
 
         :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 350]$.
         :param dist_similarity: Either 'KL' for Kullback-Leibler or 'EL' for expected likelihood. Defaults to KL.
-        :param c_min:
-        :param c_max:
+        :param c_min: covariance clamp minimum bound
+        :param c_max: covariance clamp maximum bound
+        :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param entity_constrainer: Entity constrainer function. Defaults to :func:`pykeen.utils.clamp_norm`
+        :param entity_constrainer_kwargs: Keyword arguments to be used when calling the entity constrainer
+        :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param relation_constrainer: Relation constrainer function. Defaults to :func:`pykeen.utils.clamp_norm`
+        :param relation_constrainer_kwargs: Keyword arguments to be used when calling the relation constrainer
+        :param kwargs:
+            Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
+
+        :raises ValueError: if an illegal ``dist_similarity`` is given
         """
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -110,6 +109,7 @@ class KG2E(EntityRelationEmbeddingModel):
                 constrainer=relation_constrainer,
                 constrainer_kwargs=relation_constrainer_kwargs or self.constrainer_default_kwargs,
             ),
+            **kwargs,
         )
 
         # Similarity function used for distributions
@@ -126,7 +126,7 @@ class KG2E(EntityRelationEmbeddingModel):
 
         # Additional covariance embeddings
         self.entity_covariances = Embedding.init_with_device(
-            num_embeddings=triples_factory.num_entities,
+            num_embeddings=self.num_entities,
             embedding_dim=embedding_dim,
             device=self.device,
             # Ensure positive definite covariances matrices and appropriate size by clamping
@@ -134,7 +134,7 @@ class KG2E(EntityRelationEmbeddingModel):
             constrainer_kwargs=dict(min=self.c_min, max=self.c_max),
         )
         self.relation_covariances = Embedding.init_with_device(
-            num_embeddings=triples_factory.num_relations,
+            num_embeddings=self.num_relations,
             embedding_dim=embedding_dim,
             device=self.device,
             # Ensure positive definite covariances matrices and appropriate size by clamping

--- a/src/pykeen/models/unimodal/mure.py
+++ b/src/pykeen/models/unimodal/mure.py
@@ -53,6 +53,15 @@ class MuRE(ERModel):
         :param embedding_dim: The entity embedding dimension $d$. Defaults to 200. Is usually $d \in [50, 300]$.
         :param p: The $l_p$ norm. Defaults to 2.
         :param power_norm: Should the power norm be used? Defaults to true.
+        :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.normal_`
+        :param entity_initializer_kwargs: Keyword arguments to be used when calling the entity initializer
+        :param entity_bias_initializer: Entity bias initializer function. Defaults to :func:`torch.nn.init.zeros_`
+        :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.normal_`
+        :param relation_initializer_kwargs: Keyword arguments to be used when calling the relation initializer
+        :param relation_matrix_initializer: Relation matrix initializer function.
+            Defaults to :func:`torch.nn.init.uniform_`
+        :param relation_matrix_initializer_kwargs: Keyword arguments to be used when calling the
+            relation matrix initializer
         :param kwargs: Remaining keyword arguments passed through to :class:`pykeen.models.ERModel`.
         """
         # comment:

--- a/src/pykeen/models/unimodal/ntn.py
+++ b/src/pykeen/models/unimodal/ntn.py
@@ -68,7 +68,7 @@ class NTN(EntityEmbeddingModel):
         r"""Initialize NTN.
 
         :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 350]$.
-        :param num_slices:
+        :param num_slices: The number of slices in the parameters
         :param non_linearity: A non-linear activation function. Defaults to the hyperbolic
             tangent :class:`torch.nn.Tanh`.
         :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
@@ -138,6 +138,8 @@ class NTN(EntityEmbeddingModel):
         :param h_indices: shape: (batch_size,)
         :param r_indices: shape: (batch_size,)
         :param t_indices: shape: (batch_size,)
+        :param slice_size: >0
+            The divisor for the scoring function when using slicing.
 
         :return: shape: (batch_size, num_entities)
         """

--- a/src/pykeen/models/unimodal/ntn.py
+++ b/src/pykeen/models/unimodal/ntn.py
@@ -9,11 +9,8 @@ from torch import nn
 
 from ..base import EntityEmbeddingModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 
 __all__ = [
     'NTN',
@@ -61,62 +58,58 @@ class NTN(EntityEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 100,
         num_slices: int = 4,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
         non_linearity: Optional[nn.Module] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = None,
+        **kwargs,
     ) -> None:
         r"""Initialize NTN.
 
         :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 350]$.
         :param num_slices:
         :param non_linearity: A non-linear activation function. Defaults to the hyperbolic
-         tangent :class:`torch.nn.Tanh`.
+            tangent :class:`torch.nn.Tanh`.
+        :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param kwargs:
+            Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
         """
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
             ),
+            **kwargs,
         )
         self.num_slices = num_slices
 
         self.w = nn.Parameter(data=torch.empty(
-            triples_factory.num_relations,
+            self.num_relations,
             num_slices,
             embedding_dim,
             embedding_dim,
             device=self.device,
         ), requires_grad=True)
         self.vh = nn.Parameter(data=torch.empty(
-            triples_factory.num_relations,
+            self.num_relations,
             num_slices,
             embedding_dim,
             device=self.device,
         ), requires_grad=True)
         self.vt = nn.Parameter(data=torch.empty(
-            triples_factory.num_relations,
+            self.num_relations,
             num_slices,
             embedding_dim,
             device=self.device,
         ), requires_grad=True)
         self.b = nn.Parameter(data=torch.empty(
-            triples_factory.num_relations,
+            self.num_relations,
             num_slices,
             device=self.device,
         ), requires_grad=True)
         self.u = nn.Parameter(data=torch.empty(
-            triples_factory.num_relations,
+            self.num_relations,
             num_slices,
             device=self.device,
         ), requires_grad=True)

--- a/src/pykeen/models/unimodal/ntn.py
+++ b/src/pykeen/models/unimodal/ntn.py
@@ -73,7 +73,7 @@ class NTN(EntityEmbeddingModel):
             tangent :class:`torch.nn.Tanh`.
         :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
         :param kwargs:
-            Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
+            Remaining keyword arguments to forward to :class:`pykeen.models.EntityEmbeddingModel`
         """
         super().__init__(
             entity_representations=EmbeddingSpecification(

--- a/src/pykeen/models/unimodal/pair_re.py
+++ b/src/pykeen/models/unimodal/pair_re.py
@@ -61,6 +61,12 @@ class PairRE(ERModel):
         :param embedding_dim: The entity embedding dimension $d$.
         :param p: The $l_p$ norm.
         :param power_norm: Should the power norm be used?
+        :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param entity_initializer_kwargs: Keyword arguments to be used when calling the entity initializer
+        :param entity_normalizer: Entity normalizer function. Defaults to :func:`torch.nn.functional.normalize`
+        :param entity_normalizer_kwargs: Keyword arguments to be used when calling the entity normalizer
+        :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param relation_initializer_kwargs: Keyword arguments to be used when calling the relation initializer
         :param kwargs: Remaining keyword arguments passed through to :class:`pykeen.models.ERModel`.
         """
         entity_normalizer_kwargs = _resolve_kwargs(

--- a/src/pykeen/models/unimodal/proj_e.py
+++ b/src/pykeen/models/unimodal/proj_e.py
@@ -14,9 +14,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import BCEWithLogitsLoss, Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_uniform_
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 
 __all__ = [
     'ProjE',
@@ -65,22 +63,14 @@ class ProjE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 50,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
         inner_non_linearity: Optional[nn.Module] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         relation_initializer: Hint[Initializer] = xavier_uniform_,
+        **kwargs,
     ) -> None:
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -89,6 +79,7 @@ class ProjE(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
         # Global entity projection

--- a/src/pykeen/models/unimodal/rescal.py
+++ b/src/pykeen/models/unimodal/rescal.py
@@ -2,18 +2,16 @@
 
 """Implementation of RESCAL."""
 
-from typing import Any, ClassVar, Mapping, Optional, Type
+from typing import Any, ClassVar, Mapping, Type
 
 import torch
 from torch.nn.init import uniform_
 
 from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...regularizers import LpRegularizer, Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 
 __all__ = [
     'RESCAL',
@@ -60,29 +58,25 @@ class RESCAL(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 50,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = uniform_,
         relation_initializer: Hint[Initializer] = uniform_,
+        **kwargs,
     ) -> None:
         r"""Initialize RESCAL.
 
         :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 300]$.
+        :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.uniform_`
+        :param kwargs:
+            Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
 
         .. seealso::
 
             - OpenKE `implementation of RESCAL <https://github.com/thunlp/OpenKE/blob/master/models/RESCAL.py>`_
         """
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -91,6 +85,7 @@ class RESCAL(EntityRelationEmbeddingModel):
                 shape=(embedding_dim, embedding_dim),  # d x d matrices
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102

--- a/src/pykeen/models/unimodal/rotate.py
+++ b/src/pykeen/models/unimodal/rotate.py
@@ -2,18 +2,15 @@
 
 """Implementation of the RotatE model."""
 
-from typing import Any, ClassVar, Mapping, Optional
+from typing import Any, ClassVar, Mapping
 
 import torch
 import torch.autograd
 
 from ..base import EntityRelationEmbeddingModel
-from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import init_phases, xavier_uniform_
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import Constrainer, DeviceHint, Hint, Initializer
+from ...typing import Constrainer, Hint, Initializer
 from ...utils import complex_normalize
 
 __all__ = [
@@ -59,22 +56,14 @@ class RotatE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 200,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         relation_initializer: Hint[Initializer] = init_phases,
         relation_constrainer: Hint[Constrainer] = complex_normalize,
+        **kwargs,
     ) -> None:
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -86,6 +75,7 @@ class RotatE(EntityRelationEmbeddingModel):
                 constrainer=relation_constrainer,
                 dtype=torch.cfloat,
             ),
+            **kwargs,
         )
         self.real_embedding_dim = embedding_dim
 

--- a/src/pykeen/models/unimodal/simple.py
+++ b/src/pykeen/models/unimodal/simple.py
@@ -11,8 +11,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...regularizers import PowerSumRegularizer, Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 
 __all__ = [
     'SimplE',
@@ -71,22 +70,14 @@ class SimplE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 200,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         clamp_score: Optional[Union[float, Tuple[float, float]]] = None,
         entity_initializer: Hint[Initializer] = None,
         relation_initializer: Hint[Initializer] = None,
+        **kwargs,
     ) -> None:
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -95,16 +86,17 @@ class SimplE(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
         # extra embeddings
         self.tail_entity_embeddings = Embedding.init_with_device(
-            num_embeddings=triples_factory.num_entities,
+            num_embeddings=self.num_entities,
             embedding_dim=embedding_dim,
             device=self.device,
         )
         self.inverse_relation_embeddings = Embedding.init_with_device(
-            num_embeddings=triples_factory.num_relations,
+            num_embeddings=self.num_relations,
             embedding_dim=embedding_dim,
             device=self.device,
         )

--- a/src/pykeen/models/unimodal/structured_embedding.py
+++ b/src/pykeen/models/unimodal/structured_embedding.py
@@ -63,7 +63,7 @@ class StructuredEmbedding(EntityEmbeddingModel):
 
         :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 300]$.
         :param scoring_fct_norm: The $l_p$ norm. Usually 1 for SE.
-        :param entity_initializer: Entity initializer function. Defaults to :func:`pykeen.nn.init.xavier_uniform`_
+        :param entity_initializer: Entity initializer function. Defaults to :func:`pykeen.nn.init.xavier_uniform_`
         :param entity_constrainer: Entity constrainer function. Defaults to :func:`torch.nn.functional.normalize`
         :param entity_constrainer_kwargs: Keyword arguments to be used when calling the entity constrainer
         :param kwargs:

--- a/src/pykeen/models/unimodal/trans_d.py
+++ b/src/pykeen/models/unimodal/trans_d.py
@@ -9,12 +9,9 @@ import torch.autograd
 
 from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...nn.emb import Embedding, EmbeddingSpecification
 from ...nn.init import xavier_normal_, xavier_uniform_, xavier_uniform_norm_
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import Constrainer, DeviceHint, Hint, Initializer
+from ...typing import Constrainer, Hint, Initializer
 from ...utils import clamp_norm
 
 __all__ = [
@@ -119,24 +116,16 @@ class TransD(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 50,
         relation_dim: int = 30,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         relation_initializer: Hint[Initializer] = xavier_uniform_norm_,
         entity_constrainer: Hint[Constrainer] = clamp_norm,  # type: ignore
         relation_constrainer: Hint[Constrainer] = clamp_norm,  # type: ignore
+        **kwargs,
     ) -> None:
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -149,16 +138,17 @@ class TransD(EntityRelationEmbeddingModel):
                 constrainer=relation_constrainer,
                 constrainer_kwargs=dict(maxnorm=1., p=2, dim=-1),
             ),
+            **kwargs,
         )
 
         self.entity_projections = Embedding.init_with_device(
-            num_embeddings=triples_factory.num_entities,
+            num_embeddings=self.num_entities,
             embedding_dim=embedding_dim,
             device=self.device,
             initializer=xavier_normal_,
         )
         self.relation_projections = Embedding.init_with_device(
-            num_embeddings=triples_factory.num_relations,
+            num_embeddings=self.num_relations,
             embedding_dim=relation_dim,
             device=self.device,
             initializer=xavier_normal_,

--- a/src/pykeen/models/unimodal/trans_e.py
+++ b/src/pykeen/models/unimodal/trans_e.py
@@ -2,7 +2,7 @@
 
 """TransE."""
 
-from typing import Any, ClassVar, Mapping, Optional
+from typing import Any, ClassVar, Mapping
 
 import torch
 import torch.autograd
@@ -10,12 +10,9 @@ from torch.nn import functional
 
 from ..base import EntityRelationEmbeddingModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...losses import Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_uniform_, xavier_uniform_norm_
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import Constrainer, DeviceHint, Hint, Initializer
+from ...typing import Constrainer, Hint, Initializer
 
 __all__ = [
     'TransE',
@@ -57,32 +54,26 @@ class TransE(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 50,
         scoring_fct_norm: int = 1,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         entity_constrainer: Hint[Constrainer] = functional.normalize,
         relation_initializer: Hint[Initializer] = xavier_uniform_norm_,
+        **kwargs,
     ) -> None:
         r"""Initialize TransE.
 
         :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 300]$.
         :param scoring_fct_norm: The :math:`l_p` norm applied in the interaction function. Is usually ``1`` or ``2.``.
+        :param kwargs:
+            Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
 
         .. seealso::
 
            - OpenKE `implementation of TransE <https://github.com/thunlp/OpenKE/blob/OpenKE-PyTorch/models/TransE.py>`_
         """
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -92,6 +83,7 @@ class TransE(EntityRelationEmbeddingModel):
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
         self.scoring_fct_norm = scoring_fct_norm
 

--- a/src/pykeen/models/unimodal/trans_e.py
+++ b/src/pykeen/models/unimodal/trans_e.py
@@ -60,12 +60,18 @@ class TransE(EntityRelationEmbeddingModel):
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         entity_constrainer: Hint[Constrainer] = functional.normalize,
         relation_initializer: Hint[Initializer] = xavier_uniform_norm_,
+        relation_constrainer: Hint[Constrainer] = None,
         **kwargs,
     ) -> None:
         r"""Initialize TransE.
 
         :param embedding_dim: The entity embedding dimension $d$. Is usually $d \in [50, 300]$.
         :param scoring_fct_norm: The :math:`l_p` norm applied in the interaction function. Is usually ``1`` or ``2.``.
+        :param entity_initializer: Entity initializer function. Defaults to :func:`pykeen.nn.init.xavier_uniform_`
+        :param entity_constrainer: Entity constrainer function. Defaults to :func:`torch.nn.init.normalize`
+        :param relation_initializer: Relation initializer function.
+            Defaults to :func:`pykeen.nn.init.xavier_uniform_norm_`
+        :param relation_constrainer: Relation constrainer function. Defaults to none.
         :param kwargs:
             Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
 
@@ -82,6 +88,7 @@ class TransE(EntityRelationEmbeddingModel):
             relation_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
+                constrainer=relation_constrainer,
             ),
             **kwargs,
         )

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -64,7 +64,7 @@ class TuckER(EntityRelationEmbeddingModel):
         \text{Dropout}_2(BN(\text{Dropout}_0(BN(h)) \times_1 \text{Dropout}_1(W \times_2 r))) \times_3 t
 
     where h,r,t are the head, relation, and tail embedding, W is the core tensor, \times_i denotes the tensor
-    product along the i-th mode, BN denotes batch normalization, and DO dropout.
+    product along the i-th mode, BN denotes batch normalization, and :math:`\text{Dropout}` dropout.
 
     .. seealso::
 

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -57,6 +57,15 @@ class TuckER(EntityRelationEmbeddingModel):
 
     where $\textbf{h},\textbf{t}$ correspond to rows of $\textbf{E}$ and $\textbf{r}$ to a row of $\textbf{R}$.
 
+    The dropout values correspond to the following dropouts in the model's score function:
+
+    .. math::
+
+        \text{Dropout}_2(BN(\text{Dropout}_0(BN(h)) x_1 \text{Dropout}_1(W x_2 r))) x_3 t
+
+    where h,r,t are the head, relation, and tail embedding, W is the core tensor, x_i denotes the tensor
+    product along the i-th mode, BN denotes batch normalization, and DO dropout.
+
     .. seealso::
 
        - Official implementation: https://github.com/ibalazevic/TuckER
@@ -95,17 +104,6 @@ class TuckER(EntityRelationEmbeddingModel):
         relation_initializer: Hint[Initializer] = xavier_normal_,
         **kwargs,
     ) -> None:
-        """Initialize the model.
-
-        The dropout values correspond to the following dropouts in the model's score function:
-
-        .. math::
-
-            DO_2(BN(DO_0(BN(h)) x_1 DO_1(W x_2 r))) x_3 t
-
-        where h,r,t are the head, relation, and tail embedding, W is the core tensor, x_i denotes the tensor
-        product along the i-th mode, BN denotes batch normalization, and DO dropout.
-        """
         super().__init__(
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -148,12 +148,6 @@ class TuckER(EntityRelationEmbeddingModel):
         """
         Evaluate the scoring function.
 
-        Compute scoring function W \times_1 h \times_2 r \times_3 t as in the official implementation, i.e. as
-
-            DO(BN(DO(BN(h)) \times_1 DO(W \times_2 r))) \times_3 t
-
-        where BN denotes BatchNorm and DO denotes Dropout
-
         :param h: shape: (batch_size, 1, embedding_dim) or (1, num_entities, embedding_dim)
         :param r: shape: (batch_size, relation_dim)
         :param t: shape: (1, num_entities, embedding_dim) or (batch_size, 1, embedding_dim)

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -61,9 +61,9 @@ class TuckER(EntityRelationEmbeddingModel):
 
     .. math::
 
-        \text{Dropout}_2(BN(\text{Dropout}_0(BN(h)) x_1 \text{Dropout}_1(W x_2 r))) x_3 t
+        \text{Dropout}_2(BN(\text{Dropout}_0(BN(h)) \times_1 \text{Dropout}_1(W \times_2 r))) \times_3 t
 
-    where h,r,t are the head, relation, and tail embedding, W is the core tensor, x_i denotes the tensor
+    where h,r,t are the head, relation, and tail embedding, W is the core tensor, \times_i denotes the tensor
     product along the i-th mode, BN denotes batch normalization, and DO dropout.
 
     .. seealso::
@@ -148,9 +148,9 @@ class TuckER(EntityRelationEmbeddingModel):
         """
         Evaluate the scoring function.
 
-        Compute scoring function W x_1 h x_2 r x_3 t as in the official implementation, i.e. as
+        Compute scoring function W \times_1 h \times_2 r \times_3 t as in the official implementation, i.e. as
 
-            DO(BN(DO(BN(h)) x_1 DO(W x_2 r))) x_3 t
+            DO(BN(DO(BN(h)) \times_1 DO(W \times_2 r))) \times_3 t
 
         where BN denotes BatchNorm and DO denotes Dropout
 

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -13,9 +13,7 @@ from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDD
 from ...losses import BCEAfterSigmoidLoss, Loss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_normal_
-from ...regularizers import Regularizer
-from ...triples import CoreTriplesFactory
-from ...typing import DeviceHint, Hint, Initializer
+from ...typing import Hint, Initializer
 
 __all__ = [
     'TuckER',
@@ -86,23 +84,22 @@ class TuckER(EntityRelationEmbeddingModel):
 
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
+        *,
         embedding_dim: int = 200,
         relation_dim: Optional[int] = None,
-        loss: Optional[Loss] = None,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
         dropout_0: float = 0.3,
         dropout_1: float = 0.4,
         dropout_2: float = 0.5,
-        regularizer: Optional[Regularizer] = None,
         apply_batch_normalization: bool = True,
         entity_initializer: Hint[Initializer] = xavier_normal_,
         relation_initializer: Hint[Initializer] = xavier_normal_,
+        **kwargs,
     ) -> None:
         """Initialize the model.
 
         The dropout values correspond to the following dropouts in the model's score function:
+
+        .. math::
 
             DO_2(BN(DO_0(BN(h)) x_1 DO_1(W x_2 r))) x_3 t
 
@@ -110,11 +107,6 @@ class TuckER(EntityRelationEmbeddingModel):
         product along the i-th mode, BN denotes batch normalization, and DO dropout.
         """
         super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
@@ -123,6 +115,7 @@ class TuckER(EntityRelationEmbeddingModel):
                 embedding_dim=relation_dim or embedding_dim,
                 initializer=relation_initializer,
             ),
+            **kwargs,
         )
 
         # Core tensor

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 
 """Negative sampling algorithm based on the work of of Bordes *et al.*."""
+
 import math
-from typing import Any, Collection, Mapping, Optional, Tuple
+from typing import Collection, Optional, Tuple
 
 import torch
-from class_resolver import HintOrType
 
-from .filtering import Filterer
 from .negative_sampler import NegativeSampler
-from ..triples import CoreTriplesFactory
 
 __all__ = [
     'BasicNegativeSampler',
@@ -38,40 +36,20 @@ class BasicNegativeSampler(NegativeSampler):
        actual positive triples $(h,r,t) \in \mathcal{K}$ will be removed.
     """
 
-    #: The default strategy for optimizing the negative sampler's hyper-parameters
-    hpo_default = dict(
-        num_negs_per_pos=dict(type=int, low=1, high=100, q=10),
-    )
-
     def __init__(
         self,
-        triples_factory: CoreTriplesFactory,
-        num_negs_per_pos: Optional[int] = None,
-        filtered: bool = False,
-        filterer: HintOrType[Filterer] = None,
-        filterer_kwargs: Optional[Mapping[str, Any]] = None,
+        *,
         corruption_scheme: Optional[Collection[str]] = None,
+        **kwargs,
     ) -> None:
         """Initialize the basic negative sampler with the given entities.
 
-        :param triples_factory: The factory holding the triples to sample from
-        :param num_negs_per_pos: Number of negative samples to make per positive triple. Defaults to 1.
-        :param filtered: Whether proposed corrupted triples that are in the training data should be filtered.
-            Defaults to False. See explanation in :func:`filter_negative_triples` for why this is
-            a reasonable default.
-        :param filterer: If filtered is set to True, this can be used to choose which filter module from
-            :mod:`pykeen.sampling.filtering` is used.
-        :param filterer_kwargs:
-            Additional keyword-based arguments passed to the filterer upon construction.
-        :param corruption_scheme: What sides ('h', 'r', 't') should be corrupted. Defaults to head and tail ('h', 't').
+        :param corruption_scheme:
+            What sides ('h', 'r', 't') should be corrupted. Defaults to head and tail ('h', 't').
+        :param kwargs:
+            Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
         """
-        super().__init__(
-            triples_factory=triples_factory,
-            num_negs_per_pos=num_negs_per_pos,
-            filtered=filtered,
-            filterer=filterer,
-            filterer_kwargs=filterer_kwargs,
-        )
+        super().__init__(**kwargs)
         self.corruption_scheme = corruption_scheme or ('h', 't')
         # Set the indices
         self._corruption_indices = [LOOKUP[side] for side in self.corruption_scheme]

--- a/src/pykeen/sampling/bernoulli_negative_sampler.py
+++ b/src/pykeen/sampling/bernoulli_negative_sampler.py
@@ -2,12 +2,10 @@
 
 """Negative sampling algorithm based on the work of [wang2014]_."""
 
-from typing import Any, Mapping, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
-from class_resolver import HintOrType
 
-from .filtering import Filterer
 from .negative_sampler import NegativeSampler
 from ..triples import CoreTriplesFactory
 
@@ -38,38 +36,20 @@ class BernoulliNegativeSampler(NegativeSampler):
     actual positive triples $(h,r,t) \in \mathcal{K}$ will be removed.
     """
 
-    #: The default strategy for optimizing the negative sampler's hyper-parameters
-    hpo_default = dict(
-        num_negs_per_pos=dict(type=int, low=1, high=100, q=10),
-    )
-
     def __init__(
         self,
+        *,
         triples_factory: CoreTriplesFactory,
-        num_negs_per_pos: Optional[int] = None,
-        filtered: bool = False,
-        filterer: HintOrType[Filterer] = None,
-        filterer_kwargs: Optional[Mapping[str, Any]] = None,
+        **kwargs,
     ) -> None:
         """Initialize the bernoulli negative sampler with the given entities.
 
-        :param triples_factory: The factory holding the triples to sample from
-        :param num_negs_per_pos: Number of negative samples to make per positive triple. Defaults to 1.
-        :param filtered: Whether proposed corrupted triples that are in the training data should be filtered.
-            Defaults to False. See explanation in :func:`filter_negative_triples` for why this is
-            a reasonable default.
-        :param filterer: If filtered is set to True, this can be used to choose which filter module from
-            :mod:`pykeen.sampling.filtering` is used.
-        :param filterer_kwargs:
-            Additional keyword-based arguments passed to the filterer upon construction.
+        :param triples_factory:
+            The factory holding the positive training triples
+        :param kwargs:
+            Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
         """
-        super().__init__(
-            triples_factory=triples_factory,
-            num_negs_per_pos=num_negs_per_pos,
-            filtered=filtered,
-            filterer=filterer,
-            filterer_kwargs=filterer_kwargs,
-        )
+        super().__init__(triples_factory=triples_factory, **kwargs)
         # Preprocessing: Compute corruption probabilities
         triples = triples_factory.mapped_triples
         head_rel_uniq, tail_count = torch.unique(triples[:, :2], return_counts=True, dim=0)

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -315,8 +315,7 @@ class BloomFilterer(Filterer):
         :param batch: shape: (batch_size, 3)
             A batch of elements.
 
-        :yields:
-            Indices of the k-th round, shape: (batch_size,).
+        :yields: Indices of the k-th round, shape: (batch_size,).
         """
         # pre-hash
         x = (self.mersenne * batch).sum(dim=-1)

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -21,7 +21,9 @@ class NegativeSampler(ABC):
     """A negative sampler."""
 
     #: The default strategy for optimizing the negative sampler's hyper-parameters
-    hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]]
+    hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]] = dict(
+        num_negs_per_pos=dict(type=int, low=1, high=100, q=10),
+    )
 
     #: A filterer for negative batches
     filterer: Optional[Filterer]
@@ -36,7 +38,7 @@ class NegativeSampler(ABC):
     ) -> None:
         """Initialize the negative sampler with the given entities.
 
-        :param triples_factory: The factory holding the triples to sample from
+        :param triples_factory: The factory holding the positive training triples
         :param num_negs_per_pos: Number of negative samples to make per positive triple. Defaults to 1.
         :param filtered: Whether proposed corrupted triples that are in the training data should be filtered.
             Defaults to False. See explanation in :func:`filter_negative_triples` for why this is

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -35,7 +35,7 @@ class CustomRepresentations(RepresentationModule):
 class MockModel(EntityRelationEmbeddingModel):
     """A mock model returning fake scores."""
 
-    def __init__(self, triples_factory: CoreTriplesFactory):
+    def __init__(self, *, triples_factory: CoreTriplesFactory):
         super().__init__(
             triples_factory=triples_factory,
             entity_representations=EmbeddingSpecification(embedding_dim=50),

--- a/tests/test_model_mode.py
+++ b/tests/test_model_mode.py
@@ -28,7 +28,7 @@ class TestBaseModel(unittest.TestCase):
         self.batch_size = 16
         self.embedding_dim = 8
         self.factory = Nations().training
-        self.model = TransE(self.factory, embedding_dim=self.embedding_dim).to_device_()
+        self.model = TransE(triples_factory=self.factory, embedding_dim=self.embedding_dim).to_device_()
 
     def _check_scores(self, scores) -> None:
         """Check the scores produced by a forward function."""
@@ -161,7 +161,7 @@ class TestBaseModelScoringFunctions(unittest.TestCase):
 class SimpleInteractionModel(EntityRelationEmbeddingModel):
     """A model with a simple interaction function for testing the base model."""
 
-    def __init__(self, triples_factory: TriplesFactory):
+    def __init__(self, *, triples_factory: TriplesFactory):
         super().__init__(
             triples_factory=triples_factory,
             entity_representations=EmbeddingSpecification(embedding_dim=50),

--- a/tests/training/test_utils.py
+++ b/tests/training/test_utils.py
@@ -55,7 +55,7 @@ class LossTensorTest(unittest.TestCase):
         )
 
         model = TransE(
-            factory,
+            triples_factory=factory,
             embedding_dim=8,
             preferred_device='cpu',
             loss=loss_cls,
@@ -71,7 +71,7 @@ class LossTensorTest(unittest.TestCase):
         )
 
         model = TransE(
-            factory,
+            triples_factory=factory,
             embedding_dim=8,
             preferred_device='cpu',
             loss=loss_cls,

--- a/tox.ini
+++ b/tox.ini
@@ -124,6 +124,8 @@ commands =
         src/pykeen/datasets/ \
         src/pykeen/triples/utils.py \
         src/pykeen/pipeline/ \
+        src/pykeen/sampling/ \
+        src/pykeen/models/unimodal/ \
         src/pykeen/ablation/ \
         tests/test_sampling/ \
         tests/test_training.py \


### PR DESCRIPTION
- Use `**kwargs` in more `__init__()` functions in the models and negative samplers modules (this will reduce the diff in #412)
- Turns on darglint for `pykeen.models.unimodal` and updates all docstrings until it passes
- Add a default None relation constrainer in TransE (I want this for my translational toy repo)

Blocked by #446
