### PR TITLE
🐿️ 🪚 Fix predict top k

### DIFF
--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -10,6 +10,7 @@ import numpy
 import numpy as np
 import pandas as pd
 import torch
+from tqdm.auto import tqdm
 
 from .base import Model
 from ..triples import CoreTriplesFactory, TriplesFactory
@@ -365,9 +366,15 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
     result = torch.ones(0, 3, dtype=torch.long, device=model.device)
     scores = torch.empty(0, dtype=torch.float32, device=model.device)
 
-    for r, e_start in itt.product(
-        range(model.num_relations),
-        range(0, model.num_entities, batch_size),
+    for r, e_start in tqdm(
+        itt.product(
+            range(model.num_relations),
+            range(0, model.num_entities, batch_size),
+        ),
+        desc="scoring",
+        unit="batch",
+        unit_scale=True,
+        total=model.num_relations * model.num_entities // batch_size,
     ):
         # calculate batch scores
         hs = torch.arange(e_start, min(e_start + batch_size, model.num_entities), device=model.device)

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -377,7 +377,7 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
         hr_batch = torch.stack(
             [
                 hs,
-                hs.new_empty(1).fill_(value=r).repeat(real_batch_size),
+                hs.new_full(size=(real_batch_size,), fill_value=r),
             ],
             dim=-1,
         )

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -383,7 +383,11 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
 
         # get top scores within batch
         if top_scores.numel() >= k:
-            top_scores, top_indices = top_scores.topk(k=min(k, batch_size), largest=True, sorted=False)
+            top_scores, top_indices = top_scores.topk(
+                k=min(k, top_scores.numel()),
+                largest=True,
+                sorted=False,
+            )
             top_heads, top_tails = top_indices // model.num_entities, top_indices % model.num_entities
         else:
             top_heads = hs.view(-1, 1).repeat(1, model.num_entities).view(-1)

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -391,7 +391,7 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
                 largest=True,
                 sorted=False,
             )
-            top_heads = torch.div(top_indices, model.num_entities, rounding_mode="trunc")
+            top_heads = e_start + torch.div(top_indices, model.num_entities, rounding_mode="trunc")
             top_tails = top_indices % model.num_entities
         else:
             top_heads = hs.view(-1, 1).repeat(1, model.num_entities).view(-1)

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -329,6 +329,7 @@ class _ScoreConsumer:
         raise NotImplementedError
 
     def finalize(self) -> ScorePack:
+        """Finalize the result to build a score pack."""
         return _build_pack(result=self.result, scores=self.scores, flatten=self.flatten)
 
 
