### PR TITLE
🔧🔮 Add helper function to predict scores for triples

### DIFF
--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -36,10 +36,12 @@ model:
 >>> model = result.model
 >>> # Predict tails
 >>> predicted_tails_df = predict.get_tail_prediction_df(
-...     model, 'brazil', 'intergovorgs', triples_factory=result.training)
+...     model, 'brazil', 'intergovorgs', triples_factory=result.training,
+... )
 >>> # Predict relations
 >>> predicted_relations_df = predict.get_relation_prediction_df(
-...     model, 'brazil', 'uk', triples_factory=result.training)
+...     model, 'brazil', 'uk', triples_factory=result.training,
+... )
 >>> # Predict heads
 >>> predicted_heads_df = predict.get_head_prediction_df(model, 'conferences', 'brazil', triples_factory=result.training)
 >>> # Score all triples (memory intensive)
@@ -47,7 +49,9 @@ model:
 >>> # Score top K triples
 >>> top_k_predictions_df = predict.get_all_prediction_df(model, k=150, triples_factory=result.training)
 >>> # Score training triples
->>> score_df = predict.predict_triples_df(model=model, triples=result.training.mapped_triples, triples_factory=result.training)
+>>> score_df = predict.predict_triples_df(
+...     model=model, triples=result.training.mapped_triples, triples_factory=result.training,
+... )
 >>> # save the model
 >>> result.save_to_directory('doctests/nations_rotate')
 

--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -18,6 +18,7 @@ After training a model, there are four high-level interfaces for making predicti
 2. :func:`pykeen.models.predict.get_relation_prediction_df` for a given head/tail pair
 3. :func:`pykeen.models.predict.get_head_prediction_df` for a given relation/tail pair
 4. :func:`pykeen.models.predict.get_all_prediction_df` for prioritizing links
+5. :func:`pykeen.models.predict.predict_triples` for computing scores for explicitly provided triples
 
 Scientifically, :func:`pykeen.models.predict.get_all_prediction_df` is the most interesting in a scenario where
 predictions could be tested and validated experimentally.
@@ -29,19 +30,22 @@ which will already be in memory. Each of the high-level interfaces are exposed t
 model:
 
 >>> from pykeen.pipeline import pipeline
+>>> from pykeen.models import predict
 >>> # Run the pipeline
 >>> result = pipeline(dataset='Nations', model='RotatE')
 >>> model = result.model
 >>> # Predict tails
->>> predicted_tails_df = model.get_tail_prediction_df('brazil', 'intergovorgs', triples_factory=result.training)
+>>> predicted_tails_df = predict.get_tail_prediction_df(model, 'brazil', 'intergovorgs', triples_factory=result.training)
 >>> # Predict relations
->>> predicted_relations_df = model.get_relation_prediction_df('brazil', 'uk', triples_factory=result.training)
+>>> predicted_relations_df = predict.get_relation_prediction_df(model, 'brazil', 'uk', triples_factory=result.training)
 >>> # Predict heads
->>> predicted_heads_df = model.get_head_prediction_df('conferences', 'brazil', triples_factory=result.training)
+>>> predicted_heads_df = predict.get_head_prediction_df(model, 'conferences', 'brazil', triples_factory=result.training)
 >>> # Score all triples (memory intensive)
->>> predictions_df = model.get_all_prediction_df(triples_factory=result.training)
+>>> predictions_df = predict.get_all_prediction_df(model, triples_factory=result.training)
 >>> # Score top K triples
->>> top_k_predictions_df = model.get_all_prediction_df(k=150, triples_factory=result.training)
+>>> top_k_predictions_df = predict.get_all_prediction_df(model, k=150, triples_factory=result.training)
+>>> # Score training triples
+>>> score_df = predict.predict_triples(model=model, triples=result.training.mapped_triples, triples_factory=result.training)
 >>> # save the model
 >>> result.save_to_directory('doctests/nations_rotate')
 

--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -35,9 +35,11 @@ model:
 >>> result = pipeline(dataset='Nations', model='RotatE')
 >>> model = result.model
 >>> # Predict tails
