### PR TITLE
⛪ 🚑 Add sLCWA support for Cross Entropy Loss

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -1087,18 +1087,19 @@ class CrossEntropyLoss(SetwiseLoss):
             reduction=self.reduction,
         )
 
-    def forward(
+    def process_lcwa_scores(
         self,
-        logits: torch.FloatTensor,
+        predictions: torch.FloatTensor,
         labels: torch.FloatTensor,
-    ) -> torch.FloatTensor:  # noqa: D102
-        # cross entropy expects a proper probability distribution -> normalize labels
-        p_true = functional.normalize(labels, p=1, dim=-1)
-        # Use numerically stable variant to compute log(softmax)
-        log_p_pred = logits.log_softmax(dim=-1)
-        # compute cross entropy: ce(b) = sum_i p_true(b, i) * log p_pred(b, i)
-        sample_wise_cross_entropy = -(p_true * log_p_pred).sum(dim=-1)
-        return self._reduction_method(sample_wise_cross_entropy)
+        label_smoothing: Optional[float] = None,
+        num_entities: Optional[int] = None,
+    ) -> torch.FloatTensor:
+        return functional.cross_entropy(
+            input=predictions,
+            target=labels,
+            label_smoothing=label_smoothing or 0.0,
+            reduction=self.reduction,
+        )
 
 
 @parse_docdata

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -1083,7 +1083,7 @@ class CrossEntropyLoss(SetwiseLoss):
         return functional.cross_entropy(
             input=scores,
             target=true_indices,
-            label_smoothing=label_smoothing,
+            label_smoothing=label_smoothing or 0.0,
             reduction=self.reduction,
         )
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -1093,7 +1093,7 @@ class CrossEntropyLoss(SetwiseLoss):
         labels: torch.FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> torch.FloatTensor:  # noqa: D102
         return functional.cross_entropy(
             input=predictions,
             target=labels,

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -29,7 +29,6 @@ class SLCWATrainingLoop(TrainingLoop[SLCWASampleType, SLCWABatchType]):
     """
 
     negative_sampler: NegativeSampler
-    loss_blacklist = [CrossEntropyLoss]
 
     def __init__(
         self,

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -9,7 +9,6 @@ import torch
 from class_resolver import HintOrType
 
 from .training_loop import TrainingLoop
-from ..losses import CrossEntropyLoss
 from ..sampling import NegativeSampler, negative_sampler_resolver
 from ..triples import CoreTriplesFactory, Instances
 from ..triples.instances import SLCWABatchType, SLCWASampleType

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -110,6 +110,7 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
     optimizer: Optimizer
 
     losses_per_epochs: List[float]
+    # TODO: this is always None
     loss_blacklist: ClassVar[Optional[List[Type[Loss]]]] = None
 
     hpo_default = dict(

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -13,7 +13,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from hashlib import md5
 from tempfile import NamedTemporaryFile
-from typing import IO, Any, ClassVar, Generic, List, Mapping, Optional, Tuple, Type, TypeVar, Union
+from typing import IO, Any, Generic, List, Mapping, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import torch
@@ -29,7 +29,6 @@ from .callbacks import (
     TrainingCallbackHint,
 )
 from ..constants import PYKEEN_CHECKPOINTS, PYKEEN_DEFAULT_CHECKPOINT
-from ..losses import Loss
 from ..lr_schedulers import LRScheduler
 from ..models import RGCN, Model
 from ..stoppers import Stopper

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -110,8 +110,6 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
     optimizer: Optimizer
 
     losses_per_epochs: List[float]
-    # TODO: this is always None
-    loss_blacklist: ClassVar[Optional[List[Type[Loss]]]] = None
 
     hpo_default = dict(
         num_epochs=dict(type=int, low=100, high=1000, q=100),
@@ -143,12 +141,6 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
         self.automatic_memory_optimization = automatic_memory_optimization
 
         logger.debug("we don't really need the triples factory: %s", triples_factory)
-
-        if self.loss_blacklist and isinstance(self.model.loss, tuple(self.loss_blacklist)):
-            raise TrainingApproachLossMismatchError(
-                f"Can not use loss {self.model.loss.__class__.__name__}"
-                f" with training approach {self.__class__.__name__}",
-            )
 
         # The internal epoch state tracks the last finished epoch of the training loop to allow for
         # seamless loading and saving of training checkpoints

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -48,7 +48,6 @@ from ..utils import (
 __all__ = [
     "TrainingLoop",
     "NonFiniteLossError",
-    "TrainingApproachLossMismatchError",
     "SubBatchingNotSupportedError",
 ]
 
@@ -60,10 +59,6 @@ BatchType = TypeVar("BatchType")
 
 class NonFiniteLossError(RuntimeError):
     """An exception raised for non-finite loss values."""
-
-
-class TrainingApproachLossMismatchError(TypeError):
-    """An exception when an illegal loss function is used with a given training approach."""
 
 
 class CheckpointMismatchError(RuntimeError):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -278,7 +278,7 @@ class LossTestCase(GenericTestCase[Loss]):
 
     def test_optimization_direction_slcwa(self):
         """Test whether the loss leads to increasing positive scores, and decreasing negative scores."""
-        positive_scores = torch.zeros(self.batch_size, requires_grad=True)
+        positive_scores = torch.zeros(self.batch_size, 1, requires_grad=True)
         negative_scores = torch.zeros(self.batch_size, self.num_neg_per_pos, requires_grad=True)
         optimizer = optimizer_resolver.make(query=None, params=[positive_scores, negative_scores])
         for _ in range(10):

--- a/tests/test_training/cases.py
+++ b/tests/test_training/cases.py
@@ -10,11 +10,11 @@ import unittest_templates
 from torch.optim import Adam, Optimizer
 
 from pykeen.datasets import Nations
-from pykeen.losses import CrossEntropyLoss, Loss
+from pykeen.losses import Loss
 from pykeen.models import ConvE, Model, TransE
 from pykeen.sampling.filtering import Filterer
 from pykeen.training import TrainingLoop
-from pykeen.training.training_loop import NonFiniteLossError, TrainingApproachLossMismatchError
+from pykeen.training.training_loop import NonFiniteLossError
 from pykeen.triples import TriplesFactory
 
 __all__ = [
@@ -181,16 +181,3 @@ class SLCWATrainingLoopTestCase(TrainingLoopTestCase):
         kwargs["negative_sampler"] = "basic"
         kwargs["negative_sampler_kwargs"] = {"filterer": self.filterer_cls}
         return kwargs
-
-    def test_blacklist_loss_on_slcwa(self):
-        """Test an allowed sLCWA loss."""
-        model = TransE(
-            triples_factory=self.triples_factory,
-            loss=CrossEntropyLoss(),
-        )
-        with self.assertRaises(TrainingApproachLossMismatchError):
-            self.cls(
-                model=model,
-                triples_factory=self.triples_factory,
-                automatic_memory_optimization=False,
-            )


### PR DESCRIPTION
This PR adds SLCWA support to `CrossEntropyLoss`.

It also:
* [x] refactors the code to prepare a dense batch for softmax from sparse filtered scores with appropriate fill value (used by `CrossEntropyLoss` and `NSSA`)
* [x] uses [`torch.nn.functional.cross_entropy`](https://pytorch.org/docs/stable/generated/torch.nn.functional.cross_entropy.html?highlight=cross%20entropy#torch.nn.functional.cross_entropy), since it supports label smoothing since 1.10; For SLCWA, it further uses the optimized sparse target option.
* [x] removes the list of incompatible losses for training loops, since now every loss is compatible with all loops :rocket: 
* [x] fixes a shape in a test case

**Note**: the softmax normalization is done internally by [torch.nn.CrossEntropyLoss](https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html), and thus does not need to be done manually.

Fixes #636 