### PR TITLE
🧀 🏹 Unify usage of `slice_size`

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -600,6 +600,18 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
         if self.training:
             self.regularizer.update(*tensors)
 
+    @property
+    def can_slice_h(self) -> bool:  # noqa:D102
+        return False
+
+    @property
+    def can_slice_r(self) -> bool:  # noqa:D102
+        return False
+
+    @property
+    def can_slice_t(self) -> bool:  # noqa:D102
+        return False
+
     def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:
         """Forward pass using right side (tail) prediction.
 

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -187,39 +187,45 @@ class Model(nn.Module, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:
         """Forward pass using right side (tail) prediction.
 
         This method calculates the score for all possible tails for each (head, relation) pair.
 
         :param hr_batch: shape: (batch_size, 2), dtype: long
             The indices of (head, relation) pairs.
+        :param slice_size: >0
+            The divisor for the scoring function when using slicing.
 
         :return: shape: (batch_size, num_entities), dtype: float
             For each h-r pair, the scores for all possible tails.
         """
 
     @abstractmethod
-    def score_r(self, ht_batch: torch.LongTensor) -> torch.FloatTensor:
+    def score_r(self, ht_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:
         """Forward pass using middle (relation) prediction.
 
         This method calculates the score for all possible relations for each (head, tail) pair.
 
         :param ht_batch: shape: (batch_size, 2), dtype: long
             The indices of (head, tail) pairs.
+        :param slice_size: >0
+            The divisor for the scoring function when using slicing.
 
         :return: shape: (batch_size, num_relations), dtype: float
             For each h-t pair, the scores for all possible relations.
         """
 
     @abstractmethod
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:
         """Forward pass using left side (head) prediction.
 
         This method calculates the score for all possible heads for each (relation, tail) pair.
 
         :param rt_batch: shape: (batch_size, 2), dtype: long
             The indices of (relation, tail) pairs.
+        :param slice_size: >0
+            The divisor for the scoring function when using slicing.
 
         :return: shape: (batch_size, num_entities), dtype: float
             For each r-t pair, the scores for all possible heads.
@@ -324,10 +330,7 @@ class Model(nn.Module, ABC):
         rt_batch = self._prepare_batch(batch=rt_batch, index_relation=0)
         if self.use_inverse_triples:
             scores = self.score_h_inverse(rt_batch=rt_batch, slice_size=slice_size)
-        elif slice_size is None:
-            scores = self.score_h(rt_batch)
-        else:
-            scores = self.score_h(rt_batch, slice_size=slice_size)  # type: ignore
+        scores = self.score_h(rt_batch, slice_size=slice_size)
         if self.predict_with_sigmoid:
             scores = torch.sigmoid(scores)
         return scores
@@ -362,10 +365,7 @@ class Model(nn.Module, ABC):
         """
         self.eval()  # Enforce evaluation mode
         hr_batch = self._prepare_batch(batch=hr_batch, index_relation=1)
-        if slice_size is None:
-            scores = self.score_t(hr_batch)
-        else:
-            scores = self.score_t(hr_batch, slice_size=slice_size)  # type: ignore
+        scores = self.score_t(hr_batch, slice_size=slice_size)
         if self.predict_with_sigmoid:
             scores = torch.sigmoid(scores)
         return scores
@@ -391,10 +391,7 @@ class Model(nn.Module, ABC):
         """
         self.eval()  # Enforce evaluation mode
         ht_batch = ht_batch.to(self.device)
-        if slice_size is None:
-            scores = self.score_r(ht_batch)
-        else:
-            scores = self.score_r(ht_batch, slice_size=slice_size)  # type: ignore
+        scores = self.score_r(ht_batch, slice_size=slice_size)
         if self.predict_with_sigmoid:
             scores = torch.sigmoid(scores)
         return scores
