### PR TITLE
🐺 🏆 Report success to result tracker

### DIFF
--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -62,7 +62,7 @@ class Objective:
     training_loop: Type[TrainingLoop]  # 6.
     stopper: Type[Stopper]  # 7.
     evaluator: Type[Evaluator]  # 8.
-    result_tracker: Type[ResultTracker]  # 9.
+    result_tracker: Union[ResultTracker, Type[ResultTracker]]  # 9.
     metric: str
 
     # 1. Dataset
@@ -715,7 +715,9 @@ def hpo_pipeline(
     logger.info('Filter validation triples when testing: %s', filter_validation_when_testing)
 
     # 9. Tracking
-    result_tracker_cls: Type[ResultTracker] = tracker_resolver.lookup(result_tracker)
+    result_tracker: Union[ResultTracker, Type[ResultTracker]]
+    if not isinstance(result_tracker, ResultTracker):
+        result_tracker = tracker_resolver.lookup(result_tracker)
 
     objective = Objective(
         # 1. Dataset
@@ -763,7 +765,7 @@ def hpo_pipeline(
         evaluation_kwargs=evaluation_kwargs,
         filter_validation_when_testing=filter_validation_when_testing,
         # 9. Tracker
-        result_tracker=result_tracker_cls,
+        result_tracker=result_tracker,
         result_tracker_kwargs=result_tracker_kwargs,
         # Optuna Misc.
         metric=metric,

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -262,7 +262,7 @@ class Objective:
             )
         except (MemoryError, RuntimeError) as e:
             # close run in result tracker
-            result_tracker.end_run()
+            result_tracker.end_run(success=False)
 
             trial.set_user_attr('failure', str(e))
             # Will trigger Optuna to set the state of the trial as failed

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -715,7 +715,6 @@ def hpo_pipeline(
     logger.info('Filter validation triples when testing: %s', filter_validation_when_testing)
 
     # 9. Tracking
-    result_tracker
     if not isinstance(result_tracker, ResultTracker):
         result_tracker = tracker_resolver.lookup(result_tracker)
 

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -210,6 +210,9 @@ class Objective:
         if self.stopper is not None and issubclass(self.stopper, EarlyStopper):
             self._update_stopper_callbacks(_stopper_kwargs, trial)
 
+        # create result tracker to allow to gracefully close failed trials
+        result_tracker = tracker_resolver.make(query=self.result_tracker, pos_kwargs=self.result_tracker_kwargs)
+
         try:
             result = pipeline(
                 # 1. Dataset
@@ -251,13 +254,16 @@ class Objective:
                 evaluation_kwargs=self.evaluation_kwargs,
                 filter_validation_when_testing=self.filter_validation_when_testing,
                 # 9. Tracker
-                result_tracker=self.result_tracker,
-                result_tracker_kwargs=self.result_tracker_kwargs,
+                result_tracker=result_tracker,
+                result_tracker_kwargs=None,
                 # Misc.
                 use_testing_data=False,  # use validation set during HPO!
                 device=self.device,
             )
         except (MemoryError, RuntimeError) as e:
+            # close run in result tracker
+            result_tracker.end_run()
+
             trial.set_user_attr('failure', str(e))
             # Will trigger Optuna to set the state of the trial as failed
             return None

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -715,7 +715,7 @@ def hpo_pipeline(
     logger.info('Filter validation triples when testing: %s', filter_validation_when_testing)
 
     # 9. Tracking
-    result_tracker: Union[ResultTracker, Type[ResultTracker]]
+    result_tracker
     if not isinstance(result_tracker, ResultTracker):
         result_tracker = tracker_resolver.lookup(result_tracker)
 

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -38,10 +38,13 @@ class ResultTracker:
         :param prefix: An optional prefix to prepend to every key in metrics.
         """
 
-    def end_run(self) -> None:
+    def end_run(self, success: bool = True) -> None:
         """End a run.
 
         HAS to be called after the experiment is finished.
+
+        :param success:
+            Can be used to signal failed runs. May be ignored.
         """
 
 

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -122,6 +122,8 @@ class ConsoleResultTracker(ResultTracker):
             if not self.metric_filter or self.metric_filter.match(key):
                 self.write(f"Parameter: {key} = {value}")
 
-    def end_run(self) -> None:  # noqa: D102
+    def end_run(self, success: bool = True) -> None:  # noqa: D102
+        if not success:
+            self.write("Run failed.")
         if self.start_end_run:
             self.write("Finished run.")

--- a/src/pykeen/trackers/file.py
+++ b/src/pykeen/trackers/file.py
@@ -72,7 +72,7 @@ class FileResultTracker(ResultTracker):
         path.parent.mkdir(exist_ok=True, parents=True)
         self.file = path.open(mode="w", newline="", encoding="utf8")
 
-    def end_run(self) -> None:  # noqa: D102
+    def end_run(self, success: bool = True) -> None:  # noqa: D102
         self.file.close()
 
 

--- a/src/pykeen/trackers/mlflow.py
+++ b/src/pykeen/trackers/mlflow.py
@@ -4,8 +4,6 @@
 
 from typing import Any, Dict, Mapping, Optional
 
-from mlflow.entities import RunStatus
-
 from .base import ResultTracker
 from ..utils import flatten_dictionary
 
@@ -68,5 +66,5 @@ class MLFlowResultTracker(ResultTracker):
         self.mlflow.log_params(params=params)
 
     def end_run(self, success: bool = True) -> None:  # noqa: D102
-        status = RunStatus.to_string(RunStatus.FINISHED if success else RunStatus.FAILED)
-        self.mlflow.end_run(status=status)
+        status = self.mlflow.entities.RunStatus.FINISHED if success else self.mlflow.entities.RunStatus.FAILED
+        self.mlflow.end_run(status=self.mlflow.entities.RunStatus.to_string(status))

--- a/src/pykeen/trackers/mlflow.py
+++ b/src/pykeen/trackers/mlflow.py
@@ -68,4 +68,5 @@ class MLFlowResultTracker(ResultTracker):
         self.mlflow.log_params(params=params)
 
     def end_run(self, success: bool = True) -> None:  # noqa: D102
-        self.mlflow.end_run(status=RunStatus.FINISHED if success else RunStatus.FAILED)
+        status = RunStatus.to_string(RunStatus.FINISHED) if success else RunStatus.to_string(RunStatus.FAILED)
+        self.mlflow.end_run(status=status)

--- a/src/pykeen/trackers/mlflow.py
+++ b/src/pykeen/trackers/mlflow.py
@@ -4,6 +4,8 @@
 
 from typing import Any, Dict, Mapping, Optional
 
+from mlflow.entities import RunStatus
+
 from .base import ResultTracker
 from ..utils import flatten_dictionary
 
@@ -65,5 +67,5 @@ class MLFlowResultTracker(ResultTracker):
         params = flatten_dictionary(dictionary=params, prefix=prefix)
         self.mlflow.log_params(params=params)
 
-    def end_run(self) -> None:  # noqa: D102
-        self.mlflow.end_run()
+    def end_run(self, success: bool = True) -> None:  # noqa: D102
+        self.mlflow.end_run(status=RunStatus.FINISHED if success else RunStatus.FAILED)

--- a/src/pykeen/trackers/mlflow.py
+++ b/src/pykeen/trackers/mlflow.py
@@ -68,5 +68,5 @@ class MLFlowResultTracker(ResultTracker):
         self.mlflow.log_params(params=params)
 
     def end_run(self, success: bool = True) -> None:  # noqa: D102
-        status = RunStatus.to_string(RunStatus.FINISHED) if success else RunStatus.to_string(RunStatus.FAILED)
+        status = RunStatus.to_string(RunStatus.FINISHED if success else RunStatus.FAILED)
         self.mlflow.end_run(status=status)

--- a/src/pykeen/trackers/tensorboard.py
+++ b/src/pykeen/trackers/tensorboard.py
@@ -70,6 +70,6 @@ class TensorBoardResultTracker(ResultTracker):
             self.writer.add_text(tag=str(key), text_string=str(value))
         self.writer.flush()
 
-    def end_run(self) -> None:  # noqa: D102
+    def end_run(self, success: bool = True) -> None:  # noqa: D102
         self.writer.flush()
         self.writer.close()


### PR DESCRIPTION
When running the HPO with mlflow result tracker, failing trials do not gracefully close the active run. Thus, an exception occurs:
```python-traceback
[W 2021-07-26 16:05:42,983] Trial 1 failed because of the following error: Exception('Run with UUID a3323818891c4726bdec4e192058c386 is already active. To start a new run, first end the current run with mlflow.end_run(). To start a nested run, call start_run with nested=True')
Traceback (most recent call last):
  File "ROOT/venv/lib/python3.8/site-packages/optuna/_optimize.py", line 216, in _run_trial
    value_or_values = func(trial)
  File "ROOT/venv/lib/python3.8/site-packages/pykeen/hpo/hpo.py", line 214, in __call__
    result = pipeline(
  File "ROOT/venv/lib/python3.8/site-packages/pykeen/pipeline/api.py", line 867, in pipeline
    _result_tracker.start_run(run_name=title)
  File "ROOT/venv/lib/python3.8/site-packages/pykeen/trackers/mlflow.py", line 51, in start_run
    self.mlflow.start_run(run_name=run_name)
  File "ROOT/venv/lib/python3.8/site-packages/mlflow/tracking/fluent.py", line 187, in start_run
    raise Exception(
Exception: Run with UUID a3323818891c4726bdec4e192058c386 is already active. To start a new run, first end the current run with mlflow.end_run(). To start a nested run, call start_run with nested=True
Traceback (most recent call last):
  File "ROOT/src/main.py", line 28, in <module>
    main()
  File "ROOT/src/main.py", line 9, in main
    result = hpo_pipeline(
  File "ROOT/venv/lib/python3.8/site-packages/pykeen/hpo/hpo.py", line 770, in hpo_pipeline
    study.optimize(
  File "ROOT/venv/lib/python3.8/site-packages/optuna/study.py", line 401, in optimize
    _optimize(
  File "ROOT/venv/lib/python3.8/site-packages/optuna/_optimize.py", line 65, in _optimize
    _optimize_sequential(
  File "ROOT/venv/lib/python3.8/site-packages/optuna/_optimize.py", line 162, in _optimize_sequential
    trial = _run_trial(study, func, catch)
  File "ROOT/venv/lib/python3.8/site-packages/optuna/_optimize.py", line 267, in _run_trial
    raise func_err
  File "ROOT/venv/lib/python3.8/site-packages/optuna/_optimize.py", line 216, in _run_trial
    value_or_values = func(trial)
  File "ROOT/venv/lib/python3.8/site-packages/pykeen/hpo/hpo.py", line 214, in __call__
    result = pipeline(
  File "ROOT/venv/lib/python3.8/site-packages/pykeen/pipeline/api.py", line 867, in pipeline
    _result_tracker.start_run(run_name=title)
  File "ROOT/venv/lib/python3.8/site-packages/pykeen/trackers/mlflow.py", line 51, in start_run
    self.mlflow.start_run(run_name=run_name)
  File "ROOT/venv/lib/python3.8/site-packages/mlflow/tracking/fluent.py", line 187, in start_run
    raise Exception(
Exception: Run with UUID a3323818891c4726bdec4e192058c386 is already active. To start a new run, first end the current run with mlflow.end_run(). To start a nested run, call start_run with nested=True
```

This PR aims to mitigate this by
1. creating a single result tracker instance for all HPO runs
2. adding a success flag to `end_run`. 

For now, only the console and mlflow tracker make use of the success flag, the others ignore it.