### PR TITLE
⬇️🎖️ Low rank embeddings

### DIFF
--- a/docs/source/tutorial/representations.rst
+++ b/docs/source/tutorial/representations.rst
@@ -16,14 +16,26 @@ which enrich via CompGCN layers.
 
 Decomposition
 -------------
-NodePiece
-~~~~~~~~~
+
 Since knowledge graphs may contain a large number of entities, having
 independent trainable embeddings for each of them may result in an
 excessive amount of trainable parameters. Therefore, methods have been
 developed, which do not learn independent representations, but rather
 have a set of base representations, and create individual representations
-by combining them. An example is NodePiece, which takes inspiration
+by combining them. 
+
+Low-Rank Factorization
+~~~~~~~~~~~~~~~~~~~~~~
+A simple method to reduce the number of parameters is to use a low-rank
+decomposition of the embedding matrix, as implemented in 
+:class:`pykeen.nn.emb.LowRankEmbeddingRepresentation`. Here, each
+representation is a linear combination of shared base representations.
+Typically, the number of bases is chosen smaller than the dimension of 
+each base representation.
+
+NodePiece
+~~~~~~~~~
+Another example is NodePiece, which takes inspiration
 from tokenization we encounter in, e.g.. NLP, and represents each entity
 as a set of tokens. The implementation in PyKEEN,
 :class:`pykeen.nn.emb.NodePieceRepresentation`, implements a simple yet
@@ -31,10 +43,6 @@ effective variant thereof, which uses a set of randomly chosen incident
 relations (including inverse relations) as tokens.
 
 .. seealso:: https://towardsdatascience.com/nodepiece-tokenizing-knowledge-graphs-6dd2b91847aa
-
-Bases
-~~~~~
-.. todo:: write something about :class:`pykeen.nn.emb.LowRankEmbeddingRepresentation`
 
 Label-based
 -----------

--- a/docs/source/tutorial/representations.rst
+++ b/docs/source/tutorial/representations.rst
@@ -16,7 +16,6 @@ which enrich via CompGCN layers.
 
 Decomposition
 -------------
-
 Since knowledge graphs may contain a large number of entities, having
 independent trainable embeddings for each of them may result in an
 excessive amount of trainable parameters. Therefore, methods have been

--- a/docs/source/tutorial/representations.rst
+++ b/docs/source/tutorial/representations.rst
@@ -16,6 +16,8 @@ which enrich via CompGCN layers.
 
 Decomposition
 -------------
+NodePiece
+~~~~~~~~~
 Since knowledge graphs may contain a large number of entities, having
 independent trainable embeddings for each of them may result in an
 excessive amount of trainable parameters. Therefore, methods have been
@@ -29,6 +31,10 @@ effective variant thereof, which uses a set of randomly chosen incident
 relations (including inverse relations) as tokens.
 
 .. seealso:: https://towardsdatascience.com/nodepiece-tokenizing-knowledge-graphs-6dd2b91847aa
+
+Bases
+~~~~~
+.. todo:: write something about :class:`pykeen.nn.emb.LowRankEmbeddingRepresentation`
 
 Label-based
 -----------

--- a/docs/source/tutorial/representations.rst
+++ b/docs/source/tutorial/representations.rst
@@ -21,15 +21,15 @@ independent trainable embeddings for each of them may result in an
 excessive amount of trainable parameters. Therefore, methods have been
 developed, which do not learn independent representations, but rather
 have a set of base representations, and create individual representations
-by combining them. 
+by combining them.
 
 Low-Rank Factorization
 ~~~~~~~~~~~~~~~~~~~~~~
 A simple method to reduce the number of parameters is to use a low-rank
-decomposition of the embedding matrix, as implemented in 
+decomposition of the embedding matrix, as implemented in
 :class:`pykeen.nn.emb.LowRankEmbeddingRepresentation`. Here, each
 representation is a linear combination of shared base representations.
-Typically, the number of bases is chosen smaller than the dimension of 
+Typically, the number of bases is chosen smaller than the dimension of
 each base representation.
 
 NodePiece

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -9,8 +9,8 @@ from class_resolver import Hint, HintOrType
 from torch import nn
 
 from ..nbase import EmbeddingSpecificationHint, ERModel
