### PR TITLE
🪓🪑 Fix TriplesNumericLiteralFactory split

### DIFF
--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -4,15 +4,15 @@
 
 import logging
 import pathlib
-from typing import Dict, Optional, TextIO, Tuple, Union
+from typing import Any, Dict, Optional, TextIO, Tuple, Union
 
 import numpy as np
 import torch
 
+from ..typing import EntityMapping, LabeledTriples, MappedTriples
 from .instances import MultimodalLCWAInstances, MultimodalSLCWAInstances
 from .triples_factory import TriplesFactory
 from .utils import load_triples
-from ..typing import EntityMapping, LabeledTriples
 
 __all__ = [
     'TriplesNumericLiteralsFactory',
@@ -119,4 +119,25 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
             compressed=lcwa_instances.compressed,
             numeric_literals=self.numeric_literals,
             literals_to_id=self.literals_to_id,
+        )
+
+    def clone_and_exchange_triples(
+        self,
+        mapped_triples: MappedTriples,
+        extra_metadata: Optional[Dict[str, Any]] = None,
+        keep_metadata: bool = True,
+        create_inverse_triples: Optional[bool] = None,
+    ) -> "TriplesNumericLiteralsFactory":  # noqa: D102
+        if create_inverse_triples is None:
+            create_inverse_triples = self.create_inverse_triples
+        return TriplesNumericLiteralsFactory(
+            numeric_triples = self.numeric_triples,
+            entity_to_id=self.entity_to_id,
+            relation_to_id=self.relation_to_id,
+            mapped_triples=mapped_triples,
+            create_inverse_triples=create_inverse_triples,
+            metadata={
+                **(extra_metadata or {}),
+                **(self.metadata if keep_metadata else {}),  # type: ignore
+            },
         )

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -71,7 +71,10 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         """
 
         if path is None:
-            base = TriplesFactory.from_labeled_triples(triples=triples, **kwargs)
+            if triples is None:
+                base = TriplesFactory(**kwargs)
+            else:
+                base = TriplesFactory.from_labeled_triples(triples=triples, **kwargs)
         else:
             base = TriplesFactory.from_path(path=path, **kwargs)
         super().__init__(
@@ -134,9 +137,9 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         if create_inverse_triples is None:
             create_inverse_triples = self.create_inverse_triples
         return TriplesNumericLiteralsFactory(
-                triples=mapped_triples,
                 numeric_triples=self.numeric_triples,
                 
+                mapped_triples=mapped_triples,
                 entity_to_id=self.entity_to_id,
                 relation_to_id=self.relation_to_id,
                 create_inverse_triples=create_inverse_triples,

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -9,10 +9,10 @@ from typing import Any, Dict, Optional, TextIO, Tuple, Union
 import numpy as np
 import torch
 
-from ..typing import EntityMapping, LabeledTriples, MappedTriples
 from .instances import MultimodalLCWAInstances, MultimodalSLCWAInstances
 from .triples_factory import TriplesFactory
 from .utils import load_triples
+from ..typing import EntityMapping, LabeledTriples, MappedTriples
 
 __all__ = [
     'TriplesNumericLiteralsFactory',

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -137,14 +137,13 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         if create_inverse_triples is None:
             create_inverse_triples = self.create_inverse_triples
         return TriplesNumericLiteralsFactory(
-                numeric_triples=self.numeric_triples,
-                
-                mapped_triples=mapped_triples,
-                entity_to_id=self.entity_to_id,
-                relation_to_id=self.relation_to_id,
-                create_inverse_triples=create_inverse_triples,
-                metadata={
-                    **(extra_metadata or {}),
-                    **(self.metadata if keep_metadata else {}),  # type: ignore
-                },
-            )
+            numeric_triples=self.numeric_triples,
+            mapped_triples=mapped_triples,
+            entity_to_id=self.entity_to_id,
+            relation_to_id=self.relation_to_id,
+            create_inverse_triples=create_inverse_triples,
+            metadata={
+                **(extra_metadata or {}),
+                **(self.metadata if keep_metadata else {}),  # type: ignore
+            },
+        )

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -69,14 +69,12 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         :param numeric_triples:  A 3-column numpy array with numeric triples in it. If not
          specified, you should specify ``path_to_numeric_triples``.
         """
-
-        if path is None:
-            if triples is None:
-                base = TriplesFactory(**kwargs)
-            else:
-                base = TriplesFactory.from_labeled_triples(triples=triples, **kwargs)
-        else:
+        if path is not None:
             base = TriplesFactory.from_path(path=path, **kwargs)
