### PR TITLE
🙃👓 Predict workflow with inverse relations

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -121,7 +121,7 @@ class Model(nn.Module, ABC):
         self.predict_with_sigmoid = predict_with_sigmoid
 
     @property
-    def real_num_relations(self) -> int:
+    def num_real_relations(self) -> int:
         """Return the real number of relations (without inverses)."""
         if self.use_inverse_triples:
             return self.num_relations // 2

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -209,6 +209,8 @@ class Model(nn.Module, ABC):
         :return: shape: (batch_size, num_real_relations), dtype: float
             For each h-t pair, the scores for all possible relations.
         """
+        # TODO: this currently compute (batch_size, num_relations) instead,
+        # i.e., scores for normal and inverse relations
 
     @abstractmethod
     def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:
@@ -381,7 +383,7 @@ class Model(nn.Module, ABC):
         :param slice_size: >0
             The divisor for the scoring function when using slicing.
 
-        :return: shape: (batch_size, num_relations), dtype: float
+        :return: shape: (batch_size, num_real_relations), dtype: float
             For each h-t pair, the scores for all possible relations.
         """
         self.eval()  # Enforce evaluation mode

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -120,6 +120,13 @@ class Model(nn.Module, ABC):
         """
         self.predict_with_sigmoid = predict_with_sigmoid
 
+    @property
+    def real_num_relations(self) -> int:
+        """Return the real number of relations (without inverses)."""
+        if self.use_inverse_triples:
+            return self.num_relations // 2
+        return self.num_relations
+
     def __init_subclass__(cls, **kwargs):
         """Initialize the subclass.
 
@@ -199,7 +206,7 @@ class Model(nn.Module, ABC):
         :param slice_size: >0
             The divisor for the scoring function when using slicing.
 
-        :return: shape: (batch_size, num_relations), dtype: float
+        :return: shape: (batch_size, num_real_relations), dtype: float
             For each h-t pair, the scores for all possible relations.
         """
 

--- a/src/pykeen/models/mocks.py
+++ b/src/pykeen/models/mocks.py
@@ -68,19 +68,19 @@ class FixedModel(Model):
         return self._generate_fake_scores(
             h=hr_batch[:, 0:1],
             r=hr_batch[:, 1:2],
-            t=torch.arange(self.num_entities, device=hr_batch.device).unsqueeze(dim=0),
+            t=torch.arange(self.num_entities).unsqueeze(dim=0),
         )
 
     def score_r(self, ht_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(
             h=ht_batch[:, 0:1],
-            r=torch.arange(self.num_relations, device=ht_batch.device).unsqueeze(dim=0),
+            r=torch.arange(self.num_relations).unsqueeze(dim=0),
             t=ht_batch[:, 1:2],
         )
 
     def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(
-            h=torch.arange(self.num_entities, device=rt_batch.device).unsqueeze(dim=0),
+            h=torch.arange(self.num_entities).unsqueeze(dim=0),
             r=rt_batch[:, 0:1],
             t=rt_batch[:, 1:2],
         )

--- a/src/pykeen/models/mocks.py
+++ b/src/pykeen/models/mocks.py
@@ -68,19 +68,19 @@ class FixedModel(Model):
         return self._generate_fake_scores(
             h=hr_batch[:, 0:1],
             r=hr_batch[:, 1:2],
-            t=torch.arange(self.num_entities).unsqueeze(dim=0),
+            t=torch.arange(self.num_entities, device=hr_batch.device).unsqueeze(dim=0),
         )
 
     def score_r(self, ht_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(
             h=ht_batch[:, 0:1],
-            r=torch.arange(self.num_relations).unsqueeze(dim=0),
+            r=torch.arange(self.num_relations, device=ht_batch.device).unsqueeze(dim=0),
             t=ht_batch[:, 1:2],
         )
 
     def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(
-            h=torch.arange(self.num_entities).unsqueeze(dim=0),
+            h=torch.arange(self.num_entities, device=rt_batch.device).unsqueeze(dim=0),
             r=rt_batch[:, 0:1],
             t=rt_batch[:, 1:2],
         )

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -296,7 +296,7 @@ def predict(model: Model, *, k: Optional[int] = None, batch_size: int = 1) -> Sc
     :return: A score pack of parallel triples and scores
     """
     logger.warning(
-        f"_predict is an expensive operation, involving {model.num_entities ** 2 * model.num_relations} "
+        f"_predict is an expensive operation, involving {model.num_entities ** 2 * model.real_num_relations} "
         f"score evaluations.",
     )
 
@@ -454,7 +454,7 @@ def _consume_scores(model: Model, *consumers: _ScoreConsumer, batch_size: int = 
     # TODO: fix code for inverse relations
     for r, h_start in tqdm(
         itt.product(
-            range(model.num_relations),
+            range(model.real_num_relations),
             range(0, model.num_entities, batch_size),
         ),
         desc="scoring",

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -451,6 +451,7 @@ def _consume_scores(model: Model, *consumers: _ScoreConsumer, batch_size: int = 
     # set model to evaluation mode
     model.eval()
 
+    # TODO: fix code for inverse relations
     for r, h_start in tqdm(
         itt.product(
             range(model.num_relations),

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -296,7 +296,7 @@ def predict(model: Model, *, k: Optional[int] = None, batch_size: int = 1) -> Sc
     :return: A score pack of parallel triples and scores
     """
     logger.warning(
-        f"_predict is an expensive operation, involving {model.num_entities ** 2 * model.real_num_relations} "
+        f"_predict is an expensive operation, involving {model.num_entities ** 2 * model.num_real_relations} "
         f"score evaluations.",
     )
 
@@ -451,10 +451,9 @@ def _consume_scores(model: Model, *consumers: _ScoreConsumer, batch_size: int = 
     # set model to evaluation mode
     model.eval()
 
-    # TODO: fix code for inverse relations
     for r, h_start in tqdm(
         itt.product(
-            range(model.real_num_relations),
+            range(model.num_real_relations),
             range(0, model.num_entities, batch_size),
         ),
         desc="scoring",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -93,6 +93,10 @@ class TestConvE(cases.ModelTestCase):
     #                                 7
     num_constant_init = 7
 
+    def test_predict(self):
+        """Test prediction workflow with inverse relations."""
+        predict(model=self.instance, k=10)
+
 
 class TestConvKB(cases.ModelTestCase):
     """Test the ConvKB model."""


### PR DESCRIPTION
This PR draft shows an error in the predict workflow when inverse relations are present.

#### Background
The scoring loop runs until `model.num_relations`, but for models with inverse relations it should only go until the number of real relations (without inverses).