### PR TITLE
🗳️ 🦙 Add entity and  relation mappings to checkpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_
 
 `Unreleased <https://github.com/pykeen/pykeen/compare/v1.5.0...HEAD>`_
 -----------------------------------------------------------------------
+Added
+~~~~~
+- Tutorial in using checkpoints when bringing your own data (https://github.com/pykeen/pykeen/pull/498)
 
 `1.5.0 <https://github.com/pykeen/pykeen/compare/v1.4.0...v1.5.0>`_ - 2021-06-13
 --------------------------------------------------------------------------------

--- a/docs/source/byo/data.rst
+++ b/docs/source/byo/data.rst
@@ -151,3 +151,8 @@ you should specify the splits:
 ...                                          # higher, especially with early stopper enabled
 ... )
 >>> result.save_to_directory('doctests/test_unstratified_stopped_transe')
+
+Bring Your Own Data and Checkpoints
+-----------------------------------
+For a tutorial on how to use your own data together with checkpoints
+please go to :ref:`byod_and_checkpoints_training` and :ref:`byod_and_checkpoints_manually`.

--- a/docs/source/byo/data.rst
+++ b/docs/source/byo/data.rst
@@ -1,3 +1,5 @@
+.. _bring_your_own_data:
+
 Bring Your Own Data
 ===================
 As an alternative to using a pre-packaged dataset, the training and testing can be set explicitly
@@ -152,7 +154,7 @@ you should specify the splits:
 ... )
 >>> result.save_to_directory('doctests/test_unstratified_stopped_transe')
 
-Bring Your Own Data and Checkpoints
------------------------------------
-For a tutorial on how to use your own data together with checkpoints
-please go to :ref:`byod_and_checkpoints_training` and :ref:`byod_and_checkpoints_manually`.
+Bring Your Own Data with Checkpoints
+------------------------------------
+For a tutorial on how to use your own data together with checkpoints,
+see :ref:`byod_and_checkpoints_training` and :ref:`byod_and_checkpoints_manually`.

--- a/docs/source/tutorial/checkpoints.rst
+++ b/docs/source/tutorial/checkpoints.rst
@@ -140,6 +140,8 @@ regular checkpoints as defined above, e.g. with this code:
 
 Note: Use this argument with caution, since every failed training loop will create a distinct checkpoint file.
 
+.. _byod_and_checkpoints_training:
+
 Checkpoints and Bring Your Own Data - Resuming training
 -------------------------------------------------------
 When continuing the training or general usage of a model it is of vital importance that the ``entity_to_id`` and
@@ -221,9 +223,10 @@ Now you can simply resume the pipeline with the same code as above:
 In case you feel that this is too much work we still got you covered, since PyKEEN will check in the background whether
 the provided triples factory mappings match those provided in the checkpoints and will warn you if that is not the case.
 
+.. _byod_and_checkpoints_manually:
+
 Checkpoints and Bring Your Own Data - Loading models manually
 -------------------------------------------------------------
-
 Instead of just resuming training with checkpoints as shown above, you can also manually load models from checkpoints
 for investigation or performing prediction tasks. This can be done in the following way:
 

