### PR TITLE
🏭🪓 Refactor splitting code and improve documentation

### DIFF
--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -15,7 +15,7 @@ from tqdm.auto import tqdm
 
 from .base import Model
 from ..triples import CoreTriplesFactory, TriplesFactory
-from ..triples.utils import tensor_to_df
+from ..triples.utils import tensor_to_df, triple_tensor_to_set
 from ..typing import LabeledTriples, MappedTriples, ScorePack
 from ..utils import is_cuda_oom_error
 
@@ -600,7 +600,7 @@ def get_novelty_all_mask(
     query: np.ndarray,
 ) -> np.ndarray:
     """Get novelty mask."""
-    known = {tuple(triple) for triple in mapped_triples.tolist()}
+    known = triple_tensor_to_set(mapped_triples)
     return np.asarray(
         [tuple(triple) not in known for triple in query],
         dtype=bool,

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -201,7 +201,7 @@ class PythonSetFilterer(Filterer):
         """
         super().__init__()
         # store set of triples
-        self.triples = triple_tensor_to_set(mapped_triples.tolist())
+        self.triples = triple_tensor_to_set(mapped_triples)
 
     def contains(self, batch: MappedTriples) -> torch.BoolTensor:  # noqa: D102
         return torch.as_tensor(

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -131,6 +131,7 @@ import torch
 from class_resolver import Resolver
 from torch import nn
 
+from ..triples.utils import triple_tensor_to_set
 from ..typing import MappedTriples
 
 __all__ = [
@@ -200,7 +201,7 @@ class PythonSetFilterer(Filterer):
         """
         super().__init__()
         # store set of triples
-        self.triples = set(map(tuple, mapped_triples.tolist()))
+        self.triples = triple_tensor_to_set(mapped_triples.tolist())
 
     def contains(self, batch: MappedTriples) -> torch.BoolTensor:  # noqa: D102
         return torch.as_tensor(

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -486,12 +486,12 @@ def split(
         train, test, val = split(triples, ratios)
     """
     # backwards compatibility
-    method: Type[Splitter] = splitter_resolver.lookup(method)
+    splitter_cls: Type[Splitter] = splitter_resolver.lookup(method)
     kwargs = dict()
-    if method is CleanupSplitter:
+    if splitter_cls is CleanupSplitter:
         cleaner = RandomizedCleaner if randomize_cleanup else DeterministicCleaner
         kwargs["cleaner"] = cleaner_resolver.normalize_cls(cleaner)
-    return splitter_resolver.make(method).split(
+    return splitter_resolver.make(splitter_cls).split(
         mapped_triples=mapped_triples,
         ratios=ratios,
         random_state=random_state,

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -183,7 +183,7 @@ class Cleaner:
         self,
         reference: MappedTriples,
         other: MappedTriples,
-        random_state: torch.Generator,
+        random_state: TorchRandomHint,
     ) -> Tuple[MappedTriples, MappedTriples]:
         """
         Clean up one set of triples with respect to a reference set.
@@ -203,7 +203,7 @@ class Cleaner:
     def __call__(
         self,
         triples_groups: Sequence[MappedTriples],
-        random_state: torch.Generator,
+        random_state: TorchRandomHint,
     ) -> Sequence[MappedTriples]:
         """Cleanup a list of triples array with respect to the first array."""
         reference, *others = triples_groups
@@ -267,7 +267,7 @@ class RandomizedCleaner(Cleaner):
         self,
         reference: MappedTriples,
         other: MappedTriples,
-        random_state: torch.Generator,
+        random_state: TorchRandomHint,
     ) -> Tuple[MappedTriples, MappedTriples]:  # noqa: D102
         generator = ensure_torch_random_state(random_state)
         move_id_mask = _prepare_cleanup(reference, other)
@@ -296,7 +296,7 @@ class DeterministicCleaner(Cleaner):
         self,
         reference: MappedTriples,
         other: MappedTriples,
-        random_state: torch.Generator,
+        random_state: TorchRandomHint,
     ) -> Tuple[MappedTriples, MappedTriples]:  # noqa: D102
         move_id_mask = _prepare_cleanup(reference, other)
         reference = torch.cat([reference, other[move_id_mask]])

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -353,12 +353,13 @@ class Splitter:
             the random state used to shuffle and split the triples
         :param ratios:
             There are three options for this argument.
-            First, a float can be given between 0 and 1.0, non-inclusive. The first set of triples will get this ratio and
-            the second will get the rest.
-            Second, a list of ratios can be given for which set in which order should get what ratios as in ``[0.8, 0.1]``.
+            First, a float can be given between 0 and 1.0, non-inclusive. The first set of triples will get this
+            ratio and the second will get the rest.
+            Second, a list of ratios can be given for which set in which order should get what ratios as
+            in ``[0.8, 0.1]``.
             The final ratio can be omitted because that can be calculated.
-            Third, all ratios can be explicitly set in order such as in ``[0.8, 0.1, 0.1]`` where the sum of all ratios is
-            1.0.
+            Third, all ratios can be explicitly set in order such as in ``[0.8, 0.1, 0.1]`` where the sum of
+            all ratios is 1.0.
 
         :return:
             A partition of triples, which are split (approximately) according to the ratios.
@@ -383,7 +384,13 @@ class Splitter:
 
 
 class CleanupSplitter(Splitter):
-    """TODO"""
+    """
+    The cleanup splitter first randomly splits the triples and then cleans up.
+
+    In the cleanup process, triples are moved into the train part until all entities occur at least once in train.
+
+    The splitter supports two variants of cleanup.
+    """
 
     def __init__(self, cleaner: HintOrType[Cleaner] = None) -> None:
         """
@@ -415,7 +422,7 @@ class CleanupSplitter(Splitter):
 
 
 class CoverageSplitter(Splitter):
-    """TODO"""
+    """This splitter greedily selects training triples such that each entity is covered and then splits the rest."""
 
     def split_absolute_size(
         self,

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -208,10 +208,11 @@ class Cleaner:
         """Cleanup a list of triples array with respect to the first array."""
         reference, *others = triples_groups
         # [...] is necessary for Python 3.7 compatibility
-        return [
-            reference,
-            *(self.cleanup_pair(reference=reference, other=other, random_state=random_state) for other in others),
-        ]
+        result = []
+        for other in others:
+            reference, other = self.cleanup_pair(reference=reference, other=other, random_state=random_state)
+            result.append(other)
+        return [reference, *result]
 
 
 def _prepare_cleanup(

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -469,7 +469,7 @@ def split(
         it does not necessarily have to move all of them, but it might be significantly slower since it moves one
         triple at a time.
     :param method:
-        The name of the method to use, cf. `splitter_resolver`. Defaults to "coverage".
+        The name of the method to use, cf. :data:`splitter_resolver`. Defaults to "coverage".
 
     :return:
         A partition of triples, which are split (approximately) according to the ratios.

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -2,15 +2,15 @@
 
 """Implementation of triples splitting functions."""
 
-from abc import abstractmethod
 import logging
 import typing
+from abc import abstractmethod
 from typing import Collection, Optional, Sequence, Set, Tuple, Union
-from class_resolver.api import HintOrType, Resolver
 
 import numpy
 import pandas
 import torch
+from class_resolver.api import HintOrType, Resolver
 
 from ..typing import MappedTriples, TorchRandomHint
 from ..utils import ensure_torch_random_state

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -190,6 +190,19 @@ class Cleaner:
         other: MappedTriples,
         random_state: torch.Generator,
     ) -> Tuple[MappedTriples, MappedTriples]:
+        """
+        Clean up one set of triples with respect to a reference set.
+
+        :param reference:
+            the reference set of triples, which shall contain triples for all entities
+        :param other:
+            the other set of triples
+        :param random_state:
+            the random state to use, if any randomized operations take place
+
+        :return:
+            a pair (reference, other), where some triples of other may have been moved into reference
+        """
         raise NotImplementedError
 
     def __call__(
@@ -295,6 +308,9 @@ class DeterministicCleaner(Cleaner):
         return reference, other
 
 
+cleaner_resolver = Resolver.from_subclasses(base=Cleaner, default=DeterministicCleaner)
+
+
 class Splitter:
     """A method for splitting triples."""
 
@@ -366,16 +382,13 @@ class Splitter:
         return triples_groups
 
 
-cleaner_resolver = Resolver.from_subclasses(base=Cleaner, default=DeterministicCleaner)
-
-
 class CleanupSplitter(Splitter):
     """TODO"""
 
     def __init__(self, cleaner: HintOrType[Cleaner] = None) -> None:
         """
         Initialize the splitter.
-        
+
         :param cleaner:
             the cleanup method to use. Defaults to the fast deterministic cleaner,
             which may lead to larger deviances between desired and actual triple count.

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -396,7 +396,6 @@ class CleanupSplitter(Splitter):
             the cleanup method to use. Defaults to the fast deterministic cleaner,
             which may lead to larger deviances between desired and actual triple count.
         """
-        super().__init__()
         self.cleaner = cleaner_resolver.make(cleaner)
 
     def split_absolute_size(
@@ -488,10 +487,9 @@ def split(
     # backwards compatibility
     splitter_cls: Type[Splitter] = splitter_resolver.lookup(method)
     kwargs = dict()
-    if splitter_cls is CleanupSplitter:
-        cleaner = RandomizedCleaner if randomize_cleanup else DeterministicCleaner
-        kwargs["cleaner"] = cleaner_resolver.normalize_cls(cleaner)
-    return splitter_resolver.make(splitter_cls).split(
+    if splitter_cls is CleanupSplitter and randomize_cleanup:
+        kwargs["cleaner"] = cleaner_resolver.normalize_cls(RandomizedCleaner)
+    return splitter_resolver.make(splitter_cls, pos_kwargs=kwargs).split(
         mapped_triples=mapped_triples,
         ratios=ratios,
         random_state=random_state,

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -21,11 +21,6 @@ __all__ = [
     "split",
 ]
 
-SPLIT_METHODS = (
-    "cleanup",
-    "coverage",
-)
-
 
 def _split_triples(
     mapped_triples: MappedTriples,

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -469,7 +469,7 @@ def split(
         it does not necessarily have to move all of them, but it might be significantly slower since it moves one
         triple at a time.
     :param method:
-        The name of the method to use, from SPLIT_METHODS. Defaults to "coverage".
+        The name of the method to use, cf. `splitter_resolver`. Defaults to "coverage".
 
     :return:
         A partition of triples, which are split (approximately) according to the ratios.

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -31,7 +31,7 @@ import torch
 
 from .instances import Instances, LCWAInstances, SLCWAInstances
 from .splitting import split
-from .utils import TRIPLES_DF_COLUMNS, get_entities, get_relations, load_triples, tensor_to_df
+from .utils import TRIPLES_DF_COLUMNS, get_entities, get_relations, load_triples, tensor_to_df, triple_tensor_to_set
 from ..typing import EntityMapping, LabeledTriples, MappedTriples, RelationMapping, TorchRandomHint
 from ..utils import compact_mapping, format_relative_comparison, invert_mapping
 
@@ -1164,8 +1164,8 @@ def splits_steps(a: Sequence[CoreTriplesFactory], b: Sequence[CoreTriplesFactory
     if len(a) != len(b):
         raise ValueError("Must have same number of triples factories")
 
-    train_1 = _smt(a[0].mapped_triples)
-    train_2 = _smt(b[0].mapped_triples)
+    train_1 = triple_tensor_to_set(a[0].mapped_triples)
+    train_2 = triple_tensor_to_set(b[0].mapped_triples)
 
     # FIXME currently the implementation does not consider the non-training (i.e., second-last entries)
     #  for the number of steps. Consider more interesting way to discuss splits w/ valid
@@ -1181,10 +1181,6 @@ def splits_similarity(a: Sequence[CoreTriplesFactory], b: Sequence[CoreTriplesFa
     steps = splits_steps(a, b)
     n = sum(tf.num_triples for tf in a)
     return 1 - steps / n
-
-
-def _smt(x):
-    return set(tuple(xx.detach().numpy().tolist()) for xx in x)
 
 
 def normalize_path(path: Union[str, pathlib.Path, TextIO]) -> pathlib.Path:

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -3,7 +3,7 @@
 """Instance creation utilities."""
 
 import pathlib
-from typing import Callable, Mapping, Optional, Sequence, Set, TextIO, Union
+from typing import Callable, Mapping, Optional, Sequence, Set, TextIO, Tuple, Union
 
 import numpy as np
 import pandas
@@ -16,6 +16,8 @@ __all__ = [
     "load_triples",
     "get_entities",
     "get_relations",
+    "triple_tensor_to_set",
+    "is_triple_tensor_subset",
     "tensor_to_df",
 ]
 
@@ -85,6 +87,16 @@ def load_triples(
     if column_remapping is not None:
         df = df[[df.columns[c] for c in column_remapping]]
     return df.to_numpy()
+
+
+def triple_tensor_to_set(tensor: torch.LongTensor) -> Set[Tuple[int, ...]]:
+    """Convert a tensor of triples to a set of int-tuples."""
+    return set(map(tuple, tensor.tolist()))
+
+
+def is_triple_tensor_subset(a: torch.LongTensor, b: torch.LongTensor) -> bool:
+    """Check whether one tensor of triples is a subset of another one."""
+    return triple_tensor_to_set(a).issubset(triple_tensor_to_set(b))
 
 
 def get_entities(triples: torch.LongTensor) -> Set[int]:

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -1261,7 +1261,7 @@ def tensor_to_set(tensor: torch.LongTensor) -> Set[Tuple[int, ...]]:
     return set(map(tuple, tensor.tolist()))
 
 
-def tensor_subset(a: torch.LongTensor, b: torch.LongTensor) -> bool:
+def is_tensor_subset(a: torch.LongTensor, b: torch.LongTensor) -> bool:
     """Check whether one tensor of triples is a subset of another one."""
     return tensor_to_set(a).issubset(tensor_to_set(b))
 

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -26,7 +26,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -1254,16 +1253,6 @@ def boxe_kg_arity_position_score(
 
     # Finally, compute the norm
     return negative_norm(element_wise_distance, p=p, power_norm=power_norm)
-
-
-def tensor_to_set(tensor: torch.LongTensor) -> Set[Tuple[int, ...]]:
-    """Convert a tensor of triples to a set of int-tuples."""
-    return set(map(tuple, tensor.tolist()))
-
-
-def is_tensor_subset(a: torch.LongTensor, b: torch.LongTensor) -> bool:
-    """Check whether one tensor of triples is a subset of another one."""
-    return tensor_to_set(a).issubset(tensor_to_set(b))
 
 
 if __name__ == "__main__":

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -26,6 +26,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Type,
     TypeVar,
@@ -1253,6 +1254,16 @@ def boxe_kg_arity_position_score(
 
     # Finally, compute the norm
     return negative_norm(element_wise_distance, p=p, power_norm=power_norm)
+
+
+def tensor_to_set(tensor: torch.LongTensor) -> Set[Tuple[int, ...]]:
+    """Convert a tensor of triples to a set of int-tuples."""
+    return set(map(tuple, tensor.tolist()))
+
+
+def tensor_subset(a: torch.LongTensor, b: torch.LongTensor) -> bool:
+    """Check whether one tensor of triples is a subset of another one."""
+    return tensor_to_set(a).issubset(tensor_to_set(b))
 
 
 if __name__ == "__main__":

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -56,7 +56,7 @@ from pykeen.trackers import ResultTracker
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop, TrainingLoop
 from pykeen.triples import TriplesFactory, generation
 from pykeen.triples.splitting import Cleaner, Splitter
-from pykeen.triples.utils import get_entities, is_tensor_subset, triple_tensor_to_set
+from pykeen.triples.utils import get_entities, is_triple_tensor_subset, triple_tensor_to_set
 from pykeen.typing import HeadRepresentation, Initializer, MappedTriples, RelationRepresentation, TailRepresentation
 from pykeen.utils import all_in_bounds, get_batchnorm_modules, resolve_device, set_random_seed, unpack_singletons
 from tests.constants import EPSILON
@@ -1592,8 +1592,8 @@ class CleanerTestCase(GenericTestCase[Cleaner]):
             )
         )
         # check that triples where only moved from other to reference
-        assert is_tensor_subset(self.reference, reference_clean)
-        assert is_tensor_subset(other_clean, self.other)
+        assert is_triple_tensor_subset(self.reference, reference_clean)
+        assert is_triple_tensor_subset(other_clean, self.other)
         # check that all entities occur in reference
         assert get_entities(reference_clean) == self.all_entities
 

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -56,17 +56,9 @@ from pykeen.trackers import ResultTracker
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop, TrainingLoop
 from pykeen.triples import TriplesFactory, generation
 from pykeen.triples.splitting import Cleaner, Splitter
-from pykeen.triples.utils import get_entities
+from pykeen.triples.utils import get_entities, is_tensor_subset, triple_tensor_to_set
 from pykeen.typing import HeadRepresentation, Initializer, MappedTriples, RelationRepresentation, TailRepresentation
-from pykeen.utils import (
-    all_in_bounds,
-    get_batchnorm_modules,
-    is_tensor_subset,
-    resolve_device,
-    set_random_seed,
-    tensor_to_set,
-    unpack_singletons,
-)
+from pykeen.utils import all_in_bounds, get_batchnorm_modules, resolve_device, set_random_seed, unpack_singletons
 from tests.constants import EPSILON
 from tests.mocks import CustomRepresentations
 from tests.utils import rand
@@ -1590,7 +1582,7 @@ class CleanerTestCase(GenericTestCase[Cleaner]):
             random_state=42,
         )
         # check that no triple got lost
-        assert tensor_to_set(self.mapped_triples) == tensor_to_set(
+        assert triple_tensor_to_set(self.mapped_triples) == triple_tensor_to_set(
             torch.cat(
                 [
                     reference_clean,
@@ -1630,9 +1622,11 @@ class SplitterTestCase(GenericTestCase[Splitter]):
         )
         assert len(splitted) == exp_parts
         # check that no triple got lost
-        assert tensor_to_set(self.mapped_triples) == set().union(*(tensor_to_set(triples) for triples in splitted))
+        assert triple_tensor_to_set(self.mapped_triples) == set().union(
+            *(triple_tensor_to_set(triples) for triples in splitted)
+        )
         # check that all entities are covered in first part
-        assert tensor_to_set(splitted[0]) == self.all_entities
+        assert triple_tensor_to_set(splitted[0]) == self.all_entities
 
 
 class EvaluatorTestCase(unittest.TestCase):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1576,7 +1576,7 @@ class CleanerTestCase(GenericTestCase[Cleaner]):
         # unfavourable split to ensure that cleanup is necessary
         self.reference, self.other = torch.split(
             self.mapped_triples,
-            split_size_or_sections=[24, 1592 - 24],
+            split_size_or_sections=[24, self.mapped_triples.shape[0] - 24],
             dim=0,
         )
         # check for unclean split

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -20,7 +20,6 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -1610,7 +1609,7 @@ class SplitterTestCase(GenericTestCase[Splitter]):
     """Test cases for triples splitter."""
 
     def post_instantiation_hook(self) -> None:
-        """Setup data."""
+        """Prepare data."""
         dataset = Nations()
         self.all_entities = set(range(dataset.num_entities))
         self.mapped_triples = dataset.training.mapped_triples

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1605,6 +1605,12 @@ class CleanerTestCase(GenericTestCase[Cleaner]):
         # check that all entities occur in reference
         assert get_entities(reference_clean) == self.all_entities
 
+    def test_call(self):
+        """Test call."""
+        triples_groups = [self.reference] + list(torch.split(self.other, split_size_or_sections=3, dim=0))
+        clean_groups = self.instance(triples_groups=triples_groups, random_state=42)
+        assert all(torch.is_tensor(triples) and triples.dtype for triples in clean_groups)
+
 
 class SplitterTestCase(GenericTestCase[Splitter]):
     """Test cases for triples splitter."""

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -63,7 +63,7 @@ from pykeen.utils import (
     get_batchnorm_modules,
     resolve_device,
     set_random_seed,
-    tensor_subset,
+    is_tensor_subset,
     tensor_to_set,
     unpack_singletons,
 )
@@ -1600,8 +1600,8 @@ class CleanerTestCase(GenericTestCase[Cleaner]):
             )
         )
         # check that triples where only moved from other to reference
-        assert tensor_subset(self.reference, reference_clean)
-        assert tensor_subset(other_clean, self.other)
+        assert is_tensor_subset(self.reference, reference_clean)
+        assert is_tensor_subset(other_clean, self.other)
         # check that all entities occur in reference
         assert get_entities(reference_clean) == self.all_entities
 

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -61,9 +61,9 @@ from pykeen.typing import HeadRepresentation, Initializer, MappedTriples, Relati
 from pykeen.utils import (
     all_in_bounds,
     get_batchnorm_modules,
+    is_tensor_subset,
     resolve_device,
     set_random_seed,
-    is_tensor_subset,
     tensor_to_set,
     unpack_singletons,
 )

--- a/tests/test_splitting.py
+++ b/tests/test_splitting.py
@@ -1,0 +1,129 @@
+"""Tests for splitting of triples."""
+import torch
+from pykeen.triples.splitting import DeterministicCleaner, RandomizedCleaner
+from tests.cases import CleanerTestCase
+
+
+class DeterministicCleanerTests(CleanerTestCase):
+    """Tests for deterministic cleaner."""
+
+    cls = DeterministicCleaner
+
+    def test_manual(self):
+        """Test that triples in a test set can get moved properly to the training set."""
+        training = torch.as_tensor(
+            data=[
+                [1, 1000, 2],
+                [1, 1000, 3],
+                [1, 1001, 3],
+            ],
+            dtype=torch.long,
+        )
+        testing = torch.as_tensor(
+            data=[
+                [2, 1001, 3],
+                [1, 1002, 4],
+            ],
+            dtype=torch.long,
+        )
+        expected_training = torch.as_tensor(
+            data=[
+                [1, 1000, 2],
+                [1, 1000, 3],
+                [1, 1001, 3],
+                [1, 1002, 4],
+            ],
+            dtype=torch.long,
+        )
+        expected_testing = torch.as_tensor(
+            data=[
+                [2, 1001, 3],
+            ],
+            dtype=torch.long,
+        )
+
+        new_training, new_testing = self.instance.cleanup_pair(training, testing, random_state=...)
+        assert (expected_training == new_training).all()
+        assert (expected_testing == new_testing).all()
+
+
+class RandomizedCleanerTests(CleanerTestCase):
+    """Tests for deterministic cleaner."""
+
+    cls = RandomizedCleaner
+
+    def test_manual(self):
+        """Test that triples in a test set can get moved properly to the training set."""
+        training = torch.as_tensor(
+            data=[
+                [1, 1000, 2],
+                [1, 1000, 3],
+            ],
+            dtype=torch.long,
+        )
+        testing = torch.as_tensor(
+            data=[
+                [2, 1000, 3],
+                [1, 1000, 4],
+                [2, 1000, 4],
+                [1, 1001, 3],
+            ],
+            dtype=torch.long,
+        )
+        expected_training_1 = {
+            (1, 1000, 2),
+            (1, 1000, 3),
+            (1, 1000, 4),
+            (1, 1001, 3),
+        }
+        expected_testing_1 = {
+            (2, 1000, 3),
+            (2, 1000, 4),
+        }
+
+        expected_training_2 = {
+            (1, 1000, 2),
+            (1, 1000, 3),
+            (2, 1000, 4),
+            (1, 1001, 3),
+        }
+        expected_testing_2 = {
+            (2, 1000, 3),
+            (1, 1000, 4),
+        }
+
+        new_training, new_testing = [
+            set(tuple(row) for row in arr.tolist())
+            for arr in self.instance.cleanup_pair(training, testing, random_state=None)
+        ]
+
+        if expected_training_1 == new_training:
+            self.assertEqual(expected_testing_1, new_testing)
+        elif expected_training_2 == new_training:
+            self.assertEqual(expected_testing_2, new_testing)
+        else:
+            self.fail("training was not correct")
+
+
+#     def test_get_cover_deterministic(self):
+#         """Test _get_cover_deterministic."""
+#         generated_triples = generate_triples()
+#         cover = _get_cover_deterministic(triples=generated_triples)
+
+#         # check type
+#         assert torch.is_tensor(cover)
+#         assert cover.dtype == torch.bool
+#         # check format
+#         assert cover.shape == (generated_triples.shape[0],)
+
+#         # check coverage
+#         self.assertEqual(
+#             get_entities(generated_triples),
+#             get_entities(generated_triples[cover]),
+#             msg="entity coverage is not full",
+#         )
+#         self.assertEqual(
+#             get_relations(generated_triples),
+#             get_relations(generated_triples[cover]),
+#             msg="relation coverage is not full",
+#         )

--- a/tests/test_splitting.py
+++ b/tests/test_splitting.py
@@ -12,8 +12,7 @@ from pykeen.triples.splitting import (
     get_absolute_split_sizes,
     normalize_ratios,
 )
-from pykeen.triples.utils import get_entities, get_relations
-from pykeen.utils import tensor_to_set
+from pykeen.triples.utils import get_entities, get_relations, triple_tensor_to_set
 from tests.cases import CleanerTestCase, SplitterTestCase
 
 
@@ -165,7 +164,7 @@ class RandomizedCleanerTests(CleanerTestCase):
         }
 
         new_training, new_testing = [
-            tensor_to_set(arr) for arr in self.instance.cleanup_pair(training, testing, random_state=None)
+            triple_tensor_to_set(arr) for arr in self.instance.cleanup_pair(training, testing, random_state=None)
         ]
 
         if expected_training_1 == new_training:

--- a/tests/test_splitting.py
+++ b/tests/test_splitting.py
@@ -56,7 +56,7 @@ class DeterministicCleanerTests(CleanerTestCase):
 
 
 class RandomizedCleanerTests(CleanerTestCase):
-    """Tests for deterministic cleaner."""
+    """Tests for randomized cleaner."""
 
     cls = RandomizedCleaner
 

--- a/tests/test_splitting.py
+++ b/tests/test_splitting.py
@@ -1,7 +1,15 @@
 """Tests for splitting of triples."""
 import torch
-from pykeen.triples.splitting import DeterministicCleaner, RandomizedCleaner
-from tests.cases import CleanerTestCase
+
+from pykeen.triples.splitting import (
+    CleanupSplitter,
+    CoverageSplitter,
+    DeterministicCleaner,
+    RandomizedCleaner,
+    _get_cover_deterministic,
+)
+from pykeen.triples.utils import get_entities, get_relations
+from tests.cases import CleanerTestCase, SplitterTestCase
 
 
 class DeterministicCleanerTests(CleanerTestCase):
@@ -105,25 +113,36 @@ class RandomizedCleanerTests(CleanerTestCase):
             self.fail("training was not correct")
 
 
-#     def test_get_cover_deterministic(self):
-#         """Test _get_cover_deterministic."""
-#         generated_triples = generate_triples()
-#         cover = _get_cover_deterministic(triples=generated_triples)
+class CleanupSplitterTest(SplitterTestCase):
+    """Tests for cleanup splitter."""
 
-#         # check type
-#         assert torch.is_tensor(cover)
-#         assert cover.dtype == torch.bool
-#         # check format
-#         assert cover.shape == (generated_triples.shape[0],)
+    cls = CleanupSplitter
 
-#         # check coverage
-#         self.assertEqual(
-#             get_entities(generated_triples),
-#             get_entities(generated_triples[cover]),
-#             msg="entity coverage is not full",
-#         )
-#         self.assertEqual(
-#             get_relations(generated_triples),
-#             get_relations(generated_triples[cover]),
-#             msg="relation coverage is not full",
-#         )
+
+class CoverageSplitterTest(SplitterTestCase):
+    """Tests for coverage splitter."""
+
+    cls = CoverageSplitter
+
+    def test_get_cover_deterministic(self):
+        """Test _get_cover_deterministic."""
+        # generated_triples = generate_triples()
+        cover = _get_cover_deterministic(triples=self.mapped_triples)
+
+        # check type
+        assert torch.is_tensor(cover)
+        assert cover.dtype == torch.bool
+        # check format
+        assert cover.shape == (self.mapped_triples.shape[0],)
+
+        # check coverage
+        self.assertEqual(
+            get_entities(self.mapped_triples),
+            get_entities(self.mapped_triples[cover]),
+            msg="entity coverage is not full",
+        )
+        self.assertEqual(
+            get_relations(self.mapped_triples),
+            get_relations(self.mapped_triples[cover]),
+            msg="relation coverage is not full",
+        )

--- a/tests/test_splitting.py
+++ b/tests/test_splitting.py
@@ -9,6 +9,7 @@ from pykeen.triples.splitting import (
     _get_cover_deterministic,
 )
 from pykeen.triples.utils import get_entities, get_relations
+from pykeen.utils import tensor_to_set
 from tests.cases import CleanerTestCase, SplitterTestCase
 
 
@@ -101,8 +102,7 @@ class RandomizedCleanerTests(CleanerTestCase):
         }
 
         new_training, new_testing = [
-            set(tuple(row) for row in arr.tolist())
-            for arr in self.instance.cleanup_pair(training, testing, random_state=None)
+            tensor_to_set(arr) for arr in self.instance.cleanup_pair(training, testing, random_state=None)
         ]
 
         if expected_training_1 == new_training:

--- a/tests/test_splitting.py
+++ b/tests/test_splitting.py
@@ -1,4 +1,6 @@
 """Tests for splitting of triples."""
+import numpy
+import pytest
 import torch
 
 from pykeen.triples.splitting import (
@@ -7,10 +9,71 @@ from pykeen.triples.splitting import (
     DeterministicCleaner,
     RandomizedCleaner,
     _get_cover_deterministic,
+    get_absolute_split_sizes,
+    normalize_ratios,
 )
 from pykeen.triples.utils import get_entities, get_relations
 from pykeen.utils import tensor_to_set
 from tests.cases import CleanerTestCase, SplitterTestCase
+
+
+def test_get_absolute_split_sizes():
+    """Test get_absolute_split_sizes."""
+    for num_splits, n_total in zip(
+        (2, 3, 4),
+        (100, 200, 10412),
+    ):
+        # generate random ratios
+        ratios = numpy.random.uniform(size=(num_splits,))
+        ratios = ratios / ratios.sum()
+        sizes = get_absolute_split_sizes(n_total=n_total, ratios=ratios)
+        # check size
+        assert len(sizes) == len(ratios)
+
+        # check value range
+        assert all(0 <= size <= n_total for size in sizes)
+
+        # check total split
+        assert sum(sizes) == n_total
+
+        # check consistency with ratios
+        rel_size = numpy.asarray(sizes) / n_total
+        # the number of decimal digits equivalent to 1 / n_total
+        decimal = numpy.floor(numpy.log10(n_total))
+        numpy.testing.assert_almost_equal(rel_size, ratios, decimal=decimal)
+
+
+def test_normalize_ratios():
+    """Test normalize_ratios."""
+    for ratios, exp_output in (
+        (0.5, (0.5, 0.5)),
+        ((0.3, 0.2, 0.4), (0.3, 0.2, 0.4, 0.1)),
+        ((0.3, 0.3, 0.4), (0.3, 0.3, 0.4)),
+    ):
+        output = normalize_ratios(ratios=ratios)
+        # check type
+        assert isinstance(output, tuple)
+        assert all(isinstance(ratio, float) for ratio in output)
+        # check values
+        assert len(output) >= 2
+        assert all(0 <= ratio <= 1 for ratio in output)
+        output_np = numpy.asarray(output)
+        numpy.testing.assert_almost_equal(output_np.sum(), numpy.ones(1))
+        # compare against expected
+        numpy.testing.assert_almost_equal(output_np, numpy.asarray(exp_output))
+
+
+def test_normalize_invalid_ratio():
+    """Test invalid ratios."""
+    cases = [
+        1.1,
+        [1.1],
+        [0.8, 0.3],
+        [0.8, 0.1, 0.2],
+    ]
+    for ratios in cases:
+        with pytest.raises(ValueError):
+            _ = normalize_ratios(ratios=ratios)
 
 
 class DeterministicCleanerTests(CleanerTestCase):

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -17,10 +17,9 @@ import torch
 from pykeen.datasets import Hetionet, Nations, SingleTabbedDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
 from pykeen.triples import CoreTriplesFactory, LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory
-from pykeen.triples.generation import generate_triples
 from pykeen.triples.splitting import SPLIT_METHODS, get_absolute_split_sizes, normalize_ratios
 from pykeen.triples.triples_factory import INVERSE_SUFFIX, _map_triples_elements_to_ids
-from pykeen.triples.utils import TRIPLES_DF_COLUMNS, get_entities, get_relations, load_triples
+from pykeen.triples.utils import TRIPLES_DF_COLUMNS, load_triples
 from tests.constants import RESOURCES
 
 triples = np.array(

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -17,7 +17,7 @@ import torch
 from pykeen.datasets import Hetionet, Nations, SingleTabbedDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
 from pykeen.triples import CoreTriplesFactory, LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory
-from pykeen.triples.splitting import SPLIT_METHODS, get_absolute_split_sizes, normalize_ratios
+from pykeen.triples.splitting import get_absolute_split_sizes, normalize_ratios, splitter_resolver
 from pykeen.triples.triples_factory import INVERSE_SUFFIX, _map_triples_elements_to_ids
 from pykeen.triples.utils import TRIPLES_DF_COLUMNS, load_triples
 from tests.constants import RESOURCES
@@ -299,7 +299,7 @@ class TestSplit(unittest.TestCase):
         for (
             method,
             (n, ratios),
-        ) in itt.product(SPLIT_METHODS, cases):
+        ) in itt.product(splitter_resolver.options, cases):
             with self.subTest(method=method, ratios=ratios):
                 factories_1 = self.triples_factory.split(ratios, method=method, random_state=0)
                 self.assertEqual(n, len(factories_1))

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -18,15 +18,7 @@ from pykeen.datasets import Hetionet, Nations, SingleTabbedDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
 from pykeen.triples import CoreTriplesFactory, LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory
 from pykeen.triples.generation import generate_triples
-from pykeen.triples.splitting import (
-    SPLIT_METHODS,
-    _get_cover_deterministic,
-    #_tf_cleanup_all,
-    #_tf_cleanup_deterministic,
-    #_tf_cleanup_randomized,
-    get_absolute_split_sizes,
-    normalize_ratios,
-)
+from pykeen.triples.splitting import SPLIT_METHODS, get_absolute_split_sizes, normalize_ratios
 from pykeen.triples.triples_factory import INVERSE_SUFFIX, _map_triples_elements_to_ids
 from pykeen.triples.utils import TRIPLES_DF_COLUMNS, get_entities, get_relations, load_triples
 from tests.constants import RESOURCES


### PR DESCRIPTION
This PR refactors the splitting code to use classes + class-resolver.

In particular:
* [x] refactor splitting code to use classes and `class-resolver` for choosing between them:
  * `CoverageSplitter` and
  *  `CleanupSplitter`, as well as the different cleanup options
      *  `RandomizedCleaner` and
      *  `DeterministicCleaner`
* [x] extend class docstrings where necessary
* [x] add test for individual components (splitter, cleaner)

Fixes #641 