### PR TITLE
📡 ☎️ Fix kwargs transmission on MultiTrainingCallback

### DIFF
--- a/src/pykeen/training/callbacks.py
+++ b/src/pykeen/training/callbacks.py
@@ -213,11 +213,11 @@ class MultiTrainingCallback(TrainingCallback):
 
     def on_batch(self, epoch: int, batch, batch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
-            callback.on_batch(epoch=epoch, batch=batch, batch_loss=batch_loss)
+            callback.on_batch(epoch=epoch, batch=batch, batch_loss=batch_loss, **kwargs)
 
     def post_batch(self, epoch: int, batch, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
-            callback.post_batch(epoch=epoch, batch=batch)
+            callback.post_batch(epoch=epoch, batch=batch, **kwargs)
 
     def pre_step(self, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
@@ -225,8 +225,8 @@ class MultiTrainingCallback(TrainingCallback):
 
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
-            callback.post_epoch(epoch=epoch, epoch_loss=epoch_loss)
+            callback.post_epoch(epoch=epoch, epoch_loss=epoch_loss, **kwargs)
 
     def post_train(self, losses: List[float], **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
-            callback.post_train(losses=losses)
+            callback.post_train(losses=losses, **kwargs)


### PR DESCRIPTION
## Link to the relevant Bug(s)
This PR is linked to a bug found in a discussion on issue https://github.com/pykeen/pykeen/issues/643#issuecomment-972991471. 


### Description of the Change

Pass the `kwargs`to the registered callbacks when they are called by the `MultiTrainingCallback` object

Example:
``` python
   def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
        for callback in self.callbacks:
            callback.post_epoch(epoch=epoch, epoch_loss=epoch_loss, **kwargs)

```

### Possible Drawbacks
None I can think of.

### Verification Process

I verified that the given kwargs were being indeed passed down, by printing the kwargs inside the registered callback function being called.

### Release Notes

Fixed issue where kwargs were not being transmitted from `MultiTrainingCallback` object  to its registered callbacks.