@@ -522,20 +519,12 @@ class Model(nn.Module, ABC):
     def score_t_inverse(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None):
         """Score all tails for a batch of (h,r)-pairs using the head predictions for the inverses $(*,r_{inv},h)$."""
         r_inv_h = self._prepare_inverse_batch(batch=hr_batch, index_relation=1)
-
-        if slice_size is None:
-            return self.score_h(rt_batch=r_inv_h)
-        else:
-            return self.score_h(rt_batch=r_inv_h, slice_size=slice_size)  # type: ignore
+        return self.score_h(rt_batch=r_inv_h, slice_size=slice_size)
 
     def score_h_inverse(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None):
         """Score all heads for a batch of (r,t)-pairs using the tail predictions for the inverses $(t,r_{inv},*)$."""
         t_r_inv = self._prepare_inverse_batch(batch=rt_batch, index_relation=0)
-
-        if slice_size is None:
-            return self.score_t(hr_batch=t_r_inv)
-        else:
-            return self.score_t(hr_batch=t_r_inv, slice_size=slice_size)  # type: ignore
+        return self.score_t(hr_batch=t_r_inv, slice_size=slice_size)
 
 
 class _OldAbstractModel(Model, ABC, autoreset=False):
@@ -611,13 +600,15 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
         if self.training:
             self.regularizer.update(*tensors)
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:
         """Forward pass using right side (tail) prediction.
 
         This method calculates the score for all possible tails for each (head, relation) pair.
 
         :param hr_batch: shape: (batch_size, 2), dtype: long
             The indices of (head, relation) pairs.
+        :param slice_size: >0
+            The divisor for the scoring function when using slicing.
 
         :return: shape: (batch_size, num_entities), dtype: float
             For each h-r pair, the scores for all possible tails.
@@ -634,13 +625,15 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
         scores = expanded_scores.view(hr_batch.shape[0], -1)
         return scores
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:
         """Forward pass using left side (head) prediction.
 
         This method calculates the score for all possible heads for each (relation, tail) pair.
 
         :param rt_batch: shape: (batch_size, 2), dtype: long
             The indices of (relation, tail) pairs.
+        :param slice_size: >0
+            The divisor for the scoring function when using slicing.
 
         :return: shape: (batch_size, num_entities), dtype: float
             For each r-t pair, the scores for all possible heads.
@@ -657,13 +650,15 @@ class _OldAbstractModel(Model, ABC, autoreset=False):
         scores = expanded_scores.view(rt_batch.shape[0], -1)
         return scores
 
