### PR TITLE
Use basic indexing instead of advanced indexing where possible

### DIFF
--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -925,7 +925,7 @@ class CombinedCompGCNRepresentations(nn.Module):
 
         # register buffers for adjacency matrix; we use the same format as PyTorch Geometric
         # TODO: This always uses all training triples for message passing
-        self.register_buffer(name="edge_index", tensor=triples_factory.mapped_triples[:, [0, 2]].t())
+        self.register_buffer(name="edge_index", tensor=triples_factory.mapped_triples[:, 0::2].t())
         self.register_buffer(name="edge_type", tensor=triples_factory.mapped_triples[:, 1])
 
         # initialize buffer of enriched representations

--- a/src/pykeen/triples/leakage.py
+++ b/src/pykeen/triples/leakage.py
@@ -171,7 +171,7 @@ def mapped_triples_to_sparse_matrices(
         ],
         dim=0,
     )
-    pairs, pair_id = extended_mapped_triples[:, [0, 2]].unique(dim=0, return_inverse=True)
+    pairs, pair_id = extended_mapped_triples[:, 0::2].unique(dim=0, return_inverse=True)
     n_pairs = pairs.shape[0]
     forward, backward = pair_id.split(num_triples)
     relations = mapped_triples[:, 1]

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -73,7 +73,7 @@ def _get_cover_deterministic(triples: MappedTriples) -> torch.BoolTensor:
     :return: shape: (n,)
         A boolean mask indicating whether the triple is part of the cover.
     """
-    num_entities = triples[:, [0, 2]].max() + 1
+    num_entities = triples[:, 0::2].max() + 1
     num_relations = triples[:, 1].max() + 1
     num_triples = triples.shape[0]
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -255,7 +255,7 @@ class CoreTriplesFactory:
             A new triples factory.
         """
         if num_entities is None:
-            num_entities = mapped_triples[:, [0, 2]].max().item() + 1
+            num_entities = mapped_triples[:, 0::2].max().item() + 1
         if num_relations is None:
             num_relations = mapped_triples[:, 1].max().item() + 1
         if entity_ids is None:
@@ -909,7 +909,7 @@ class TriplesFactory(CoreTriplesFactory):
             ``pip install git+https://github.com/kavgan/word_cloud.git``.
         """
         return self._word_cloud(
-            ids=self.mapped_triples[:, [0, 2]],
+            ids=self.mapped_triples[:, 0::2],
             id_to_label=self.entity_labeling.id_to_label,
             top=top or 100,
         )

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -84,7 +84,7 @@ def load_triples(
 
 def get_entities(triples: torch.LongTensor) -> Set[int]:
     """Get all entities from the triples."""
-    return set(triples[:, [0, 2]].flatten().tolist())
+    return set(triples[:, 0::2].flatten().tolist())
 
 
 def get_relations(triples: torch.LongTensor) -> Set[int]:


### PR DESCRIPTION
Advanced indexing leads to copying, while basic indexing only returns a view, cf. https://pytorch.org/docs/stable/tensor_view.html

The changes should not heavily affect performance, since all of them seem to be called only once during a training run.