### PR TITLE
🐚 ⚛ Store pipeline configuration in pipeline result

### DIFF
--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -184,7 +184,6 @@ the :class:`pykeen.datasets.Nations`
 """
 
 import ftplib
-import inspect
 import json
 import logging
 import os
@@ -212,7 +211,7 @@ from ..optimizers import optimizer_resolver
 from ..regularizers import Regularizer, regularizer_resolver
 from ..sampling import NegativeSampler, negative_sampler_resolver
 from ..stoppers import EarlyStopper, Stopper, stopper_resolver
-from ..trackers import PythonResultTracker, ResultTracker, resolve_result_trackers
+from ..trackers import ResultTracker, resolve_result_trackers
 from ..training import SLCWATrainingLoop, TrainingLoop, training_loop_resolver
 from ..triples import CoreTriplesFactory
 from ..typing import Hint, HintType, MappedTriples, OneOrSequence
@@ -1162,9 +1161,7 @@ def pipeline(  # noqa: C901
     _result_tracker.log_params(params=training_kwargs, prefix="training")
 
     # Add logging for debugging
-    configuration_tracker = _result_tracker.trackers[-1]
-    assert isinstance(configuration_tracker, PythonResultTracker)
-    configuration = configuration_tracker.configuration
+    configuration = result_tracker.get_configuration()
     logging.debug("Run Pipeline based on following config:")
     for key, value in configuration.items():
         logging.debug(f"{key}: {value}")

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1230,10 +1230,7 @@ def pipeline(  # noqa: C901
     if use_tqdm is not None:
         evaluation_kwargs["use_tqdm"] = use_tqdm
     # Add logging about evaluator for debugging
-    logging.debug("Evaluation will be run with following parameters:")
-    logging.debug(f"evaluation_kwargs: {evaluation_kwargs}")
-    # TODO: log this?
-    # configuration_tracker.log_params(...)
+    _result_tracker.log_params(params=evaluator_kwargs, prefix="evaluation_kwargs")
     evaluate_start_time = time.time()
     metric_results: MetricResults = _safe_evaluate(
         model=model_instance,

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -806,7 +806,7 @@ def pipeline(  # noqa: C901
     evaluator_kwargs: Optional[Mapping[str, Any]] = None,
     evaluation_kwargs: Optional[Mapping[str, Any]] = None,
     # 9. Tracking
-    result_tracker: Union[None, OneOrSequence[HintType[ResultTracker]]] = None,
+    result_tracker: Optional[OneOrSequence[HintType[ResultTracker]]] = None,
     result_tracker_kwargs: Optional[OneOrSequence[Optional[Mapping[str, Any]]]] = None,
     # Misc
     metadata: Optional[Dict[str, Any]] = None,

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1177,6 +1177,8 @@ def pipeline(  # noqa: C901
     )
     assert losses is not None  # losses is only none if it's doing search mode
     training_end_time = time.time() - training_start_time
+    step = training_kwargs.get("num_epochs")
+    _result_tracker.log_metrics(metrics=dict(total_training=training_end_time), step=step, prefix="times")
 
     if use_testing_data:
         mapped_triples = testing.mapped_triples
@@ -1240,9 +1242,10 @@ def pipeline(  # noqa: C901
         evaluation_fallback=evaluation_fallback,
     )
     evaluate_end_time = time.time() - evaluate_start_time
+    _result_tracker.log_metrics(metrics=dict(final_evaluation=evaluate_end_time), step=step, prefix="times")
     _result_tracker.log_metrics(
         metrics=metric_results.to_dict(),
-        step=training_kwargs.get("num_epochs"),
+        step=step,
     )
     _result_tracker.end_run()
 

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -752,12 +752,15 @@ def _build_model_helper(
             # copy default value
             model_kwargs.setdefault(name, param.default)
 
-    return model_resolver.make(
-        model,
-        triples_factory=training_triples_factory,
-        loss=loss_instance,
-        **model_kwargs,
-    ), model_kwargs
+    return (
+        model_resolver.make(
+            model,
+            triples_factory=training_triples_factory,
+            loss=loss_instance,
+            **model_kwargs,
+        ),
+        model_kwargs,
+    )
 
 
 def _resolve_result_trackers(

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1061,11 +1061,14 @@ def pipeline(  # noqa: C901
         prefix="model",
     )
 
+    optimizer_kwargs = dict(optimizer_kwargs or {})
     optimizer_instance = optimizer_resolver.make(
         optimizer,
         optimizer_kwargs,
         params=model_instance.get_grad_params(),
     )
+    for key, value in optimizer_instance.defaults.items():
+        optimizer_kwargs.setdefault(key, value)
     _result_tracker.log_params(
         params=dict(cls=optimizer_instance.__class__.__name__, kwargs=optimizer_kwargs),
         prefix="optimizer",

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1161,7 +1161,7 @@ def pipeline(  # noqa: C901
     _result_tracker.log_params(params=training_kwargs, prefix="training")
 
     # Add logging for debugging
-    configuration = result_tracker.get_configuration()
+    configuration = _result_tracker.get_configuration()
     logging.debug("Run Pipeline based on following config:")
     for key, value in configuration.items():
         logging.debug(f"{key}: {value}")

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -755,8 +755,7 @@ def _resolve_result_trackers(
 ) -> MultiResultTracker:
     """Resolve and compose result trackers."""
     if result_tracker is None:
-        result_tracker = [ResultTracker]
-        result_tracker_kwargs = [None]
+        result_tracker = []
     result_tracker = upgrade_to_sequence(result_tracker)
     if result_tracker_kwargs is None:
         result_tracker_kwargs = [None] * len(result_tracker)

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -719,7 +719,9 @@ def _get_model_defaults(model: Model) -> Mapping[str, Any]:
         name: param.default
         for name, param in model_resolver.signature(model).parameters.items()
         # skip special parameters
-        if name != "self" and param.kind not in {param.VAR_POSITIONAL, param.VAR_KEYWORD}
+        if name != "self"
+        and param.kind not in {param.VAR_POSITIONAL, param.VAR_KEYWORD}
+        and param.default != param.empty
     }
 
 

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -905,11 +905,12 @@ def pipeline(  # noqa: C901
     :param evaluation_kwargs:
         Keyword arguments to pass to the evaluator's evaluate function on call
 
-    :param result_tracker:
-        The ResultsTracker class or name
-        # TODO
-    :param result_tracker_kwargs:
-        The keyword arguments passed to the results tracker on instantiation
+    :param result_tracker: Either none (will result in a Python result tracker),
+        a single tracker (as either a class, instance, or string for class name), or a list
+        of trackers (as either a class, instance, or string for class name
+    :param result_tracker_kwargs: Either none (will use all defaults), a single dictionary
+        (will be used for all trackers), or a list of dictionaries with the same length
+        as the result trackers
 
     :param metadata:
         A JSON dictionary to store with the experiment

--- a/src/pykeen/trackers/__init__.py
+++ b/src/pykeen/trackers/__init__.py
@@ -43,19 +43,19 @@ tracker_resolver = Resolver.from_subclasses(
 
 
 def resolve_result_trackers(
-    result_tracker_: Optional[OneOrSequence[HintType[ResultTracker]]] = None,
-    result_tracker_kwargs_: Optional[OneOrSequence[Optional[Mapping[str, Any]]]] = None,
+    result_tracker: Optional[OneOrSequence[HintType[ResultTracker]]] = None,
+    result_tracker_kwargs: Optional[OneOrSequence[Optional[Mapping[str, Any]]]] = None,
 ) -> MultiResultTracker:
     """Resolve and compose result trackers."""
-    if result_tracker_ is None:
+    if result_tracker is None:
         result_trackers = []
     else:
-        result_trackers = upgrade_to_sequence(result_tracker_)
+        result_trackers = upgrade_to_sequence(result_tracker)
 
-    if result_tracker_kwargs_ is None:
+    if result_tracker_kwargs is None:
         result_tracker_kwargses = [None] * len(result_trackers)
     else:
-        result_tracker_kwargses = upgrade_to_sequence(result_tracker_kwargs_)
+        result_tracker_kwargses = upgrade_to_sequence(result_tracker_kwargs)
 
     if len(result_tracker_kwargses) == 1 and len(result_trackers) == 0:
         raise ValueError

--- a/src/pykeen/trackers/__init__.py
+++ b/src/pykeen/trackers/__init__.py
@@ -43,7 +43,7 @@ tracker_resolver = Resolver.from_subclasses(
 
 
 def resolve_result_trackers(
-    result_tracker: Union[None, OneOrSequence[HintType[ResultTracker]]] = None,
+    result_tracker: Optional[OneOrSequence[HintType[ResultTracker]]] = None,
     result_tracker_kwargs: Optional[OneOrSequence[Optional[Mapping[str, Any]]]] = None,
 ) -> MultiResultTracker:
     """Resolve and compose result trackers."""

--- a/src/pykeen/trackers/__init__.py
+++ b/src/pykeen/trackers/__init__.py
@@ -2,7 +2,7 @@
 
 """Result trackers in PyKEEN."""
 
-from typing import Any, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional, Sequence
 
 from class_resolver import HintType, Resolver
 
@@ -56,11 +56,13 @@ def resolve_result_trackers(
         as the result trackers
     :returns: A multi-result trackers that offloads to all contained result trackers
     """