-    def score_r(self, ht_batch: torch.LongTensor) -> torch.FloatTensor:
+    def score_r(self, ht_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:
         """Forward pass using middle (relation) prediction.
 
         This method calculates the score for all possible relations for each (head, tail) pair.
 
         :param ht_batch: shape: (batch_size, 2), dtype: long
             The indices of (head, tail) pairs.
+        :param slice_size: >0
+            The divisor for the scoring function when using slicing.
 
         :return: shape: (batch_size, num_relations), dtype: float
             For each h-t pair, the scores for all possible relations.

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -317,7 +317,8 @@ class Model(nn.Module, ABC):
         rt_batch = self._prepare_batch(batch=rt_batch, index_relation=0)
         if self.use_inverse_triples:
             scores = self.score_h_inverse(rt_batch=rt_batch, slice_size=slice_size)
-        scores = self.score_h(rt_batch, slice_size=slice_size)
+        else:
+            scores = self.score_h(rt_batch, slice_size=slice_size)
         if self.predict_with_sigmoid:
             scores = torch.sigmoid(scores)
         return scores

--- a/src/pykeen/models/baseline/models.py
+++ b/src/pykeen/models/baseline/models.py
@@ -21,6 +21,10 @@ __all__ = [
 class EvaluationOnlyModel(Model, ABC):
     """A model which only implements the methods used for evaluation."""
 
+    can_slice_h = False
+    can_slice_r = False
+    can_slice_t = False
+
     def __init__(self, triples_factory: CoreTriplesFactory):
         """Non-parametric models take a minimal set of arguments.
 

--- a/src/pykeen/models/baseline/models.py
+++ b/src/pykeen/models/baseline/models.py
@@ -3,6 +3,7 @@
 """Non-parametric baseline models."""
 
 from abc import ABC
+from typing import Optional
 
 import numpy
 import torch
@@ -47,7 +48,7 @@ class EvaluationOnlyModel(Model, ABC):
         """Non-parametric models do not implement :meth:`Model.score_hrt`."""
         raise RuntimeError
 
-    def score_r(self, ht_batch: torch.LongTensor):  # noqa:D102
+    def score_r(self, ht_batch: torch.LongTensor, slice_size: Optional[int] = None):  # noqa:D102
         """Non-parametric models do not implement :meth:`Model.score_r`."""
         raise RuntimeError
 
@@ -120,7 +121,7 @@ class MarginalDistributionBaseline(EvaluationOnlyModel):
         else:
             self.head_per_tail = self.tail_per_head = None
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa:D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa:D102
         return marginal_score(
             entity_relation_batch=hr_batch,
             per_entity=self.tail_per_head,
@@ -128,7 +129,7 @@ class MarginalDistributionBaseline(EvaluationOnlyModel):
             num_entities=self.num_entities,
         )
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa:D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa:D102
         return marginal_score(
             entity_relation_batch=rt_batch.flip(1),
             per_entity=self.head_per_tail,

--- a/src/pykeen/models/mocks.py
+++ b/src/pykeen/models/mocks.py
@@ -5,7 +5,7 @@
 These are useful for baselines.
 """
 
-from typing import Any, ClassVar, Mapping
+from typing import Any, ClassVar, Mapping, Optional
 
 import torch
 
@@ -64,21 +64,21 @@ class FixedModel(Model):
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(*hrt_batch.t()).unsqueeze(dim=-1)
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(
             h=hr_batch[:, 0:1],
             r=hr_batch[:, 1:2],
             t=torch.arange(self.num_entities, device=hr_batch.device).unsqueeze(dim=0),
         )
 
-    def score_r(self, ht_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_r(self, ht_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(
             h=ht_batch[:, 0:1],
             r=torch.arange(self.num_relations, device=ht_batch.device).unsqueeze(dim=0),
             t=ht_batch[:, 1:2],
         )
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._generate_fake_scores(
             h=torch.arange(self.num_entities, device=rt_batch.device).unsqueeze(dim=0),
             r=rt_batch[:, 0:1],

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -180,6 +180,7 @@ class _NewAbstractModel(Model, ABC):
             h_indices=hrt_batch[:, 0],
             r_indices=hrt_batch[:, 1],
             t_indices=hrt_batch[:, 2],
+            # TODO can slices be used here?
         ).view(hrt_batch.shape[0], 1)
 
     def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -180,11 +180,12 @@ class _NewAbstractModel(Model, ABC):
         :return: shape: (batch_size, 1), dtype: float
             The score for each triple.
         """
+        # Note: slicing cannot be used here: the indices for score_hrt only havea batch
+        # dimension, and slicing along this dimension is already considered by sub-batching.
         return self(
             h_indices=hrt_batch[:, 0],
             r_indices=hrt_batch[:, 1],
             t_indices=hrt_batch[:, 2],
-            # TODO can slices be used here?
         ).view(hrt_batch.shape[0], 1)
 
     def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -60,6 +60,10 @@ class _NewAbstractModel(Model, ABC):
     #: The default parameters for the default regularizer class
     regularizer_default_kwargs: ClassVar[Optional[Mapping[str, Any]]] = None
 
+    can_slice_h = True
+    can_slice_r = True
+    can_slice_t = True
+
     def _reset_parameters_(self):  # noqa: D401
         """Reset all parameters of the model in-place."""
         # cf. https://github.com/mberr/ea-sota-comparison/blob/6debd076f93a329753d819ff4d01567a23053720/src/kgm/utils/torch_utils.py#L317-L372   # noqa:E501

--- a/src/pykeen/models/unimodal/conv_e.py
+++ b/src/pykeen/models/unimodal/conv_e.py
@@ -318,7 +318,7 @@ class ConvE(EntityRelationEmbeddingModel):
 
         return x
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         h = self.entity_embeddings(indices=hr_batch[:, 0]).view(
             -1,
             self.input_channels,
@@ -344,7 +344,7 @@ class ConvE(EntityRelationEmbeddingModel):
 
         return x
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         rt_batch_size = rt_batch.shape[0]
         h = self.entity_embeddings(indices=None)
         r = self.relation_embeddings(indices=rt_batch[:, 0]).view(

--- a/src/pykeen/models/unimodal/distmult.py
+++ b/src/pykeen/models/unimodal/distmult.py
@@ -2,7 +2,7 @@
 
 """Implementation of DistMult."""
 
-from typing import Any, ClassVar, Mapping, Type
+from typing import Any, ClassVar, Mapping, Optional, Type
 
 import torch
 from torch.nn import functional
@@ -142,7 +142,7 @@ class DistMult(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=hr_batch[:, 0]).view(-1, 1, self.embedding_dim)
         r = self.relation_embeddings(indices=hr_batch[:, 1]).view(-1, 1, self.embedding_dim)
@@ -156,7 +156,7 @@ class DistMult(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=None).view(1, -1, self.embedding_dim)
         r = self.relation_embeddings(indices=rt_batch[:, 0]).view(-1, 1, self.embedding_dim)

--- a/src/pykeen/models/unimodal/ermlp.py
+++ b/src/pykeen/models/unimodal/ermlp.py
@@ -108,7 +108,7 @@ class ERMLP(EntityRelationEmbeddingModel):
         # Compute scores
         return self.mlp(x_s)
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=hr_batch[:, 0])
         r = self.relation_embeddings(indices=hr_batch[:, 1])
@@ -134,7 +134,7 @@ class ERMLP(EntityRelationEmbeddingModel):
         scores = scores.view(-1, self.num_entities)
         return scores
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=None)
         r = self.relation_embeddings(indices=rt_batch[:, 0])

--- a/src/pykeen/models/unimodal/ermlpe.py
+++ b/src/pykeen/models/unimodal/ermlpe.py
@@ -2,7 +2,7 @@
 
 """An implementation of the extension to ERMLP."""
 
-from typing import Any, ClassVar, Mapping, Type
+from typing import Any, ClassVar, Mapping, Optional, Type
 
 import torch
 from torch import nn
@@ -133,7 +133,7 @@ class ERMLPE(EntityRelationEmbeddingModel):
 
         return x
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         h = self.entity_embeddings(indices=hr_batch[:, 0]).view(-1, self.embedding_dim)
         r = self.relation_embeddings(indices=hr_batch[:, 1]).view(-1, self.embedding_dim)
         t = self.entity_embeddings(indices=None).transpose(1, 0)
@@ -153,7 +153,7 @@ class ERMLPE(EntityRelationEmbeddingModel):
 
         return x
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         h = self.entity_embeddings(indices=None)
         r = self.relation_embeddings(indices=rt_batch[:, 0]).view(-1, self.embedding_dim)
         t = self.entity_embeddings(indices=rt_batch[:, 1]).view(-1, self.embedding_dim)

--- a/src/pykeen/models/unimodal/hole.py
+++ b/src/pykeen/models/unimodal/hole.py
@@ -141,7 +141,7 @@ class HolE(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         h = self.entity_embeddings(indices=hr_batch[:, 0]).unsqueeze(dim=1)
         r = self.relation_embeddings(indices=hr_batch[:, 1]).unsqueeze(dim=1)
         t = self.entity_embeddings(indices=None).unsqueeze(dim=0)
@@ -153,7 +153,7 @@ class HolE(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         h = self.entity_embeddings(indices=None).unsqueeze(dim=0)
         r = self.relation_embeddings(indices=rt_batch[:, 0]).unsqueeze(dim=1)
         t = self.entity_embeddings(indices=rt_batch[:, 1]).unsqueeze(dim=1)

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -191,10 +191,10 @@ class KG2E(EntityRelationEmbeddingModel):
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._score(h_indices=hrt_batch[:, 0], r_indices=hrt_batch[:, 1], t_indices=hrt_batch[:, 2]).view(-1, 1)
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._score(h_indices=hr_batch[:, 0], r_indices=hr_batch[:, 1])
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._score(r_indices=rt_batch[:, 0], t_indices=rt_batch[:, 1])
 
     @staticmethod

--- a/src/pykeen/models/unimodal/proj_e.py
+++ b/src/pykeen/models/unimodal/proj_e.py
@@ -118,7 +118,7 @@ class ProjE(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=hr_batch[:, 0])
         r = self.relation_embeddings(indices=hr_batch[:, 1])
@@ -130,7 +130,7 @@ class ProjE(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=None)
         r = self.relation_embeddings(indices=rt_batch[:, 0])

--- a/src/pykeen/models/unimodal/rescal.py
+++ b/src/pykeen/models/unimodal/rescal.py
@@ -2,7 +2,7 @@
 
 """Implementation of RESCAL."""
 
-from typing import Any, ClassVar, Mapping, Type
+from typing import Any, ClassVar, Mapping, Optional, Type
 
 import torch
 from torch.nn.init import uniform_
@@ -105,7 +105,7 @@ class RESCAL(EntityRelationEmbeddingModel):
 
         return scores[:, :, 0]
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         h = self.entity_embeddings(indices=hr_batch[:, 0]).unsqueeze(dim=1)
         r = self.relation_embeddings(indices=hr_batch[:, 1])
         t = self.entity_embeddings(indices=None).unsqueeze(dim=0).transpose(-1, -2)
@@ -118,7 +118,7 @@ class RESCAL(EntityRelationEmbeddingModel):
 
         return scores[:, 0, :]
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         """Forward pass using left side (head) prediction."""
         # Get embeddings
         h = self.entity_embeddings(indices=None).unsqueeze(dim=0)

--- a/src/pykeen/models/unimodal/rotate.py
+++ b/src/pykeen/models/unimodal/rotate.py
@@ -2,7 +2,7 @@
 
 """Implementation of the RotatE model."""
 
-from typing import Any, ClassVar, Mapping
+from typing import Any, ClassVar, Mapping, Optional
 
 import torch
 import torch.autograd
@@ -136,7 +136,7 @@ class RotatE(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=hr_batch[:, 0]).view(-1, 1, self.real_embedding_dim, 2)
         r = self.relation_embeddings(indices=hr_batch[:, 1]).view(-1, 1, self.real_embedding_dim, 2)
@@ -152,7 +152,7 @@ class RotatE(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         r = self.relation_embeddings(indices=rt_batch[:, 0]).view(-1, 1, self.real_embedding_dim, 2)
         t = self.entity_embeddings(indices=rt_batch[:, 1]).view(-1, 1, self.real_embedding_dim, 2)

--- a/src/pykeen/models/unimodal/simple.py
+++ b/src/pykeen/models/unimodal/simple.py
@@ -148,8 +148,8 @@ class SimplE(EntityRelationEmbeddingModel):
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._score(h_indices=hrt_batch[:, 0], r_indices=hrt_batch[:, 1], t_indices=hrt_batch[:, 2]).view(-1, 1)
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._score(h_indices=hr_batch[:, 0], r_indices=hr_batch[:, 1], t_indices=None)
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._score(h_indices=None, r_indices=rt_batch[:, 0], t_indices=rt_batch[:, 1])

--- a/src/pykeen/models/unimodal/trans_d.py
+++ b/src/pykeen/models/unimodal/trans_d.py
@@ -229,8 +229,8 @@ class TransD(EntityRelationEmbeddingModel):
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
         return self._score(h_indices=hrt_batch[:, 0], r_indices=hrt_batch[:, 1], t_indices=hrt_batch[:, 2])
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._score(h_indices=hr_batch[:, 0], r_indices=hr_batch[:, 1], t_indices=None)
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         return self._score(h_indices=None, r_indices=rt_batch[:, 0], t_indices=rt_batch[:, 1])

--- a/src/pykeen/models/unimodal/trans_e.py
+++ b/src/pykeen/models/unimodal/trans_e.py
@@ -2,7 +2,7 @@
 
 """TransE."""
 
-from typing import Any, ClassVar, Mapping
+from typing import Any, ClassVar, Mapping, Optional
 
 import torch.autograd
 from torch import linalg
@@ -108,7 +108,7 @@ class TransE(EntityRelationEmbeddingModel):
         #  this will require some benchmarking.
         return -linalg.vector_norm(h + r - t, dim=-1, ord=self.scoring_fct_norm, keepdim=True)
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=hr_batch[:, 0])
         r = self.relation_embeddings(indices=hr_batch[:, 1])
@@ -117,7 +117,7 @@ class TransE(EntityRelationEmbeddingModel):
         # TODO: Use torch.cdist (see note above in score_hrt())
         return -linalg.vector_norm(h[:, None, :] + r[:, None, :] - t[None, :, :], dim=-1, ord=self.scoring_fct_norm)
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=None)
         r = self.relation_embeddings(indices=rt_batch[:, 0])

--- a/src/pykeen/models/unimodal/trans_h.py
+++ b/src/pykeen/models/unimodal/trans_h.py
@@ -2,7 +2,7 @@
 
 """An implementation of TransH."""
 
-from typing import Any, ClassVar, Mapping, Type
+from typing import Any, ClassVar, Mapping, Optional, Type
 
 import torch
 from torch import linalg
@@ -146,7 +146,7 @@ class TransH(EntityRelationEmbeddingModel):
 
         return -linalg.vector_norm(ph + d_r - pt, ord=2, dim=-1, keepdim=True)
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=hr_batch[:, 0])
         d_r = self.relation_embeddings(indices=hr_batch[:, 1])
@@ -162,7 +162,7 @@ class TransH(EntityRelationEmbeddingModel):
 
         return -linalg.vector_norm(ph[:, None, :] + d_r[:, None, :] - pt, ord=2, dim=-1)
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=None)
         rel_id = rt_batch[:, 0]

--- a/src/pykeen/models/unimodal/trans_r.py
+++ b/src/pykeen/models/unimodal/trans_r.py
@@ -3,7 +3,7 @@
 """Implementation of TransR."""
 
 from functools import partial
-from typing import Any, ClassVar, Mapping
+from typing import Any, ClassVar, Mapping, Optional
 
 import torch
 import torch.autograd
@@ -166,7 +166,7 @@ class TransR(EntityRelationEmbeddingModel):
 
         return self.interaction_function(h=h, r=r, t=t, m_r=m_r).view(-1, 1)
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=hr_batch[:, 0]).unsqueeze(dim=1)
         r = self.relation_embeddings(indices=hr_batch[:, 1]).unsqueeze(dim=1)
