### PR TITLE
🇷🇪 🧰 Fix negative score shape for SLCWA

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -1110,6 +1110,7 @@ class NSSALoss(SetwiseLoss):
             negative_scores = negative_scores_
 
         # compute weights (without gradient tracking)
+        assert negative_scores.ndimension() == 2
         weights = negative_scores.detach().mul(self.inverse_softmax_temperature).softmax(dim=-1)
 
         return self(

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -82,9 +82,11 @@ class SLCWATrainingLoop(TrainingLoop[SLCWASampleType, SLCWABatchType]):
 
         # apply filter mask
         if positive_filter is None:
+            negative_score_shape = negative_batch.shape[:2]
             negative_batch = negative_batch.view(-1, 3)
         else:
             negative_batch = negative_batch[positive_filter]
+            negative_score_shape = negative_batch.shape[:-1]
 
         # Ensure they reside on the device (should hold already for most simple negative samplers, e.g.
         # BasicNegativeSampler, BernoulliNegativeSampler
@@ -92,7 +94,7 @@ class SLCWATrainingLoop(TrainingLoop[SLCWASampleType, SLCWABatchType]):
 
         # Compute negative and positive scores
         positive_scores = self.model.score_hrt(positive_batch)
-        negative_scores = self.model.score_hrt(negative_batch).view(*negative_batch.shape[:-1])
+        negative_scores = self.model.score_hrt(negative_batch).view(*negative_score_shape)
 
         return (
             self.loss.process_slcwa_scores(


### PR DESCRIPTION
the SLCWA training loop gave the flattened version of negative scores, instead of the original shape, even if no filtering was used. This caused the softmax in NSSA to normalize across batch-elements, leading to erroneous behavior for sum reduction.

cf. https://github.com/pykeen/pykeen/pull/618#issuecomment-964012965