+    result_trackers: Sequence[HintType[ResultTracker]]
     if result_tracker is None:
         result_trackers = []
     else:
         result_trackers = upgrade_to_sequence(result_tracker)
 
+    result_tracker_kwargses: Sequence[Optional[Mapping[str, Any]]]
     if result_tracker_kwargs is None:
         result_tracker_kwargses = [None] * len(result_trackers)
     else:

--- a/src/pykeen/trackers/__init__.py
+++ b/src/pykeen/trackers/__init__.py
@@ -2,7 +2,7 @@
 
 """Result trackers in PyKEEN."""
 
-from typing import Any, List, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 from class_resolver import HintType, Resolver
 

--- a/src/pykeen/trackers/__init__.py
+++ b/src/pykeen/trackers/__init__.py
@@ -2,7 +2,9 @@
 
 """Result trackers in PyKEEN."""
 
-from class_resolver import Resolver
+from typing import Any, Mapping, Optional, Union
+
+from class_resolver import HintType, Resolver
 
 from .base import ConsoleResultTracker, MultiResultTracker, PythonResultTracker, ResultTracker, TrackerHint
 from .file import CSVResultTracker, FileResultTracker, JSONResultTracker
@@ -10,6 +12,8 @@ from .mlflow import MLFlowResultTracker
 from .neptune import NeptuneResultTracker
 from .tensorboard import TensorBoardResultTracker
 from .wandb import WANDBResultTracker
