### PR TITLE
🔮↩️ adjust predict_* methods for inverse relations

### DIFF
--- a/src/pykeen/models/mocks.py
+++ b/src/pykeen/models/mocks.py
@@ -18,7 +18,10 @@ __all__ = [
 
 
 class FixedModel(Model):
-    """A mock model returning fixed scores.
+    r"""A mock model returning fixed scores.
+
+    .. math ::
+        score(h, r, t) = h \cdot |\mathcal{E}| \cdot |\mathcal{R}| + r \cdot |\mathcal{E}| + t
 
     ---
     name: Fixed Model

--- a/src/pykeen/triples/__init__.py
+++ b/src/pykeen/triples/__init__.py
@@ -10,7 +10,7 @@ from .instances import (
     MultimodalSLCWAInstances,
     SLCWAInstances,
 )
-from .triples_factory import CoreTriplesFactory, TriplesFactory, RelationInverter, relation_inverter
+from .triples_factory import CoreTriplesFactory, RelationInverter, TriplesFactory, relation_inverter
 from .triples_numeric_literals_factory import TriplesNumericLiteralsFactory
 
 __all__ = [

--- a/src/pykeen/triples/__init__.py
+++ b/src/pykeen/triples/__init__.py
@@ -10,7 +10,7 @@ from .instances import (
     MultimodalSLCWAInstances,
     SLCWAInstances,
 )
-from .triples_factory import CoreTriplesFactory, TriplesFactory
+from .triples_factory import CoreTriplesFactory, TriplesFactory, RelationInverter, relation_inverter
 from .triples_numeric_literals_factory import TriplesNumericLiteralsFactory
 
 __all__ = [
@@ -21,6 +21,8 @@ __all__ = [
     "MultimodalLCWAInstances",
     "SLCWAInstances",
     "CoreTriplesFactory",
+    "RelationInverter",
+    "relation_inverter",
     "TriplesFactory",
     "TriplesNumericLiteralsFactory",
 ]

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -2,12 +2,12 @@
 
 """Implementation of basic instance factory which creates just instances based on standard KG triples."""
 
-from abc import abstractmethod
 import dataclasses
 import itertools
 import logging
 import pathlib
 import re
+from abc import abstractmethod
 from typing import (
     Any,
     Callable,

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -2,12 +2,28 @@
 
 """Implementation of basic instance factory which creates just instances based on standard KG triples."""
 
+from abc import abstractmethod
 import dataclasses
 import itertools
 import logging
 import pathlib
 import re
-from typing import Any, Callable, Collection, Dict, List, Mapping, Optional, Sequence, Set, TextIO, Type, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    TextIO,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import numpy as np
 import pandas as pd
@@ -28,6 +44,8 @@ __all__ = [
     "cat_triples",
     "splits_steps",
     "splits_similarity",
+    "RelationInverter",
+    "relation_inverter",
 ]
 
 logger = logging.getLogger(__name__)
@@ -137,6 +155,56 @@ def _ensure_ids(
 ) -> Collection[int]:
     """Convert labels to IDs."""
     return [label_to_id[l_or_i] if isinstance(l_or_i, str) else l_or_i for l_or_i in labels_or_ids]
+
+
+RelationID = TypeVar("RelationID", int, torch.LongTensor)
+
+
+class RelationInverter:
+    """An interface for inverse-relation ID mapping."""
+
+    # TODO: method is_inverse?
+
+    @abstractmethod
+    def get_inverse_id(self, relation_id: RelationID) -> RelationID:
+        """Get the inverse ID for a given relation."""
+        # TODO: inverse of inverse?
+        raise NotImplementedError
+
+    @abstractmethod
+    def _map(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:
+        raise NotImplementedError
+
+    @abstractmethod
+    def invert_(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:
+        """Invert relations in a batch (in-place)."""
+        raise NotImplementedError
+
+    def map(self, batch: torch.LongTensor, index: int = 1, invert: bool = False) -> torch.LongTensor:
+        """Map relations of batch, optionally also inverting them."""
+        batch = self._map(batch=batch, index=index)
+        return self.invert_(batch=batch, index=index) if invert else batch
+
+
+class DefaultRelationInverter(RelationInverter):
+    """Maps normal relations to even IDs, and the corresponding inverse to the next odd ID."""
+
+    def get_inverse_id(self, relation_id: RelationID) -> RelationID:  # noqa: D102
+        return relation_id + 1
+
+    def _map(self, batch: torch.LongTensor, index: int = 1, invert: bool = False) -> torch.LongTensor:  # noqa: D102
+        batch = batch.clone()
+        batch[:, index] *= 2
+        return batch
+
+    def invert_(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:  # noqa: D102
+        # The number of relations stored in the triples factory includes the number of inverse relations
+        # Id of inverse relation: relation + 1
+        batch[:, index] += 1
+        return batch
+
+
+relation_inverter = DefaultRelationInverter()
 
 
 @dataclasses.dataclass
@@ -325,11 +393,7 @@ class CoreTriplesFactory:
         """Get the inverse relation identifier for the given relation."""
         if not self.create_inverse_triples:
             raise ValueError("Can not get inverse triple, they have not been created.")
-        return self._get_inverse_relation_id(relation)
-
-    @staticmethod
-    def _get_inverse_relation_id(relation_id: Union[int, torch.LongTensor]) -> Union[int, torch.LongTensor]:
-        return relation_id + 1
+        return relation_inverter.get_inverse_id(relation_id=relation)
 
     def _add_inverse_triples_if_necessary(self, mapped_triples: MappedTriples) -> MappedTriples:
         """Add inverse triples if they shall be created."""
@@ -337,12 +401,10 @@ class CoreTriplesFactory:
             return mapped_triples
 
         logger.info("Creating inverse triples.")
-        h, r, t = mapped_triples.t()
-        r = 2 * r
         return torch.cat(
             [
-                torch.stack([h, r, t], dim=-1),
-                torch.stack([t, self._get_inverse_relation_id(r), h], dim=-1),
+                relation_inverter.map(batch=mapped_triples),
+                relation_inverter.map(batch=mapped_triples, invert=True).flip(1),
             ]
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@
 """Test that models can be executed."""
 
 import importlib
+import itertools
 import os
 import unittest
 from typing import Any, MutableMapping, Optional
@@ -10,11 +11,10 @@ from typing import Any, MutableMapping, Optional
 import numpy
 import torch
 import unittest_templates
-from pykeen.datasets.nations import Nations
-import itertools
 
 import pykeen.experiments
 import pykeen.models
+from pykeen.datasets.nations import Nations
 from pykeen.models import (
     EntityRelationEmbeddingModel,
     ERModel,


### PR DESCRIPTION
This PR refactors the prediction with inverse relations code.

* [x] adds a `RelationInverter` component for future extensibility of different ways how to compute the IDs of inverse relations
* [x] reduces code duplication in adding inverse triples / computing the IDs of inverse relations
* [x] adds `FixedModel`s score formula to the docstring
* [x] adds a test for prediction with inverse relations

Fixes #698

#### Alternative

An alternative, which breaks backwards compatibility with directly loading weights from old models, would be to change the IDs of inverse relations, such that the original relation IDs are not changed, i.e,
```
0       relation_1
1       relation_2
...
(R-1)   relation_R
R       inverse_relation_1
(R+1)   inverse_relation_2
...
(2*R-1) inverse_relation_R
```