### PR TITLE
✂️🧵 Enable pruning during HPO

### DIFF
--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -243,12 +243,12 @@ class Objective:
             kwargs_ranges=self.training_kwargs_ranges,
         )
 
-        _stopper_kwargs = dict(self.stopper_kwargs or {})
-        if self.stopper is not None and issubclass(self.stopper, EarlyStopper):
-            self._update_stopper_callbacks(_stopper_kwargs, trial, metric=self.metric)
-
         # create result tracker to allow to gracefully close failed trials
         result_tracker = tracker_resolver.make(query=self.result_tracker, pos_kwargs=self.result_tracker_kwargs)
+
+        _stopper_kwargs = dict(self.stopper_kwargs or {})
+        if self.stopper is not None and issubclass(self.stopper, EarlyStopper):
+            self._update_stopper_callbacks(_stopper_kwargs, trial, metric=self.metric, result_tracker=result_tracker)
 
         try:
             result = pipeline(

--- a/tests/test_hpo.py
+++ b/tests/test_hpo.py
@@ -48,7 +48,7 @@ class TestInvalidConfigurations(unittest.TestCase):
 class TestHPOObjective(unittest.TestCase):
     """Test HPO objective."""
 
-    def _test_re_raise(self, MockTrial, exception: Type[Exception]):
+    def _test_re_raise(self, MockTrial, exception: Type[Exception]):  # noqa: N803
         """Test whether the given exception is raised when evaluating with the mocked trial."""
         objective = Objective(
             dataset=Nations,
@@ -66,13 +66,13 @@ class TestHPOObjective(unittest.TestCase):
 
     @patch("pykeen.pipeline.pipeline", side_effect=MemoryError)
     @patch("optuna.Trial")
-    def test_re_raise_memory_error(self, _mock_pipeline, MockTrial):
+    def test_re_raise_memory_error(self, _mock_pipeline, MockTrial):  # noqa: N803
         """Check that memory errors are re-raised (to be catched by study.optimize)."""
         self._test_re_raise(MockTrial=MockTrial, exception=MemoryError)
 
     @patch("pykeen.pipeline.pipeline", side_effect=RuntimeError)
     @patch("optuna.Trial")
-    def test_re_raise_runtime_error(self, _mock_pipeline, MockTrial):
+    def test_re_raise_runtime_error(self, _mock_pipeline, MockTrial):  # noqa: N803
         """Check that runtime errors are re-raised (to be catched by study.optimize)."""
         self._test_re_raise(MockTrial=MockTrial, exception=RuntimeError)
 

--- a/tests/test_hpo.py
+++ b/tests/test_hpo.py
@@ -4,11 +4,13 @@
 
 import tempfile
 import unittest
-from unittest.mock import MagicMock
+from typing import Type
+from unittest.mock import MagicMock, patch
 
 import optuna
 import pytest
 from optuna.trial import TrialState
+from torch.optim import Adam
 
 from pykeen.datasets.nations import (
     NATIONS_TEST_PATH,
@@ -17,9 +19,15 @@ from pykeen.datasets.nations import (
     Nations,
     NationsLiteral,
 )
+from pykeen.evaluation import RankBasedEvaluator
 from pykeen.hpo import hpo_pipeline
-from pykeen.hpo.hpo import ExtraKeysError, suggest_kwargs
+from pykeen.hpo.hpo import ExtraKeysError, Objective, suggest_kwargs
+from pykeen.losses import MarginRankingLoss
+from pykeen.models import FixedModel
+from pykeen.stoppers.stopper import NopStopper
 from pykeen.trackers import ResultTracker, tracker_resolver
+from pykeen.trackers.base import PythonResultTracker
+from pykeen.training import LCWATrainingLoop
 from pykeen.triples import TriplesFactory
 
 
@@ -35,6 +43,38 @@ class TestInvalidConfigurations(unittest.TestCase):
                 stopper="early",
                 training_kwargs_ranges=dict(epochs=...),
             )
+
+
+class TestHPOObjective(unittest.TestCase):
+    """Test HPO objective."""
+
+    def _test_re_raise(self, MockTrial, exception: Type[Exception]):
+        """Test whether the given exception is raised when evaluating with the mocked trial."""
+        objective = Objective(
+            dataset=Nations,
+            model=FixedModel,
+            loss=MarginRankingLoss,
+            optimizer=Adam,
+            training_loop=LCWATrainingLoop,
+            stopper=NopStopper,
+            evaluator=RankBasedEvaluator,
+            result_tracker=PythonResultTracker,
+            metric="...",
+        )
+        with self.assertRaises(expected_exception=exception):
+            objective(trial=MockTrial())
+
+    @patch("pykeen.pipeline.pipeline", side_effect=MemoryError)
+    @patch("optuna.Trial")
+    def test_re_raise_memory_error(self, _mock_pipeline, MockTrial):
+        """Check that memory errors are re-raised (to be catched by study.optimize)."""
+        self._test_re_raise(MockTrial=MockTrial, exception=MemoryError)
+
+    @patch("pykeen.pipeline.pipeline", side_effect=RuntimeError)
+    @patch("optuna.Trial")
+    def test_re_raise_runtime_error(self, _mock_pipeline, MockTrial):
+        """Check that runtime errors are re-raised (to be catched by study.optimize)."""
+        self._test_re_raise(MockTrial=MockTrial, exception=RuntimeError)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The previous code did not properly utilize optuna's pruning function, thus rendering the `pruner` option inside the `hpo_pipeline` useless. This code fixes it, following the example [here](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.MedianPruner.html).


**Note**: if you only want to have pruning (but no early stopping), you still need to set `stopper="early"` with a huge patience such that it never stops based on the stopper. This limitation comes from the fact that we currently only evaluate ever via the early stopper.

Also fixes #541 along the way.