+        elif triples is None:
+            base = TriplesFactory(**kwargs)
+        else:
+            base = TriplesFactory.from_labeled_triples(triples=triples, **kwargs)
         super().__init__(
             entity_to_id=base.entity_to_id,
             relation_to_id=base.relation_to_id,

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -69,6 +69,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         :param numeric_triples:  A 3-column numpy array with numeric triples in it. If not
          specified, you should specify ``path_to_numeric_triples``.
         """
+
         if path is None:
             base = TriplesFactory.from_labeled_triples(triples=triples, **kwargs)
         else:
@@ -85,11 +86,13 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         elif path_to_numeric_triples is not None and numeric_triples is not None:
             raise ValueError('Must not specify both path_to_numeric_triples and numeric_triples')
         elif path_to_numeric_triples is not None:
-            numeric_triples = load_triples(path_to_numeric_triples)
+            self.numeric_triples = load_triples(path_to_numeric_triples)
+        else:
+            self.numeric_triples = numeric_triples
 
         assert self.entity_to_id is not None
         self.numeric_literals, self.literals_to_id = create_matrix_of_literals(
-            numeric_triples=numeric_triples,
+            numeric_triples=self.numeric_triples,
             entity_to_id=self.entity_to_id,
         )
 
@@ -131,13 +134,14 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         if create_inverse_triples is None:
             create_inverse_triples = self.create_inverse_triples
         return TriplesNumericLiteralsFactory(
-            numeric_triples = self.numeric_triples,
-            entity_to_id=self.entity_to_id,
-            relation_to_id=self.relation_to_id,
-            mapped_triples=mapped_triples,
-            create_inverse_triples=create_inverse_triples,
-            metadata={
-                **(extra_metadata or {}),
-                **(self.metadata if keep_metadata else {}),  # type: ignore
-            },
-        )
+                triples=mapped_triples,
+                numeric_triples=self.numeric_triples,
+                
+                entity_to_id=self.entity_to_id,
+                relation_to_id=self.relation_to_id,
+                create_inverse_triples=create_inverse_triples,
+                metadata={
+                    **(extra_metadata or {}),
+                    **(self.metadata if keep_metadata else {}),  # type: ignore
+                },
+            )

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -512,7 +512,7 @@ class TestLiterals(unittest.TestCase):
 
         triples_numeric_literal_factory = TriplesNumericLiteralsFactory(
             triples=triples_larger,
-            numeric_triples=numeric_triples
+            numeric_triples=numeric_triples,
         )
 
         left, right = triples_numeric_literal_factory.split()

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -494,6 +494,35 @@ class TestLiterals(unittest.TestCase):
         self.assertEqual(NATIONS_TRAIN_PATH, y.metadata['path'])
         self.assertEqual(NATIONS_TRAIN_PATH, z.metadata['path'])
 
+    def test_triples_numeric_literals_factory_split(self):
+        """Test splitting a TriplesNumericLiteralsFactory object."""
+        # Slightly larger number of triples to guarantee split can find coverage of all entities and relations.
+        triples_larger = np.array(
+            [
+                ['peter', 'likes', 'chocolate_cake'],
+                ['chocolate_cake', 'isA', 'dish'],
+                ['susan', 'likes', 'chocolate_cake'],
+                ['susan', 'likes', 'pizza'],
+                ['peter', 'likes', 'susan'],
+                ['peter', 'isA', 'person'],
+                ['susan', 'isA', 'person'],
+            ],
+            dtype=str,
+        )
+
+        triples_numeric_literal_factory = TriplesNumericLiteralsFactory(
+            triples=triples_larger,
+            numeric_triples=numeric_triples
+        )
+
+        left, right = triples_numeric_literal_factory.split()
+
+        self.assertIsInstance(left, TriplesNumericLiteralsFactory)
+        self.assertIsInstance(right, TriplesNumericLiteralsFactory)
+
+        assert (left.numeric_literals == triples_numeric_literal_factory.numeric_literals).all()
+        assert (right.numeric_literals == triples_numeric_literal_factory.numeric_literals).all()
+
 
 class TestUtils(unittest.TestCase):
     """Test triples utilities."""

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ description = Run the pre-commit tool
 [testenv:flake8]
 skip_install = true
 deps =
-    flake8
+    flake8<4.0.0
     flake8-bandit
     flake8-colors
     flake8-docstrings<1.6


### PR DESCRIPTION
Closes #593

### Link to the relevant Bug(s)

This pull request is relative to the `TriplesNumericLiteralFactory` splitting bug mentioned on issue #593.

### Description of the Change

The fix was done with small changes to the `TriplesNumericLiteralFactory` class.

* Overwriting the `clone_and_exchange_triples` that it had from the parent (`TriplesFactory`). The new clone_and_exchange_triples returns a  `TriplesNumericLiteralFactory` to which it is passed the `numeric_triples` of the original `TriplesNumericLiteralFactory` that is being spliced.

* `TriplesNumericLiteralFactory` now has a new optional constructor parameter `numeric_triples`.

* `numeric_triples` is now an attribute of `TriplesNumericLiteralFactory` that can be accessed from outside. 


### Possible Drawbacks

I don't think there is any drawback deriving from this change.


### Verification Process

Running the code example given of issue #593, now correctly returns:

```
TriplesNumericLiteralsFactory(num_entities=8, num_relations=2, num_triples=7, inverse_triples=Falsenum_literals=3)
TriplesNumericLiteralsFactory(num_entities=8, num_relations=2, num_triples=2, inverse_triples=Falsenum_literals=3)
```

### Release Notes

Make it so that when using split on a `TriplesNumericLiteralFactory` object the return objects are also `TriplesNumericLiteralFactory` objects.