--- a/docs/source/tutorial/checkpoints.rst
+++ b/docs/source/tutorial/checkpoints.rst
@@ -149,8 +149,8 @@ label to identifier (``entity_to_id``) and relation label to identifier (``relat
 as the ones that were used when saving the checkpoint. If they are not, then any downstream usage will be nonsense.
 
 If you're using a dataset provided by PyKEEN, you're automatically covered. However, when using your own datasets
-(see :ref:`bring_your_own_data`), you are responsible for making sure this is the case. Below are two typical examples of
-combining bringing your own data with checkpoints.
+(see :ref:`bring_your_own_data`), you are responsible for making sure this is the case. Below are two typical examples
+of combining bringing your own data with checkpoints.
 
 Resuming Training
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorial/checkpoints.rst
+++ b/docs/source/tutorial/checkpoints.rst
@@ -153,14 +153,15 @@ of using your own data:
 
 >>> from pykeen.pipeline import pipeline
 >>> from pykeen.triples import TriplesFactory
->>> train = TriplesFactory.from_path('/my/data/train_triples_1.txt')
+>>> from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH, NATIONS_VALIDATE_PATH
+>>> train = TriplesFactory.from_path(NATIONS_TRAIN_PATH)
 >>> val = TriplesFactory.from_path(
-...     '/my/data/val_triples_1.txt',
+...     path=NATIONS_VALIDATE_PATH,
 ...     entity_to_id=train.entity_to_id,
 ...     relation_to_id=train.relation_to_id,
 ...     )
 >>> test = TriplesFactory.from_path(
-...     '/my/data/test_triples_1.txt',
+...     path=NATIONS_TEST_PATH,
 ...     entity_to_id=train.entity_to_id,
 ...     relation_to_id=train.relation_to_id,
 ...     )
@@ -193,15 +194,20 @@ the mappings from the checkpoint in the following way.
 You have now loaded the checkpoint that contains the mappings, which now can be used to create mappings that match the
 model saved in the checkpoint in the following way
 
->>> train = TriplesFactory.from_path('/my/data/train_triples_sampled.txt',
+>>> from pykeen.triples import TriplesFactory
+>>> from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH, NATIONS_VALIDATE_PATH
+>>> train = TriplesFactory.from_path(
+...     path=NATIONS_TRAIN_PATH,
 ...     entity_to_id=checkpoint['entity_to_id_dict'],
 ...     relation_to_id=checkpoint['relation_to_id_dict'],
 ...     )
->>> val = TriplesFactory.from_path('/my/data/val_triples_1.txt',
+>>> val = TriplesFactory.from_path(
+...     path=NATIONS_VALIDATE_PATH,
 ...     entity_to_id=checkpoint['entity_to_id_dict'],
 ...     relation_to_id=checkpoint['relation_to_id_dict'],
 ...     )
->>> test = TriplesFactory.from_path('/my/data/test_triples_1.txt',
+>>> test = TriplesFactory.from_path(
+...     path=NATIONS_TEST_PATH,
 ...     entity_to_id=checkpoint['entity_to_id_dict'],
 ...     relation_to_id=checkpoint['relation_to_id_dict'],
 ...     )
@@ -238,7 +244,9 @@ for investigation or performing prediction tasks. This can be done in the follow
 You have now loaded the checkpoint that contains both the model as well as the ``entity_to_id`` and ``relation_to_id``
 mapping from the example above. To load these into PyKEEN you just have to do the following:
 
->>> train = TriplesFactory.from_path('/my/data/train_triples_1.txt',
+>>> from pykeen.datasets.nations import NATIONS_TRAIN_PATH
+>>> train = TriplesFactory.from_path(
+...     path=NATIONS_TRAIN_PATH,
 ...     entity_to_id=checkpoint['entity_to_id_dict'],
 ...     relation_to_id=checkpoint['relation_to_id_dict'],
 ...     )

--- a/docs/source/tutorial/checkpoints.rst
+++ b/docs/source/tutorial/checkpoints.rst
@@ -142,8 +142,8 @@ Note: Use this argument with caution, since every failed training loop will crea
 
 .. _byod_and_checkpoints_training:
 
-Checkpoints and Bring Your Own Data - Resuming training
--------------------------------------------------------
+Checkpoints When Bringing Your Own Data: Resuming Training
+----------------------------------------------------------
 When continuing the training or general usage of a model it is of vital importance that the ``entity_to_id`` and
 ``relation_to_id`` mappings that were used when saving the checkpoint are the same as when continuing to use the model.
 When using datasets provided by PyKEEN we have you covered, since PyKEEN makes sure this is the case. However,
@@ -200,17 +200,17 @@ model saved in the checkpoint in the following way
 ...     path=NATIONS_TRAIN_PATH,
 ...     entity_to_id=checkpoint['entity_to_id_dict'],
 ...     relation_to_id=checkpoint['relation_to_id_dict'],
-...     )
+... )
 >>> val = TriplesFactory.from_path(
 ...     path=NATIONS_VALIDATE_PATH,
 ...     entity_to_id=checkpoint['entity_to_id_dict'],
 ...     relation_to_id=checkpoint['relation_to_id_dict'],
-...     )
+... )
 >>> test = TriplesFactory.from_path(
 ...     path=NATIONS_TEST_PATH,
 ...     entity_to_id=checkpoint['entity_to_id_dict'],
 ...     relation_to_id=checkpoint['relation_to_id_dict'],
-...     )
+... )
 
 Now you can simply resume the pipeline with the same code as above:
 
@@ -249,7 +249,7 @@ mapping from the example above. To load these into PyKEEN you just have to do th
 ...     path=NATIONS_TRAIN_PATH,
 ...     entity_to_id=checkpoint['entity_to_id_dict'],
 ...     relation_to_id=checkpoint['relation_to_id_dict'],
-...     )
+... )
 
 ... now load the model and pass the train triples factory to the model
 

--- a/docs/source/tutorial/checkpoints.rst
+++ b/docs/source/tutorial/checkpoints.rst
@@ -182,7 +182,7 @@ dataset in order to ensure that those datasets are created with the same mapping
 As we have set the argument ``checkpoint_name='my_checkpoint.pt'`` when running the pipeline, PyKEEN saves the
 checkpoint in ``/your/home/dir/.data/pykeen/checkpoints/my_checkpoint.pt``.
 
