### PR TITLE
🔮 💃 Reimplement NTN with new-style model

### DIFF
--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -8,7 +8,7 @@ score value is model-dependent, and usually it cannot be directly interpreted as
 
 from class_resolver import Resolver
 
-from .base import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, _OldAbstractModel
+from .base import EntityRelationEmbeddingModel, Model, _OldAbstractModel
 from .multimodal import ComplExLiteral, DistMultLiteral, LiteralModel
 from .nbase import ERModel, _NewAbstractModel
 from .resolve import make_model, make_model_cls
@@ -47,7 +47,6 @@ __all__ = [
     # Base Models
     'Model',
     '_OldAbstractModel',
-    'EntityEmbeddingModel',
     'EntityRelationEmbeddingModel',
     '_NewAbstractModel',
     'ERModel',
@@ -98,7 +97,6 @@ model_resolver = Resolver.from_subclasses(
         LiteralModel,
         # Old style models should never be looked up
         _OldAbstractModel,
-        EntityEmbeddingModel,
         EntityRelationEmbeddingModel,
     },
 )

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -27,7 +27,6 @@ from ..utils import NoRandomSeedNecessary, _can_slice, extend_batch, resolve_dev
 __all__ = [
     'Model',
     '_OldAbstractModel',
-    'EntityEmbeddingModel',
     'EntityRelationEmbeddingModel',
 ]
 
@@ -678,61 +677,6 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
 
     def _free_graph_and_cache(self):
         self.regularizer.reset()
-
-
-class EntityEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):
-    """A base module for most KGE models that have one embedding for entities."""
-
-    entity_embeddings: Embedding
-
-    def __init__(
-        self,
-        *,
-        triples_factory: CoreTriplesFactory,
-        entity_representations: EmbeddingSpecification,
-        loss: Optional[Loss] = None,
-        predict_with_sigmoid: bool = False,
-        preferred_device: DeviceHint = None,
-        random_seed: Optional[int] = None,
-        regularizer: Optional[Regularizer] = None,
-    ) -> None:
-        """Initialize the entity embedding model.
-
-        .. seealso:: Constructor of the base class :class:`pykeen.models.Model`
-        """
-        super().__init__(
-            triples_factory=triples_factory,
-            loss=loss,
-            preferred_device=preferred_device,
-            random_seed=random_seed,
-            regularizer=regularizer,
-            predict_with_sigmoid=predict_with_sigmoid,
-        )
-        self.entity_embeddings = entity_representations.make(
-            num_embeddings=triples_factory.num_entities,
-            device=self.device,
-        )
-
-    @property
-    def embedding_dim(self) -> int:  # noqa:D401
-        """The entity embedding dimension."""
-        return self.entity_embeddings.embedding_dim
-
-    @property
-    def entity_representations(self) -> Sequence[RepresentationModule]:  # noqa:D401
-        """The entity representations.
-
-        This property provides forward compatibility with the new-style :class:`pykeen.models.ERModel`.
-        """
-        return [self.entity_embeddings]
-
-    def _reset_parameters_(self):  # noqa: D102
-        self.entity_embeddings.reset_parameters()
-
-    def post_parameter_update(self) -> None:  # noqa: D102
-        # make sure to call this first, to reset regularizer state!
-        super().post_parameter_update()
-        self.entity_embeddings.post_parameter_update()
 
 
 class EntityRelationEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):

--- a/src/pykeen/models/unimodal/ntn.py
+++ b/src/pykeen/models/unimodal/ntn.py
@@ -4,20 +4,21 @@
 
 from typing import Any, ClassVar, Mapping, Optional
 
-import torch
+from class_resolver import Hint, HintOrType
 from torch import nn
 
-from ..base import EntityEmbeddingModel
+from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...nn.emb import EmbeddingSpecification
-from ...typing import Hint, Initializer
+from ...nn import EmbeddingSpecification
+from ...nn.modules import NTNInteraction
+from ...typing import Initializer
 
 __all__ = [
     'NTN',
 ]
 
 
