### PR TITLE
⚰️ 📽️ Remove literal representations

### DIFF
--- a/src/pykeen/models/multimodal/base.py
+++ b/src/pykeen/models/multimodal/base.py
@@ -6,7 +6,7 @@ from typing import Sequence, Union
 
 from ..nbase import EmbeddingSpecificationHint, ERModel
 from ...nn.emb import Embedding, EmbeddingSpecification, RepresentationModule
-from ...nn.init import create_init_from_pretrained
+from ...nn.init import PretrainedInitializer
 from ...nn.modules import LiteralInteraction
 from ...triples import TriplesNumericLiteralsFactory
 from ...typing import HeadRepresentation, RelationRepresentation, TailRepresentation
@@ -32,7 +32,7 @@ class LiteralModel(ERModel[HeadRepresentation, RelationRepresentation, TailRepre
         literal_representation = Embedding(
             num_embeddings=num_embeddings,
             shape=shape,
-            initializer=create_init_from_pretrained(pretrained=literals),
+            initializer=PretrainedInitializer(tensor=literals),
             trainable=False,
         )
         super().__init__(

--- a/src/pykeen/models/multimodal/base.py
+++ b/src/pykeen/models/multimodal/base.py
@@ -5,7 +5,8 @@
 from typing import Sequence, Union
 
 from ..nbase import EmbeddingSpecificationHint, ERModel
-from ...nn.emb import EmbeddingSpecification, LiteralRepresentation, RepresentationModule
+from ...nn.emb import Embedding, EmbeddingSpecification, RepresentationModule
+from ...nn.init import create_init_from_pretrained
 from ...nn.modules import LiteralInteraction
 from ...triples import TriplesNumericLiteralsFactory
 from ...typing import HeadRepresentation, RelationRepresentation, TailRepresentation
@@ -26,8 +27,13 @@ class LiteralModel(ERModel[HeadRepresentation, RelationRepresentation, TailRepre
         relation_representations: EmbeddingSpecificationHint = None,
         **kwargs,
     ):
-        literal_representation = LiteralRepresentation(
-            numeric_literals=triples_factory.get_numeric_literals_tensor(),
+        literals = triples_factory.get_numeric_literals_tensor()
+        num_embeddings, *shape = literals.shape
+        literal_representation = Embedding(
+            num_embeddings=num_embeddings,
+            shape=shape,
+            initializer=create_init_from_pretrained(pretrained=literals),
+            trainable=False,
         )
         super().__init__(
             triples_factory=triples_factory,

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -41,7 +41,6 @@ from ..utils import Bias, activation_resolver, clamp_norm, complex_normalize, co
 __all__ = [
     "RepresentationModule",
     "Embedding",
-    "LiteralRepresentation",
     "EmbeddingSpecification",
     "RGCNRepresentations",
     "NodePieceRepresentation",
@@ -458,28 +457,6 @@ class Embedding(RepresentationModule):
         if self.dropout is not None:
             x = self.dropout(x)
         return x
-
-
-class LiteralRepresentation(Embedding):
-    """Literal representations."""
-
-    def __init__(
-        self,
-        numeric_literals: torch.FloatTensor,
-    ):
-        self._numeric_literals = numeric_literals
-        num_embeddings, embedding_dim = numeric_literals.shape
-        super().__init__(
-            num_embeddings=num_embeddings,
-            embedding_dim=embedding_dim,
-            initializer=self._initialize_literals,
-        )
-        # freeze
-        self._embeddings.requires_grad_(False)
-
-    # use this instead of a lambda to make sure that it can be pickled
-    def _initialize_literals(self, _) -> torch.FloatTensor:
-        return self._numeric_literals
 
 
 @dataclass

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -19,7 +19,6 @@ from ..typing import Initializer
 from ..utils import compose
 
 __all__ = [
-    "create_init_from_pretrained",
     "xavier_uniform_",
     "xavier_uniform_norm_",
     "xavier_normal_",
@@ -27,6 +26,7 @@ __all__ = [
     "uniform_norm_",
     "normal_norm_",
     "init_phases",
+    "PretrainedInitializer",
     "LabelBasedInitializer",
 ]
 
@@ -161,43 +161,6 @@ class PretrainedInitializer:
         if x.shape != self.tensor.shape:
             raise ValueError(f"shape does not match: expected {self.tensor.shape} but got {x.shape}")
         return self.tensor.to(device=x.device, dtype=x.dtype)
-
-
-def create_init_from_pretrained(pretrained: torch.FloatTensor) -> Initializer:
-    """
-    Create an initializer via a constant vector.
-
-    :param pretrained:
-        the tensor of pretrained embeddings.
-
-    :return:
-        an initializer, which fills a tensor with the given weights.
-
-    Added in https://github.com/pykeen/pykeen/pull/638.
-
-    Example usage:
-
-    .. code-block::
-
-        import torch
-        from pykeen.pipeline import pipeline
-        from pykeen.nn.init import create_init_from_pretrained
-
-        # this is usually loaded from somewhere else
-        # the shape must match, as well as the entity-to-id mapping
-        pretrained_embedding_tensor = torch.rand(14, 128)
-
-        result = pipeline(
-            dataset="nations",
-            model="transe",
-            model_kwargs=dict(
-                embedding_dim=pretrained_embedding_tensor.shape[-1],
-                entity_initializer=create_init_from_pretrained(pretrained_embedding_tensor),
-            ),
-        )
-    """
-    warnings.warn(message="Please directly use `PretrainedInitializer`.", category=DeprecationWarning)
-    return PretrainedInitializer(tensor=pretrained)
 
 
 class LabelBasedInitializer(PretrainedInitializer):

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -14,7 +14,6 @@ from torch.nn import functional
 
 from .utils import TransformerEncoder
 from ..triples import TriplesFactory
-from ..typing import Initializer
 from ..utils import compose
 
 __all__ = [

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -120,7 +120,7 @@ def init_quaternions(
     return x.view(num_elements, 4 * dim)
 
 
-class PretrainedInitializer(Initializer):
+class PretrainedInitializer:
     """
     Initialize tensor with pretrained weights.
 

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -4,7 +4,6 @@
 
 import logging
 import math
-import warnings
 from typing import Optional, Sequence
 
 import numpy as np
@@ -121,7 +120,7 @@ def init_quaternions(
     return x.view(num_elements, 4 * dim)
 
 
-class PretrainedInitializer:
+class PretrainedInitializer(Initializer):
     """
     Initialize tensor with pretrained weights.
 

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -12,11 +12,9 @@ import unittest_templates
 
 import pykeen.nn.emb
 from pykeen.datasets import get_dataset
-from pykeen.datasets.nations import NationsLiteral
 from pykeen.nn.emb import (
     Embedding,
     EmbeddingSpecification,
-    LiteralRepresentation,
     RepresentationModule,
     SubsetRepresentationModule,
 )
@@ -57,15 +55,6 @@ class EmbeddingTests(cases.RepresentationTestCase):
         first = dropout_instance(indices)
         second = dropout_instance(indices)
         assert not torch.allclose(first, second)
-
-
-class LiteralEmbeddingTests(cases.RepresentationTestCase):
-    """Tests for literal embeddings."""
-
-    cls = LiteralRepresentation
-    kwargs = dict(
-        numeric_literals=NationsLiteral().training.numeric_literals,
-    )
 
 
 class TensorEmbeddingTests(cases.RepresentationTestCase):

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -12,12 +12,7 @@ import unittest_templates
 
 import pykeen.nn.emb
 from pykeen.datasets import get_dataset
-from pykeen.nn.emb import (
-    Embedding,
-    EmbeddingSpecification,
-    RepresentationModule,
-    SubsetRepresentationModule,
-)
+from pykeen.nn.emb import Embedding, EmbeddingSpecification, RepresentationModule, SubsetRepresentationModule
 from pykeen.triples.generation import generate_triples_factory
 from tests import cases, mocks
 

--- a/tests/test_nn/test_init.py
+++ b/tests/test_nn/test_init.py
@@ -49,7 +49,7 @@ class PretrainedInitializerTestCase(cases.InitializerTestCase):
     def setUp(self) -> None:
         """Prepare for test."""
         self.pretrained = torch.rand(*self.shape)
-        self.initializer = pykeen.nn.init.create_init_from_pretrained(pretrained=self.pretrained)
+        self.initializer = pykeen.nn.init.PretrainedInitializer(tensor=self.pretrained)
 
     def _verify_initialization(self, x: torch.FloatTensor) -> None:  # noqa: D102
         assert (x == self.pretrained).all()


### PR DESCRIPTION
This PR removes the explicit class for literal representations, which can be replaced by a non-trainable `Embedding` with an pretrained embedding initializer. This reduces code duplication, but also gives access to all the gimmicks from `Embedding`, e.g., dropout and normalizers.

<del>The PR also deprecates the `create_init_from_pretrained` for a class, which allows code duplication reduction with the `LabelBasedInitializer`.</del>