### PR TITLE
🩹 🕶️ Fix view in NSSA Loss

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -637,7 +637,7 @@ class NSSALoss(SetwiseLoss):
             # negative_scores have already been filtered in the sampler!
             # (dense) softmax requires unfiltered scores / masking
             negative_scores_ = torch.zeros_like(batch_filter, dtype=positive_scores.dtype)
-            negative_scores_[batch_filter] = negative_scores
+            negative_scores_[batch_filter] = negative_scores.view(1, -1)
             # we need to fill the scores with -inf for all filtered negative examples
             # EXCEPT if all negative samples are filtered (since softmax over only -inf yields nan)
             fill_mask = ~batch_filter

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -637,7 +637,7 @@ class NSSALoss(SetwiseLoss):
             # negative_scores have already been filtered in the sampler!
             # (dense) softmax requires unfiltered scores / masking
             negative_scores_ = torch.zeros_like(batch_filter, dtype=positive_scores.dtype)
-            negative_scores_[batch_filter] = negative_scores.view(1, -1)
+            negative_scores_[batch_filter] = negative_scores
             # we need to fill the scores with -inf for all filtered negative examples
             # EXCEPT if all negative samples are filtered (since softmax over only -inf yields nan)
             fill_mask = ~batch_filter

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -100,7 +100,7 @@ class SLCWATrainingLoop(TrainingLoop[SLCWASampleType, SLCWABatchType]):
 
         # Compute negative and positive scores
         positive_scores = self.model.score_hrt(positive_batch)
