### PR TITLE
Make the `pipeline` function part of the top-level `pykeen` namespace

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -19,6 +19,10 @@ values =
 [bumpverion:part:build]
 values = [0-9A-Za-z-]+
 
+[bumpversion:file:setup.cfg]
+search = version = {current_version}
+replace = version = {new_version}
+
 [bumpversion:file:src/pykeen/version.py]
 search = VERSION = '{current_version}'
 replace = VERSION = '{new_version}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 # Configuring setup()
 [metadata]
 name = pykeen
-version = attr: src.pykeen.version.VERSION
+version = 1.5.1-dev
 description = A package for training and evaluating multimodal knowledge graph embeddings
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/pykeen/__init__.py
+++ b/src/pykeen/__init__.py
@@ -13,8 +13,8 @@ approach
 (:class:`pykeen.training.SLCWATrainingLoop`) and evaluates with rank-based evaluation
 (:class:`pykeen.evaluation.RankBasedEvaluator`).
 
->>> from pykeen.pipeline import pipeline
->>> result = pipeline(
+>>> import pykeen
+>>> result = pykeen.pipeline(
 ...     model='TransE',
 ...     dataset='Nations',
 ... )
@@ -32,6 +32,7 @@ If you're in a Jupyter notebook, it will be pretty printed as an HTML table.
 
 import logging
 
+from .pipeline import pipeline  # noqa: F401
 from .version import env, get_git_branch, get_git_hash, get_version  # noqa: F401
 
 # This will set the global logging level to info to ensure that info messages are shown in all parts of the software.


### PR DESCRIPTION
This means you can do:

```python
import pykeen
result = pykeen.pipeline(
    model='TransE',
    dataset='Nations',
)
```

which is great for examples and simplicity, but there are a few concerns:

1. This means that *everything* has to be imported transitively on `import pykeen` since the pipeline basically relies on most modules in the library
2. Lesser concern: need to change some of the config in version tracking (the attr: thing doesn't work if you import code in the top level)