### PR TITLE
📏🪕 Compute Candidate Set Sizes

### DIFF
--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -13,7 +13,7 @@ from typing import Iterable, List, Optional, Tuple, Type, Union
 import click
 import docdata
 import pandas as pd
-from more_click import verbose_option
+from more_click import log_level_option, verbose_option
 from tqdm import tqdm
 
 from . import dataset_resolver, get_dataset
@@ -222,8 +222,10 @@ def verify(dataset: str):
 @verbose_option
 @click.option("-d", "--dataset", help="Regex for filtering datasets by name")
 @click.option("-m", "--max-triples", type=int, default=None)
-def expected_metrics(dataset: str, max_triples: Optional[int]):
+@log_level_option(default=logging.ERROR)
+def expected_metrics(dataset: str, max_triples: Optional[int], log_level: str):
     """Compute expected metrics for all datasets (matching the given pattern)."""
+    logging.getLogger("pykeen").setLevel(level=log_level)
     directory = PYKEEN_DATASETS
     df_data: List[Tuple[str, str, str, str, float]] = []
     for _dataset_name, dataset_cls in _iter_datasets(regex_name_filter=dataset, max_triples=max_triples):

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -57,12 +57,12 @@ def _iter_datasets(regex_name_filter=None, max_triples: Optional[int] = None) ->
 
             regex_name_filter = re.compile(regex_name_filter)
         it = [(name, dataset) for name, dataset in it if regex_name_filter.match(name)]
