### PR TITLE
💪 💃🏼 Better logging on missing entries in `model_kwargs` in the `pipeline()`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ install_requires =
     more_click
     pystow>=0.1.5
     docdata
-    class_resolver>=0.0.12
+    class_resolver>=0.0.13
 
 zip_safe = false
 include_package_data = True

--- a/src/pykeen/pipeline/exc.py
+++ b/src/pykeen/pipeline/exc.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+"""Exceptions for the pipeline."""
+
+from textwrap import dedent
+
+from class_resolver import KeywordArgumentError
+
+__all__ = [
+    'ModelArgumentError',
+]
+
+
+class ModelArgumentError(TypeError):
+    """Thrown when the pipeline is unable to build a model because of a missing kwarg."""
+
+    def __init__(self, e: KeywordArgumentError):
+        self.e = e
+
+    def __str__(self) -> str:
+        return dedent(f"""\
+        {self.e}
+
+        Please specify the '{self.e.name}' as a key in the 'model_kwargs' dictionary passed to pipeline().
+        """)


### PR DESCRIPTION
References #544 

Since the `pipeline()` function is a bit magical with respect to how it instantiates things, the logging is a bit insufficient (as demonstrated in #544).

This PR leverages new functionality in the `class_resolver` to intercept an exception and wrap it with more information for the user to fix their code.

## Demo

```python
from pykeen.pipeline import pipeline

if __name__ == '__main__':
    result = pipeline(
        model='RGCN',
        dataset='countries'
    )
```

Before this PR, this code produced the following traceback:

```python-traceback
Traceback (most recent call last):
  File "/Users/cthoyt/dev/class_resolver/src/class_resolver/api.py", line 212, in make
    return cls(**(pos_kwargs or {}), **kwargs)  # type: ignore
TypeError: __init__() missing 1 required keyword-only argument: 'interaction'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/cthoyt/dev/pykeen/scratch/test.py", line 4, in <module>
    result = pipeline(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/pipeline/api.py", line 920, in pipeline
    model_instance = _build_model_helper(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/pipeline/api.py", line 643, in _build_model_helper
    return model_resolver.make(
  File "/Users/cthoyt/dev/class_resolver/src/class_resolver/api.py", line 215, in make
    raise KeywordArgumentError(cls, e.args[0])
class_resolver.api.KeywordArgumentError: RGCN: __init__() missing 1 required keyword-only argument: 'interaction'
```

After this PR, this code produces the following traceback:

```python-traceback
Traceback (most recent call last):
  File "/Users/cthoyt/dev/class_resolver/src/class_resolver/api.py", line 212, in make
    return cls(**(pos_kwargs or {}), **kwargs)  # type: ignore
TypeError: __init__() missing 1 required keyword-only argument: 'interaction'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/cthoyt/dev/pykeen/src/pykeen/pipeline/api.py", line 646, in _build_model_helper
    return model_resolver.make(
  File "/Users/cthoyt/dev/class_resolver/src/class_resolver/api.py", line 215, in make
    raise KeywordArgumentError(cls, e.args[0])
class_resolver.api.KeywordArgumentError: RGCN: __init__() missing 1 required keyword-only argument: 'interaction'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/cthoyt/dev/pykeen/scratch/test.py", line 4, in <module>
    result = pipeline(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/pipeline/api.py", line 925, in pipeline
    model_instance = _build_model_helper(
  File "/Users/cthoyt/dev/pykeen/src/pykeen/pipeline/api.py", line 653, in _build_model_helper
    raise ModelArgumentError(e)
pykeen.pipeline.exc.ModelArgumentError: RGCN: __init__() missing 1 required keyword-only argument: 'interaction'

Please specify the 'interaction' as a key in the 'model_kwargs' dictionary passed to pipeline().
```

Note that there's one extra level of information that's PyKEEN specific