-from ...nn.emb import EmbeddingSpecification, RGCNRepresentations
-from ...nn.message_passing import Decomposition
+from ...nn.emb import EmbeddingSpecification
+from ...nn.message_passing import Decomposition, RGCNRepresentations
 from ...nn.modules import Interaction, interaction_resolver
 from ...nn.weighting import EdgeWeighting
 from ...regularizers import Regularizer

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -460,6 +460,24 @@ class Embedding(RepresentationModule):
         return x
 
 
+class LowRankEmbeddingRepresentation(RepresentationModule):
+    """Low-rank embeddings."""
+
+    def __init__(self, max_id: int, shape: Sequence[int], num_bases: int = 3):
+        super().__init__(max_id=max_id, shape=shape)
+        self.weight = nn.Parameter(torch.rand(max_id, num_bases))
+        self.bases = nn.Parameter(torch.randn(num_bases, *shape))
+
+    def forward(
+        self,
+        indices: Optional[torch.LongTensor] = None,
+    ) -> torch.FloatTensor:  # noqa: D102
+        weight = self.weight
+        if indices is not None:
+            weight = weight[indices]
+        return torch.tensordot(weight, self.bases, dims=([-1], [-(len(self.shape) + 1)]))
+
+
 class LiteralRepresentation(Embedding):
     """Literal representations."""
 

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -50,6 +50,7 @@ __all__ = [
     "SingleCompGCNRepresentation",
     "LabelBasedTransformerRepresentation",
     "SubsetRepresentationModule",
+    # Utils
     "constrainers",
     "initializers",
     "normalizers",
@@ -608,6 +609,7 @@ def process_shape(
     return dim, shape
 
 
+#: Initializers
 initializers = {
     "xavier_uniform": xavier_uniform_,
     "xavier_uniform_norm": xavier_uniform_norm_,
@@ -621,6 +623,7 @@ initializers = {
     "init_phases": init_phases,
 }
 
+#: Constrainers
 constrainers = {
     "normalize": functional.normalize,
     "complex_normalize": complex_normalize,

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -49,6 +49,7 @@ __all__ = [
     "CombinedCompGCNRepresentations",
     "SingleCompGCNRepresentation",
     "LabelBasedTransformerRepresentation",
+    "SubsetRepresentationModule",
     "constrainers",
     "initializers",
     "normalizers",

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -469,7 +469,7 @@ class LowRankEmbeddingRepresentation(RepresentationModule):
     but rather having shared bases among all indices, and only learn the weights of the linear combination.
 
     .. math ::
-        E[i] = \sum B[i, k] * W[k]
+        E[i] = \sum_k B[i, k] * W[k]
     """
 
     def __init__(

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -24,12 +24,12 @@ from .init import (
     init_phases,
     normal_norm_,
     uniform_norm_,
+    uniform_norm_p1_,
     xavier_normal_,
     xavier_normal_norm_,
     xavier_uniform_,
     xavier_uniform_norm_,
 )
-from .message_passing import Decomposition, RGCNLayer
 from .utils import TransformerEncoder
 from .weighting import EdgeWeighting, SymmetricEdgeWeighting, edge_weight_resolver
 from ..constants import AGGREGATIONS
@@ -41,9 +41,9 @@ from ..utils import Bias, activation_resolver, clamp_norm, complex_normalize, co
 __all__ = [
     "RepresentationModule",
     "Embedding",
+    "LowRankEmbeddingRepresentation",
     "LiteralRepresentation",
     "EmbeddingSpecification",
-    "RGCNRepresentations",
     "NodePieceRepresentation",
     "CompGCNLayer",
     "CombinedCompGCNRepresentations",
@@ -471,7 +471,15 @@ class LowRankEmbeddingRepresentation(RepresentationModule):
         E[i] = \sum B[i, k] * W[k]
     """
 
-    def __init__(self, *, max_id: int, shape: Sequence[int], num_bases: int = 3, **kwargs):
+    def __init__(
+        self,
+        *,
+        max_id: int,
+        shape: Sequence[int],
+        num_bases: int = 3,
+        weight_initializer: Initializer = uniform_norm_p1_,
+        **kwargs,
+    ):
         """
         Initialize the representations.
 
@@ -481,14 +489,21 @@ class LowRankEmbeddingRepresentation(RepresentationModule):
             the shape of an individual base representation.
         :param num_bases:
             the number of bases. More bases increase expressivity, but also increase the number of trainable parameters.
+        :param weight_initializer:
+            the initializer for basis weights
         :param kwargs:
             additional keyword based arguments passed to :class:`pykeen.nn.emb.Embedding`, which is used for the base
             representations.
         """
         super().__init__(max_id=max_id, shape=shape)
         self.bases = Embedding(num_embeddings=num_bases, shape=shape, **kwargs)
-        # initialize as random convex combination
-        self.weight = nn.Parameter(functional.normalize(torch.rand(max_id, num_bases), p=1, dim=-1))
+        self.weight_initializer = weight_initializer
+        self.weight = nn.Parameter(torch.empty(max_id, num_bases))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:  # noqa: D102
+        self.bases.reset_parameters()
+        self.weight.data = self.weight_initializer(self.weight)
 
     def forward(
         self,
@@ -496,12 +511,12 @@ class LowRankEmbeddingRepresentation(RepresentationModule):
     ) -> torch.FloatTensor:  # noqa: D102
         # get all base representations, shape: (num_bases, *shape)
         bases = self.bases(indices=None)
-        # get base weights, shape: (*, num_bases)
+        # get base weights, shape: (*batch_dims, num_bases)
         weight = self.weight
         if indices is not None:
             weight = weight[indices]
-        # weighted linear combination of bases
-        return torch.tensordot(weight, bases, dims=([-1], [1]))
+        # weighted linear combination of bases, shape: (*batch_dims, *shape)
+        return torch.tensordot(weight, bases, dims=([-1], [0]))
 
 
 class LiteralRepresentation(Embedding):
@@ -636,197 +651,6 @@ def _handle(
         rv = functools.partial(value, **kwargs)  # type: ignore
         return cast(X, rv)
     return value
-
-
-class RGCNRepresentations(RepresentationModule):
-    r"""Entity representations enriched by R-GCN.
-
-    The GCN employed by the entity encoder is adapted to include typed edges.
-    The forward pass of the GCN is defined by:
-
-     .. math::
-
-        \textbf{e}_{i}^{l+1} = \sigma \left( \sum_{r \in \mathcal{R}}\sum_{j\in \mathcal{N}_{i}^{r}}
-        \frac{1}{c_{i,r}} \textbf{W}_{r}^{l} \textbf{e}_{j}^{l} + \textbf{W}_{0}^{l} \textbf{e}_{i}^{l}\right)
-
-    where $\mathcal{N}_{i}^{r}$ is the set of neighbors of node $i$ that are connected to
-    $i$ by relation $r$, $c_{i,r}$ is a fixed normalization constant (but it can also be introduced as an additional
-    parameter), and $\textbf{W}_{r}^{l} \in \mathbb{R}^{d^{(l)} \times d^{(l)}}$ and
-    $\textbf{W}_{0}^{l} \in \mathbb{R}^{d^{(l)} \times d^{(l)}}$ are weight matrices of the `l`-th layer of the
-    R-GCN.
-
-    The encoder aggregates for each node $e_i$ the latent representations of its neighbors and its
-    own latent representation $e_{i}^{l}$ into a new latent representation $e_{i}^{l+1}$.
-    In contrast to standard GCN, R-GCN defines relation specific transformations
-    $\textbf{W}_{r}^{l}$ which depend on the type and direction of an edge.
-
-    Since having one matrix for each relation introduces a large number of additional parameters, the authors instead
-    propose to use a decomposition, cf. :class:`pykeen.nn.message_passing.Decomposition`.
-    """
-
-    def __init__(
-        self,
-        triples_factory: CoreTriplesFactory,
-        embedding_specification: EmbeddingSpecification,
-        num_layers: int = 2,
-        use_bias: bool = True,
-        activation: Hint[nn.Module] = None,
-        activation_kwargs: Optional[Mapping[str, Any]] = None,
-        edge_dropout: float = 0.4,
-        self_loop_dropout: float = 0.2,
-        edge_weighting: Hint[EdgeWeighting] = None,
-        decomposition: Hint[Decomposition] = None,
-        decomposition_kwargs: Optional[Mapping[str, Any]] = None,
-        regularizer: Hint[Regularizer] = None,
-        regularizer_kwargs: Optional[Mapping[str, Any]] = None,
-    ):
-        """Instantiate the R-GCN encoder.
-
-        :param triples_factory:
-            The triples factory holding the training triples used for message passing.
-        :param embedding_specification:
-            The base embedding specification.
-        :param num_layers:
-            The number of layers.
-        :param use_bias:
-            Whether to use a bias.
-        :param activation:
-            The activation.
-        :param activation_kwargs:
-            Additional keyword based arguments passed if the activation is not pre-instantiated. Ignored otherwise.
-        :param edge_dropout:
-            The edge dropout to use. Does not apply to self-loops.
-        :param self_loop_dropout:
-            The self-loop dropout to use.
-        :param edge_weighting:
-            The edge weighting mechanism.
-        :param decomposition:
-            The decomposition, cf. :class:`pykeen.nn.message_passing.Decomposition`.
-        :param decomposition_kwargs:
-            Additional keyword based arguments passed to the decomposition upon instantiation.
-        :param regularizer:
-            A regularizer, which is applied to the selected embeddings in forward pass
-        :param regularizer_kwargs:
-            Additional keyword arguments passed to the regularizer
-        """
-        base_embeddings = embedding_specification.make(num_embeddings=triples_factory.num_entities)
-        super().__init__(max_id=triples_factory.num_entities, shape=base_embeddings.shape)
-        self.entity_embeddings = base_embeddings
-
-        if triples_factory.create_inverse_triples:
-            raise ValueError(
-                "RGCN internally creates inverse triples. It thus expects a triples factory without them.",
-            )
-
-        # Resolve edge weighting
-        self.edge_weighting = edge_weight_resolver.make(query=edge_weighting)
-
-        # dropout
-        self.edge_dropout = edge_dropout
-        self_loop_dropout = self_loop_dropout or edge_dropout
-
-        # Save graph using buffers, such that the tensors are moved together with the model
-        h, r, t = triples_factory.mapped_triples.t()
-        self.register_buffer("sources", h)
-        self.register_buffer("targets", t)
-        self.register_buffer("edge_types", r)
-
-        dim = base_embeddings.embedding_dim
-        self.layers = nn.ModuleList(
-            RGCNLayer(
-                input_dim=dim,
-                num_relations=triples_factory.num_relations,
-                output_dim=dim,
-                use_bias=use_bias,
-                # no activation on last layer
-                # cf. https://github.com/MichSchli/RelationPrediction/blob/c77b094fe5c17685ed138dae9ae49b304e0d8d89/code/common/model_builder.py#L275  # noqa: E501
-                activation=activation if i < num_layers - 1 else None,
-                activation_kwargs=activation_kwargs,
-                self_loop_dropout=self_loop_dropout,
-                decomposition=decomposition,
-                decomposition_kwargs=decomposition_kwargs,
-            )
-            for i in range(num_layers)
-        )
-
-        # buffering of enriched representations
-        self.enriched_embeddings = None
-
-        if regularizer is not None:
-            regularizer = regularizer_resolver.make(regularizer, pos_kwargs=regularizer_kwargs)
-        self.regularizer = regularizer
-
-    def post_parameter_update(self) -> None:  # noqa: D102
-        super().post_parameter_update()
-
-        # invalidate enriched embeddings
-        self.enriched_embeddings = None
-
-    def reset_parameters(self):  # noqa: D102
-        self.entity_embeddings.reset_parameters()
-
-        for m in self.layers:
-            if hasattr(m, "reset_parameters"):
-                m.reset_parameters()
-            elif any(p.requires_grad for p in m.parameters()):
-                logger.warning("Layers %s has parameters, but no reset_parameters.", m)
-
-    def _real_forward(self) -> torch.FloatTensor:
-        if self.enriched_embeddings is not None:
-            return self.enriched_embeddings
-
-        # Bind fields
-        # shape: (num_entities, embedding_dim)
-        x = self.entity_embeddings(indices=None)
-        sources = self.sources
-        targets = self.targets
-        edge_types = self.edge_types
-
-        # Edge dropout: drop the same edges on all layers (only in training mode)
-        if self.training and self.edge_dropout is not None:
-            # Get random dropout mask
-            edge_keep_mask = torch.rand(self.sources.shape[0], device=x.device) > self.edge_dropout
-
-            # Apply to edges
-            sources = sources[edge_keep_mask]
-            targets = targets[edge_keep_mask]
-            edge_types = edge_types[edge_keep_mask]
-
-        # fixed edges -> pre-compute weights
-        if self.edge_weighting is not None and sources.numel() > 0:
-            edge_weights = torch.empty_like(sources, dtype=torch.float32)
-            for r in range(edge_types.max().item() + 1):
-                mask = edge_types == r
-                if mask.any():
-                    edge_weights[mask] = self.edge_weighting(sources[mask], targets[mask])
-        else:
-            edge_weights = None
-
-        for layer in self.layers:
-            x = layer(
-                x=x,
-                source=sources,
-                target=targets,
-                edge_type=edge_types,
-                edge_weights=edge_weights,
-            )
-
-        # Cache enriched representations
-        self.enriched_embeddings = x
-
-        return x
-
-    def forward(
-        self,
-        indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
-        """Enrich the entity embeddings of the decoder using R-GCN message propagation."""
-        x = self._real_forward()
-        if indices is not None:
-            x = x[indices]
-        if self.regularizer is not None:
-            self.regularizer.update(x)
-        return x
 
 
 class CompGCNLayer(nn.Module):

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -2,6 +2,7 @@
 
 """Embedding weight initialization routines."""
 
+import functools
 import logging
 import math
 from typing import Optional, Sequence
@@ -24,6 +25,7 @@ __all__ = [
     "xavier_normal_",
     "xavier_normal_norm_",
     "uniform_norm_",
+    "uniform_norm_p1_",
     "normal_norm_",
     "init_phases",
     "LabelBasedInitializer",
@@ -93,6 +95,10 @@ uniform_norm_ = compose(
 normal_norm_ = compose(
     torch.nn.init.normal_,
     functional.normalize,
+)
+uniform_norm_p1_ = compose(
+    torch.nn.init.uniform_,
+    functools.partial(functional.normalize, p=1),
 )
 
 

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -200,7 +200,7 @@ class BasesDecomposition(Decomposition):
         )
         self.memory_intense = memory_intense
 
-    def reset_parameters(self):
+    def reset_parameters(self):  # noqa: D102
         self.relation_representations.reset_parameters()
 
     def _get_weight(self, relation_id: int) -> torch.FloatTensor:

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -10,16 +10,23 @@ import torch
 from class_resolver import Resolver
 from class_resolver.api import Hint
 from torch import nn
-from torch.nn import functional
 
-from pykeen.utils import activation_resolver
+from .emb import EmbeddingSpecification, LowRankEmbeddingRepresentation, RepresentationModule
+from .init import uniform_norm_p1_
+from .weighting import EdgeWeighting, edge_weight_resolver
+from ..regularizers import Regularizer, regularizer_resolver
+from ..triples import CoreTriplesFactory
+from ..utils import activation_resolver
 
 __all__ = [
+    "RGCNRepresentations",
     "Decomposition",
     "BasesDecomposition",
     "BlockDecomposition",
     "decomposition_resolver",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 def _reduce_relation_specific(
@@ -179,36 +186,22 @@ class BasesDecomposition(Decomposition):
 
         # Heuristic for default value
         if num_bases is None:
-            logging.info("No num_bases was provided. Falling back to 2.")
+            logger.info("No num_bases was provided. Falling back to 2.")
             num_bases = 2
 
         if num_bases > num_relations:
             raise ValueError("The number of bases should not exceed the number of relations.")
 
-        # weights
-        self.bases = nn.Parameter(
-            torch.empty(
-                num_bases,
-                self.input_dim,
-                self.output_dim,
-            ),
-            requires_grad=True,
-        )
-        self.relation_base_weights = nn.Parameter(
-            torch.empty(
-                num_relations,
-                num_bases,
-            ),
-            requires_grad=True,
+        self.relation_representations = LowRankEmbeddingRepresentation(
+            max_id=num_relations,
+            shape=(self.input_dim, self.output_dim),
+            weight_initializer=uniform_norm_p1_,
+            initializer=nn.init.xavier_normal_,
         )
         self.memory_intense = memory_intense
 
-    def reset_parameters(self):  # noqa: D102
-        nn.init.xavier_normal_(self.bases)
-        # Random convex-combination of bases for initialization (guarantees that initial weight matrices are
-        # initialized properly)
-        nn.init.uniform_(self.relation_base_weights)
-        functional.normalize(self.relation_base_weights.data, p=1, dim=1, out=self.relation_base_weights.data)
+    def reset_parameters(self):
+        self.relation_representations.reset_parameters()
 
     def _get_weight(self, relation_id: int) -> torch.FloatTensor:
         """Construct weight matrix for a specific relation ID.
@@ -219,7 +212,7 @@ class BasesDecomposition(Decomposition):
         :return:
             A 2-D matrix.
         """
-        return torch.einsum("bij,b->ij", self.bases, self.relation_base_weights[relation_id])
+        return self.relation_representations(indices=relation_id).squeeze(dim=0)
 
     def _forward_memory_intense(
         self,
@@ -232,10 +225,9 @@ class BasesDecomposition(Decomposition):
     ) -> torch.FloatTensor:
         # other relations
         m = torch.einsum(
-            "mi,mb,bij->mj",
+            "mi,mij->mj",
             x.index_select(dim=0, index=source),
-            self.relation_base_weights.index_select(dim=0, index=edge_type),
-            self.bases,
+            self.relation_representations(indices=edge_type),
         )
         if edge_weights is not None:
             m = m * edge_weights.unsqueeze(dim=-1)
@@ -351,7 +343,7 @@ class BlockDecomposition(Decomposition):
         )
 
         if num_blocks is None:
-            logging.info("Using a heuristic to determine the number of blocks.")
+            logger.info("Using a heuristic to determine the number of blocks.")
             num_blocks = min(i for i in range(2, input_dim + 1) if input_dim % i == 0)
 
         block_size, remainder = divmod(input_dim, num_blocks)
@@ -566,3 +558,194 @@ class RGCNLayer(nn.Module):
 
 
 decomposition_resolver = Resolver.from_subclasses(base=Decomposition, default=BasesDecomposition)
+
+
+class RGCNRepresentations(RepresentationModule):
+    r"""Entity representations enriched by R-GCN.
+
+    The GCN employed by the entity encoder is adapted to include typed edges.
+    The forward pass of the GCN is defined by:
+
+     .. math::
+
+        \textbf{e}_{i}^{l+1} = \sigma \left( \sum_{r \in \mathcal{R}}\sum_{j\in \mathcal{N}_{i}^{r}}
+        \frac{1}{c_{i,r}} \textbf{W}_{r}^{l} \textbf{e}_{j}^{l} + \textbf{W}_{0}^{l} \textbf{e}_{i}^{l}\right)
+
+    where $\mathcal{N}_{i}^{r}$ is the set of neighbors of node $i$ that are connected to
+    $i$ by relation $r$, $c_{i,r}$ is a fixed normalization constant (but it can also be introduced as an additional
+    parameter), and $\textbf{W}_{r}^{l} \in \mathbb{R}^{d^{(l)} \times d^{(l)}}$ and
+    $\textbf{W}_{0}^{l} \in \mathbb{R}^{d^{(l)} \times d^{(l)}}$ are weight matrices of the `l`-th layer of the
+    R-GCN.
+
+    The encoder aggregates for each node $e_i$ the latent representations of its neighbors and its
+    own latent representation $e_{i}^{l}$ into a new latent representation $e_{i}^{l+1}$.
+    In contrast to standard GCN, R-GCN defines relation specific transformations
+    $\textbf{W}_{r}^{l}$ which depend on the type and direction of an edge.
+
+    Since having one matrix for each relation introduces a large number of additional parameters, the authors instead
+    propose to use a decomposition, cf. :class:`pykeen.nn.message_passing.Decomposition`.
+    """
+
+    def __init__(
+        self,
+        triples_factory: CoreTriplesFactory,
+        embedding_specification: EmbeddingSpecification,
+        num_layers: int = 2,
+        use_bias: bool = True,
+        activation: Hint[nn.Module] = None,
+        activation_kwargs: Optional[Mapping[str, Any]] = None,
+        edge_dropout: float = 0.4,
+        self_loop_dropout: float = 0.2,
+        edge_weighting: Hint[EdgeWeighting] = None,
+        decomposition: Hint[Decomposition] = None,
+        decomposition_kwargs: Optional[Mapping[str, Any]] = None,
+        regularizer: Hint[Regularizer] = None,
+        regularizer_kwargs: Optional[Mapping[str, Any]] = None,
+    ):
+        """Instantiate the R-GCN encoder.
+
+        :param triples_factory:
+            The triples factory holding the training triples used for message passing.
+        :param embedding_specification:
+            The base embedding specification.
+        :param num_layers:
+            The number of layers.
+        :param use_bias:
+            Whether to use a bias.
+        :param activation:
+            The activation.
+        :param activation_kwargs:
+            Additional keyword based arguments passed if the activation is not pre-instantiated. Ignored otherwise.
+        :param edge_dropout:
+            The edge dropout to use. Does not apply to self-loops.
+        :param self_loop_dropout:
+            The self-loop dropout to use.
+        :param edge_weighting:
+            The edge weighting mechanism.
+        :param decomposition:
+            The decomposition, cf. :class:`pykeen.nn.message_passing.Decomposition`.
+        :param decomposition_kwargs:
+            Additional keyword based arguments passed to the decomposition upon instantiation.
+        :param regularizer:
+            A regularizer, which is applied to the selected embeddings in forward pass
+        :param regularizer_kwargs:
+            Additional keyword arguments passed to the regularizer
+        """
+        base_embeddings = embedding_specification.make(num_embeddings=triples_factory.num_entities)
+        super().__init__(max_id=triples_factory.num_entities, shape=base_embeddings.shape)
+        self.entity_embeddings = base_embeddings
+
+        if triples_factory.create_inverse_triples:
+            raise ValueError(
+                "RGCN internally creates inverse triples. It thus expects a triples factory without them.",
+            )
+
+        # Resolve edge weighting
+        self.edge_weighting = edge_weight_resolver.make(query=edge_weighting)
+
+        # dropout
+        self.edge_dropout = edge_dropout
+        self_loop_dropout = self_loop_dropout or edge_dropout
+
+        # Save graph using buffers, such that the tensors are moved together with the model
+        h, r, t = triples_factory.mapped_triples.t()
+        self.register_buffer("sources", h)
+        self.register_buffer("targets", t)
+        self.register_buffer("edge_types", r)
+
+        dim = base_embeddings.embedding_dim
+        self.layers = nn.ModuleList(
+            RGCNLayer(
+                input_dim=dim,
+                num_relations=triples_factory.num_relations,
+                output_dim=dim,
+                use_bias=use_bias,
+                # no activation on last layer
+                # cf. https://github.com/MichSchli/RelationPrediction/blob/c77b094fe5c17685ed138dae9ae49b304e0d8d89/code/common/model_builder.py#L275  # noqa: E501
+                activation=activation if i < num_layers - 1 else None,
+                activation_kwargs=activation_kwargs,
+                self_loop_dropout=self_loop_dropout,
+                decomposition=decomposition,
+                decomposition_kwargs=decomposition_kwargs,
+            )
+            for i in range(num_layers)
+        )
+
+        # buffering of enriched representations
+        self.enriched_embeddings = None
+
+        if regularizer is not None:
+            regularizer = regularizer_resolver.make(regularizer, pos_kwargs=regularizer_kwargs)
+        self.regularizer = regularizer
+
+    def post_parameter_update(self) -> None:  # noqa: D102
+        super().post_parameter_update()
+
+        # invalidate enriched embeddings
+        self.enriched_embeddings = None
+
+    def reset_parameters(self):  # noqa: D102
+        self.entity_embeddings.reset_parameters()
+
+        for m in self.layers:
+            if hasattr(m, "reset_parameters"):
+                m.reset_parameters()
+            elif any(p.requires_grad for p in m.parameters()):
+                logger.warning("Layers %s has parameters, but no reset_parameters.", m)
+
+    def _real_forward(self) -> torch.FloatTensor:
+        if self.enriched_embeddings is not None:
+            return self.enriched_embeddings
+
+        # Bind fields
+        # shape: (num_entities, embedding_dim)
+        x = self.entity_embeddings(indices=None)
+        sources = self.sources
+        targets = self.targets
+        edge_types = self.edge_types
+
+        # Edge dropout: drop the same edges on all layers (only in training mode)
+        if self.training and self.edge_dropout is not None:
+            # Get random dropout mask
+            edge_keep_mask = torch.rand(self.sources.shape[0], device=x.device) > self.edge_dropout
+
+            # Apply to edges
+            sources = sources[edge_keep_mask]
+            targets = targets[edge_keep_mask]
+            edge_types = edge_types[edge_keep_mask]
+
+        # fixed edges -> pre-compute weights
+        if self.edge_weighting is not None and sources.numel() > 0:
+            edge_weights = torch.empty_like(sources, dtype=torch.float32)
+            for r in range(edge_types.max().item() + 1):
+                mask = edge_types == r
+                if mask.any():
+                    edge_weights[mask] = self.edge_weighting(sources[mask], targets[mask])
+        else:
+            edge_weights = None
+
+        for layer in self.layers:
+            x = layer(
+                x=x,
+                source=sources,
+                target=targets,
+                edge_type=edge_types,
+                edge_weights=edge_weights,
+            )
+
+        # Cache enriched representations
+        self.enriched_embeddings = x
+
+        return x
+
+    def forward(
+        self,
+        indices: Optional[torch.LongTensor] = None,
+    ) -> torch.FloatTensor:
+        """Enrich the entity embeddings of the decoder using R-GCN message propagation."""
+        x = self._real_forward()
+        if indices is not None:
+            x = x[indices]
+        if self.regularizer is not None:
+            self.regularizer.update(x)
+        return x

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -11,6 +11,7 @@ import torch
 import unittest_templates
 
 import pykeen.nn.emb
+import pykeen.nn.message_passing
 from pykeen.datasets import get_dataset
 from pykeen.datasets.nations import NationsLiteral
 from pykeen.nn.emb import (
@@ -98,7 +99,7 @@ class TensorEmbeddingTests(cases.RepresentationTestCase):
 class RGCNRepresentationTests(cases.RepresentationTestCase):
     """Test RGCN representations."""
 
-    cls = pykeen.nn.emb.RGCNRepresentations
+    cls = pykeen.nn.message_passing.RGCNRepresentations
     num_entities: ClassVar[int] = 8
     num_relations: ClassVar[int] = 7
     num_triples: ClassVar[int] = 31

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -17,6 +17,7 @@ from pykeen.nn.emb import (
     Embedding,
     EmbeddingSpecification,
     LiteralRepresentation,
+    LowRankEmbeddingRepresentation,
     RepresentationModule,
     SubsetRepresentationModule,
 )
@@ -57,6 +58,16 @@ class EmbeddingTests(cases.RepresentationTestCase):
         first = dropout_instance(indices)
         second = dropout_instance(indices)
         assert not torch.allclose(first, second)
+
+
+class LowRankEmbeddingRepresentationTests(cases.RepresentationTestCase):
+    """Tests for low-rank embedding representations."""
+
+    cls = LowRankEmbeddingRepresentation
+    kwargs = dict(
+        max_id=10,
+        shape=(3, 7),
+    )
 
 
 class LiteralEmbeddingTests(cases.RepresentationTestCase):

--- a/tests/test_nn/test_emb.py
+++ b/tests/test_nn/test_emb.py
@@ -18,7 +18,6 @@ from pykeen.nn.emb import (
     Embedding,
     EmbeddingSpecification,
     LiteralRepresentation,
-    LowRankEmbeddingRepresentation,
     RepresentationModule,
     SubsetRepresentationModule,
 )
@@ -64,7 +63,7 @@ class EmbeddingTests(cases.RepresentationTestCase):
 class LowRankEmbeddingRepresentationTests(cases.RepresentationTestCase):
     """Tests for low-rank embedding representations."""
 
-    cls = LowRankEmbeddingRepresentation
+    cls = pykeen.nn.emb.LowRankEmbeddingRepresentation
     kwargs = dict(
         max_id=10,
         shape=(3, 7),


### PR DESCRIPTION
This PR adds a representation module, which factorizes the `Embedding` matrix into a matrix of basis representations, and trainable linear weights.

It is an alternative way to reduce the number of trainable parameters, while keeping the embedding dimension. 

* [x] It is essentially the same as 
https://github.com/pykeen/pykeen/blob/c8f6af64ab1ed75c8ca188eabd8eaa263806057c/src/pykeen/nn/message_passing.py#L141-L150

so there may be some potential to reduce duplication. -> 78d9b62 