### PR TITLE
🧹📖 Cleanup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,17 +214,6 @@ have a suggestion for another dataset to include in PyKEEN, please let us know
 | powersum | [`pykeen.regularizers.PowerSumRegularizer`](https://pykeen.readthedocs.io/en/latest/api/pykeen.regularizers.PowerSumRegularizer.html) | A simple x^p based regularizer.                          |
 | transh   | [`pykeen.regularizers.TransHRegularizer`](https://pykeen.readthedocs.io/en/latest/api/pykeen.regularizers.TransHRegularizer.html)     | A regularizer for the soft constraints in TransH.        |
 
-### Optimizers (6)
-
-| Name     | Reference                                                                                 | Description                                                             |
-|----------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| adadelta | [`torch.optim.Adadelta`](https://pytorch.org/docs/stable/optim.html#torch.optim.Adadelta) | Implements Adadelta algorithm.                                          |
-| adagrad  | [`torch.optim.Adagrad`](https://pytorch.org/docs/stable/optim.html#torch.optim.Adagrad)   | Implements Adagrad algorithm.                                           |
-| adam     | [`torch.optim.Adam`](https://pytorch.org/docs/stable/optim.html#torch.optim.Adam)         | Implements Adam algorithm.                                              |
-| adamax   | [`torch.optim.Adamax`](https://pytorch.org/docs/stable/optim.html#torch.optim.Adamax)     | Implements Adamax algorithm (a variant of Adam based on infinity norm). |
-| adamw    | [`torch.optim.AdamW`](https://pytorch.org/docs/stable/optim.html#torch.optim.AdamW)       | Implements AdamW algorithm.                                             |
-| sgd      | [`torch.optim.SGD`](https://pytorch.org/docs/stable/optim.html#torch.optim.SGD)           | Implements stochastic gradient descent (optionally with momentum).      |
-
 ### Training Loops (2)
 
 | Name   | Reference                                                                                                                                | Description                                                                               |
@@ -304,20 +293,6 @@ have a suggestion for another dataset to include in PyKEEN, please let us know
 | python      | [`pykeen.trackers.PythonResultTracker`](https://pykeen.readthedocs.io/en/latest/api/pykeen.trackers.PythonResultTracker.html)           | A tracker which stores everything in Python dictionaries. |
 | tensorboard | [`pykeen.trackers.TensorBoardResultTracker`](https://pykeen.readthedocs.io/en/latest/api/pykeen.trackers.TensorBoardResultTracker.html) | A tracker for TensorBoard.                                |
 | wandb       | [`pykeen.trackers.WANDBResultTracker`](https://pykeen.readthedocs.io/en/latest/api/pykeen.trackers.WANDBResultTracker.html)             | A tracker for Weights and Biases.                         |
-
-## Hyper-parameter Optimization
-
-### Samplers (3)
-
-| Name   | Reference                                                                                                                         | Description                                                     |
-|--------|-----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
-| grid   | [`optuna.samplers.GridSampler`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.GridSampler.html)     | Sampler using grid search.                                      |
-| random | [`optuna.samplers.RandomSampler`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.RandomSampler.html) | Sampler using random sampling.                                  |
-| tpe    | [`optuna.samplers.TPESampler`](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.TPESampler.html)       | Sampler using TPE (Tree-structured Parzen Estimator) algorithm. |
-
-Any sampler class extending the [optuna.samplers.BaseSampler](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.BaseSampler.html#optuna.samplers.BaseSampler),
-such as their sampler implementing the [CMA-ES](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.CmaEsSampler.html#optuna.samplers.CmaEsSampler)
-algorithm, can also be used.
 
 ## Experimentation
 

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -521,8 +521,6 @@ def get_readme() -> str:
             link_fmt="https://pykeen.readthedocs.io/en/latest/api/{}.html",
         ),
         n_negative_samplers=len(negative_sampler_resolver.lookup_dict),
-        optimizers=_help_optimizers(tablefmt, link_fmt="https://pytorch.org/docs/stable/optim.html#{}"),
-        n_optimizers=len(optimizer_resolver.lookup_dict),
         stoppers=_help_stoppers(
             tablefmt,
             link_fmt="https://pykeen.readthedocs.io/en/latest/reference/stoppers.html#{}",
@@ -534,11 +532,6 @@ def get_readme() -> str:
         n_metrics=len(get_metric_list()),
         trackers=_help_trackers(tablefmt, link_fmt="https://pykeen.readthedocs.io/en/latest/api/{}.html"),
         n_trackers=len(tracker_resolver.lookup_dict),
-        hpo_samplers=_help_hpo_samplers(
-            tablefmt,
-            link_fmt="https://optuna.readthedocs.io/en/stable/reference/generated/{}.html",
-        ),
-        n_hpo_samplers=len(sampler_resolver.lookup_dict),
     )
 
 

--- a/src/pykeen/templates/README.md
+++ b/src/pykeen/templates/README.md
@@ -128,10 +128,6 @@ have a suggestion for another dataset to include in PyKEEN, please let us know
 
 {{ regularizers }}
 
-### Optimizers ({{ n_optimizers }})
-
-{{ optimizers }}
-
 ### Training Loops ({{ n_training_loops }})
 
 {{ training_loops }}
@@ -155,16 +151,6 @@ have a suggestion for another dataset to include in PyKEEN, please let us know
 ### Trackers ({{ n_trackers }})
 
 {{ trackers }}
-
-## Hyper-parameter Optimization
-
-### Samplers ({{ n_hpo_samplers }})
-
-{{ hpo_samplers }}
-
-Any sampler class extending the [optuna.samplers.BaseSampler](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.BaseSampler.html#optuna.samplers.BaseSampler),
-such as their sampler implementing the [CMA-ES](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.CmaEsSampler.html#optuna.samplers.CmaEsSampler)
-algorithm, can also be used.
 
 ## Experimentation
 


### PR DESCRIPTION
This PR cleans up the `README.md` by removing
* the `Optimizers` section, listing only `torch.optim.*` components, and
* the `HPO/Samplers` section, listing only `optuna.samplers.*` components.

The relevant documentation about what values can be passed to the respective parameters of the `pipeline` functions should be present in the `pipeline` documentation.