@@ -175,7 +175,7 @@ class TransR(EntityRelationEmbeddingModel):
 
         return self.interaction_function(h=h, r=r, t=t, m_r=m_r)
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=None).unsqueeze(dim=0)
         r = self.relation_embeddings(indices=rt_batch[:, 0]).unsqueeze(dim=1)

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -193,7 +193,7 @@ class TuckER(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_t(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=hr_batch[:, 0]).unsqueeze(1)
         r = self.relation_embeddings(indices=hr_batch[:, 1])
@@ -204,7 +204,7 @@ class TuckER(EntityRelationEmbeddingModel):
 
         return scores
 
-    def score_h(self, rt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
         # Get embeddings
         h = self.entity_embeddings(indices=None).unsqueeze(0)
         r = self.relation_embeddings(indices=rt_batch[:, 0])

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -94,10 +94,7 @@ class LCWATrainingLoop(TrainingLoop[LCWASampleType, LCWABatchType]):
         batch_pairs = batch_pairs[start:stop].to(device=self.device)
         batch_labels_full = batch_labels_full[start:stop].to(device=self.device)
 
-        if slice_size is None:
-            predictions = self.score_method(batch_pairs)
-        else:
-            predictions = self.score_method(batch_pairs, slice_size=slice_size)  # type: ignore
+        predictions = self.score_method(batch_pairs, slice_size=slice_size)
 
         return (
             self.loss.process_lcwa_scores(

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -4,7 +4,6 @@
 
 import ftplib
 import functools
-import inspect
 import itertools as itt
 import json
 import logging
@@ -857,11 +856,6 @@ def unpack_singletons(*xs: Tuple[X]) -> Sequence[Union[X, Tuple[X]]]:
     (1, (1, 2), (1, 2, 3))
     """
     return tuple(x[0] if len(x) == 1 else x for x in xs)
-
-
-def _can_slice(fn) -> bool:
-    """Check if a model's score_X function can slice."""
-    return "slice_size" in inspect.getfullargspec(fn).args
 
 
 def extend_batch(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -887,17 +887,6 @@ class InverseRelationPredictionTests(unittest_templates.GenericTestCase[pykeen.m
         scores = self.instance.predict_h(rt_batch=rt_batch)
         assert torch.allclose(scores, expected_scores)
 
-    def test_predict_r(self):
-        """Test predict_r."""
-        ht_batch = self._combination_batch(tails=False)
-        expected_scores = self.instance._generate_fake_scores(
-            h=ht_batch[:, 0, None],
-            r=torch.arange(self.factory.num_relations).unsqueeze(dim=0),
-            t=ht_batch[:, 1, None],
-        )
-        scores = self.instance.predict_r(ht_batch=ht_batch)
-        assert torch.allclose(scores, expected_scores)
-
     def test_predict_t(self):
         """Test predict_t."""
         hr_batch = self._combination_batch(tails=False)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -885,7 +885,7 @@ class InverseRelationPredictionTests(unittest_templates.GenericTestCase[pykeen.m
             t=torch.arange(self.factory.num_entities).unsqueeze(dim=0),
         )
         scores = self.instance.predict_h(rt_batch=rt_batch)
-        self.assertTrue(torch.allclose(scores, expected_scores))
+        assert torch.allclose(scores, expected_scores)
 
     def test_predict_r(self):
         """Test predict_r."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -885,6 +885,17 @@ class InverseRelationPredictionTests(unittest_templates.GenericTestCase[pykeen.m
             t=torch.arange(self.factory.num_entities).unsqueeze(dim=0),
         )
         scores = self.instance.predict_h(rt_batch=rt_batch)
+        self.assertTrue(torch.allclose(scores, expected_scores))
+
+    def test_predict_r(self):
+        """Test predict_r."""
+        ht_batch = self._combination_batch(tails=False)
+        expected_scores = self.instance._generate_fake_scores(
+            h=ht_batch[:, 0, None],
+            r=torch.arange(self.factory.num_relations).unsqueeze(dim=0),
+            t=ht_batch[:, 1, None],
+        )
+        scores = self.instance.predict_r(ht_batch=ht_batch)
         assert torch.allclose(scores, expected_scores)
 
     def test_predict_t(self):


### PR DESCRIPTION
This PR adds the `slice_size` keyword argument to all models, including the legacy model style, even where it doesn't actually do anything. This also means the previous way of calculating `can_slice` is no longer valid, and this is now directly implemented on the base model level.

This unifies the interface significantly and is one step towards making it easier to do #722.

This PR **does not** implement slicing for old-style models, nor suggest that we should. I still think we should bite the bullet and upgrade all old-style models then throw away the legacy code (and accept any minor memory/time performance hits for making the codebase more maintainable), but that's a discussion for another time.
