### PR TITLE
💾 🧪 WD50K (triples) dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 <p align="center">
   <a href="#installation">Installation</a> •
   <a href="#quickstart">Quickstart</a> •
-  <a href="#datasets-26">Datasets</a> •
+  <a href="#datasets-27">Datasets</a> •
   <a href="#models-30">Models</a> •
   <a href="#supporters">Support</a> •
   <a href="#citation">Citation</a>
@@ -97,7 +97,7 @@ The full documentation can be found at https://pykeen.readthedocs.io.
 Below are the models, datasets, training modes, evaluators, and metrics implemented
 in ``pykeen``.
 
-### Datasets (26)
+### Datasets (27)
 
 The following datasets are built in to PyKEEN. The citation for each dataset corresponds to either the paper
 describing the dataset, the first paper published using the dataset with knowledge graph embedding models,
@@ -129,6 +129,7 @@ have a suggestion for another dataset to include in PyKEEN, please let us know
 | OpenBioLink                        | [`pykeen.datasets.OpenBioLink`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OpenBioLink.html)     | [Breit *et al*., 2020](https://doi.org/10.1093/bioinformatics/btaa274)                                                  |     180992 |          28 |   4563407 |
 | OpenBioLink                        | [`pykeen.datasets.OpenBioLinkLQ`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OpenBioLinkLQ.html) | [Breit *et al*., 2020](https://doi.org/10.1093/bioinformatics/btaa274)                                                  |     480876 |          32 |  27320889 |
 | Unified Medical Language System    | [`pykeen.datasets.UMLS`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.UMLS.html)                   | [`ZhenfengLei/KGDatasets`](https://github.com/ZhenfengLei/KGDatasets)                                                   |        135 |          46 |      6529 |
+| WD50K (triples)                    | [`pykeen.datasets.WD50KT`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.WD50KT.html)               | [Galkin *et al*., 2020](https://www.aclweb.org/anthology/2020.emnlp-main.596/)                                          |      40107 |         473 |    232344 |
 | WK3l-120k Family                   | [`pykeen.datasets.WK3l120k`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.WK3l120k.html)           | [Chen *et al*., 2017](https://www.ijcai.org/Proceedings/2017/0209.pdf)                                                  |     119748 |        3109 |   1375406 |
 | WK3l-15k Family                    | [`pykeen.datasets.WK3l15k`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.WK3l15k.html)             | [Chen *et al*., 2017](https://www.ijcai.org/Proceedings/2017/0209.pdf)                                                  |      15126 |        1841 |    209041 |
 | WordNet-18                         | [`pykeen.datasets.WN18`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.WN18.html)                   | [Bordes *et al*., 2014](https://arxiv.org/abs/1301.3485)                                                                |      40943 |          18 |    151442 |

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -48,3 +48,7 @@ References
 
 .. [sakai2021] Sakai, T. (2021). `On Fuhr's Guideline for IR Evaluation
    <https://doi.org/10.1145/3451964.3451976>`_. SIGIR Forum, 54(1), 1-8.
+
+.. [galkin2020] Galkin, M., *et al.* (2020). `Message Passing for Hyper-Relational Knowledge Graphs
+   <https://doi.org/10.18653/v1/2020.emnlp-main.596>`_. Proceedings of the 2020 Conference on Empirical
+   Methods in Natural Language Processing (EMNLP), 7346–7359.

--- a/setup.cfg
+++ b/setup.cfg
@@ -136,6 +136,7 @@ pykeen.datasets =
     wn18rr           = pykeen.datasets.wordnet:WN18RR
     yago310          = pykeen.datasets.yago:YAGO310
     db100k           = pykeen.datasets.db100k:DB100K
+    wd50kt           = pykeen.datasets.wd50k:WD50KT
 
 ######################
 # Doc8 Configuration #

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -35,6 +35,7 @@ from .umls import UMLS
 from .wk3l import WK3l15k
 from .wordnet import WN18, WN18RR
 from .yago import YAGO310
+from .wd50k import WD50K_Triples
 from ..triples import CoreTriplesFactory
 
 __all__ = [
@@ -63,6 +64,7 @@ __all__ = [
     'DBpedia50',
     'DB100K',
     'Countries',
+    'WD50K_Triples',
     # Utilities
     'dataset_resolver',
     'get_dataset',

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -32,10 +32,10 @@ from .nations import Nations
 from .ogb import OGBBioKG, OGBWikiKG
 from .openbiolink import OpenBioLink, OpenBioLinkLQ
 from .umls import UMLS
+from .wd50k import WD50KT
 from .wk3l import WK3l15k
 from .wordnet import WN18, WN18RR
 from .yago import YAGO310
-from .wd50k import WD50KT
 from ..triples import CoreTriplesFactory
 
 __all__ = [

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -35,7 +35,7 @@ from .umls import UMLS
 from .wk3l import WK3l15k
 from .wordnet import WN18, WN18RR
 from .yago import YAGO310
-from .wd50k import WD50K_Triples
+from .wd50k import WD50KT
 from ..triples import CoreTriplesFactory
 
 __all__ = [
@@ -64,7 +64,7 @@ __all__ = [
     'DBpedia50',
     'DB100K',
     'Countries',
-    'WD50K_Triples',
+    'WD50KT',
     # Utilities
     'dataset_resolver',
     'get_dataset',

--- a/src/pykeen/datasets/wd50k.py
+++ b/src/pykeen/datasets/wd50k.py
@@ -4,6 +4,8 @@
 
 - GitHub Repository: https://github.com/migalkin/StarE/tree/master/data/clean/wd50k/
 - Paper: https://www.aclweb.org/anthology/2020.emnlp-main.596/
+
+Get a summary with ``python -m pykeen.datasets.wd50k``,
 """
 
 import click

--- a/src/pykeen/datasets/wd50k.py
+++ b/src/pykeen/datasets/wd50k.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+"""The Wikidata-based WD50K dataset (triple-only version) from [galkin2020]_.
+
+- GitHub Repository: https://github.com/migalkin/StarE/tree/master/data/clean/wd50k/
+- Paper: https://www.aclweb.org/anthology/2020.emnlp-main.596/
+"""
+
+import click
+from docdata import parse_docdata
+from more_click import verbose_option
+
+from .base import UnpackedRemoteDataset
+
+BASE_URL = 'https://raw.githubusercontent.com/migalkin/StarE/master/data/clean/wd50k/'
+TRIPLES_VALID_URL = f'{BASE_URL}/triples/valid.txt'
+TRIPLES_TEST_URL = f'{BASE_URL}/triples/test.txt'
+TRIPLES_TRAIN_URL = f'{BASE_URL}/triples/train.txt'
+
+
+@parse_docdata
+class WD50K_Triples(UnpackedRemoteDataset):
+    """The triple-only version of WD50K.
+
+    ---
+    name: WD50K (triples)
+    citation:
+        author: Galkin
+        year: 2020
+        link: https://www.aclweb.org/anthology/2020.emnlp-main.596/
+        github: migalkin/StarE
+    statistics:
+        entities: 40107
+        relations: 473
+        training: 164631
+        testing: 45284
+        validation: 22429
+        triples: 232344
+    """
+
+    def __init__(self, create_inverse_triples: bool = False, **kwargs):
+        """Initialize the WD50K (triples) dataset from [galkin2020]_.
+
+        :param create_inverse_triples: Should inverse triples be created? Defaults to false.
+        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        """
+        super().__init__(
+            training_url=TRIPLES_TRAIN_URL,
+            testing_url=TRIPLES_TEST_URL,
+            validation_url=TRIPLES_VALID_URL,
+            create_inverse_triples=create_inverse_triples,
+            load_triples_kwargs={'delimiter':','},
+            **kwargs,
+        )
+
+
+
+@click.command()
+@verbose_option
+def _main():
+    for cls in [WD50K_Triples]:
+        click.secho(f'Loading {cls.__name__}', fg='green', bold=True)
+        d = cls()
+        d.summarize()
+
+
+if __name__ == '__main__':
+    _main()

--- a/src/pykeen/datasets/wd50k.py
+++ b/src/pykeen/datasets/wd50k.py
@@ -52,10 +52,9 @@ class WD50KT(UnpackedRemoteDataset):
             testing_url=TRIPLES_TEST_URL,
             validation_url=TRIPLES_VALID_URL,
             create_inverse_triples=create_inverse_triples,
-            load_triples_kwargs={'delimiter':','},
+            load_triples_kwargs={'delimiter': ','},
             **kwargs,
         )
-
 
 
 @click.command()

--- a/src/pykeen/datasets/wd50k.py
+++ b/src/pykeen/datasets/wd50k.py
@@ -30,6 +30,7 @@ class WD50KT(UnpackedRemoteDataset):
         author: Galkin
         year: 2020
         link: https://www.aclweb.org/anthology/2020.emnlp-main.596/
+        arxiv: 2009.10847
         github: migalkin/StarE
     statistics:
         entities: 40107

--- a/src/pykeen/datasets/wd50k.py
+++ b/src/pykeen/datasets/wd50k.py
@@ -21,8 +21,8 @@ TRIPLES_TRAIN_URL = f'{BASE_URL}/triples/train.txt'
 
 
 @parse_docdata
-class WD50K_Triples(UnpackedRemoteDataset):
-    """The triple-only version of WD50K.
+class WD50KT(UnpackedRemoteDataset):
+    """The triples-only version of WD50K.
 
     ---
     name: WD50K (triples)
@@ -60,7 +60,7 @@ class WD50K_Triples(UnpackedRemoteDataset):
 @click.command()
 @verbose_option
 def _main():
-    for cls in [WD50K_Triples]:
+    for cls in [WD50KT]:
         click.secho(f'Loading {cls.__name__}', fg='green', bold=True)
         d = cls()
         d.summarize()


### PR DESCRIPTION
This PR addresses #509 and adds the triple-only version of WD50K named as WD50K_Triples (hoping that in the future there will be WD50K_Statements and so). 

Stats:
```
entities: 40107
relations: 473
training: 164631
testing: 45284
validation: 22429
triples: 232344
```

See how it's listed on the README at https://github.com/pykeen/pykeen/tree/wd50k_triples_dataset#datasets-27
