### PR TITLE
Update ComplEx to ERModel

### DIFF
--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -5,22 +5,23 @@
 from typing import Any, ClassVar, Mapping, Optional, Type
 
 import torch
+from class_resolver.api import HintOrType
 from torch.nn.init import normal_
 
-from ..base import EntityRelationEmbeddingModel
+from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
 from ...nn.emb import EmbeddingSpecification
+from ...nn.modules import ComplExInteraction
 from ...regularizers import LpRegularizer, Regularizer
 from ...typing import Hint, Initializer
-from ...utils import split_complex
 
 __all__ = [
     "ComplEx",
 ]
 
 
-class ComplEx(EntityRelationEmbeddingModel):
+class ComplEx(ERModel):
     r"""An implementation of ComplEx [trouillon2016]_.
 
     ComplEx is an extension of :class:`pykeen.models.DistMult` that uses complex valued representations for the
@@ -64,8 +65,6 @@ class ComplEx(EntityRelationEmbeddingModel):
     loss_default: ClassVar[Type[Loss]] = SoftplusLoss
     #: The default parameters for the default loss function class
     loss_default_kwargs: ClassVar[Mapping[str, Any]] = dict(reduction="mean")
-    #: The regularizer used by [trouillon2016]_ for ComplEx.
-    regularizer_default: ClassVar[Type[Regularizer]] = LpRegularizer
     #: The LP settings used by [trouillon2016]_ for ComplEx.
     regularizer_default_kwargs: ClassVar[Mapping[str, Any]] = dict(
         weight=0.01,
@@ -81,6 +80,8 @@ class ComplEx(EntityRelationEmbeddingModel):
         # https://github.com/ttrouill/complex/blob/dc4eb93408d9a5288c986695b58488ac80b1cc17/efe/models.py#L481-L487
         entity_initializer: Hint[Initializer] = normal_,
         relation_initializer: Hint[Initializer] = normal_,
+        regularizer: HintOrType[Regularizer] = LpRegularizer,
+        regularizer_kwargs: Optional[Mapping[str, Any]] = None,
         **kwargs,
     ) -> None:
         """Initialize ComplEx.