-When you are sure that you're datasets shown above are the same, you can simply rerun that code and PyKEEN will
+When you are sure that your datasets shown above are the same, you can simply rerun that code and PyKEEN will
 automatically resume the training where it has left. However, if you only have changed the dataset or you sample it, you
 need to make sure that the mappings are correct when resuming training from the checkpoint. This can be done by loading
 the mappings from the checkpoint in the following way.

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -1093,8 +1093,8 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
         entity_to_id_dict = None
         # Only save mappings when non-PyKEEN datasets were used
         if (
-            '/pykeen/datasets/' in str(triples_factory.metadata['path'])
-            or '/.data/pykeen/datasets/' in str(triples_factory.metadata['path'])
+            '/pykeen/datasets/' not in str(triples_factory.metadata['path'])
+            and '/.data/pykeen/datasets/' not in str(triples_factory.metadata['path'])
         ):
             if triples_factory is not None:
                 relation_to_id_dict = triples_factory.relation_to_id

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -277,7 +277,10 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
         if checkpoint_name:
             checkpoint_path = checkpoint_directory.joinpath(checkpoint_name)
             if checkpoint_path.is_file():
-                best_epoch_model_file_path, last_best_epoch = self._load_state(path=checkpoint_path)
+                best_epoch_model_file_path, last_best_epoch = self._load_state(
+                    path=checkpoint_path,
+                    triples_factory=triples_factory,
+                )
                 if stopper is not None:
                     stopper_dict = stopper.load_summary_dict_from_training_loop_checkpoint(path=checkpoint_path)
                     # If the stopper dict has any keys, those are written back to the stopper
@@ -684,7 +687,7 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
                     and stopper.best_epoch != last_best_epoch
                     and best_epoch_model_file_path is not None
                 ):
-                    self._save_state(path=best_epoch_model_file_path)
+                    self._save_state(path=best_epoch_model_file_path, triples_factory=triples_factory)
                     last_best_epoch = epoch
             # When the training loop failed, a fallback checkpoint is created to resume training.
             except (MemoryError, RuntimeError) as e:
@@ -701,6 +704,7 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
                         path=checkpoint_on_failure_file_path,
                         stopper=stopper,
                         best_epoch_model_checkpoint_file_path=best_epoch_model_checkpoint_file_path,
+                        triples_factory=triples_factory,
                     )
                     logger.warning(
                         "However, don't worry we got you covered. PyKEEN just saved a checkpoint when this "
@@ -732,6 +736,7 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
                         path=checkpoint_path,
                         stopper=stopper,
                         best_epoch_model_checkpoint_file_path=best_epoch_model_checkpoint_file_path,
+                        triples_factory=triples_factory,
                     )  # type: ignore
                     last_checkpoint = time.time()
 
@@ -1043,6 +1048,7 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
         path: Union[IO[bytes], str, pathlib.Path],
         stopper: Optional[Stopper] = None,
         best_epoch_model_checkpoint_file_path: Optional[pathlib.Path] = None,
+        triples_factory: Optional[CoreTriplesFactory] = None,
     ) -> None:
         """Save the state of the training loop.
 
@@ -1053,6 +1059,8 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
             if training should stop early
         :param best_epoch_model_checkpoint_file_path:
             The file path for the checkpoint of the best epoch model when using early stopping.
+        :param triples_factory:
+            The triples factory being used in the current training loop.
         """
         if self.optimizer is None:
             raise ValueError
@@ -1080,6 +1088,18 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
         else:
             lr_scheduler_state_dict = self.lr_scheduler.state_dict()
 