-class NTN(EntityEmbeddingModel):
+class NTN(ERModel):
     r"""An implementation of NTN from [socher2013]_.
 
     NTN uses a bilinear tensor layer instead of a standard linear neural network layer:
@@ -61,7 +62,8 @@ class NTN(EntityEmbeddingModel):
         *,
         embedding_dim: int = 100,
         num_slices: int = 4,
-        non_linearity: Optional[nn.Module] = None,
+        non_linearity: HintOrType[nn.Module] = None,
+        non_linearity_kwargs: Optional[Mapping[str, Any]] = None,
         entity_initializer: Hint[Initializer] = None,
         **kwargs,
     ) -> None:
@@ -71,180 +73,32 @@ class NTN(EntityEmbeddingModel):
         :param num_slices: The number of slices in the parameters
         :param non_linearity: A non-linear activation function. Defaults to the hyperbolic
             tangent :class:`torch.nn.Tanh`.
+        :param non_linearity_kwargs: If the ``non_linearity`` is passed as a class, these keyword arguments
+            are used during its instantiation.
         :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
         :param kwargs:
             Remaining keyword arguments to forward to :class:`pykeen.models.EntityEmbeddingModel`
         """
         super().__init__(
+            interaction=NTNInteraction(
+                activation=non_linearity,
+                activation_kwargs=non_linearity_kwargs,
+            ),
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
             ),
+            relation_representations=[
+                # w: (k, d, d)
+                EmbeddingSpecification(shape=(num_slices, embedding_dim, embedding_dim)),
+                # vh: (k, d)
+                EmbeddingSpecification(shape=(num_slices, embedding_dim)),
+                # vt: (k, d)
+                EmbeddingSpecification(shape=(num_slices, embedding_dim)),
+                # b: (k,)
+                EmbeddingSpecification(shape=(num_slices,)),
+                # u: (k,)
+                EmbeddingSpecification(shape=(num_slices,)),
+            ],
             **kwargs,
         )