@@ -441,8 +442,8 @@ def _consume_scores(model: Model, *consumers: _ScoreConsumer, batch_size: int = 
 
     :param model:
         the model, will be set to evaluation mode
-    :param consumer:
-        the consumer's of score batches
+    :param consumers:
+        the consumers of score batches
     :param batch_size:
         the batch size to use  # TODO: automatic batch size maximization
     """

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -365,12 +365,12 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
     result = torch.ones(0, 3, dtype=torch.long, device=model.device)
     scores = torch.empty(0, dtype=torch.float32, device=model.device)
 
-    for r, e in itt.product(
+    for r, e_start in itt.product(
         range(model.num_relations),
         range(0, model.num_entities, batch_size),
     ):
         # calculate batch scores
-        hs = torch.arange(e, min(e + batch_size, model.num_entities), device=model.device)
+        hs = torch.arange(e_start, min(e_start + batch_size, model.num_entities), device=model.device)
         real_batch_size = hs.shape[0]
 
         # create h-r batch on device, shape: (batch_size, 2)
@@ -402,7 +402,7 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
         top_triples = torch.stack(
             [
                 top_heads,
-                top_heads.new_empty(top_heads.shape).fill_(value=r),
+                top_heads.new_full(size=top_heads.shape, fill_value=r, dtype=top_heads.dtype),
                 top_tails,
             ],
             dim=-1,

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -2,6 +2,7 @@
 
 """Prediction workflows."""
 
+from abc import abstractmethod
 import itertools as itt
 import logging
 from typing import Optional, Sequence, Tuple, Union
@@ -309,19 +310,145 @@ def predict(model: Model, *, k: Optional[int] = None, batch_size: int = 1) -> Sc
     return _predict_all(model=model, batch_size=batch_size)
 
 
+class _ScoreConsumer:
+    """A consumer of scores for visitor pattern."""
+
+    result: torch.LongTensor
+    scores: torch.FloatTensor
+    flatten: bool
+
+    @abstractmethod
+    def __call__(
+        self,
+        head_id_range: Tuple[int, int],
+        relation_id: int,
+        hr_batch: torch.LongTensor,
+        scores: torch.FloatTensor,
+    ) -> None:
+        """Consume scores for the given hr_batch."""
+        raise NotImplemented
+
+    def finalize(self) -> ScorePack:
+        return _build_pack(result=self.result, scores=self.scores, flatten=self.flatten)
+
+
+class _TopKScoreConsumer(_ScoreConsumer):
+    """Collect top-k triples & scores."""
+
+    flatten = False
+
+    def __init__(self, k: int, device: torch.device) -> None:
+        """
+        Initialize the consumer.
+
+        :param k:
+            the number of top-scored triples to collect
+        :param device:
+            the model's device
+        """
+        self.k = k
+        # initialize buffer on device
+        self.result = torch.empty(0, 3, dtype=torch.long, device=device)
+        self.scores = torch.empty(0, device=device)
+
+    def __call__(
+        self,
+        head_id_range: Tuple[int, int],
+        relation_id: int,
+        hr_batch: torch.LongTensor,
+        scores: torch.FloatTensor,
+    ) -> None:  # noqa: D102
+        batch_size, num_entities = scores.shape
+
+        # reshape, shape: (batch_size * num_entities,)
+        top_scores = scores.view(-1)
+
+        # get top scores within batch
+        if top_scores.numel() >= self.k:
+            top_scores, top_indices = top_scores.topk(
+                k=min(self.k, top_scores.numel()),
+                largest=True,
+                sorted=False,
+            )
+            h_start = head_id_range[0]
+            top_heads = h_start + torch.div(top_indices, num_entities, rounding_mode="trunc")
+            top_tails = top_indices % num_entities
+        else:
+            top_heads = hr_batch[:, 0].view(-1, 1).repeat(1, num_entities).view(-1)
+            top_tails = torch.arange(num_entities, device=hr_batch.device).view(1, -1).repeat(batch_size, 1).view(-1)
+
+        top_triples = torch.stack(
+            [
+                top_heads,
+                top_heads.new_full(size=top_heads.shape, fill_value=relation_id, dtype=top_heads.dtype),
+                top_tails,
+            ],
+            dim=-1,
+        )
+
+        # append to global top scores
+        self.scores = torch.cat([self.scores, top_scores])
+        self.result = torch.cat([self.result, top_triples])
+
+        # reduce size if necessary
+        if self.result.shape[0] > self.k:
+            self.scores, indices = self.scores.topk(k=self.k, largest=True, sorted=False)
+            self.result = self.result[indices]
+
+
+class _AllConsumer(_ScoreConsumer):
+    """Collect scores for all triples."""
+
+    flatten = True
+
+    def __init__(self, num_entities: int, num_relations: int) -> None:
+        """
+        Initialize the consumer.
+
+        :param num_entities:
+            the number of entities
+        :param num_relations:
+            the number of relations
+        """
+        assert num_entities ** 2 * num_relations < (2 ** 63 - 1)
+        # initialize buffer on cpu
+        self.scores = torch.empty(num_relations, num_entities, num_entities, device="cpu")
+        # Explicitly create triples
+        self.result = torch.stack(
+            [
+                torch.arange(num_relations).view(-1, 1, 1).repeat(1, num_entities, num_entities),
+                torch.arange(num_entities).view(1, -1, 1).repeat(num_relations, 1, num_entities),
+                torch.arange(num_entities).view(1, 1, -1).repeat(num_relations, num_entities, 1),
+            ],
+            dim=-1,
+        ).view(-1, 3)[:, [1, 0, 2]]
+
+    def __call__(
+        self,
+        head_id_range: Tuple[int, int],
+        relation_id: int,
+        hr_batch: torch.LongTensor,
+        scores: torch.FloatTensor,
+    ) -> None:  # noqa: D102
+        h_start, h_stop = head_id_range
+        self.scores[relation_id, h_start:h_stop, :] = scores.to(self.scores.device)
+
+
 @torch.inference_mode()
-def _predict_all(model: Model, *, batch_size: int = 1) -> ScorePack:
-    """Compute and store scores for all triples.
-
-    :param model: A PyKEEN model
-    :param batch_size: The batch size to use for calculating scores
-    :return: A score pack of parallel triples and scores
+def _consume_scores(model: Model, *consumers: _ScoreConsumer, batch_size: int = 1) -> None:
     """
-    model.eval()  # set model to evaluation mode
+    Batch-wise calculation of all triple scores and consumption.
 
-    # initialize buffer on cpu
-    scores = torch.empty(model.num_relations, model.num_entities, model.num_entities, dtype=torch.float32)
-    assert model.num_entities ** 2 * model.num_relations < (2 ** 63 - 1)
+    :param model:
+        the model, will be set to evaluation mode
+    :param consumer:
+        the consumer's of score batches
+    :param batch_size:
+        the batch size to use  # TODO: automatic batch size maximization
+    """
+    # TODO: in the future, we may want to expose this method
+    # set model to evaluation mode
+    model.eval()
 
     for r, h_start in tqdm(
         itt.product(
@@ -343,19 +470,22 @@ def _predict_all(model: Model, *, batch_size: int = 1) -> ScorePack:
             ],
             dim=-1,
         )
-        scores[r, h_start : h_start + batch_size, :] = model.predict_t(hr_batch=hr_batch).to(scores.device)
+        scores = model.predict_t(hr_batch=hr_batch)
+        for consumer in consumers:
+            consumer(head_id_range=(h_start, h_stop), relation_id=r, hr_batch=hr_batch, scores=scores)
 
-    # Explicitly create triples
-    result = torch.stack(
-        [
-            torch.arange(model.num_relations).view(-1, 1, 1).repeat(1, model.num_entities, model.num_entities),
-            torch.arange(model.num_entities).view(1, -1, 1).repeat(model.num_relations, 1, model.num_entities),
-            torch.arange(model.num_entities).view(1, 1, -1).repeat(model.num_relations, model.num_entities, 1),
-        ],
-        dim=-1,
-    ).view(-1, 3)[:, [1, 0, 2]]
 
-    return _build_pack(result=result, scores=scores, flatten=True)
+@torch.inference_mode()
+def _predict_all(model: Model, *, batch_size: int = 1) -> ScorePack:
+    """Compute and store scores for all triples.
+
+    :param model: A PyKEEN model
+    :param batch_size: The batch size to use for calculating scores
+    :return: A score pack of parallel triples and scores
+    """
+    consumer = _AllConsumer(num_entities=model.num_entities, num_relations=model.num_relations)
+    _consume_scores(model, consumer, batch_size=batch_size)
+    return consumer.finalize()
 
 
 @torch.inference_mode()
@@ -367,72 +497,9 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
     :param batch_size: The batch size to use for calculating scores
     :return: A score pack of parallel triples and scores
     """
-    model.eval()  # set model to evaluation mode
-
-    # initialize buffer on device
-    result = torch.ones(0, 3, dtype=torch.long, device=model.device)
-    scores = torch.empty(0, dtype=torch.float32, device=model.device)
-
-    for r, h_start in tqdm(
-        itt.product(
-            range(model.num_relations),
-            range(0, model.num_entities, batch_size),
-        ),
-        desc="scoring",
-        unit="batch",
-        unit_scale=True,
-        total=model.num_relations * model.num_entities // batch_size,
-    ):
-        # calculate batch scores
-        h_stop = min(h_start + batch_size, model.num_entities)
-        hs = torch.arange(h_start, h_stop, device=model.device)
-        real_batch_size = hs.shape[0]
-
-        # create h-r batch on device, shape: (batch_size, 2)
-        hr_batch = torch.stack(
-            [
-                hs,
-                hs.new_full(size=(real_batch_size,), fill_value=r),
-            ],
-            dim=-1,
-        )
-        # predict scores, shape: (batch_size * num_entities,)
-        top_scores = model.predict_t(hr_batch=hr_batch).view(-1)
-
-        # get top scores within batch
-        if top_scores.numel() >= k:
-            top_scores, top_indices = top_scores.topk(
-                k=min(k, top_scores.numel()),
-                largest=True,
-                sorted=False,
-            )
-            top_heads = h_start + torch.div(top_indices, model.num_entities, rounding_mode="trunc")
-            top_tails = top_indices % model.num_entities
-        else:
-            top_heads = hs.view(-1, 1).repeat(1, model.num_entities).view(-1)
-            top_tails = (
-                torch.arange(model.num_entities, device=hs.device).view(1, -1).repeat(real_batch_size, 1).view(-1)
-            )
-
-        top_triples = torch.stack(
-            [
-                top_heads,
-                top_heads.new_full(size=top_heads.shape, fill_value=r, dtype=top_heads.dtype),
-                top_tails,
-            ],
-            dim=-1,
-        )
-
-        # append to global top scores
-        scores = torch.cat([scores, top_scores])
-        result = torch.cat([result, top_triples])
-
-        # reduce size if necessary
-        if result.shape[0] > k:
-            scores, indices = scores.topk(k=k, largest=True, sorted=False)
-            result = result[indices]
-
-    return _build_pack(result=result, scores=scores)
+    consumer = _TopKScoreConsumer(k=k, device=model.device)
+    _consume_scores(model, consumer, batch_size=batch_size)
+    return consumer.finalize()
 
 
 def _build_pack(result: torch.LongTensor, scores: torch.FloatTensor, flatten: bool = False) -> ScorePack:

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -2,9 +2,9 @@
 
 """Prediction workflows."""
 
-from abc import abstractmethod
 import itertools as itt
 import logging
+from abc import abstractmethod
 from typing import Optional, Sequence, Tuple, Union
 
 import numpy
@@ -326,7 +326,7 @@ class _ScoreConsumer:
         scores: torch.FloatTensor,
     ) -> None:
         """Consume scores for the given hr_batch."""
-        raise NotImplemented
+        raise NotImplementedError
 
     def finalize(self) -> ScorePack:
         return _build_pack(result=self.result, scores=self.scores, flatten=self.flatten)

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -391,7 +391,8 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
                 largest=True,
                 sorted=False,
             )
-            top_heads, top_tails = top_indices // model.num_entities, top_indices % model.num_entities
+            top_heads = torch.div(top_indices, model.num_entities, rounding_mode="trunc")
+            top_tails = top_indices % model.num_entities
         else:
             top_heads = hs.view(-1, 1).repeat(1, model.num_entities).view(-1)
             top_tails = (

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -372,6 +372,8 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
         # calculate batch scores
         hs = torch.arange(e, min(e + batch_size, model.num_entities), device=model.device)
         real_batch_size = hs.shape[0]
+
+        # create h-r batch on device, shape: (batch_size, 2)
         hr_batch = torch.stack(
             [
                 hs,
@@ -379,6 +381,7 @@ def _predict_k(model: Model, *, k: int, batch_size: int = 1) -> ScorePack:
             ],
             dim=-1,
         )
+        # predict scores, shape: (batch_size * num_entities,)
         top_scores = model.predict_t(hr_batch=hr_batch).view(-1)
 
         # get top scores within batch

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -548,7 +548,7 @@ class TestTransE(cases.DistanceModelTestCase):
             get_all_prediction_df(
                 model=self.instance,
                 triples_factory=self.factory,
-                batch_size=16,
+                batch_size=1,
                 k=k,
             )
             .nlargest(n=min(ks), columns="score")


### PR DESCRIPTION
This PR fixes the erratic behavior of `get_all_prediction_df` as observed in #689.

The root cause was a faulty `head_id`, which used the batch-local entity offset, rather than the global entity ID. Since the default batch size is 1, this led to `head_id` being often zero.

Furthermore, this PR does a bit of clean-up in this part of the code. In particular:

* [x] Fix a deprecation warning in torch 1.10
```python-traceback
.../src/pykeen/models/predict.py:387: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').
  top_heads, top_tails = top_indices // model.num_entities, top_indices % model.num_entities
```

* [x] Small improvements in creating temporary tensors using `torch.full` instead of a sequence `torch.empty(...).fill_(...).repeat(...)`.

* [x] Reduce code duplication in the (non-public) methods `_predict_k` and `_predict_all` by introducing a general `_consume_scores` function, which contains the code for iterating over batches and computing all scores, and a newly introduced non-public base class `_ScoreConsumer` which processes batches of computed scores. The functionality from `_predict_k` and `_predict_all` can be recovered by using the appropriate subclass as consumer. We may expose the consumer class(es) as well the `_consume_score` method in the future to allow for customized aggregation, e.g., keeping the `top_k` predictions per relation, the top-k unknowns, etc.

* [x] Add a progress bar via `tqdm` to the score computation. Since all scores are computed, this method typically takes a longer time and hence a progress report is useful.

* [x] Improve the non-docstring documentation by adding a few more comments to the code.

* [x] Add a test for `get_all_prediction_df`. In contrast to the other prediction dataframe methods, this test is added to `TransE` instead of `DistMult`, since distance-based interaction functions are less likely to produce exactly equal scores.

Fixes #689 