### PR TITLE
Add get_config method to Loss

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -541,6 +541,12 @@ class MarginRankingLoss(PairwiseLoss):
             neg_scores - pos_scores + self.margin,
         ))
 
+    def get_config(self) -> Mapping[str, Any]:  # noqa: D102
+        config = dict(super().get_config())
+        config["margin"] = self.margin
+        config["margin_activation"] = margin_activation_resolver.normalize_inst(self.margin_activation)
+        return config
+
 
 @parse_docdata
 class DoubleMarginLoss(PointwiseLoss):
@@ -761,6 +767,14 @@ class DoubleMarginLoss(PointwiseLoss):
             (1.0 - labels) * self.margin_activation(self.negative_margin + predictions),
         )
 
+    def get_config(self) -> Mapping[str, Any]:  # noqa: D102
+        config = dict(super().get_config())
+        config["positive_margin"] = self.positive_margin
+        config["negative_margin"] = self.negative_margin
+        config["positive_negative_balance"] = self.positive_weight
+        config["margin_activation"] = margin_activation_resolver.normalize_inst(self.margin_activation)
+        return config
+
 
 @parse_docdata
 class SoftplusLoss(PointwiseLoss):
@@ -964,6 +978,12 @@ class NSSALoss(SetwiseLoss):
 
         return loss
 
+    def get_config(self) -> Mapping[str, Any]:  # noqa: D102
+        config = dict(super().get_config())
+        config["adversarial_temperature"] = self.inverse_softmax_temperature
+        config["margin"] = self.margin
+        return config
+
 
 @parse_docdata
 class FocalLoss(PointwiseLoss):
@@ -1037,6 +1057,12 @@ class FocalLoss(PointwiseLoss):
             loss = alpha_t * loss
 
         return self._reduction_method(loss)
+
+    def get_config(self) -> Mapping[str, Any]:  # noqa: D102
+        config = dict(super().get_config())
+        config["gamma"] = self.gamma
+        config["alpha"] = self.alpha
+        return config
 
 
 loss_resolver = Resolver.from_subclasses(

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -321,13 +321,8 @@ class Loss(_Loss):
 
     def get_config(self) -> MutableMapping[str, Any]:
         """Return the configuration necessary to re-instantiate the module as a JSON-serializable dictionary."""
-        reduction_name = None
-        for key, value in _REDUCTION_METHODS.items():
-            if self._reduction_method is value:
-                reduction_name = key
-        assert reduction_name is not None
         return {
-            "reduction": reduction_name,
+            "reduction": self.reduction,
         }
 
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -150,7 +150,7 @@ triples $\mathcal{b}$ in the subset $\mathcal{B} \in 2^{2^{\mathcal{T}}}$.
 
 import logging
 from textwrap import dedent
-from typing import Any, ClassVar, Mapping, Optional, Set, Tuple
+from typing import Any, ClassVar, Mapping, MutableMapping, Optional, Set, Tuple
 
 import torch
 from class_resolver import Hint, Resolver
@@ -319,8 +319,8 @@ class Loss(_Loss):
         )
         return self(predictions, labels)
 
-    def get_config(self) -> Mapping[str, Any]:
-        """Return the configuration necessary to re-instantiate the module as dictionary."""
+    def get_config(self) -> MutableMapping[str, Any]:
+        """Return the configuration necessary to re-instantiate the module as a JSON-serializable dictionary."""
         reduction_name = None
         for key, value in _REDUCTION_METHODS.items():
             if self._reduction_method is value:
@@ -541,8 +541,8 @@ class MarginRankingLoss(PairwiseLoss):
             neg_scores - pos_scores + self.margin,
         ))
 
-    def get_config(self) -> Mapping[str, Any]:  # noqa: D102
-        config = dict(super().get_config())
+    def get_config(self) -> MutableMapping[str, Any]:  # noqa: D102
+        config = super().get_config()
         config["margin"] = self.margin
         config["margin_activation"] = margin_activation_resolver.normalize_inst(self.margin_activation)
         return config
@@ -767,8 +767,8 @@ class DoubleMarginLoss(PointwiseLoss):
             (1.0 - labels) * self.margin_activation(self.negative_margin + predictions),
         )
 