-        self.num_slices = num_slices
-
-        self.w = nn.Parameter(data=torch.empty(
-            self.num_relations,
-            num_slices,
-            embedding_dim,
-            embedding_dim,
-            device=self.device,
-        ), requires_grad=True)
-        self.vh = nn.Parameter(data=torch.empty(
-            self.num_relations,
-            num_slices,
-            embedding_dim,
-            device=self.device,
-        ), requires_grad=True)
-        self.vt = nn.Parameter(data=torch.empty(
-            self.num_relations,
-            num_slices,
-            embedding_dim,
-            device=self.device,
-        ), requires_grad=True)
-        self.b = nn.Parameter(data=torch.empty(
-            self.num_relations,
-            num_slices,
-            device=self.device,
-        ), requires_grad=True)
-        self.u = nn.Parameter(data=torch.empty(
-            self.num_relations,
-            num_slices,
-            device=self.device,
-        ), requires_grad=True)
-        if non_linearity is None:
-            non_linearity = nn.Tanh()
-        self.non_linearity = non_linearity
-
-    def _reset_parameters_(self):  # noqa: D102
-        super()._reset_parameters_()
-        nn.init.normal_(self.w)
-        nn.init.normal_(self.vh)
-        nn.init.normal_(self.vt)
-        nn.init.normal_(self.b)
-        nn.init.normal_(self.u)
-
-    def _score(
-        self,
-        h_indices: Optional[torch.LongTensor] = None,
-        r_indices: Optional[torch.LongTensor] = None,
-        t_indices: Optional[torch.LongTensor] = None,
-        slice_size: int = None,
-    ) -> torch.FloatTensor:
-        """
-        Compute scores for NTN.
-
-        :param h_indices: shape: (batch_size,)
-        :param r_indices: shape: (batch_size,)
-        :param t_indices: shape: (batch_size,)
-        :param slice_size: >0
-            The divisor for the scoring function when using slicing.
-
-        :return: shape: (batch_size, num_entities)
-        """
-        assert r_indices is not None
-
-        #: shape: (batch_size, num_entities, d)
-        h_all = self.entity_embeddings.get_in_canonical_shape(indices=h_indices)
-        t_all = self.entity_embeddings.get_in_canonical_shape(indices=t_indices)
-
-        if slice_size is None:
-            return self._interaction_function(h=h_all, t=t_all, r_indices=r_indices)
-
-        if h_all.shape[1] > t_all.shape[1]:
-            h_was_split = True
-            split_tensor = torch.split(h_all, slice_size, dim=1)
-            constant_tensor = t_all
-        else:
-            h_was_split = False
-            split_tensor = torch.split(t_all, slice_size, dim=1)
-            constant_tensor = h_all
-
-        scores_arr = []
-        for split in split_tensor:
-            if h_was_split:
-                h = split
-                t = constant_tensor
-            else:
-                h = constant_tensor
-                t = split
-            score = self._interaction_function(h=h, t=t, r_indices=r_indices)
-            scores_arr.append(score)
-
-        return torch.cat(scores_arr, dim=1)
-
-    def _interaction_function(
-        self,
-        h: torch.FloatTensor,
-        t: torch.FloatTensor,
-        r_indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
-        #: Prepare h: (b, e, d) -> (b, e, 1, 1, d)
-        h_for_w = h.unsqueeze(dim=-2).unsqueeze(dim=-2)
-
-        #: Prepare t: (b, e, d) -> (b, e, 1, d, 1)
-        t_for_w = t.unsqueeze(dim=-2).unsqueeze(dim=-1)
-
-        #: Prepare w: (R, k, d, d) -> (b, k, d, d) -> (b, 1, k, d, d)
-        w_r = self.w.index_select(dim=0, index=r_indices).unsqueeze(dim=1)
-
-        # h.T @ W @ t, shape: (b, e, k, 1, 1)
-        hwt = (h_for_w @ w_r @ t_for_w)
-
-        #: reduce (b, e, k, 1, 1) -> (b, e, k)
-        hwt = hwt.squeeze(dim=-1).squeeze(dim=-1)
-
-        #: Prepare vh: (R, k, d) -> (b, k, d) -> (b, 1, k, d)
-        vh_r = self.vh.index_select(dim=0, index=r_indices).unsqueeze(dim=1)
-
-        #: Prepare h: (b, e, d) -> (b, e, d, 1)
-        h_for_v = h.unsqueeze(dim=-1)
-
-        # V_h @ h, shape: (b, e, k, 1)
-        vhh = vh_r @ h_for_v
-
-        #: reduce (b, e, k, 1) -> (b, e, k)
-        vhh = vhh.squeeze(dim=-1)
-
-        #: Prepare vt: (R, k, d) -> (b, k, d) -> (b, 1, k, d)
-        vt_r = self.vt.index_select(dim=0, index=r_indices).unsqueeze(dim=1)
-
-        #: Prepare t: (b, e, d) -> (b, e, d, 1)
-        t_for_v = t.unsqueeze(dim=-1)
-
-        # V_t @ t, shape: (b, e, k, 1)
-        vtt = vt_r @ t_for_v
-
-        #: reduce (b, e, k, 1) -> (b, e, k)
-        vtt = vtt.squeeze(dim=-1)
-
-        #: Prepare b: (R, k) -> (b, k) -> (b, 1, k)
-        b = self.b.index_select(dim=0, index=r_indices).unsqueeze(dim=1)
-
-        # a = f(h.T @ W @ t + Vh @ h + Vt @ t + b), shape: (b, e, k)
-        pre_act = hwt + vhh + vtt + b
-        act = self.non_linearity(pre_act)
-
-        # prepare u: (R, k) -> (b, k) -> (b, 1, k, 1)
-        u = self.u.index_select(dim=0, index=r_indices).unsqueeze(dim=1).unsqueeze(dim=-1)
-
-        # prepare act: (b, e, k) -> (b, e, 1, k)
-        act = act.unsqueeze(dim=-2)
-
-        # compute score, shape: (b, e, 1, 1)
-        score = act @ u
-
-        # reduce
-        score = score.squeeze(dim=-1).squeeze(dim=-1)
-
-        return score
-
-    def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=hrt_batch[:, 0], r_indices=hrt_batch[:, 1], t_indices=hrt_batch[:, 2])
-
-    def score_t(self, hr_batch: torch.LongTensor, slice_size: int = None) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=hr_batch[:, 0], r_indices=hr_batch[:, 1], slice_size=slice_size)
-
-    def score_h(self, rt_batch: torch.LongTensor, slice_size: int = None) -> torch.FloatTensor:  # noqa: D102
-        return self._score(r_indices=rt_batch[:, 0], t_indices=rt_batch[:, 1], slice_size=slice_size)