-    it = tqdm(
+    it_tqdm = tqdm(
         it,
         desc="Datasets",
     )
-    for k, v in it:
-        it.set_postfix(name=k)
+    for k, v in it_tqdm:
+        it_tqdm.set_postfix(name=k)
         yield k, v
 
 

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -7,7 +7,7 @@ import json
 import logging
 import pathlib
 from textwrap import dedent
-from typing import Union
+from typing import List, Tuple, Union
 
 import click
 import docdata
@@ -214,7 +214,7 @@ def verify(dataset: str):
 def expected_metrics(dataset: str):
     """Compute expected metrics for all datasets (matching the given pattern)."""
     directory = PYKEEN_DATASETS
-    df_data = []
+    df_data: List[Tuple[str, str, str, str, float]] = []
     for _dataset_name, dataset_cls in _iter_datasets(regex_name_filter=dataset):
         dataset_instance = get_dataset(dataset=dataset_cls)
         dataset_name = dataset_instance.__class__.__name__.lower()

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -212,6 +212,7 @@ def verify(dataset: str):
 @verbose_option
 @click.option("--dataset", help="Regex for filtering datasets by name")
 def expected_metrics(dataset: str):
+    """Compute expected metrics for all datasets (matching the given pattern)."""
     directory = PYKEEN_DATASETS
     for _dataset_name, dataset_cls in _iter_datasets(regex_name_filter=dataset):
         dataset_instance = get_dataset(dataset=dataset_cls)

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -184,8 +184,8 @@ def verify(dataset: str):
     """Verify dataset integrity."""
     data = []
     keys = None
-    for name, dataset in _iter_datasets(regex_name_filter=dataset):
-        dataset_instance = get_dataset(dataset=dataset)
+    for name, dataset_cls in _iter_datasets(regex_name_filter=dataset):
+        dataset_instance = get_dataset(dataset=dataset_cls)
         data.append(
             list(
                 itt.chain(

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -228,7 +228,7 @@ def expected_metrics(dataset: str, max_triples: Optional[int]):
             click.echo("Skip OGB WikiKG")
             continue
         dataset_instance = get_dataset(dataset=dataset_cls)
-        dataset_name = dataset_instance.__class__.__name__.lower()
+        dataset_name = dataset_resolver.normalize_inst(dataset_instance)
         d = directory.joinpath(dataset_name, "analysis")
         d.mkdir(parents=True, exist_ok=True)
         expected_metrics = dict()

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -5,6 +5,7 @@
 import itertools as itt
 import json
 import logging
+import math
 import pathlib
 from textwrap import dedent
 from typing import Iterable, List, Optional, Tuple, Type, Union
@@ -255,6 +256,9 @@ def expected_metrics(dataset: str, max_triples: Optional[int]):
             df.to_csv(output_path, sep="\t", index=False)
 
             # expected metrics
+            ks = (1, 3, 5, 10) + tuple(
+                10 ** i for i in range(2, int(math.ceil(math.log(dataset_instance.num_entities))))
+            )
             this_metrics = dict()
             for label, sides in dict(
                 head=["head"],
@@ -264,7 +268,7 @@ def expected_metrics(dataset: str, max_triples: Optional[int]):
                 candidate_set_sizes = df[[f"{side}_candidates" for side in sides]]
                 this_metrics[label] = {
                     "mean_rank": expected_mean_rank(candidate_set_sizes),
-                    **{f"hits_at_{k}": expected_hits_at_k(candidate_set_sizes, k=k) for k in (1, 3, 5, 10)},
+                    **{f"hits_at_{k}": expected_hits_at_k(candidate_set_sizes, k=k) for k in ks},
                 }
             expected_metrics[key] = this_metrics
         with d.joinpath("expected_metrics.json").open("w") as file:

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -42,10 +42,12 @@ def summarize():
             click.secho(str(e), fg="red", bold=True)
 
 
-def _iter_datasets(regex_name_filter=None, max_triples: Optional[int] = None) -> Iterable[Tuple[str, Type[Dataset]]]:
-    def _get_num_triples(pair: Tuple[str, Type[Dataset]]) -> int:
-        return docdata.get_docdata(pair[1])["statistics"]["triples"]
+def _get_num_triples(pair: Tuple[str, Type[Dataset]]) -> int:
+    """Extract the number of triples from docdata."""
+    return docdata.get_docdata(pair[1])["statistics"]["triples"]
 
+
+def _iter_datasets(regex_name_filter=None, max_triples: Optional[int] = None) -> Iterable[Tuple[str, Type[Dataset]]]:
     it = sorted(
         dataset_resolver.lookup_dict.items(),
         key=_get_num_triples,

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -7,7 +7,7 @@ import json
 import logging
 import pathlib
 from textwrap import dedent
-from typing import List, Optional, Tuple, Type, Union
+from typing import Iterable, List, Optional, Tuple, Type, Union
 
 import click
 import docdata
@@ -41,7 +41,7 @@ def summarize():
             click.secho(str(e), fg="red", bold=True)
 
 
-def _iter_datasets(regex_name_filter=None, max_triples: Optional[int] = None):
+def _iter_datasets(regex_name_filter=None, max_triples: Optional[int] = None) -> Iterable[Tuple[str, Type[Dataset]]]:
     def _get_num_triples(pair: Tuple[str, Type[Dataset]]) -> int:
         return docdata.get_docdata(pair[1])["statistics"]["triples"]
 

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -36,6 +36,7 @@ __all__ = [
     "MetricResults",
     "filter_scores_",
     "evaluate",
+    "prepare_filter_triples",
 ]
 
 logger = logging.getLogger(__name__)
@@ -487,7 +488,7 @@ def filter_scores_(
     return scores
 
 
-def _prepare_filter_triples(
+def prepare_filter_triples(
     mapped_triples: MappedTriples,
     additional_filter_triples: Union[None, MappedTriples, List[MappedTriples]] = None,
 ) -> MappedTriples:
@@ -515,8 +516,7 @@ def _prepare_filter_triples(
     if torch.is_tensor(additional_filter_triples):
         additional_filter_triples = [additional_filter_triples]
 
-    # TODO: check for duplicates?
-    return torch.cat([*additional_filter_triples, mapped_triples], dim=0)
+    return torch.cat([*additional_filter_triples, mapped_triples], dim=0).unique(dim=0)
 
 
 def evaluate(
@@ -643,7 +643,7 @@ def evaluate(
 
     # Prepare for result filtering
     if filtering_necessary or positive_masks_required:
-        all_pos_triples = _prepare_filter_triples(
+        all_pos_triples = prepare_filter_triples(
             mapped_triples=mapped_triples,
             additional_filter_triples=additional_filter_triples,
         ).to(device=device)
@@ -891,7 +891,7 @@ def get_candidate_set_size(
     ).reset_index()
 
     # determine filter triples
-    filter_triples = _prepare_filter_triples(
+    filter_triples = prepare_filter_triples(
         mapped_triples=mapped_triples,
         additional_filter_triples=additional_filter_triples,
     )

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -617,6 +617,9 @@ def numeric_expected_value(
     return expectation / num_samples
 
 
+# TODO: closed-forms for other metrics?
+
+
 def expected_mean_rank(
     num_candidates: Union[Sequence[int], np.ndarray],
 ) -> float:

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -635,4 +635,4 @@ def expected_hits_at_k(
     :return:
         the expected mean rank
     """
-    return k * np.mean(np.reciprocal(np.asanyarray(num_candidates)))
+    return k * np.mean(np.reciprocal(np.asanyarray(num_candidates, dtype=float)))

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -626,13 +626,12 @@ def expected_hits_at_k(
 
     .. math ::
 
-        E[Hits@k] = \frac{1}{n} \sum \limits_{i=1}^{n} \frac{k}{CSS[i]}
-                  = k \cdot \frac{1}{n} \sum \limits_{i=1}^{n} CSS[i]^{-1}
+        E[Hits@k] = \frac{1}{n} \sum \limits_{i=1}^{n} min(\frac{k}{CSS[i]}, 1.0)
 
     :param num_candidates:
         the number of candidates for each individual rank computation
 
     :return:
-        the expected mean rank
+        the expected Hits@k value
     """
-    return k * np.mean(np.reciprocal(np.asanyarray(num_candidates, dtype=float)))
+    return k * np.mean(np.reciprocal(np.asanyarray(num_candidates, dtype=float)).clip(min=None, max=1 / k))

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -595,3 +595,44 @@ class RankBasedEvaluator(Evaluator):
             adjusted_arithmetic_mean_rank_index=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK_INDEX]),
             hits_at_k=dict(hits_at_k),
         )
+
+
+def expected_mean_rank(
+    num_candidates: Union[Sequence[int], np.ndarray],
+) -> float:
+    r"""
+    Calculate the expected mean rank under random ordering.
+
+    .. math ::
+
+        E[MR] = \frac{1}{n} \sum \limits_{i=1}^{n} \frac{1 + CSS[i]}{2}
+              = \frac{1}{2}(1 + \frac{1}{n} \sum \limits_{i=1}^{n} CSS[i])
+
+    :param num_candidates:
+        the number of candidates for each individual rank computation
+
+    :return:
+        the expected mean rank
+    """
+    return 0.5 * (1 + np.mean(np.asanyarray(num_candidates)))
+
+
+def expected_hits_at_k(
+    num_candidates: Union[Sequence[int], np.ndarray],
+    k: int,
+) -> float:
+    r"""
+    Calculate the expected Hits@k under random ordering.
+
+    .. math ::
+
+        E[Hits@k] = \frac{1}{n} \sum \limits_{i=1}^{n} \frac{k}{CSS[i]}
+                  = k \cdot \frac{1}{n} \sum \limits_{i=1}^{n} CSS[i]^{-1}
+
+    :param num_candidates:
+        the number of candidates for each individual rank computation
+
+    :return:
+        the expected mean rank
+    """
+    return k * np.mean(np.reciprocal(np.asanyarray(num_candidates)))

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -607,13 +607,13 @@ def numeric_expected_value(
 
     Depending on the metric, the estimate may not be very accurate and converage slowly, cf. https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_discrete.expect.html#scipy-stats-rv-discrete-expect
     """
-    metric = all_type_funcs[metric]
+    metric_func = all_type_funcs[metric]
     num_candidates = np.asarray(num_candidates)
     generator = np.random.default_rng()
     expectation = 0
     for _ in range(num_samples):
         ranks = generator.integers(low=0, high=num_candidates)
-        expectation += metric(ranks)
+        expectation += metric_func(ranks)
     return expectation / num_samples
 
 

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -605,7 +605,8 @@ def numeric_expected_value(
     """
     Compute expected metric value by summation.
 
-    Depending on the metric, the estimate may not be very accurate and converage slowly, cf. https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_discrete.expect.html#scipy-stats-rv-discrete-expect
+    Depending on the metric, the estimate may not be very accurate and converage slowly, cf.
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_discrete.expect.html
     """
     metric_func = all_type_funcs[metric]
     num_candidates = np.asarray(num_candidates)

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -597,6 +597,26 @@ class RankBasedEvaluator(Evaluator):
         )
 
 
+def numeric_expected_value(
+    metric: str,
+    num_candidates: Union[Sequence[int], np.ndarray],
+    num_samples: int,
+) -> float:
+    """
+    Compute expected metric value by summation.
+
+    Depending on the metric, the estimate may not be very accurate and converage slowly, cf. https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.rv_discrete.expect.html#scipy-stats-rv-discrete-expect
+    """
+    metric = all_type_funcs[metric]
+    num_candidates = np.asarray(num_candidates)
+    generator = np.random.default_rng()
+    expectation = 0
+    for _ in range(num_samples):
+        ranks = generator.integers(low=0, high=num_candidates)
+        expectation += metric(ranks)
+    return expectation / num_samples
+
+
 def expected_mean_rank(
     num_candidates: Union[Sequence[int], np.ndarray],
 ) -> float:

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -622,7 +622,6 @@ class ExpectedMetricsTests(unittest.TestCase):
 
     def test_expected_mean_rank(self):
         """Test expected_mean_rank."""
-        generator: numpy.random.Generator = numpy.random.default_rng(seed=42)
         # test different shapes
         for num_candidates, total in self._iter_num_candidates():
             emr = expected_mean_rank(num_candidates=num_candidates)

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -7,7 +7,6 @@ import itertools
 import logging
 import unittest
 from operator import attrgetter
-from types import MappingProxyType
 from typing import Collection, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -5,9 +5,9 @@
 import dataclasses
 import itertools
 import logging
-from types import MappingProxyType
 import unittest
 from operator import attrgetter
+from types import MappingProxyType
 from typing import Collection, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -642,3 +642,7 @@ class ExpectedMetricsTests(unittest.TestCase):
             assert ehk <= 1.0
             if total <= k:
                 self.assertAlmostEqual(ehk, 1.0)
+
+    def test_expected_hits_at_k_manual(self):
+        """Test expected Hits@k, where some candidate set sizes are smaller than k, but not all."""
+        self.assertAlmostEqual(expected_hits_at_k([5, 20], k=10), (1 + 0.5) / 2)


### PR DESCRIPTION
This PR adds utilities to compute candidate set sizes, and expected metrics under random ordering without setting up a model.