### PR TITLE
🔨 🛣️ Use more `pathlib`

### DIFF
--- a/src/pykeen/ablation/ablation.py
+++ b/src/pykeen/ablation/ablation.py
@@ -216,7 +216,7 @@ def _run_ablation_experiments(
             continue
 
         best_pipeline_dir = output_directory.joinpath('best_pipeline')
-        best_pipeline_dir.mkdir(exist_ok=True)
+        best_pipeline_dir.mkdir(exist_ok=True, parents=True)
         logger.info('Re-training best pipeline and saving artifacts in %s', best_pipeline_dir)
         hpo_pipeline_result.replicate_best_pipeline(
             replicates=best_replicates,
@@ -471,7 +471,7 @@ def prepare_ablation(  # noqa:C901
         dataset_name = normalize_string(dataset) if isinstance(dataset, str) else 'user_data'
         experiment_name = f'{counter:04d}_{dataset_name}_{normalize_string(model)}'
         output_directory = directory.joinpath(experiment_name)
-        output_directory.mkdir(exist_ok=True)
+        output_directory.mkdir(exist_ok=True, parents=True)
         # TODO what happens if already exists?
 
         _experiment_optuna_config = {
@@ -485,7 +485,7 @@ def prepare_ablation(  # noqa:C901
         _experiment_optuna_config['storage'] = f'sqlite:///{output_directory.as_posix()}/optuna_results.db'
         if save_artifacts:
             save_model_directory = output_directory.joinpath('artifacts')
-            save_model_directory.mkdir(exist_ok=True)
+            save_model_directory.mkdir(exist_ok=True, parents=True)
             _experiment_optuna_config['save_model_directory'] = save_model_directory.as_posix()
 
         hpo_config: Dict[str, Any] = dict()

--- a/src/pykeen/ablation/ablation.py
+++ b/src/pykeen/ablation/ablation.py
@@ -5,9 +5,9 @@
 import itertools as itt
 import json
 import logging
-import os
+import pathlib
 import time
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 from uuid import uuid4
 
 from ..training import _TRAINING_LOOP_SUFFIX
@@ -29,7 +29,7 @@ Mapping3D = Mapping[str, Mapping[str, Mapping[str, Any]]]
 
 def ablation_pipeline(
     datasets: Union[str, List[str]],
-    directory: str,
+    directory: Union[str, pathlib.Path],
     models: Union[str, List[str]],
     losses: Union[str, List[str]],
     optimizers: Union[str, List[str]],
@@ -140,6 +140,8 @@ def ablation_pipeline(
     :param create_unique_subdir: Defines, whether a unique sub-directory for the experimental artifacts should
         be created. The sub-directory name is defined  by the  current  data + a unique id.
     """
+    if isinstance(directory, str):
+        directory = pathlib.Path(directory).resolve()
     if create_unique_subdir:
         directory = _create_path_with_id(directory=directory)
 
@@ -192,12 +194,12 @@ def ablation_pipeline(
 
 
 def _run_ablation_experiments(
-    directories: List[Tuple[str, str]],
+    directories: Sequence[Tuple[Union[str, pathlib.Path], Union[str, pathlib.Path]]],
     best_replicates: Optional[int] = None,
     dry_run: bool = False,
     move_to_cpu: bool = True,
     discard_replicates: bool = False,
-):
+) -> None:
     """Run ablation experiments."""
     if dry_run:
         return
@@ -205,14 +207,16 @@ def _run_ablation_experiments(
     from pykeen.hpo import hpo_pipeline_from_path
 
     for output_directory, rv_config_path in directories:
+        if isinstance(output_directory, str):
+            output_directory = pathlib.Path(output_directory).resolve()
         hpo_pipeline_result = hpo_pipeline_from_path(rv_config_path)
         hpo_pipeline_result.save_to_directory(output_directory)
 
         if not best_replicates:
             continue
 
-        best_pipeline_dir = os.path.join(output_directory, 'best_pipeline')
-        os.makedirs(best_pipeline_dir, exist_ok=True)
+        best_pipeline_dir = output_directory.joinpath('best_pipeline')
+        best_pipeline_dir.mkdir(exist_ok=True)
         logger.info('Re-training best pipeline and saving artifacts in %s', best_pipeline_dir)
         hpo_pipeline_result.replicate_best_pipeline(
             replicates=best_replicates,
@@ -222,10 +226,10 @@ def _run_ablation_experiments(
         )
 
 
-def _create_path_with_id(directory: str) -> str:
+def _create_path_with_id(directory: pathlib.Path) -> pathlib.Path:
     """Add unique id to path."""
     datetime = time.strftime('%Y-%m-%d-%H-%M')
-    return os.path.join(directory, f'{datetime}_{uuid4()}')
+    return directory.joinpath(f'{datetime}_{uuid4()}')
 
 
 def ablation_pipeline_from_config(
@@ -265,7 +269,11 @@ def ablation_pipeline_from_config(
     )
 
 
-def prepare_ablation_from_path(path: str, directory: str, save_artifacts: bool) -> List[Tuple[str, str]]:
+def prepare_ablation_from_path(
+    path: Union[str, pathlib.Path],
+    directory: Union[str, pathlib.Path],
+    save_artifacts: bool,
+) -> List[Tuple[pathlib.Path, pathlib.Path]]:
     """Prepare a set of ablation study directories.
 
     :param path: Path to configuration file defining the ablation studies.
@@ -275,6 +283,8 @@ def prepare_ablation_from_path(path: str, directory: str, save_artifacts: bool) 
         created.
     :return: pairs of output directories and HPO config paths inside those directories
     """
+    if isinstance(directory, str):
+        directory = pathlib.Path(directory).resolve()
     directory = _create_path_with_id(directory=directory)
     with open(path) as file:
         config = json.load(file)
@@ -283,9 +293,9 @@ def prepare_ablation_from_path(path: str, directory: str, save_artifacts: bool) 
 
 def prepare_ablation_from_config(
     config: Mapping[str, Any],
-    directory: str,
+    directory: Union[str, pathlib.Path],
     save_artifacts: bool,
-) -> List[Tuple[str, str]]:
+) -> List[Tuple[pathlib.Path, pathlib.Path]]:
     """Prepare a set of ablation study directories.
 
     :param config: Dictionary defining the ablation studies.
@@ -315,7 +325,7 @@ def prepare_ablation(  # noqa:C901
     losses: Union[str, List[str]],
     optimizers: Union[str, List[str]],
     training_loops: Union[str, List[str]],
-    directory: str,
+    directory: Union[str, pathlib.Path],
     *,
     epochs: Optional[int] = None,
     create_inverse_triples: Union[bool, List[bool]] = False,
@@ -347,7 +357,7 @@ def prepare_ablation(  # noqa:C901
     stopper_kwargs: Optional[Mapping[str, Any]] = None,
     metadata: Optional[Mapping] = None,
     save_artifacts: bool = True,
-) -> List[Tuple[str, str]]:
+) -> List[Tuple[pathlib.Path, pathlib.Path]]:
     """Prepare an ablation directory.
 
     :param datasets: A dataset name or list of dataset names.
@@ -414,6 +424,8 @@ def prepare_ablation(  # noqa:C901
             If the dataset is not specified correctly, i.e., dataset is not of type str, or a dictionary containing
             the paths to the training, testing, and validation data.
     """
+    if isinstance(directory, str):
+        directory = pathlib.Path(directory).resolve()
     if isinstance(datasets, str):
         datasets = [datasets]
     if isinstance(create_inverse_triples, bool):
@@ -458,8 +470,8 @@ def prepare_ablation(  # noqa:C901
     ) in enumerate(it):
         dataset_name = normalize_string(dataset) if isinstance(dataset, str) else 'user_data'
         experiment_name = f'{counter:04d}_{dataset_name}_{normalize_string(model)}'
-        output_directory = os.path.join(directory, experiment_name)
-        os.makedirs(output_directory, exist_ok=True)
+        output_directory = directory.joinpath(experiment_name)
+        output_directory.mkdir(exist_ok=True)
         # TODO what happens if already exists?
 
         _experiment_optuna_config = {
@@ -470,11 +482,11 @@ def prepare_ablation(  # noqa:C901
             'sampler': sampler,
             'pruner': pruner,
         }
-        _experiment_optuna_config['storage'] = f'sqlite:///{output_directory}/optuna_results.db'
+        _experiment_optuna_config['storage'] = f'sqlite:///{output_directory.as_posix()}/optuna_results.db'
         if save_artifacts:
-            save_model_directory = os.path.join(output_directory, 'artifacts')
-            os.makedirs(save_model_directory, exist_ok=True)
-            _experiment_optuna_config['save_model_directory'] = save_model_directory
+            save_model_directory = output_directory.joinpath('artifacts')
+            save_model_directory.mkdir(exist_ok=True)
+            _experiment_optuna_config['save_model_directory'] = save_model_directory.as_posix()
 
         hpo_config: Dict[str, Any] = dict()
         hpo_config['stopper'] = stopper
@@ -588,8 +600,8 @@ def prepare_ablation(  # noqa:C901
             optuna=_experiment_optuna_config,
         )
 
-        rv_config_path = os.path.join(output_directory, 'hpo_config.json')
-        with open(rv_config_path, 'w') as file:
+        rv_config_path = output_directory.joinpath('hpo_config.json')
+        with rv_config_path.open('w') as file:
             json.dump(rv_config, file, indent=2, ensure_ascii=True)
 
         directories.append((output_directory, rv_config_path))

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -16,6 +16,7 @@ later, but that will cause problems - the code will get executed twice:
 import inspect
 import os
 import sys
+from pathlib import Path
 from typing import Optional
 
 import click
@@ -40,7 +41,7 @@ from .triples.utils import EXTENSION_IMPORTERS, PREFIX_IMPORTERS
 from .utils import get_until_first_blank
 from .version import env_table
 
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = Path(__file__).resolve().parent
 
 
 @click.group()
@@ -443,7 +444,7 @@ def readme(check: bool):
 def get_readme() -> str:
     """Get the readme."""
     from jinja2 import FileSystemLoader, Environment
-    loader = FileSystemLoader(os.path.join(HERE, 'templates'))
+    loader = FileSystemLoader(HERE.joinpath('templates'))
     environment = Environment(
         autoescape=True,
         loader=loader,

--- a/src/pykeen/experiments/cli.py
+++ b/src/pykeen/experiments/cli.py
@@ -108,7 +108,7 @@ def run(
 
 def _help_reproduce(
     *,
-    directory: str,
+    directory: Union[str, pathlib.Path],
     path: Union[str, pathlib.Path],
     replicates: int,
     move_to_cpu: bool = False,
@@ -127,7 +127,10 @@ def _help_reproduce(
     """
     from pykeen.pipeline import replicate_pipeline_from_path
 
-    if not os.path.exists(path):
+    if isinstance(path, str):
+        path = pathlib.Path(path).resolve()
+
+    if not path.is_file():
         click.secho(f'Could not find configuration at {path}', fg='red')
         sys.exit(1)
     click.echo(f'Running configuration at {path}')
@@ -138,9 +141,11 @@ def _help_reproduce(
         experiment_id = f'{datetime}_{uuid4()}_{file_name}'
     else:
         experiment_id = f'{datetime}_{uuid4()}'
-    output_directory = os.path.join(directory, experiment_id)
 
-    os.makedirs(output_directory, exist_ok=True)
+    if isinstance(directory, str):
+        directory = pathlib.Path(directory).resolve()
+    output_directory = directory.joinpath(experiment_id)
+    output_directory.mkdir(exist_ok=True, parents=True)
 
     replicate_pipeline_from_path(
         path=path,

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -319,7 +319,7 @@ class HpoPipelineResult(Result):
         """Dump the results of a study to the given directory."""
         if isinstance(directory, str):
             directory = pathlib.Path(directory).resolve()
-        directory.mkdir(exist_ok=True)
+        directory.mkdir(exist_ok=True, parents=True)
 
         # Output study information
         with directory.joinpath('study.json').open('w') as file:
@@ -330,7 +330,7 @@ class HpoPipelineResult(Result):
         df.to_csv(directory.joinpath('trials.tsv'), sep='\t', index=False)
 
         best_pipeline_directory = directory.joinpath('best_pipeline')
-        best_pipeline_directory.mkdir(exist_ok=True)
+        best_pipeline_directory.mkdir(exist_ok=True, parents=True)
         # Output best trial as pipeline configuration file
         with best_pipeline_directory.joinpath('pipeline_config.json').open('w') as file:
             json.dump(self._get_best_study_config(), file, indent=2, sort_keys=True)

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -175,7 +175,6 @@ import pathlib
 import pickle
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, Collection, Dict, Iterable, List, Mapping, MutableMapping, Optional, Type, Union
 
 import pandas as pd
@@ -304,7 +303,7 @@ class PipelineResult(Result):
         from .plot_utils import plot
         return plot(self, **kwargs)
 
-    def save_model(self, path: str) -> None:
+    def save_model(self, path: Union[str, pathlib.Path]) -> None:
         """Save the trained model to the given path using :func:`torch.save`.
 
         :param path: The path to which the model is saved. Should have an extension appropriate for a pickle,
@@ -333,21 +332,23 @@ class PipelineResult(Result):
 
     def save_to_directory(
         self,
-        directory: Union[str, Path],
+        directory: Union[str, pathlib.Path],
         *,
         save_metadata: bool = True,
         save_replicates: bool = True,
         **_kwargs,
     ) -> None:
         """Save all artifacts in the given directory."""
-        os.makedirs(directory, exist_ok=True)
+        if isinstance(directory, str):
+            directory = pathlib.Path(directory).resolve()
+        directory.mkdir(exist_ok=True, parents=True)
 
-        with open(os.path.join(directory, 'metadata.json'), 'w') as file:
+        with directory.joinpath('metadata.json').open('w') as file:
             json.dump(self.metadata, file, indent=2, sort_keys=True)
-        with open(os.path.join(directory, 'results.json'), 'w') as file:
+        with directory.joinpath('results.json').open('w') as file:
             json.dump(self._get_results(), file, indent=2, sort_keys=True)
         if save_replicates:
-            self.save_model(os.path.join(directory, 'trained_model.pkl'))
+            self.save_model(directory.joinpath('trained_model.pkl'))
 
     def save_to_ftp(self, directory: str, ftp: ftplib.FTP) -> None:
         """Save all artifacts to the given directory in the FTP server.
@@ -392,6 +393,7 @@ class PipelineResult(Result):
             server = FTPServer(address, handler)
             server.serve_forever()
         """
+        # TODO use pathlib here
         ensure_ftp_directory(ftp=ftp, directory=directory)
 
         metadata_path = os.path.join(directory, 'metadata.json')
@@ -442,7 +444,7 @@ class PipelineResult(Result):
 
 def replicate_pipeline_from_path(
     path: Union[str, pathlib.Path],
-    directory: str,
+    directory: Union[str, pathlib.Path],
     replicates: int,
     move_to_cpu: bool = False,
     save_replicates: bool = True,
@@ -471,7 +473,7 @@ def replicate_pipeline_from_path(
 
 def replicate_pipeline_from_config(
     config: Mapping[str, Any],
-    directory: str,
+    directory: Union[str, pathlib.Path],
     replicates: int,
     move_to_cpu: bool = False,
     save_replicates: bool = True,
@@ -507,7 +509,7 @@ def _iterate_moved(pipeline_results: Iterable[PipelineResult]):
 
 def save_pipeline_results_to_directory(
     *,
-    directory: str,
+    directory: Union[str, pathlib.Path],
     pipeline_results: Iterable[PipelineResult],
     move_to_cpu: bool = False,
     save_metadata: bool = False,
@@ -524,21 +526,27 @@ def save_pipeline_results_to_directory(
     :param save_replicates: Should the artifacts of the replicates be saved?
     :param width: How many leading zeros should be put in the replicate names?
     """
-    replicates_directory = os.path.join(directory, 'replicates')
+    if isinstance(directory, str):
+        directory = pathlib.Path(directory).resolve()
+    replicates_directory = directory.joinpath('replicates')
     losses_rows = []
 
     if move_to_cpu:
         pipeline_results = _iterate_moved(pipeline_results)
 
     for i, pipeline_result in enumerate(pipeline_results):
-        sd = os.path.join(replicates_directory, f'replicate-{i:0{width}}')
-        os.makedirs(sd, exist_ok=True)
-        pipeline_result.save_to_directory(sd, save_metadata=save_metadata, save_replicates=save_replicates)
+        replicate_directory = replicates_directory.joinpath(f'replicate-{i:0{width}}')
+        replicate_directory.mkdir(exist_ok=True, parents=True)
+        pipeline_result.save_to_directory(
+            replicate_directory,
+            save_metadata=save_metadata,
+            save_replicates=save_replicates,
+        )
         for epoch, loss in enumerate(pipeline_result.losses):
             losses_rows.append((i, epoch, loss))
 
     losses_df = pd.DataFrame(losses_rows, columns=['Replicate', 'Epoch', 'Loss'])
-    losses_df.to_csv(os.path.join(directory, 'all_replicates_losses.tsv'), sep='\t', index=False)
+    losses_df.to_csv(directory.joinpath('all_replicates_losses.tsv'), sep='\t', index=False)
 
 
 def pipeline_from_path(

--- a/tests/test_experiment_integrity.py
+++ b/tests/test_experiment_integrity.py
@@ -33,7 +33,7 @@ def _append():
             logger.warning('Way too much to do for RGCN...')
             continue
         _x = _generate(model, config, path)
-        _x.__name__ = f'test_integrity_{model}_{config[:-len(".json")]}'
+        _x.__name__ = f'test_integrity_{model}_{config.stem}'
         setattr(TestExperimentIntegrity, _x.__name__, _x)
 
 


### PR DESCRIPTION
After #143 and #407, this PR makes more use of `pathlib`. It maintains compatibility where any place you could put a string before, you still can. This means that it adds a bit of internal code for converting strings into paths.