--- a/src/pykeen/models/unimodal/ntn.py
+++ b/src/pykeen/models/unimodal/ntn.py
@@ -38,6 +38,12 @@ class NTN(ERModel):
     for each relation a separate neural network which makes the model very expressive, but at the same time
     computationally expensive.
 
+    .. note::
+
+        We split the original $V_r$ matrix into two parts, to separate $V_r [h; r] = V_r^h h + V_r^t t$.
+        The latter is more efficient, if $h$ and $t$ are not of the same shape,
+        e.g., since we are in a :meth:`score_h` / :meth:`score_t` setting.
+
     .. seealso::
 
        - Original Implementation (Matlab): `<https://github.com/khurram18/NeuralTensorNetworks>`_

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1068,11 +1068,24 @@ class NTNInteraction(
     relation_shape = ("kdd", "kd", "kd", "k", "k")
     func = pkf.ntn_interaction
 
-    def __init__(self, non_linearity: Optional[nn.Module] = None):
+    def __init__(
+        self,
+        activation: HintOrType[nn.Module] = None,
+        activation_kwargs: Optional[Mapping[str, Any]] = None,
+    ):
+        """Initialize NTN with the given non-linear activation function.
+
+        :param activation: A non-linear activation function. Defaults to the hyperbolic
+            tangent :class:`torch.nn.Tanh` if none, otherwise uses the :data:`pykeen.utils.activation_resolver`
+            for lookup.
+        :param activation_kwargs: If the ``activation`` is passed as a class, these keyword arguments
+            are used during its instantiation.
+        """
         super().__init__()
-        if non_linearity is None:
-            non_linearity = nn.Tanh()
-        self.non_linearity = non_linearity
+        if activation is None:
+            self.non_linearity = nn.Tanh()
+        else:
+            self.non_linearity = activation_resolver.make(activation, activation_kwargs)
 
     @staticmethod
     def _prepare_hrt_for_functional(

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -32,7 +32,7 @@ from pykeen.datasets.base import LazyDataset
 from pykeen.datasets.kinships import KINSHIPS_TRAIN_PATH
 from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH
 from pykeen.losses import Loss, PairwiseLoss, PointwiseLoss, SetwiseLoss, UnsupportedLabelSmoothingError
-from pykeen.models import EntityEmbeddingModel, EntityRelationEmbeddingModel, Model, RESCAL
+from pykeen.models import EntityRelationEmbeddingModel, Model, RESCAL
 from pykeen.models.cli import build_cli_from_cls
 from pykeen.nn.emb import RepresentationModule
 from pykeen.nn.modules import FunctionalInteraction, Interaction, LiteralInteraction
@@ -1012,8 +1012,6 @@ class ModelTestCase(unittest_templates.GenericTestCase[Model]):
             """Test whether two embeddings are equal."""
             return (a(indices=None) == b(indices=None)).all()
 
-        if isinstance(original_model, EntityEmbeddingModel):
-            assert not _equal_embeddings(original_model.entity_embeddings, loaded_model.entity_embeddings)
         if isinstance(original_model, EntityRelationEmbeddingModel):
             assert not _equal_embeddings(original_model.relation_embeddings, loaded_model.relation_embeddings)
 
@@ -1021,8 +1019,6 @@ class ModelTestCase(unittest_templates.GenericTestCase[Model]):
             file_path = os.path.join(tmpdirname, 'test.pt')
             original_model.save_state(path=file_path)
             loaded_model.load_state(path=file_path)
-        if isinstance(original_model, EntityEmbeddingModel):
-            assert _equal_embeddings(original_model.entity_embeddings, loaded_model.entity_embeddings)
         if isinstance(original_model, EntityRelationEmbeddingModel):
             assert _equal_embeddings(original_model.relation_embeddings, loaded_model.relation_embeddings)
 
@@ -1219,19 +1215,7 @@ Traceback
 
     def test_custom_representations(self):
         """Tests whether we can provide custom representations."""
-        if isinstance(self.instance, EntityEmbeddingModel):
-            old_embeddings = self.instance.entity_embeddings
-            self.instance.entity_embeddings = CustomRepresentations(
-                num_entities=self.factory.num_entities,
-                shape=old_embeddings.shape,
-            )
-            # call some functions
-            self.instance.reset_parameters_()
-            self.test_score_hrt()
-            self.test_score_t()
-            # reset to old state
-            self.instance.entity_embeddings = old_embeddings
-        elif isinstance(self.instance, EntityRelationEmbeddingModel):
+        if isinstance(self.instance, EntityRelationEmbeddingModel):
             old_embeddings = self.instance.relation_embeddings
             self.instance.relation_embeddings = CustomRepresentations(
                 num_entities=self.factory.num_relations,

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1257,18 +1257,6 @@ class BaseKG2ETest(ModelTestCase):
             assert all_in_bounds(cov(indices=None), low=self.instance.c_min, high=self.instance.c_max)
 
 
-class BaseNTNTest(ModelTestCase):
-    """Test the NTN model."""
-
-    cls = pykeen.models.NTN
-
-    def test_can_slice(self):
-        """Test that the slicing properties are calculated correctly."""
-        self.assertTrue(self.instance.can_slice_h)
-        self.assertFalse(self.instance.can_slice_r)
-        self.assertTrue(self.instance.can_slice_t)
-
-
 class BaseRGCNTest(ModelTestCase):
     """Test the R-GCN model."""
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -219,27 +219,13 @@ class TestKG2EWithEL(cases.BaseKG2ETest):
     }
 
 
-class TestNTNLowMemory(cases.BaseNTNTest):
-    """Test the NTN model with automatic memory optimization."""
+class TestNTN(cases.ModelTestCase):
+    """Test the NTN model."""
+
+    cls = pykeen.models.NTN
 
     kwargs = {
         'num_slices': 2,
-    }
-
-    training_loop_kwargs = {
-        'automatic_memory_optimization': True,
-    }
-
-
-class TestNTNHighMemory(cases.BaseNTNTest):
-    """Test the NTN model without automatic memory optimization."""
-
-    kwargs = {
-        'num_slices': 2,
-    }
-
-    training_loop_kwargs = {
-        'automatic_memory_optimization': False,
     }
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,7 +14,7 @@ import unittest_templates
 import pykeen.experiments
 import pykeen.models
 from pykeen.models import (
-    ERModel, EntityEmbeddingModel, EntityRelationEmbeddingModel, Model,
+    ERModel, EntityRelationEmbeddingModel, Model,
     _NewAbstractModel, _OldAbstractModel, model_resolver,
 )
 from pykeen.models.multimodal.base import LiteralModel
@@ -34,7 +34,6 @@ SKIP_MODULES = {
     _NewAbstractModel,
     # DummyModel,
     LiteralModel,
-    EntityEmbeddingModel,
     EntityRelationEmbeddingModel,
     ERModel,
     MockModel,


### PR DESCRIPTION
As a follow-up to #521, this PR re-implements NTN using the new style model. Because of the much more efficient matrix multiplication, NTN was one of the major improvements for new style models. This PR also removes the now unused EntityEmbeddingModel base class