### PR TITLE
📜 🔧  Fixed docstring for ComplEx interaction: conjugate for Eq1 and fixed Eq2

### DIFF
--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -30,7 +30,7 @@ class ComplEx(EntityRelationEmbeddingModel):
 
     .. math::
 
-        f(h,r,t) =  Re(\mathbf{e}_h\odot\mathbf{r}_r\odot\mathbf{e}_t)
+        f(h,r,t) =  Re(\mathbf{e}_h\odot\mathbf{r}_r\odot\bar{\mathbf{e}}_t)
 
     Which expands to:
 
@@ -38,8 +38,8 @@ class ComplEx(EntityRelationEmbeddingModel):
 
         f(h,r,t) = \left\langle Re(\mathbf{e}_h),Re(\mathbf{r}_r),Re(\mathbf{e}_t)\right\rangle
         + \left\langle Im(\mathbf{e}_h),Re(\mathbf{r}_r),Im(\mathbf{e}_t)\right\rangle
-        + \left\langle Re(\mathbf{e}_h),Re(\mathbf{r}_r),Im(\mathbf{e}_t)\right\rangle
-        - \left\langle Im(\mathbf{e}_h),Im(\mathbf{r}_r),Im(\mathbf{e}_t)\right\rangle
+        + \left\langle Re(\mathbf{e}_h),Im(\mathbf{r}_r),Im(\mathbf{e}_t)\right\rangle
+        - \left\langle Im(\mathbf{e}_h),Im(\mathbf{r}_r),Re(\mathbf{e}_t)\right\rangle
 
     where $Re(\textbf{x})$ and $Im(\textbf{x})$ denote the real and imaginary parts of the complex valued vector
     $\textbf{x}$. Because the Hadamard product is not commutative in the complex space, ComplEx can model


### PR DESCRIPTION
This PR fixes a docstring for ComplEx: both formulas were a bit incorrect: 
* Equation 1 should have a complex conjugate `\bar{\mathbf{e}}_t` 
* Equation 2 has a different combination of Re and Im parts - now they correspond to the [original paper](http://proceedings.mlr.press/v48/trouillon16.pdf) (see Eq 11 there)