+        # TODO: Find easy and robust way to determine whether this is not a PyKEEN provided dataset
+        relation_to_id_dict = None
+        entity_to_id_dict = None
+        # Only save mappings when non-PyKEEN datasets were used
+        if (
+            '/pykeen/datasets/' in str(triples_factory.metadata['path'])
+            or '/.data/pykeen/datasets/' in str(triples_factory.metadata['path'])
+        ):
+            if triples_factory is not None:
+                relation_to_id_dict = triples_factory.relation_to_id
+                entity_to_id_dict = triples_factory.entity_to_id
+
         torch.save(
             {
                 'epoch': self._epoch,
@@ -1096,6 +1116,9 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
                 'torch_cuda_random_state': torch_cuda_random_state,
                 # This is an entire checkpoint for the optional best model when using early stopping
                 'best_epoch_model_checkpoint': best_epoch_model_checkpoint,
+                # Saving triples factory related states
+                'relation_to_id_dict': relation_to_id_dict,
+                'entity_to_id_dict': entity_to_id_dict,
             },
             path,
             pickle_protocol=pickle.HIGHEST_PROTOCOL,
@@ -1105,11 +1128,17 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
     def _load_state(
         self,
         path: Union[str, pathlib.Path],
+        triples_factory: Optional[CoreTriplesFactory] = None,
     ) -> Tuple[Optional[pathlib.Path], Optional[int]]:
         """Load the state of the training loop from a checkpoint.
 
         :param path:
             Path of the file where to load the state from.
+        :param triples_factory:
+            The triples factory being used in the current training loop. This is being used to check whether the
+            entity and relation to id mappings from the checkpoint match those provided by the current triples
+            factory. Note: This is only used when the checkpoint was saved using custom datasets not provided by
+            PyKEEN.
 
         :return:
             Temporary file path of the best epoch model and the best epoch when using early stoppers, None otherwise.
@@ -1155,6 +1184,25 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
                 best_epoch_model_file_path,
                 pickle_protocol=pickle.HIGHEST_PROTOCOL,
             )
+
+        # Check whether the triples factory mappings match those from the checkpoints
+        relation_to_id_dict = checkpoint['relation_to_id_dict']
+        entity_to_id_dict = checkpoint['entity_to_id_dict']
+        if relation_to_id_dict is not None and entity_to_id_dict is not None and triples_factory is not None:
+            if relation_to_id_dict != triples_factory.relation_to_id:
+                logger.warning(
+                    'The model provided by the checkpoint was trained on different relation_to_id mappings than the '
+                    'ones provided by the current triples factory. This will most likely render the current learning '
+                    'state of your model useless. This is usually caused by using a completely different dataset '
+                    'or sampling a sub-dataset from a bigger dataset before handing it to the PyKEEN triples factory.'
+                )
+            if entity_to_id_dict != triples_factory.entity_to_id:
+                logger.warning(
+                    'The model provided by the checkpoint was trained on different entity_to_id mappings than the '
+                    'ones provided by the current triples factory. This will most likely render the current learning '
+                    'state of your model useless. This is usually caused by using a completely different dataset '
+                    'or sampling a sub-dataset from a bigger dataset before handing it to the PyKEEN triples factory.'
+                )
 
         self._epoch = checkpoint['epoch']
         self.losses_per_epochs = checkpoint['loss']

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -29,7 +29,7 @@ from ..models import Model, RGCN
 from ..stoppers import Stopper
 from ..trackers import ResultTracker
 from ..training.schlichtkrull_sampler import GraphSampler
-from ..triples import CoreTriplesFactory, Instances
+from ..triples import CoreTriplesFactory, Instances, TriplesFactory
 from ..utils import (
     format_relative_comparison, get_batchnorm_modules, is_cuda_oom_error, is_cudnn_error,
     normalize_string,
@@ -1090,7 +1090,7 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
 
         relation_to_id_dict = None
         entity_to_id_dict = None
-        if triples_factory is not None:
+        if triples_factory is not None and isinstance(triples_factory, TriplesFactory):
             relation_to_id_dict = triples_factory.relation_to_id
             entity_to_id_dict = triples_factory.entity_to_id
 
@@ -1181,7 +1181,12 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
         # Check whether the triples factory mappings match those from the checkpoints
         relation_to_id_dict = checkpoint.get('relation_to_id_dict')
         entity_to_id_dict = checkpoint.get('entity_to_id_dict')
-        if relation_to_id_dict is not None and entity_to_id_dict is not None and triples_factory is not None:
+        if (
+            relation_to_id_dict is not None
+            and entity_to_id_dict is not None
+            and triples_factory is not None
+            and isinstance(triples_factory, TriplesFactory)
+        ):
             if relation_to_id_dict != triples_factory.relation_to_id:
                 logger.warning(
                     'The model provided by the checkpoint was trained on different relation_to_id mappings than the '


### PR DESCRIPTION
Closes #482

This PR will introduce the saving of entity and relation to id mappings when non-PyKEEN datasets are used.

As shown in #482  not doing so basically renders checkpoints for custom datasets useless, since the mapping for that model is not known anymore. When the dataset that was used is not known exactly, e.g., when the user has multiples versions of one datasets or the dataset was sampled from a bigger dataset, the user effectively is not able to recreate those mappings.

To avoid this, this PR introduces two new functionalities:
1. It saves the entity_to_id and relation_to_id mappings for custom datasets when saving checkpoints.
   -  This allows users to recreate a triples factory that matches the mapping that was used to train the model
2. When using those checkpoints it checks whether the current triples_factory's entity and relation to id mappings match those that were used when the checkpoint was created.
    - This adds an extra layer of security for the user, since it avoids silly mistakes like predicting with a model that was trained with different mappings, which most likely will cause random results that seem very confusing to users.

I also have added a tutorial to show how to use those functions.