### PR TITLE
🚫 🛑 Add empty default `loss_kwargs`

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -644,6 +644,8 @@ class PairwiseLogisticLoss(SoftMarginRankingLoss):
     name: Pairwise logistic
     """
 
+    hpo_default: ClassVar[Mapping[str, Any]] = dict()
+
     def __init__(self, reduction: str = "mean"):
         super().__init__(margin=0.0, reduction=reduction)
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -644,6 +644,7 @@ class PairwiseLogisticLoss(SoftMarginRankingLoss):
     name: Pairwise logistic
     """
 
+    # Ensures that invalid "margin" hyper-parameter of superclass is not used within the ablation pipeline.
     hpo_default: ClassVar[Mapping[str, Any]] = dict()
 
     def __init__(self, reduction: str = "mean"):
@@ -972,6 +973,7 @@ class SoftplusLoss(SoftPointwiseHingeLoss):
     name: Softplus
     """
 
+    # Ensures that invalid "margin" hyper-parameter of superclass is not used within the ablation pipeline.
     hpo_default: ClassVar[Mapping[str, Any]] = dict()
 
     def __init__(self, reduction: str = "mean") -> None:

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -970,6 +970,8 @@ class SoftplusLoss(SoftPointwiseHingeLoss):
     name: Softplus
     """
 
+    hpo_default: ClassVar[Mapping[str, Any]] = dict()
+
     def __init__(self, reduction: str = "mean") -> None:
         super().__init__(margin=0.0, reduction=reduction)
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -644,7 +644,8 @@ class PairwiseLogisticLoss(SoftMarginRankingLoss):
     name: Pairwise logistic
     """
 
-    # Ensures that invalid "margin" hyper-parameter of superclass is not used within the ablation pipeline.
+    # Ensures that for this class incompatible hyper-parameter "margin" of superclass is not used
+    # within the ablation pipeline.
     hpo_default: ClassVar[Mapping[str, Any]] = dict()
 
     def __init__(self, reduction: str = "mean"):
@@ -973,7 +974,8 @@ class SoftplusLoss(SoftPointwiseHingeLoss):
     name: Softplus
     """
 
-    # Ensures that invalid "margin" hyper-parameter of superclass is not used within the ablation pipeline.
+    # Ensures that for this class incompatible hyper-parameter "margin" of superclass is not used
+    # within the ablation pipeline.
     hpo_default: ClassVar[Mapping[str, Any]] = dict()
 
     def __init__(self, reduction: str = "mean") -> None:


### PR DESCRIPTION
In this PR, we add an empty `hpo_default` dictionary to `SoftplusLoss` in order to avoid inheriting those values from `SoftPointwiseHingeLoss,` which are invalid for the `SoftplusLoss` and causes an exception when composing the loss function within the ablation pipeline.

An example that causes this issue is:

```python
from pykeen.ablation import ablation_pipeline

# We do not provide loss_kwargs/loss_kwargs_ranges
ablation_pipeline(
    datasets="Nations",
    models="RotatE",
    losses="SoftplusLoss",
    training_loops="lcwa",
    optimizers="Adam",
    directory="/out",
)
```