->>> predicted_tails_df = predict.get_tail_prediction_df(model, 'brazil', 'intergovorgs', triples_factory=result.training)
+>>> predicted_tails_df = predict.get_tail_prediction_df(
+...     model, 'brazil', 'intergovorgs', triples_factory=result.training)
 >>> # Predict relations
->>> predicted_relations_df = predict.get_relation_prediction_df(model, 'brazil', 'uk', triples_factory=result.training)
+>>> predicted_relations_df = predict.get_relation_prediction_df(
+...     model, 'brazil', 'uk', triples_factory=result.training)
 >>> # Predict heads
 >>> predicted_heads_df = predict.get_head_prediction_df(model, 'conferences', 'brazil', triples_factory=result.training)
 >>> # Score all triples (memory intensive)

--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -33,6 +33,8 @@ model:
 >>> from pykeen.models import predict
 >>> # Run the pipeline
 >>> result = pipeline(dataset='Nations', model='RotatE')
+>>> # save the model
+>>> result.save_to_directory('doctests/nations_rotate')
 >>> model = result.model
 >>> # Predict tails
 >>> predicted_tails_df = predict.get_tail_prediction_df(
@@ -48,12 +50,12 @@ model:
 >>> predictions_df = predict.get_all_prediction_df(model, triples_factory=result.training)
 >>> # Score top K triples
 >>> top_k_predictions_df = predict.get_all_prediction_df(model, k=150, triples_factory=result.training)
->>> # Score training triples
+>>> # Score a given list of triples
 >>> score_df = predict.predict_triples_df(
-...     model=model, triples=result.training.mapped_triples, triples_factory=result.training,
+...     model=model,
+...     triples=[('brazil', 'conferences', 'uk'), ('brazil', 'intergovorgs', 'uk')],
+...     triples_factory=result.training,
 ... )
->>> # save the model
->>> result.save_to_directory('doctests/nations_rotate')
 
 Loading a Model
 ~~~~~~~~~~~~~~~

--- a/docs/source/tutorial/making_predictions.rst
+++ b/docs/source/tutorial/making_predictions.rst
@@ -45,7 +45,7 @@ model:
 >>> # Score top K triples
 >>> top_k_predictions_df = predict.get_all_prediction_df(model, k=150, triples_factory=result.training)
 >>> # Score training triples
->>> score_df = predict.predict_triples(model=model, triples=result.training.mapped_triples, triples_factory=result.training)
+>>> score_df = predict.predict_triples_df(model=model, triples=result.training.mapped_triples, triples_factory=result.training)
 >>> # save the model
 >>> result.save_to_directory('doctests/nations_rotate')
 

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -561,7 +561,11 @@ def predict_triples(
     >>> from pykeen.pipeline import pipeline
     >>> result = pipeline(dataset="nations", model="TransE")
     >>> from pykeen.models.predict import predict_triples
-    >>> df = predict_triples(model=result.model, triples=result.training.mapped_triples, triples_factory=result.training)
+    >>> df = predict_triples(
+    ...     model=result.model,
+    ...     triples=result.training.mapped_triples,
+    ...     triples_factory=result.training,
+    ... )
 
     :param model:
         The model.

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -13,6 +13,7 @@ import torch
 from .base import Model
 from ..triples import CoreTriplesFactory, TriplesFactory
 from ..typing import LabeledTriples, MappedTriples, ScorePack
+from ..utils import is_cuda_oom_error
 
 __all__ = [
     'predict',
@@ -21,8 +22,6 @@ __all__ = [
     'get_relation_prediction_df',
     'get_tail_prediction_df',
 ]
-
-from ..utils import is_cuda_oom_error
 
 logger = logging.getLogger(__name__)
 

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -550,9 +550,9 @@ def _predict_triples(
 
 
 def predict_triples_df(
-    *,
     model: Model,
-    triples: Union[MappedTriples, LabeledTriples],
+    *,
+    triples: Union[None, MappedTriples, LabeledTriples],
     triples_factory: Optional[CoreTriplesFactory] = None,
     batch_size: Optional[int] = None,
 ) -> pd.DataFrame:
@@ -572,7 +572,8 @@ def predict_triples_df(
     :param model:
         The model.
     :param triples: shape: (num_triples, 3)
-        The triples, either label-based or ID-based.
+        The triples, either label-based or ID-based. If None, a triples factory has to be provided, and its triples will
+        be used.
     :param triples_factory:
         The triples factory. Must be given if triples are label-based. If provided and triples are ID-based, add labels
         to result.
@@ -585,6 +586,12 @@ def predict_triples_df(
     :raises ValueError:
         If label-based triples have been provided, but the triples factory does not provide a mapping.
     """
+    if triples is None:
+        if triples_factory is None:
+            raise ValueError("If no triples are provided, a triples_factory must be provided.")
+
+        triples = triples_factory.mapped_triples
+
     if not torch.is_tensor(triples) or triples.dtype != torch.long:
         if triples_factory is None or not isinstance(triples_factory, TriplesFactory):
             raise ValueError("If triples are not ID-based, a triples_factory must be provided and label-based.")

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -552,12 +552,17 @@ def predict_triples(
     *,
     model: Model,
     triples: Union[MappedTriples, LabeledTriples],
-    # we only need the labeling component
-    triples_factory: Optional[TriplesFactory] = None,
+    triples_factory: Optional[CoreTriplesFactory] = None,
     batch_size: Optional[int] = None,
 ) -> pd.DataFrame:
     """
     Predict on labeled or mapped triples.
+
+    Example:
+    >>> from pykeen.pipeline import pipeline
+    >>> result = pipeline(dataset="nations", model="TransE")
+    >>> from pykeen.models.predict import predict_triples
+    >>> df = predict_triples(model=result.model, triples=result.training.mapped_triples, triples_factory=result.training)
 
     :param model:
         The model.
@@ -569,12 +574,12 @@ def predict_triples(
     :param batch_size:
         The batch size to use. Use None for automatic memory optimization.
 
-    :return: columns: head | relation | tail |
+    :return: columns: head_id | relation_id | tail_id | score | *
         A dataframe with one row per triple.
     """
     if not torch.is_tensor(triples) or triples.dtype != torch.long:
-        if triples_factory is None:
-            raise ValueError("If triples are not ID-based, a triples_factory must be provided.")
+        if triples_factory is None or not isinstance(triples_factory, TriplesFactory):
+            raise ValueError("If triples are not ID-based, a triples_factory must be provided and label-based.")
 
         # convert to ID-based
         triples = triples_factory.map_triples(triples)

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -12,6 +12,7 @@ import torch
 
 from .base import Model
 from ..triples import CoreTriplesFactory, TriplesFactory
+from ..triples.utils import tensor_to_df
 from ..typing import LabeledTriples, MappedTriples, ScorePack
 from ..utils import is_cuda_oom_error
 
@@ -594,5 +595,8 @@ def predict_triples_df(
     assert torch.is_tensor(triples)
 
     scores = _predict_triples(model=model, mapped_triples=triples, batch_size=batch_size).squeeze(dim=1)
+
+    if triples_factory is None:
+        return tensor_to_df(tensor=triples, score=scores)
 
     return triples_factory.tensor_to_df(tensor=triples, score=scores)

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -579,6 +579,9 @@ def predict_triples(
 
     :return: columns: head_id | relation_id | tail_id | score | *
         A dataframe with one row per triple.
+
+    :raise ValueError:
+        If label-based triples have been provided, but the triples factory does not provide a mapping.
     """
     if not torch.is_tensor(triples) or triples.dtype != torch.long:
         if triples_factory is None or not isinstance(triples_factory, TriplesFactory):

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -17,6 +17,7 @@ from ..utils import is_cuda_oom_error
 
 __all__ = [
     'predict',
+    'predict_triples_df',
     'get_all_prediction_df',
     'get_head_prediction_df',
     'get_relation_prediction_df',
@@ -547,7 +548,7 @@ def _predict_triples(
         raise error
 
 
-def predict_triples(
+def predict_triples_df(
     *,
     model: Model,
     triples: Union[MappedTriples, LabeledTriples],
@@ -560,8 +561,8 @@ def predict_triples(
     Example:
     >>> from pykeen.pipeline import pipeline
     >>> result = pipeline(dataset="nations", model="TransE")
-    >>> from pykeen.models.predict import predict_triples
-    >>> df = predict_triples(
+    >>> from pykeen.models.predict import predict_triples_df
+    >>> df = predict_triples_df(
     ...     model=result.model,
     ...     triples=result.training.mapped_triples,
     ...     triples_factory=result.training,

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -581,7 +581,7 @@ def predict_triples_df(
     :return: columns: head_id | relation_id | tail_id | score | *
         A dataframe with one row per triple.
 
-    :raise ValueError:
+    :raises ValueError:
         If label-based triples have been provided, but the triples factory does not provide a mapping.
     """
     if not torch.is_tensor(triples) or triples.dtype != torch.long:

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -599,7 +599,7 @@ def predict_triples_df(
 
         triples = triples_factory.mapped_triples
 
-    if not torch.is_tensor(triples) or triples.dtype != torch.long:
+    if not isinstance(triples, torch.Tensor) or triples.dtype != torch.long:
         if triples_factory is None or not isinstance(triples_factory, TriplesFactory):
             raise ValueError("If triples are not ID-based, a triples_factory must be provided and label-based.")
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -167,8 +167,8 @@ class Labeling:
     def __post_init__(self):
         """Precompute inverse mappings."""
         self.id_to_label = invert_mapping(mapping=self.label_to_id)
-        self._vectorized_mapper = np.vectorize(self.label_to_id.get)
-        self._vectorized_labeler = np.vectorize(self.id_to_label.get)
+        self._vectorized_mapper = np.vectorize(self.label_to_id.get, otypes=[int])
+        self._vectorized_labeler = np.vectorize(self.id_to_label.get, otypes=[str])
 
     def label(
         self,

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1002,6 +1002,14 @@ class TriplesFactory(CoreTriplesFactory):
             invert_relation_selection=invert_relation_selection,
         ).with_labels(entity_to_id=self.entity_to_id, relation_to_id=self.relation_to_id)
 
+    def map_triples(self, triples: LabeledTriples) -> MappedTriples:
+        """Convert label-based triples to ID-based triples."""
+        return _map_triples_elements_to_ids(
+            triples=triples,
+            entity_to_id=self.entity_to_id,
+            relation_to_id=self.relation_to_id,
+        )
+
 
 def cat_triples(*triples_factories: CoreTriplesFactory) -> MappedTriples:
     """Concatenate several triples factories."""

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -15,7 +15,7 @@ import torch
 
 from .instances import Instances, LCWAInstances, SLCWAInstances
 from .splitting import split
-from .utils import get_entities, get_relations, load_triples
+from .utils import TRIPLES_DF_COLUMNS, get_entities, get_relations, load_triples, tensor_to_df
 from ..typing import EntityMapping, LabeledTriples, MappedTriples, RelationMapping, TorchRandomHint
 from ..utils import compact_mapping, format_relative_comparison, invert_mapping, torch_is_in_1d
 
@@ -33,7 +33,6 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 INVERSE_SUFFIX = '_inverse'
-TRIPLES_DF_COLUMNS = ('head_id', 'head_label', 'relation_id', 'relation_label', 'tail_id', 'tail_label')
 
 
 def create_entity_mapping(triples: LabeledTriples) -> EntityMapping:
@@ -531,32 +530,7 @@ class CoreTriplesFactory:
         :return:
             A dataframe with n rows, and 6 + len(kwargs) columns.
         """
-        # Input validation
-        additional_columns = set(kwargs.keys())
-        forbidden = additional_columns.intersection(TRIPLES_DF_COLUMNS)
-        if len(forbidden) > 0:
-            raise ValueError(
-                f'The key-words for additional arguments must not be in {TRIPLES_DF_COLUMNS}, but {forbidden} were '
-                f'used.',
-            )
-
-        # convert to numpy
-        tensor = tensor.cpu().numpy()
-        data = dict(zip(['head_id', 'relation_id', 'tail_id'], tensor.T))
-
-        # Additional columns
-        for key, values in kwargs.items():
-            # convert PyTorch tensors to numpy
-            if isinstance(values, torch.Tensor):
-                values = values.cpu().numpy()
-            data[key] = values
-
-        # convert to dataframe
-        rv = pd.DataFrame(data=data)
-
-        # Re-order columns
-        columns = list(TRIPLES_DF_COLUMNS[::2]) + sorted(set(rv.columns).difference(TRIPLES_DF_COLUMNS))
-        return rv.loc[:, columns]
+        return tensor_to_df(tensor=tensor, **kwargs)
 
     def new_with_restriction(
         self,

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -6,6 +6,7 @@ import pathlib
 from typing import Callable, Mapping, Optional, Sequence, Set, TextIO, Union
 
 import numpy as np
+import pandas
 import torch
 from pkg_resources import iter_entry_points
 
@@ -16,6 +17,8 @@ __all__ = [
     'get_entities',
     'get_relations',
 ]
+
+TRIPLES_DF_COLUMNS = ('head_id', 'head_label', 'relation_id', 'relation_label', 'tail_id', 'tail_label')
 
 
 def _load_importers(group_subname: str) -> Mapping[str, Callable[[str], LabeledTriples]]:
@@ -90,3 +93,49 @@ def get_entities(triples: torch.LongTensor) -> Set[int]:
 def get_relations(triples: torch.LongTensor) -> Set[int]:
     """Get all relations from the triples."""
     return set(triples[:, 1].tolist())
+
+
+def tensor_to_df(
+    tensor: torch.LongTensor,
+    **kwargs: Union[torch.Tensor, np.ndarray, Sequence],
+) -> pandas.DataFrame:
+    """Take a tensor of triples and make a pandas dataframe with labels.
+
+    :param tensor: shape: (n, 3)
+        The triples, ID-based and in format (head_id, relation_id, tail_id).
+    :param kwargs:
+        Any additional number of columns. Each column needs to be of shape (n,). Reserved column names:
+        {"head_id", "head_label", "relation_id", "relation_label", "tail_id", "tail_label"}.
+
+    :return:
+        A dataframe with n rows, and 3 + len(kwargs) columns.
+
+    :raises ValueError:
+        If a reserved column name appears in kwargs.
+    """
+    # Input validation
+    additional_columns = set(kwargs.keys())
+    forbidden = additional_columns.intersection(TRIPLES_DF_COLUMNS)
+    if len(forbidden) > 0:
+        raise ValueError(
+            f'The key-words for additional arguments must not be in {TRIPLES_DF_COLUMNS}, but {forbidden} were '
+            f'used.',
+        )
+
+    # convert to numpy
+    tensor = tensor.cpu().numpy()
+    data = dict(zip(['head_id', 'relation_id', 'tail_id'], tensor.T))
+
+    # Additional columns
+    for key, values in kwargs.items():
+        # convert PyTorch tensors to numpy
+        if isinstance(values, torch.Tensor):
+            values = values.cpu().numpy()
+        data[key] = values
+
+    # convert to dataframe
+    rv = pandas.DataFrame(data=data)
+
+    # Re-order columns
+    columns = list(TRIPLES_DF_COLUMNS[::2]) + sorted(set(rv.columns).difference(TRIPLES_DF_COLUMNS))
+    return rv.loc[:, columns]

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -16,6 +16,7 @@ __all__ = [
     'load_triples',
     'get_entities',
     'get_relations',
+    'tensor_to_df',
 ]
 
 TRIPLES_DF_COLUMNS = ('head_id', 'head_label', 'relation_id', 'relation_label', 'tail_id', 'tail_label')

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,7 +14,7 @@ from pykeen.datasets import EagerDataset, Nations
 from pykeen.models import ERModel, Model
 from pykeen.models.predict import (
     get_all_prediction_df, get_head_prediction_df, get_relation_prediction_df,
-    get_tail_prediction_df, predict_triples,
+    get_tail_prediction_df, predict_triples_df,
 )
 from pykeen.models.resolve import DimensionError, make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
@@ -173,7 +173,7 @@ class TestPipeline(unittest.TestCase):
 
     def test_predict_triples(self):
         """Test scoring explicitly provided triples."""
-        df = predict_triples(
+        df = predict_triples_df(
             model=self.model,
             triples=self.testing_mapped_triples,
             triples_factory=self.dataset.training,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,6 +5,7 @@
 import tempfile
 import unittest
 
+import pandas
 import pandas as pd
 import torch
 
@@ -13,7 +14,7 @@ from pykeen.datasets import EagerDataset, Nations
 from pykeen.models import ERModel, Model
 from pykeen.models.predict import (
     get_all_prediction_df, get_head_prediction_df, get_relation_prediction_df,
-    get_tail_prediction_df,
+    get_tail_prediction_df, predict_triples,
 )
 from pykeen.models.resolve import DimensionError, make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
@@ -169,6 +170,17 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(possible, len(all_df.index))
         self.assertEqual(self.dataset.training.num_triples, all_df['in_training'].sum())
         self.assertEqual(self.testing_mapped_triples.shape[0], all_df['in_testing'].sum())
+
+    def test_predict_triples(self):
+        """Test scoring explicitly provided triples."""
+        df = predict_triples(
+            model=self.model,
+            triples=self.testing_mapped_triples,
+            triples_factory=self.dataset.training,
+        )
+        assert isinstance(df, pandas.DataFrame)
+        assert df.shape[0] == self.testing_mapped_triples.shape[0]
+        assert {"head_id", "relation_id", "tail_id", "score"}.issubset(df.columns)
 
 
 class TestPipelineTriples(unittest.TestCase):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -173,14 +173,15 @@ class TestPipeline(unittest.TestCase):
 
     def test_predict_triples(self):
         """Test scoring explicitly provided triples."""
-        df = predict_triples_df(
-            model=self.model,
-            triples=self.testing_mapped_triples,
-            triples_factory=self.dataset.training,
-        )
-        assert isinstance(df, pandas.DataFrame)
-        assert df.shape[0] == self.testing_mapped_triples.shape[0]
-        assert {"head_id", "relation_id", "tail_id", "score"}.issubset(df.columns)
+        for triples_factory in (None, self.dataset.training):
+            df = predict_triples_df(
+                model=self.model,
+                triples=self.testing_mapped_triples,
+                triples_factory=triples_factory,
+            )
+            assert isinstance(df, pandas.DataFrame)
+            assert df.shape[0] == self.testing_mapped_triples.shape[0]
+            assert {"head_id", "relation_id", "tail_id", "score"}.issubset(df.columns)
 
 
 class TestPipelineTriples(unittest.TestCase):

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -20,8 +20,8 @@ from pykeen.triples.splitting import (
     _tf_cleanup_randomized,
     get_absolute_split_sizes, normalize_ratios,
 )
-from pykeen.triples.triples_factory import INVERSE_SUFFIX, TRIPLES_DF_COLUMNS, _map_triples_elements_to_ids
-from pykeen.triples.utils import get_entities, get_relations, load_triples
+from pykeen.triples.triples_factory import INVERSE_SUFFIX, _map_triples_elements_to_ids
+from pykeen.triples.utils import TRIPLES_DF_COLUMNS, get_entities, get_relations, load_triples
 from tests.constants import RESOURCES
 
 triples = np.array(


### PR DESCRIPTION
This PR adds a function `predict_triples` similar to existing `predict_*` methods, which allows to predict scores for explicitly provided triples. It also adds some convenience methods to allow using labeled triples in conjunction with a triples factory. If a triples factory is provided, and it provides labels, these are also added to the result dataframe.

It also added some basic automatic batch size optimization, which does not come close to what we did for training / evaluation. Thus, it may be nice to merge them at some point.