@@ -92,81 +93,24 @@ class ComplEx(EntityRelationEmbeddingModel):
         :param kwargs:
             Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
         """
+        regularizer_kwargs = regularizer_kwargs or ComplEx.regularizer_default_kwargs
         super().__init__(
+            interaction=ComplExInteraction,
             entity_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=entity_initializer,
+                # use torch's native complex data type
                 dtype=torch.cfloat,
+                regularizer=regularizer,
+                regularizer_kwargs=regularizer_kwargs,
             ),
             relation_representations=EmbeddingSpecification(
                 embedding_dim=embedding_dim,
                 initializer=relation_initializer,
+                # use torch's native complex data type
                 dtype=torch.cfloat,
+                regularizer=regularizer,
+                regularizer_kwargs=regularizer_kwargs,
             ),
             **kwargs,
         )
-
-    @staticmethod
-    def interaction_function(
-        h: torch.FloatTensor,
-        r: torch.FloatTensor,
-        t: torch.FloatTensor,
-    ) -> torch.FloatTensor:
-        """Evaluate the interaction function of ComplEx for given embeddings.
-
-        The embeddings have to be in a broadcastable shape.
-
-        :param h:
-            Head embeddings.
-        :param r:
-            Relation embeddings.
-        :param t:
-            Tail embeddings.
-
-        :return: shape: (...)
-            The scores.
-        """
-        # split into real and imaginary part
-        (h_re, h_im), (r_re, r_im), (t_re, t_im) = [split_complex(x=x) for x in (h, r, t)]
-
-        # ComplEx space bilinear product
-        # *: Elementwise multiplication
-        return sum(
-            (hh * rr * tt).sum(dim=-1)
-            for hh, rr, tt in [
-                (h_re, r_re, t_re),
-                (h_re, r_im, t_im),
-                (h_im, r_re, t_im),
-                (-h_im, r_im, t_re),
-            ]
-        )
-
-    def forward(
-        self,
-        h_indices: Optional[torch.LongTensor],
-        r_indices: Optional[torch.LongTensor],
-        t_indices: Optional[torch.LongTensor],
-    ) -> torch.FloatTensor:
-        """Unified score function."""
-        # get embeddings
-        h = self.entity_embeddings.get_in_canonical_shape(indices=h_indices)
-        r = self.relation_embeddings.get_in_canonical_shape(indices=r_indices)
-        t = self.entity_embeddings.get_in_canonical_shape(indices=t_indices)
-
-        # Regularization
-        self.regularize_if_necessary(h, r, t)
-
-        # Compute scores
-        return self.interaction_function(h=h, r=r, t=t)
-
-    def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self(h_indices=hrt_batch[:, 0], r_indices=hrt_batch[:, 1], t_indices=hrt_batch[:, 2]).view(-1, 1)
-
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self(h_indices=hr_batch[:, 0], r_indices=hr_batch[:, 1], t_indices=None)
-
-    def score_r(self, ht_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self(h_indices=ht_batch[:, 0], r_indices=None, t_indices=ht_batch[:, 1])
-
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self(h_indices=None, r_indices=rt_batch[:, 0], t_indices=rt_batch[:, 1])

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -90,6 +90,10 @@ class ComplEx(ERModel):
             The embedding dimensionality of the entity embeddings.
         :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.normal_`
         :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.normal_`
+        :param regularizer:
+            the regularizer to apply.
+        :param regularizer_kwargs:
+            additional keyword arguments passed to the regularizer. Defaults to `ComplEx.regularizer_default_kwargs`.
         :param kwargs:
             Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
         """

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -44,14 +44,6 @@ def batched_dot(
     return _batched_dot_manual(a, b)
 
 
-def batched_complex(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-) -> torch.FloatTensor:
-    return _complex_native_complex(h=h, r=r, t=t)
-
-
 # TODO benchmark
 def _complex_broadcast_optimized(
     h: torch.FloatTensor,
@@ -188,3 +180,12 @@ def _complex_stacked_select(
     else:
         t = r * t
     return h @ t.transpose(-2, -1)
+
+
+def batched_complex(
+    h: torch.FloatTensor,
+    r: torch.FloatTensor,
+    t: torch.FloatTensor,
+) -> torch.FloatTensor:
+    """Compute real part of tri-linear complex dot product."""
+    return _complex_native_complex(h=h, r=r, t=t)

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -7,12 +7,11 @@ import torch
 
 from ..utils import extended_einsum, split_complex, tensor_product, view_complex, view_complex_native
 
-
-
 __all__ = [
     "batched_dot",
     "batched_complex",
 ]
+
 
 def _batched_dot_manual(
     a: torch.FloatTensor,

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -101,7 +101,7 @@ def _complex_einsum(
     x[1, 0, 1] = 1
     x[1, 1, 0] = -1
     return extended_einsum(
-        "ijk,bhdi,brdj,btdk->bhrt",
+        "ijk,bhrtdi,bhrtdj,bhrtdk->bhrt",
         x,
         h.view(*h.shape[:-1], -1, 2),
         r.view(*r.shape[:-1], -1, 2),

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -5,8 +5,14 @@
 import numpy
 import torch
 
-from ..utils import extended_einsum, split_complex, tensor_product, view_complex
+from ..utils import extended_einsum, split_complex, tensor_product, view_complex, view_complex_native
 
+
+
+__all__ = [
+    "batched_dot",
+    "batched_complex",
+]
 
 def _batched_dot_manual(
     a: torch.FloatTensor,
@@ -37,6 +43,14 @@ def batched_dot(
 ) -> torch.FloatTensor:
     """Compute "element-wise" dot-product between batched vectors."""
     return _batched_dot_manual(a, b)
+
+
+def batched_complex(
+    h: torch.FloatTensor,
+    r: torch.FloatTensor,
+    t: torch.FloatTensor,
+) -> torch.FloatTensor:
+    return _complex_native_complex(h=h, r=r, t=t)
 
 
 # TODO benchmark
@@ -101,7 +115,7 @@ def _complex_native_complex(
     t: torch.FloatTensor,
 ) -> torch.FloatTensor:
     """Use torch built-ins for computation with complex numbers."""
-    h, r, t = [view_complex(x=x) for x in (h, r, t)]
+    h, r, t = [view_complex_native(x=x) for x in (h, r, t)]
     return torch.real(tensor_product(h, r, torch.conj(t)).sum(dim=-1))
 
 

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -342,7 +342,7 @@ class Embedding(RepresentationModule):
         if dtype is None:
             dtype = torch.get_default_dtype()
 
-        # work-around until full complex support
+        # work-around until full complex support (torch==1.10 still does not work)
         # TODO: verify that this is our understanding of complex!
         if dtype.is_complex:
             shape = tuple(shape[:-1]) + (2 * shape[-1],)

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -17,7 +17,7 @@ import numpy
 import torch
 from torch import nn
 
-from .compute_kernel import _complex_native_complex, batched_dot
+from .compute_kernel import batched_complex, batched_dot
 from .sim import KG2E_SIMILARITIES
 from ..moves import irfft, rfft
 from ..typing import GaussianDistribution
@@ -131,7 +131,7 @@ def complex_interaction(
     :return: shape: (batch_size, num_heads, num_relations, num_tails)
         The scores.
     """
-    return _complex_native_complex(h, r, t)
+    return batched_complex(h, r, t)
 
 
 @_add_cuda_warning

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -342,6 +342,10 @@ def view_complex(x: torch.FloatTensor) -> torch.Tensor:
     return torch.complex(real=real, imag=imag)
 
 
+def view_complex_native(x: torch.FloatTensor) -> torch.Tensor:
+    return torch.view_as_complex(x.view(*x.shape[:-1], -1, 2))
+
+
 def combine_complex(
     x_re: torch.FloatTensor,
     x_im: torch.FloatTensor,

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -343,6 +343,7 @@ def view_complex(x: torch.FloatTensor) -> torch.Tensor:
 
 
 def view_complex_native(x: torch.FloatTensor) -> torch.Tensor:
+    """Convert a PyKEEN complex tensor representation into a torch one using :func:`torch.view_as_complex`."""
     return torch.view_as_complex(x.view(*x.shape[:-1], -1, 2))
 
 


### PR DESCRIPTION
This PR updates ComplEx to use the new-style `ERModel`

### Choosing a compute kernel for ComplEx

<summary>Benchmark on RTX2080 Ti</summary>
<details>

```python
from typing import Tuple

import torch
from torch.utils.benchmark import Compare, Timer
from tqdm.auto import tqdm

import pykeen.nn.compute_kernel as cc


def prepare(b: int, n: int, d: int, use_case: str, device: str) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
    hs = (b, 1, 1, 1, 2 * d)
    rs = (b, 1, 1, 1, 2 * d)
    ts = (b, 1, 1, 1, 2 * d)
    if use_case == "score_hrt":
        pass
    elif use_case == "score_t":
        ts = (1, 1, 1, n, 2 * d)
    elif use_case == "score_h":
        hs = (1, n, 1, 1, 2 * d)
    else:
        raise ValueError(use_case)

    return (
        torch.rand(*hs, device=device),
        torch.rand(*rs, device=device),
        torch.rand(*ts, device=device),
    )


def main():
    if torch.cuda.is_available():
        devices = ["cuda"]
    else:
        devices = ["cpu"]
    print(devices)
    methods = (
        cc._complex_broadcast_optimized,
        cc._complex_direct,
        cc._complex_einsum,
        cc._complex_native_complex,
        cc._complex_native_complex_select,
        cc._complex_select,
        cc._complex_stacked,
        cc._complex_stacked_select,
    )
    settings = [
        (256, 15_000, 512, "score_hrt"),
        (32, 15_000, 512, "score_h"),
        (32, 15_000, 512, "score_t"),
        (256, 40_000, 512, "score_hrt"),
        (8, 40_000, 512, "score_h"),
        (8, 40_000, 512, "score_t"),
    ]
    total = len(devices) * len(methods) * len(settings)
    compare = Compare(
        results=list(
            tqdm(
                (
                    Timer(
                        stmt=f"cc.{method.__name__}(h=h, r=r, t=t)",
                        setup=f'h, r, t = prepare(b={b}, n={n}, d={d}, use_case="{use_case}", device="{device}")',
                        globals=dict(
                            cc=cc,
                            prepare=prepare,
                        ),
                        env=f"b={b}, n={n}, d={d}",
                        description=use_case,
                    ).blocked_autorange()
                    for b, n, d, use_case in settings
                    for device in devices
                    for method in methods
                ),
                total=total,
            )
        )
    )
    compare.colorize()
    compare.trim_significant_figures()
    compare.print()


if __name__ == "__main__":
    main()

```

#### Results
```
                                                                             |  score_hrt  |  score_h  |  score_t
1 threads: ------------------------------------------------------------------------------------------------------
  (b=256, n=15000, d=512)  cc._complex_broadcast_optimized(h=h, r=r, t=t)    |     221     |           |         
                           cc._complex_direct(h=h, r=r, t=t)                 |     140     |           |         
                           cc._complex_einsum(h=h, r=r, t=t)                 |     423     |           |         
                           cc._complex_native_complex(h=h, r=r, t=t)         |      71     |           |         
                           cc._complex_native_complex_select(h=h, r=r, t=t)  |     100     |           |         
                           cc._complex_select(h=h, r=r, t=t)                 |     170     |           |         
                           cc._complex_stacked(h=h, r=r, t=t)                |     140     |           |         
                           cc._complex_stacked_select(h=h, r=r, t=t)         |     190     |           |         
  (b=256, n=40000, d=512)  cc._complex_broadcast_optimized(h=h, r=r, t=t)    |     224     |           |         
                           cc._complex_direct(h=h, r=r, t=t)                 |     140     |           |         
                           cc._complex_einsum(h=h, r=r, t=t)                 |     423     |           |         
                           cc._complex_native_complex(h=h, r=r, t=t)         |      75     |           |         
                           cc._complex_native_complex_select(h=h, r=r, t=t)  |     130     |           |         
                           cc._complex_select(h=h, r=r, t=t)                 |     170     |           |         
                           cc._complex_stacked(h=h, r=r, t=t)                |     140     |           |         
                           cc._complex_stacked_select(h=h, r=r, t=t)         |     190     |           |         
  (b=32, n=15000, d=512)   cc._complex_broadcast_optimized(h=h, r=r, t=t)    |             |   21720   |   21710 
                           cc._complex_direct(h=h, r=r, t=t)                 |             |   36450   |   21670 
                           cc._complex_einsum(h=h, r=r, t=t)                 |             |   90300   |     336 
                           cc._complex_native_complex(h=h, r=r, t=t)         |             |   10900   |   11100 
                           cc._complex_native_complex_select(h=h, r=r, t=t)  |             |   11100   |   11400 
                           cc._complex_select(h=h, r=r, t=t)                 |             |   20940   |    3445 
                           cc._complex_stacked(h=h, r=r, t=t)                |             |   36890   |   22290 
                           cc._complex_stacked_select(h=h, r=r, t=t)         |             |   40140   |    7480 
  (b=8, n=40000, d=512)    cc._complex_broadcast_optimized(h=h, r=r, t=t)    |             |   14500   |   14480 
                           cc._complex_direct(h=h, r=r, t=t)                 |             |   24290   |   14450 
                           cc._complex_einsum(h=h, r=r, t=t)                 |             |   69690   |     524 
                           cc._complex_native_complex(h=h, r=r, t=t)         |             |    7260   |    7870 
                           cc._complex_native_complex_select(h=h, r=r, t=t)  |             |    7895   |    8510 
                           cc._complex_select(h=h, r=r, t=t)                 |             |   14000   |    2302 
                           cc._complex_stacked(h=h, r=r, t=t)                |             |   25510   |   16270 
                           cc._complex_stacked_select(h=h, r=r, t=t)         |             |   27780   |    6411 

Times are in microseconds (us).
```
</details>

TL;DR: native complex is fastest for `score_hrt` / `score_t`. For `score_h` einsum is faster.


### Comparison to `master`

<summary>Benchmark on RTX2080 Ti</summary>
<details>

Using default settings, and (a somewhat arbitrary) fixed `batch_size=256` on RTX 2080 Ti: `nan` indicates OOM.

#### old
| model   | dataset   |   training |   evaluation |   score_hrt |       score_h |       score_t |  device   | git_hash   |                                                                 
|:--------|:----------|-----------:|-------------:|------------:|--------------:|--------------:|:-----------|:-----------|
| complex | fb15k237  |   6.8168   |    16.3357   | 0.000343446 | nan           |   0.0666306   |  cuda     | b3375345   |
| complex | nations   |   0.182782 |     0.127749 | 0.000350535 |   0.000319821 |   0.000316372 |  cuda     | b3375345   |
| complex | wn18rr    |   3.01705  |     6.71486  | 0.000342343 | nan           | nan           |  cuda     | b3375345   |

#### new
| model   | dataset   |   training |   evaluation |   score_hrt |       score_h |       score_t |  device   | git_hash   |                                                                 
|:--------|:----------|-----------:|-------------:|------------:|--------------:|--------------:|:-----------|:-----------|
| complex | fb15k237  |   4.96571  |     7.2699   | 0.000283919 |   0.0332715   |   0.0335903   | cuda     | e03bba90   |
| complex | nations   |   0.154651 |     0.127478 | 0.000278247 |   0.000257923 |   0.000254081 |  cuda     | e03bba90   |
| complex | wn18rr    |   2.57455  |     3.09619  | 0.000286655 | nan           | nan           |  cuda     | e03bba90   |
</details>

TL;DR: new version seems to be faster, and sometimes more memory efficient.