### PR TITLE
📉 🏰 Fix epoch loss for loss reduction != "mean"

### DIFF
--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -661,7 +661,10 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
                     self.lr_scheduler.step(epoch=epoch)
 
                 # Track epoch loss
-                epoch_loss = current_epoch_loss / num_training_instances
+                if self.model.loss.reduction == "mean":
+                    epoch_loss = current_epoch_loss / num_training_instances
+                else:
+                    epoch_loss = current_epoch_loss / len(train_data_loader)
                 self.losses_per_epochs.append(epoch_loss)
 
                 # Print loss information to console


### PR DESCRIPTION
Fixes #622 

The epoch loss for `sum` loss aggregation has been wrong, as observed in #618. This was caused by dividing the sum of batch losses by the number of training samples, rather than the number of training batches. For mean reduction, this did not happen, since there was some special code to make sure that the batches' contribution to the final loss term was proportional to the `batch_size`, i.e., incomplete final batches had a smaller contribution to the total loss than "full" batches.