-        negative_scores = self.model.score_hrt(negative_batch)
+        negative_scores = self.model.score_hrt(negative_batch).view(negative_batch.shape[:-1])
         # negative_scores = self.model.score_hrt(negative_batch.view(-1, 3)).view(*negative_batch.shape[:-1])
 
         return self.loss.process_slcwa_scores(

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -100,8 +100,7 @@ class SLCWATrainingLoop(TrainingLoop[SLCWASampleType, SLCWABatchType]):
 
         # Compute negative and positive scores
         positive_scores = self.model.score_hrt(positive_batch)
-        negative_scores = self.model.score_hrt(negative_batch).view(negative_batch.shape[:-1])
-        # negative_scores = self.model.score_hrt(negative_batch.view(-1, 3)).view(*negative_batch.shape[:-1])
+        negative_scores = self.model.score_hrt(negative_batch).view(*negative_batch.shape[:-1])
 
         return self.loss.process_slcwa_scores(
             positive_scores=positive_scores,

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -53,7 +53,7 @@ class MockModel(EntityRelationEmbeddingModel):
         return batch_scores
 
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self._generate_fake_scores(batch=hrt_batch)
+        return self.scores[torch.randint(high=self.num_entities, size=hrt_batch.shape[:-1])]
 
     def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(batch=hr_batch)

--- a/tests/test_training/cases.py
+++ b/tests/test_training/cases.py
@@ -174,12 +174,12 @@ class SLCWATrainingLoopTestCase(TrainingLoopTestCase):
     """A generic test case for sLCWA training loops."""
 
     #: Should negative samples be filtered?
-    filterer: ClassVar[Optional[Type[Filterer]]] = None
+    filterer_cls: ClassVar[Optional[Type[Filterer]]] = None
 
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
         kwargs["negative_sampler"] = "basic"
-        kwargs["negative_sampler_kwargs"] = {"filterer": self.filterer}
+        kwargs["negative_sampler_kwargs"] = {"filterer": self.filterer_cls}
         return kwargs
 
     def test_blacklist_loss_on_slcwa(self):

--- a/tests/test_training/cases.py
+++ b/tests/test_training/cases.py
@@ -10,7 +10,7 @@ import unittest_templates
 from torch.optim import Adam, Optimizer
 
 from pykeen.datasets import Nations
-from pykeen.losses import CrossEntropyLoss
+from pykeen.losses import CrossEntropyLoss, Loss, MarginRankingLoss
 from pykeen.models import ConvE, Model, TransE
 from pykeen.sampling.filtering import Filterer
 from pykeen.training import TrainingLoop
@@ -28,6 +28,8 @@ class TrainingLoopTestCase(unittest_templates.GenericTestCase[TrainingLoop]):
 
     model: Model
     factory: TriplesFactory
+    loss_cls: ClassVar[Type[Loss]]
+    loss: Loss
     optimizer_cls: ClassVar[Type[Optimizer]] = Adam
     optimizer: Optimizer
     random_seed = 0
@@ -38,7 +40,8 @@ class TrainingLoopTestCase(unittest_templates.GenericTestCase[TrainingLoop]):
     def pre_setup_hook(self) -> None:
         """Prepare case-level variables before the setup() function."""
         self.triples_factory = Nations().training
-        self.model = TransE(triples_factory=self.triples_factory, random_seed=self.random_seed)
+        self.loss = self.loss_cls()
+        self.model = TransE(triples_factory=self.triples_factory, loss=self.loss, random_seed=self.random_seed)
         self.optimizer = self.optimizer_cls(self.model.get_grad_params())
 
     def _with_model(self, model: Model) -> TrainingLoop:

--- a/tests/test_training/cases.py
+++ b/tests/test_training/cases.py
@@ -10,7 +10,7 @@ import unittest_templates
 from torch.optim import Adam, Optimizer
 
 from pykeen.datasets import Nations
-from pykeen.losses import CrossEntropyLoss, Loss, MarginRankingLoss
+from pykeen.losses import CrossEntropyLoss, Loss
 from pykeen.models import ConvE, Model, TransE
 from pykeen.sampling.filtering import Filterer
 from pykeen.training import TrainingLoop

--- a/tests/test_training/test_training_loop.py
+++ b/tests/test_training/test_training_loop.py
@@ -2,33 +2,86 @@
 
 """Test for sLCWA and LCWA."""
 
+from pykeen.losses import MarginRankingLoss, NSSALoss, SoftplusLoss
 from pykeen.sampling.filtering import BloomFilterer, PythonSetFilterer
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop
 from tests.test_training import cases
 
 
-class UnfilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
-    """Test sLCWA with unfiltered negative sampling."""
+class MRUnfilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
+    """Test sLCWA with unfiltered negative sampling with margin ranking loss."""
 
     cls = SLCWATrainingLoop
     filterer = None
+    loss_cls = MarginRankingLoss
 
 
-class SetFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
-    """Test sLCWA with set filtered negative sampling."""
+class NSSAUnfilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
+    """Test sLCWA with unfiltered negative sampling with NSSA loss."""
+
+    cls = SLCWATrainingLoop
+    filterer = None
+    loss_cls = NSSALoss
+
+
+class SoftplusUnfilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
+    """Test sLCWA with unfiltered negative sampling with softplus loss."""
+
+    cls = SLCWATrainingLoop
+    filterer = None
+    loss_cls = SoftplusLoss
+
+
+class MRSetFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
+    """Test sLCWA with set filtered negative sampling with margin ranking loss."""
 
     cls = SLCWATrainingLoop
     filterer = PythonSetFilterer
+    loss_cls = MarginRankingLoss
 
 
+class NSSASetFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
+    """Test sLCWA with set filtered negative sampling with NSSA loss."""
+
+    cls = SLCWATrainingLoop
+    filterer = PythonSetFilterer
+    loss_cls = NSSALoss
+
+
+class SoftplusSetFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
+    """Test sLCWA with set filtered negative sampling with softplus loss."""
+
+    cls = SLCWATrainingLoop
+    filterer = PythonSetFilterer
+    loss_cls = SoftplusLoss
+
+
+# Multiple permutations of loss not necessary for bloom filter since it's more of a
+# filter vs. no filter thing.
 class BloomFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
     """Test sLCWA with bloom filtered negative sampling."""
 
     cls = SLCWATrainingLoop
     filterer = BloomFilterer
+    loss_cls = MarginRankingLoss
 
 
-class LCWATrainingLoopTestCase(cases.TrainingLoopTestCase):
-    """Test LCWA."""
+class MRLossLCWATrainingLoopTestCase(cases.TrainingLoopTestCase):
+    """Test LCWA with margin ranking loss."""
 
     cls = LCWATrainingLoop
+    loss_cls = MarginRankingLoss
+
+
+class NSSALossLCWATrainingLoopTestCase(cases.TrainingLoopTestCase):
+    """Test LCWA with NSSA loss."""
+
+    cls = LCWATrainingLoop
+    loss_cls = NSSALoss
+
+
+class SoftPlusLCWATrainingLoopTestCase(cases.TrainingLoopTestCase):
+    """Test LCWA with softplus loss."""
+
+    cls = LCWATrainingLoop
+    loss_cls = SoftplusLoss

--- a/tests/test_training/test_training_loop.py
+++ b/tests/test_training/test_training_loop.py
@@ -12,7 +12,7 @@ class MRUnfilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
     """Test sLCWA with unfiltered negative sampling with margin ranking loss."""
 
     cls = SLCWATrainingLoop
-    filterer = None
+    filterer_cls = None
     loss_cls = MarginRankingLoss
 
 
@@ -20,7 +20,7 @@ class NSSAUnfilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
     """Test sLCWA with unfiltered negative sampling with NSSA loss."""
 
     cls = SLCWATrainingLoop
-    filterer = None
+    filterer_cls = None
     loss_cls = NSSALoss
 
 
@@ -28,7 +28,7 @@ class SoftplusUnfilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCas
     """Test sLCWA with unfiltered negative sampling with softplus loss."""
 
     cls = SLCWATrainingLoop
-    filterer = None
+    filterer_cls = None
     loss_cls = SoftplusLoss
 
 
@@ -36,7 +36,7 @@ class MRSetFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
     """Test sLCWA with set filtered negative sampling with margin ranking loss."""
 
     cls = SLCWATrainingLoop
-    filterer = PythonSetFilterer
+    filterer_cls = PythonSetFilterer
     loss_cls = MarginRankingLoss
 
 
@@ -44,7 +44,7 @@ class NSSASetFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
     """Test sLCWA with set filtered negative sampling with NSSA loss."""
 
     cls = SLCWATrainingLoop
-    filterer = PythonSetFilterer
+    filterer_cls = PythonSetFilterer
     loss_cls = NSSALoss
 
 
@@ -52,7 +52,7 @@ class SoftplusSetFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCa
     """Test sLCWA with set filtered negative sampling with softplus loss."""
 
     cls = SLCWATrainingLoop
-    filterer = PythonSetFilterer
+    filterer_cls = PythonSetFilterer
     loss_cls = SoftplusLoss
 
 
@@ -62,7 +62,7 @@ class BloomFilteredSLCWATrainingLoopTestCase(cases.SLCWATrainingLoopTestCase):
     """Test sLCWA with bloom filtered negative sampling."""
 
     cls = SLCWATrainingLoop
-    filterer = BloomFilterer
+    filterer_cls = BloomFilterer
     loss_cls = MarginRankingLoss
 
 


### PR DESCRIPTION
As a follow-up to #448, I added some tests in #417 for different combinations of training loops, losses, and negative filterers to make sure everything was covered. I noticed that the combination of sLCWA + filtering + NSSA loss had a bug where the filtered batch was the wrong size. This PR fixes.

Minimal code that causes the issue:

```python
from pykeen.pipeline import pipeline

if __name__ == '__main__':
    pipeline(
        dataset='Nations',
        model='TransE',
        loss='NSSA',
        training_loop='sLCWA',
        negative_sampler='basic',
        negative_sampler_kwargs=dict(filtered=True),
    )
```

Traceback:
```python-traceback
Traceback (most recent call last):
  File "/Users/cthoyt/dev/pykeen/scratch/qe.py", line 4, in <module>
    pipeline(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/pipeline/api.py", line 1016, in pipeline
    losses = training_loop_instance.train(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/training/training_loop.py", line 301, in train
    result = self._train(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/training/training_loop.py", line 689, in _train
    raise e
  File "/Users/cthoyt/dev/pykeen/src/pykeen/training/training_loop.py", line 598, in _train
    batch_loss = self._forward_pass(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/training/training_loop.py", line 742, in _forward_pass
    loss = self._process_batch(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/training/slcwa.py", line 106, in _process_batch
    return self.loss.process_slcwa_scores(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/losses.py", line 640, in process_slcwa_scores
    negative_scores_[batch_filter] = negative_scores
RuntimeError: shape mismatch: value tensor of shape [171, 1] cannot be broadcast to indexing result of shape [171]
```