-    def get_config(self) -> Mapping[str, Any]:  # noqa: D102
-        config = dict(super().get_config())
+    def get_config(self) -> MutableMapping[str, Any]:  # noqa: D102
+        config = super().get_config()
         config["positive_margin"] = self.positive_margin
         config["negative_margin"] = self.negative_margin
         config["positive_negative_balance"] = self.positive_weight
@@ -978,8 +978,8 @@ class NSSALoss(SetwiseLoss):
 
         return loss
 
-    def get_config(self) -> Mapping[str, Any]:  # noqa: D102
-        config = dict(super().get_config())
+    def get_config(self) -> MutableMapping[str, Any]:  # noqa: D102
+        config = super().get_config()
         config["adversarial_temperature"] = self.inverse_softmax_temperature
         config["margin"] = self.margin
         return config
@@ -1058,8 +1058,8 @@ class FocalLoss(PointwiseLoss):
 
         return self._reduction_method(loss)
 
-    def get_config(self) -> Mapping[str, Any]:  # noqa: D102
-        config = dict(super().get_config())
+    def get_config(self) -> MutableMapping[str, Any]:  # noqa: D102
+        config = super().get_config()
         config["gamma"] = self.gamma
         config["alpha"] = self.alpha
         return config

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -319,6 +319,17 @@ class Loss(_Loss):
         )
         return self(predictions, labels)
 
+    def get_config(self) -> Mapping[str, Any]:
+        """Return the configuration necessary to re-instantiate the module as dictionary."""
+        reduction_name = None
+        for key, value in _REDUCTION_METHODS.items():
+            if self._reduction_method is value:
+                reduction_name = key
+        assert reduction_name is not None
+        return {
+            "reduction": reduction_name,
+        }
+
 
 class PointwiseLoss(Loss):
     """Pointwise loss functions compute an independent loss term for each triple-label pair."""

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -282,6 +282,25 @@ class LossTestCase(GenericTestCase[Loss]):
         # negative scores decreased compared to positive ones
         assert (negative_scores < positive_scores.unsqueeze(dim=1) - 1.0e-06).all()
 
+    def test_get_config(self):
+        """Test whether get_config allows re-instantiation."""
+        # re-instantiate from config
+        config = self.instance.get_config()
+        instance = self.cls(**config)
+
+        # check equivalent instance by equivalent loss values.
+        positive = torch.rand(self.batch_size, 1)
+        negative = torch.rand(self.batch_size, self.num_neg_per_pos)
+        first_loss = self.instance.process_slcwa_scores(
+            positive_scores=positive,
+            negative_scores=negative,
+        )
+        second_loss = instance.process_slcwa_scores(
+            positive_scores=positive,
+            negative_scores=negative,
+        )
+        assert torch.allclose(first_loss, second_loss)
+
 
 class PointwiseLossTestCase(LossTestCase):
     """Base unit test for label-based losses."""

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 """Test cases for PyKEEN."""
-
+import io
+import json
 import logging
 import os
 import pathlib
@@ -282,7 +283,7 @@ class LossTestCase(GenericTestCase[Loss]):
         # negative scores decreased compared to positive ones
         assert (negative_scores < positive_scores.unsqueeze(dim=1) - 1.0e-06).all()
 
-    def test_get_config(self):
+    def test_get_config_reinstantiation(self):
         """Test whether get_config allows re-instantiation."""
         # re-instantiate from config
         config = self.instance.get_config()
@@ -300,6 +301,12 @@ class LossTestCase(GenericTestCase[Loss]):
             negative_scores=negative,
         )
         assert torch.allclose(first_loss, second_loss)
+
+    def test_get_config_json(self):
+        """Test whether the configuration can be serialized to JSON."""
+        config = self.instance.get_config()
+        with io.StringIO() as mock_file:
+            json.dump(config, mock_file)
 
 
 class PointwiseLossTestCase(LossTestCase):


### PR DESCRIPTION
This PR adds a `get_config` method to `Loss` and its subclasses. The method is inspired by https://keras.io/api/layers/base_layer/#getconfig-method and can be used to obtain all parameters necessary to re-instantiate an equivalent instance. It prefers "simple" forms, e.g., converts the reduction method of margin activation to string representation.

This method can be used in the future for logging hyperparameters, or creating JSONified configurations.

There is also a test which checks whether the re-instantiated loss instance produces the same loss values for a random batch of scores.

#### Alternative

Instead of making this a class method, we could also extend the class resolver to also provide the "inverse way" of extracting the configuration from an instance.