### PR TITLE
🐄 🛸 Update implementation of HPO suggestion

### DIFF
--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -779,11 +779,14 @@ def suggest_kwargs(
                     base=info.get('q') or info.get('base') or 2,
                 )
             elif scale is None or scale == 'linear':
+                # get log from info - could either be a boolean or string
+                log = info.get('log') in {True, 'TRUE', 'True', 'true', 't', 'YES', 'Yes', 'yes', 'y'}
                 _kwargs[name] = trial.suggest_int(
                     name=prefixed_name,
                     low=low,
                     high=high,
                     step=info.get('q') or info.get('step') or 1,
+                    log=log,
                 )
             else:
                 logger.warning(f'Unhandled scale {scale} for parameter {name} of data type {dtype}')

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -769,7 +769,8 @@ def suggest_kwargs(
         prefixed_name = f'{prefix}.{name}'
         dtype, low, high = info['type'], info.get('low'), info.get('high')
         if dtype in {int, 'int'}:
-            if info.get('scale') in {'power_two', 'power'}:
+            scale = info.get('scale')
+            if scale in {'power_two', 'power'}:
                 _kwargs[name] = suggest_discrete_power_int(
                     trial=trial,
                     name=prefixed_name,
@@ -777,13 +778,15 @@ def suggest_kwargs(
                     high=high,
                     base=info.get('q') or info.get('base') or 2,
                 )
-            else:
+            elif scale is None or scale == 'linear':
                 _kwargs[name] = trial.suggest_int(
                     name=prefixed_name,
                     low=low,
                     high=high,
                     step=info.get('q') or info.get('step') or 1,
                 )
+            else:
+                logger.warning(f'Unhandled scale {scale} for parameter {name} of data type {dtype}')
 
         elif dtype in {float, 'float'}:
             if info.get('scale') == 'log':

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -21,7 +21,9 @@ class NegativeSampler(ABC):
     """A negative sampler."""
 
     #: The default strategy for optimizing the negative sampler's hyper-parameters
-    hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]]
+    hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]] = dict(
+        num_negs_per_pos=dict(type=int, low=0, high=2, scale='power', base=10),
+    )
 
     #: A filterer for negative batches
     filterer: Optional[Filterer]

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -21,9 +21,7 @@ class NegativeSampler(ABC):
     """A negative sampler."""
 
     #: The default strategy for optimizing the negative sampler's hyper-parameters
-    hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]] = dict(
-        num_negs_per_pos=dict(type=int, low=0, high=2, scale='power', base=10),
-    )
+    hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]]
 
     #: A filterer for negative batches
     filterer: Optional[Filterer]

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -21,7 +21,9 @@ class NegativeSampler(ABC):
     """A negative sampler."""
 
     #: The default strategy for optimizing the negative sampler's hyper-parameters
-    hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]]
+    hpo_default: ClassVar[Mapping[str, Mapping[str, Any]]] = dict(
+        num_negs_per_pos=dict(type=int, low=1, high=100, log=True),
+    )
 
     #: A filterer for negative batches
     filterer: Optional[Filterer]

--- a/tests/test_hpo.py
+++ b/tests/test_hpo.py
@@ -122,15 +122,10 @@ class TestHyperparameterOptimization(unittest.TestCase):
 
     def test_sampling_values_from_2_power_x(self):
         """Test making a study that has a range defined by f(x) = 2^x."""
-
-        def objective(trial):
-            suggest_kwargs(prefix='model', trial=trial, kwargs_ranges=model_kwargs_ranges)
-            return 1.
-
         model_kwargs_ranges = dict(
             embedding_dim=dict(type=int, low=0, high=4, scale='power_two'),
         )
-
+        objective = _test_suggest(model_kwargs_ranges)
         study = optuna.create_study()
         study.optimize(objective, n_trials=2)
 
@@ -138,14 +133,33 @@ class TestHyperparameterOptimization(unittest.TestCase):
         self.assertIn(('params', 'model.embedding_dim'), df.columns)
         self.assertTrue(df[('params', 'model.embedding_dim')].isin({1, 2, 4, 8, 16}).all())
 
-        model_kwargs_ranges = dict(
-            embedding_dim=dict(type=int, low=0, high=4, scale='power_two'),
-        )
-
+        objective = _test_suggest(model_kwargs_ranges)
         with self.assertRaises(Exception) as context:
             study = optuna.create_study()
             study.optimize(objective, n_trials=2)
             self.assertIn('Upper bound 4 is not greater than lower bound 4.', context.exception)
+
+    def test_sampling_values_from_power_x(self):
+        """Test making a study that has a range defined by f(x) = base^x."""
+        kwargs_ranges = dict(
+            embedding_dim=dict(type=int, low=0, high=2, scale='power', base=10),
+        )
+        objective = _test_suggest(kwargs_ranges)
+        study = optuna.create_study()
+        study.optimize(objective, n_trials=2)
+
+        df = study.trials_dataframe(multi_index=True)
+        self.assertIn(('params', 'model.embedding_dim'), df.columns)
+        values = df[('params', 'model.embedding_dim')]
+        self.assertTrue(values.isin({1, 10, 100}).all(), msg=f'Got values: {values}')
+
+
+def _test_suggest(kwargs_ranges):
+    def objective(trial):
+        suggest_kwargs(prefix='model', trial=trial, kwargs_ranges=kwargs_ranges)
+        return 1.
+
+    return objective
 
 
 @pytest.mark.slow


### PR DESCRIPTION
This PR does the following:

1. Replaces the custom implementation of a default discrete integer distribution with the one added recently in Optuna (I think based on my suggestion!). This gets us free handling of questionable bounds/step size combinations that's built in to Optuna.
2. Generalizes the power_two scale to allow arbitrary powers to be set.
3. Adds the `log` option to linear integer search
4. Updates the default negative sampler range to use the `log` option