+from ..typing import OneOrSequence
+from ..utils import upgrade_to_sequence
 
 __all__ = [
     # Base classes
@@ -28,6 +32,7 @@ __all__ = [
     # Utilities
     "tracker_resolver",
     "TrackerHint",
+    "resolve_result_trackers",
 ]
 
 tracker_resolver = Resolver.from_subclasses(
@@ -35,3 +40,25 @@ tracker_resolver = Resolver.from_subclasses(
     default=ResultTracker,
     skip={FileResultTracker, MultiResultTracker},
 )
+
+
+def resolve_result_trackers(
+    result_tracker: Union[None, OneOrSequence[HintType[ResultTracker]]] = None,
+    result_tracker_kwargs: Optional[OneOrSequence[Optional[Mapping[str, Any]]]] = None,
+) -> MultiResultTracker:
+    """Resolve and compose result trackers."""
+    if result_tracker is None:
+        result_tracker = []
+    result_tracker = upgrade_to_sequence(result_tracker)
+    if result_tracker_kwargs is None:
+        result_tracker_kwargs = [None] * len(result_tracker)
+    result_tracker_kwargs = upgrade_to_sequence(result_tracker_kwargs)
+    if len(result_tracker_kwargs) == 1 and len(result_tracker) > 1:
+        result_tracker_kwargs = list(result_tracker_kwargs) * len(result_tracker)
+    return MultiResultTracker(
+        trackers=[
+            tracker_resolver.make(query=_result_tracker, pos_kwargs=_result_tracker_kwargs)
+            for _result_tracker, _result_tracker_kwargs in zip(result_tracker, result_tracker_kwargs)
+        ]
+        + [PythonResultTracker(store_metrics=False)]  # always add a Python result tracker for storing the configuration
+    )

--- a/src/pykeen/trackers/__init__.py
+++ b/src/pykeen/trackers/__init__.py
@@ -46,7 +46,16 @@ def resolve_result_trackers(
     result_tracker: Optional[OneOrSequence[HintType[ResultTracker]]] = None,
     result_tracker_kwargs: Optional[OneOrSequence[Optional[Mapping[str, Any]]]] = None,
 ) -> MultiResultTracker:
-    """Resolve and compose result trackers."""
+    """Resolve and compose result trackers.
+
+    :param result_tracker: Either none (will result in a Python result tracker),
+        a single tracker (as either a class, instance, or string for class name), or a list
+        of trackers (as either a class, instance, or string for class name
+    :param result_tracker_kwargs: Either none (will use all defaults), a single dictionary
+        (will be used for all trackers), or a list of dictionaries with the same length
+        as the result trackers
+    :returns: A multi-result trackers that offloads to all contained result trackers
+    """
     if result_tracker is None:
         result_trackers = []
     else:

--- a/src/pykeen/trackers/__init__.py
+++ b/src/pykeen/trackers/__init__.py
@@ -57,12 +57,12 @@ def resolve_result_trackers(
     else:
         result_tracker_kwargses = upgrade_to_sequence(result_tracker_kwargs)
 
-    if len(result_tracker_kwargses) == 1 and len(result_trackers) == 0:
-        raise ValueError
-    elif len(result_tracker_kwargses) == 1 and len(result_trackers) > 1:
+    if 0 < len(result_tracker_kwargses) and 0 == len(result_trackers):
+        raise ValueError("Kwargs were given but no result trackers")
+    elif 1 == len(result_tracker_kwargses) == 1 and 1 < len(result_trackers):
         result_tracker_kwargses = list(result_tracker_kwargses) * len(result_trackers)
     elif len(result_tracker_kwargses) != len(result_trackers):
-        raise ValueError("Mismatch in number number of trackers and kwarg")
+        raise ValueError("Mismatch in number number of trackers and kwargs")
 
     trackers = [
         tracker_resolver.make(query=_result_tracker, pos_kwargs=_result_tracker_kwargs)

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -78,14 +78,18 @@ class PythonResultTracker(ResultTracker):
     #: The configuration dictionary, a mapping from name -> value
     configuration: MutableMapping[str, Any]
 
+    #: Should metrics be stored when running ``log_metrics()``?
+    store_metrics: bool
+
     #: The metrics, a mapping from step -> (name -> value)
-    metrics: Optional[MutableMapping[Optional[int], Mapping[str, float]]]
+    metrics: MutableMapping[Optional[int], Mapping[str, float]]
 
     def __init__(self, store_metrics: bool = True) -> None:
         """Initialize the tracker."""
         super().__init__()
+        self.store_metrics = store_metrics
         self.configuration = dict()
-        self.metrics = dict() if store_metrics else None
+        self.metrics = dict()
         self.run_name = None
 
     def start_run(self, run_name: Optional[str] = None) -> None:  # noqa: D102
@@ -102,7 +106,7 @@ class PythonResultTracker(ResultTracker):
         step: Optional[int] = None,
         prefix: Optional[str] = None,
     ) -> None:  # noqa: D102
-        if self.metrics is None:
+        if not self.store_metrics:
             return
 
         if prefix is not None:

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -79,13 +79,13 @@ class PythonResultTracker(ResultTracker):
     configuration: MutableMapping[str, Any]
 
     #: The metrics, a mapping from step -> (name -> value)
-    metrics: MutableMapping[Optional[int], Mapping[str, float]]
+    metrics: Optional[MutableMapping[Optional[int], Mapping[str, float]]]
 
-    def __init__(self) -> None:
+    def __init__(self, store_metrics: bool = True) -> None:
         """Initialize the tracker."""
         super().__init__()
         self.configuration = dict()
-        self.metrics = dict()
+        self.metrics = dict() if store_metrics else None
         self.run_name = None
 
     def start_run(self, run_name: Optional[str] = None) -> None:  # noqa: D102
@@ -102,6 +102,9 @@ class PythonResultTracker(ResultTracker):
         step: Optional[int] = None,
         prefix: Optional[str] = None,
     ) -> None:  # noqa: D102
+        if self.metrics is None:
+            return
+
         if prefix is not None:
             metrics = {f"{prefix}.{key}": value for key, value in metrics.items()}
         self.metrics[step] = metrics

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -238,3 +238,8 @@ class MultiResultTracker(ResultTracker):
     def end_run(self, success: bool = True) -> None:  # noqa: D102
         for tracker in self.trackers:
             tracker.end_run(success=success)
+
+    def get_configuration(self):
+        """Get the configuration from a Python result tracker."""
+        tracker = next(_tracker for _tracker in self.trackers if isinstance(_tracker, PythonResultTracker))
+        return tracker.configuration


### PR DESCRIPTION
This PR

1. adds support for multiple trackers to `pipeline`, and
2. stores the configuration (or at least some part of it) to the pipeline result.
3. enriches the model parameters in the configuration by inserting the default parameters which can be read from the `__init__` signature.


It partially may solve #673 .

related: #586

#### Known limitations

This does not properly address dynamically inferred default value, or `**kwargs`


#### Release Notes
This PR changes how some parameters are logged to bring it more in-line with the `pipeline`'s parameter names and structure.