### PR TITLE
Demonstrate use of PyG message passing in R-GCN

### DIFF
--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -726,8 +726,7 @@ class RGCNRepresentations(RepresentationModule):
         for layer in self.layers:
             x = layer(
                 x=x,
-                source=sources,
-                target=targets,
+                edge_index=(sources, targets),
                 edge_type=edge_types,
                 edge_weights=edge_weights,
             )

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -577,4 +577,40 @@ class RGCNLayer(nn.Module):
         return y
 
 
+class PygRGCNLayer(Layer):
+    """An alternate implementation of the R-GCN layer using PyG."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        num_relations: int,
+        output_dim: Optional[int] = None,
+        use_bias: bool = True,
+    ):
+        """Initialize the PyG convolution."""
+        from torch_geometric.nn import RGCNConv
+
+        super().__init__()
+        self.conv = RGCNConv(
+            in_channels=input_dim,
+            out_channels=output_dim,
+            num_relations=num_relations,
+            bias=use_bias,
+        )
+
+    def reset_parameters(self):  # noqa: D102
+        self.conv.reset_parameters()
+
+    def forward(
+        self,
+        x: torch.FloatTensor,
+        edge_index: Tuple[torch.LongTensor, torch.LongTensor],
+        edge_type: torch.LongTensor,
+        edge_weights: Optional[torch.FloatTensor] = None,
+    ):  # noqa: D102
+        if edge_weights is not None:
+            raise NotImplementedError
+        return self.conv(x, edge_index, edge_type)
+
+
 decomposition_resolver = Resolver.from_subclasses(base=Decomposition, default=BasesDecomposition)

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -546,7 +546,20 @@ class RGCNLayer(nn.Module):
         x: torch.FloatTensor,
         edge_index: Tuple[torch.LongTensor, torch.LongTensor],
         edge_type: torch.LongTensor,
-    ):  # noqa: D102
+    ):
+        """
+        Calculate enriched entity representations.
+
+        :param x: shape: (num_entities, input_dim)
+            The input entity representations.
+        :param edge_index:
+            A tuple of the source and target indices,both with shape (num_triples,)
+        :param edge_type: shape: (num_triples,)
+            The relation type per triple.
+
+        :return: shape: (num_entities, output_dim)
+            Enriched entity representations.
+        """
         source, target = edge_index
 
         if self.edge_weighting is not None and source.numel() > 0:


### PR DESCRIPTION
Closes #435

This PR abstracts a base class for message passing layers and updates its forward signature to better match PyG. It then gives an incomplete demo on how you could stick PyG's R-GCN conv in there, which could potentially be swapped out for any. Currently it doesn't do anything with edge weights, though. CC: @mberr 