### PR TITLE
🪛🔗 Change interactions' shape

### DIFF
--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -191,6 +191,16 @@ def repeat_if_necessary(
     If a model does not have entity/relation representations, the scores for
     `score_{h,t}` / `score_r` are always the same. For efficiency, they are thus
     only computed once, but to meet the API, they have to be brought into the correct shape afterwards.
+
+    :param scores: shape: (batch_size, ?)
+        the score tensor
+    :param representations:
+        the representations. If empty (i.e. no representations for this 1:n scoring), repetition needs to be applied
+    :param num:
+        the number of times to repeat, if necessary.
+
+    :return:
+        the score tensor, which has been repeated, if necessary
     """
     if representations:
         return scores

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -359,9 +359,16 @@ class ERModel(
             The relation indices.
         :param t_indices:
             The tail indices.
+        :param slice_size:
+            The slice size.
+        :param slice_dim:
+            The dimension along which to slice
 
         :return:
             The scores
+
+        :raises NotImplementedError:
+            if score repetition becomes necessary
         """
         if not self.entity_representations or not self.relation_representations:
             raise NotImplementedError("repeat scores not implemented for general case.")

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -363,6 +363,8 @@ class ERModel(
         :return:
             The scores
         """
+        if not self.entity_representations or not self.relation_representations:
+            raise NotImplementedError("repeat scores not implemented for general case.")
         h, r, t = self._get_representations(h=h_indices, r=r_indices, t=t_indices)
         return self.interaction.score(h=h, r=r, t=t, slice_size=slice_size, slice_dim=slice_dim)
 
@@ -379,6 +381,8 @@ class ERModel(
         """
         # Note: slicing cannot be used here: the indices for score_hrt only have a batch
         # dimension, and slicing along this dimension is already considered by sub-batching.
+        # Note: we do not delegate to the general method for performance reasons
+        # Note: repetition is not necessary here
         h, r, t = self._get_representations(h=hrt_batch[:, 0], r=hrt_batch[:, 1], t=hrt_batch[:, 2])
         return self.interaction.score_hrt(h=h, r=r, t=t)
 

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -346,7 +346,7 @@ class ERModel(
         r_indices: torch.LongTensor,
         t_indices: torch.LongTensor,
         slice_size: Optional[int] = None,
-        slice_dim: Optional[int] = None,
+        slice_dim: int = 0,
     ) -> torch.FloatTensor:
         """Forward pass.
 

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -340,6 +340,32 @@ class ERModel(
             regularizer.add_parameter(parameter=param)
         self.weight_regularizers.append(regularizer)
 
+    def forward(
+        self,
+        h_indices: torch.LongTensor,
+        r_indices: torch.LongTensor,
+        t_indices: torch.LongTensor,
+        slice_size: Optional[int] = None,
+        slice_dim: Optional[int] = None,
+    ) -> torch.FloatTensor:
+        """Forward pass.
+
+        This method takes head, relation and tail indices and calculates the corresponding scores.
+        It supports broadcasting.
+
+        :param h_indices:
+            The head indices.
+        :param r_indices:
+            The relation indices.
+        :param t_indices:
+            The tail indices.
+
+        :return:
+            The scores
+        """
+        h, r, t = self._get_representations(h=h_indices, r=r_indices, t=t_indices)
+        return self.interaction.score(h=h, r=r, t=t, slice_size=slice_size, slice_dim=slice_dim)
+
     def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:
         """Forward pass.
 

--- a/src/pykeen/models/unimodal/cp.py
+++ b/src/pykeen/models/unimodal/cp.py
@@ -93,17 +93,17 @@ class CP(ERModel):
 
     def _get_representations(
         self,
-        h_indices: Optional[torch.LongTensor],
-        r_indices: Optional[torch.LongTensor],
-        t_indices: Optional[torch.LongTensor],
+        h: Optional[torch.LongTensor],
+        r: Optional[torch.LongTensor],
+        t: Optional[torch.LongTensor],
     ) -> Tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:  # noqa: D102
         # Override to allow different head and tail entity representations
         h, r, t = [
             [representation(indices=indices) for representation in representations]
             for indices, representations in (
-                (h_indices, self.entity_representations[0:1]),  # <== this is different
-                (r_indices, self.relation_representations),
-                (t_indices, self.entity_representations[1:2]),  # <== this is different
+                (h, self.entity_representations[0:1]),  # <== this is different
+                (r, self.relation_representations),
+                (t, self.entity_representations[1:2]),  # <== this is different
             )
         ]
         # normalization

--- a/src/pykeen/models/unimodal/cp.py
+++ b/src/pykeen/models/unimodal/cp.py
@@ -99,11 +99,11 @@ class CP(ERModel):
     ) -> Tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:  # noqa: D102
         # Override to allow different head and tail entity representations
         h, r, t = [
-            [representation.get_in_more_canonical_shape(dim=dim, indices=indices) for representation in representations]
-            for dim, indices, representations in (
-                ("h", h_indices, self.entity_representations[0:1]),  # <== this is different
-                ("r", r_indices, self.relation_representations),
-                ("t", t_indices, self.entity_representations[1:2]),  # <== this is different
+            [representation(indices=indices) for representation in representations]
+            for indices, representations in (
+                (h_indices, self.entity_representations[0:1]),  # <== this is different
+                (r_indices, self.relation_representations),
+                (t_indices, self.entity_representations[1:2]),  # <== this is different
             )
         ]
         # normalization

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -147,59 +147,6 @@ class RepresentationModule(nn.Module, ABC):
             x = x.unsqueeze(dim=1)
         return x
 
-    def get_in_more_canonical_shape(
-        self,
-        dim: Union[int, str],
-        indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
-        """Get representations in canonical shape.
-
-        The canonical shape is given as
-
-        (batch_size, d_1, d_2, d_3, ``*``)
-
-        fulfilling the following properties:
-
-        Let i = dim. If indices is None, the return shape is (1, d_1, d_2, d_3) with d_i = num_representations,
-        d_i = 1 else. If indices is not None, then batch_size = indices.shape[0], and d_i = 1 if
-        indices.ndimension() = 1 else d_i = indices.shape[1]
-
-        The canonical shape is given by (batch_size, 1, ``*``) if indices is not None, where batch_size=len(indices),
-        or (1, num, ``*``) if indices is None with num equal to the total number of embeddings.
-
-        Examples:
-        >>> emb = EmbeddingSpecification(shape=(20,)).make(num_embeddings=10)
-        >>> # Get head representations for given batch indices
-        >>> emb.get_in_more_canonical_shape(dim="h", indices=torch.arange(5)).shape
-        (5, 1, 1, 1, 20)
-        >>> # Get head representations for given 2D batch indices, as e.g. used by fast slcwa scoring
-        >>> emb.get_in_more_canonical_shape(dim="h", indices=torch.arange(6).view(2, 3)).shape
-        (2, 3, 1, 1, 20)
-        >>> # Get head representations for 1:n scoring
-        >>> emb.get_in_more_canonical_shape(dim="h", indices=None).shape
-        (1, 10, 1, 1, 20)
-
-        :param dim:
-            The dimension along which to expand for ``indices=None``, or ``indices.ndimension() == 2``.
-        :param indices:
-            The indices. Either None, in which care all embeddings are returned, or a 1 or 2 dimensional index tensor.
-
-        :return: shape: (batch_size, d1, d2, d3, ``*self.shape``)
-        """
-        r_shape: Tuple[int, ...]
-        if indices is None:
-            x = self(indices=indices)
-            r_shape = (1, self.max_id)
-        else:
-            flat_indices = indices.view(-1)
-            x = self(indices=flat_indices)
-            if indices.ndimension() > 1:
-                x = x.view(*indices.shape, -1)
-            r_shape = tuple(indices.shape)
-            if len(r_shape) < 2:
-                r_shape = r_shape + (1,)
-        return convert_to_canonical_shape(x=x, dim=dim, num=r_shape[1], batch_size=r_shape[0], suffix_shape=self.shape)
-
     @property
     def embedding_dim(self) -> int:
         """Return the "embedding dimension". Kept for backward compatibility."""

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -36,7 +36,7 @@ from ..constants import AGGREGATIONS
 from ..regularizers import Regularizer, regularizer_resolver
 from ..triples import CoreTriplesFactory, TriplesFactory
 from ..typing import Constrainer, Hint, HintType, Initializer, Normalizer
-from ..utils import Bias, activation_resolver, clamp_norm, complex_normalize, convert_to_canonical_shape
+from ..utils import Bias, activation_resolver, clamp_norm, complex_normalize
 
 __all__ = [
     "RepresentationModule",

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -1290,12 +1290,7 @@ def cp_interaction(
     :return: shape: batch_dims
         The scores.
     """
-    return extended_einsum(
-        "bhrtkd,bhrtkd,bhrtkd->bhrt",
-        h,
-        r,
-        t,
-    )
+    return (h * r * t).sum(dim=(-2, -1))
 
 
 def triple_re_interaction(

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -343,7 +343,6 @@ def ermlp_interaction(
         The scores.
     """
     # same shape
-    prefix = h.shape[:-1]
     *prefix, dim = h.shape
     if h.shape == r.shape and h.shape == t.shape:
         return final(activation(hidden(torch.cat([h, r, t], dim=-1).view(-1, 3 * dim)))).view(prefix)

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -1170,7 +1170,7 @@ def cross_e_interaction(
         The relation-specific interaction vector.
     :param t: shape: (*batch_dims, dim)
         The tail representations.
-    :param bias: shape: (1, 1, 1, 1, dim)
+    :param bias: shape: (dim,)
         The combination bias.
     :param activation:
         The combination activation. Should be :class:`torch.nn.Tanh` for consistency with the CrossE paper.
@@ -1187,7 +1187,7 @@ def cross_e_interaction(
     # relation interaction (notice that h has been updated)
     r = h * r
     # combination
-    x = activation(h + r + bias)
+    x = activation(h + r + bias.view(*(1 for _ in h.shape[:-1]), -1))
     if dropout is not None:
         x = dropout(x)
     # similarity

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -340,7 +340,7 @@ def ermlp_interaction(
     """
     # same shape
     prefix = h.shape[:-1]
-    dim = h.shape[-1]
+    *prefix, dim = h.shape
     if h.shape == r.shape and h.shape == t.shape:
         return final(activation(hidden(torch.cat([h, r, t], dim=-1).view(-1, 3 * dim)))).view(prefix)
 

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -2,10 +2,8 @@
 
 """Functional forms of interaction methods.
 
-The functional forms always assume the general form of the interaction function, where head, relation and tail
-representations are provided in shape (batch_size, num_heads, 1, 1, ``*``), (batch_size, 1, num_relations, 1, ``*``),
-and (batch_size, 1, 1, num_tails, ``*``), and return a score tensor of shape
-(batch_size, num_heads, num_relations, num_tails).
+These implementations allow for an arbitrary number of batch dimensions,
+as well as broadcasting and thus naturally support slicing and 1:n scoring.
 """
 
 from __future__ import annotations

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -123,14 +123,14 @@ def complex_interaction(
     .. math ::
         Re(\langle h, r, conj(t) \rangle)
 
-    :param h: shape: (batch_size, num_heads, 1, 1, `2*dim`)
+    :param h: shape: (*batch_dims, `2*dim`)
         The complex head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, 2*dim)
+    :param r: shape: (*batch_dims, 2*dim)
         The complex relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, 2*dim)
+    :param t: shape: (*batch_dims, 2*dim)
         The complex tail representations.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return batched_complex(h, r, t)
@@ -150,13 +150,13 @@ def conve_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the ConvE interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
-    :param t_bias: shape: (batch_size, 1, 1, num_tails, 1)
+    :param t_bias: shape: (*batch_dims, 1)
         The tail entity bias.
     :param input_channels:
         The number of input channels.
@@ -169,7 +169,7 @@ def conve_interaction(
     :param hr1d:
         The second module, transforming the 1D flattened output of the 2D module.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # repeat if necessary, and concat head and relation, batch_size', num_input_channels, 2*height, width
@@ -193,7 +193,7 @@ def conve_interaction(
     x = x.view(-1, h.shape[1], r.shape[2], 1, h.shape[-1])
 
     # For efficient calculation, each of the convolved [h, r] rows has only to be multiplied with one t row
-    # output_shape: (batch_size, num_heads, num_relations, num_tails)
+    # output_shape: batch_dims
     t = t.transpose(-1, -2)
     x = (x @ t).squeeze(dim=-2)
 
@@ -215,11 +215,11 @@ def convkb_interaction(
     .. math::
         W_L drop(act(W_C \ast ([h; r; t]) + b_C)) + b_L
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param conv:
         The 3x1 convolution.
@@ -230,7 +230,7 @@ def convkb_interaction(
     :param linear:
         The final linear layer.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # decompose convolution for faster computation in 1-n case
@@ -276,14 +276,14 @@ def distmult_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the DistMult interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return tensor_product(h, r, t).sum(dim=-1)
@@ -299,14 +299,14 @@ def dist_ma_interaction(
     .. math ::
         \langle h, r\rangle + \langle r, t\rangle + \langle h, t\rangle
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return batched_dot(h, r) + batched_dot(r, t) + batched_dot(h, t)
@@ -322,11 +322,11 @@ def ermlp_interaction(
 ) -> torch.FloatTensor:
     r"""Evaluate the ER-MLP interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param hidden:
         The first linear layer.
@@ -335,7 +335,7 @@ def ermlp_interaction(
     :param final:
         The second linear layer.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # same shape
@@ -362,16 +362,16 @@ def ermlpe_interaction(
 ) -> torch.FloatTensor:
     r"""Evaluate the ER-MLPE interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param mlp:
         The MLP.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # repeat if necessary, and concat head and relation, (batch_size, num_heads, num_relations, 1, 2 * embedding_dim)
@@ -395,14 +395,14 @@ def hole_interaction(
 ) -> torch.FloatTensor:  # noqa: D102
     """Evaluate the HolE interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # composite: (b, h, 1, t, d)
@@ -456,24 +456,24 @@ def kg2e_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the KG2E interaction function.
 
-    :param h_mean: shape: (batch_size, num_heads, 1, 1, d)
+    :param h_mean: shape: (*batch_dims, d)
         The head entity distribution mean.
-    :param h_var: shape: (batch_size, num_heads, 1, 1, d)
+    :param h_var: shape: (*batch_dims, d)
         The head entity distribution variance.
-    :param r_mean: shape: (batch_size, 1, num_relations, 1, d)
+    :param r_mean: shape: (*batch_dims, d)
         The relation distribution mean.
-    :param r_var: shape: (batch_size, 1, num_relations, 1, d)
+    :param r_var: shape: (*batch_dims, d)
         The relation distribution variance.
-    :param t_mean: shape: (batch_size, 1, 1, num_tails, d)
+    :param t_mean: shape: (*batch_dims, d)
         The tail entity distribution mean.
-    :param t_var: shape: (batch_size, 1, 1, num_tails, d)
+    :param t_var: shape: (*batch_dims, d)
         The tail entity distribution variance.
     :param similarity:
         The similarity measures for gaussian distributions. From {"KL", "EL"}.
     :param exact:
         Whether to leave out constants to accelerate similarity computation.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return KG2E_SIMILARITIES[similarity](
@@ -500,24 +500,24 @@ def ntn_interaction(
 
         f(h,r,t) = u_r^T act(h W_r t + V_r h + V_r' t + b_r)
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param w: shape: (batch_size, 1, num_relations, 1, k, dim, dim)
+    :param w: shape: (*batch_dims, k, dim, dim)
         The relation specific transformation matrix W_r.
-    :param vh: shape: (batch_size, 1, num_relations, 1, k, dim)
+    :param vh: shape: (*batch_dims, k, dim)
         The head transformation matrix V_h.
-    :param vt: shape: (batch_size, 1, num_relations, 1, k, dim)
+    :param vt: shape: (*batch_dims, k, dim)
         The tail transformation matrix V_h.
-    :param b: shape: (batch_size, 1, num_relations, 1, k)
+    :param b: shape: (*batch_dims, k)
         The relation specific offset b_r.
-    :param u: shape: (batch_size, 1, num_relations, 1, k)
+    :param u: shape: (*batch_dims, k)
         The relation specific final linear transformation b_r.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param activation:
         The activation function.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     x = activation(
@@ -548,11 +548,11 @@ def proje_interaction(
 
         f(h, r, t) = g(t z(D_e h + D_r r + b_c) + b_p)
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param d_e: shape: (dim,)
         Global entity projection.
@@ -565,7 +565,7 @@ def proje_interaction(
     :param activation:
         The activation function.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     num_heads, num_relations, num_tails, dim, _ = _extract_sizes(h, r, t)
@@ -587,14 +587,14 @@ def rescal_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the RESCAL interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim, dim)
+    :param r: shape: (*batch_dims, dim, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return extended_einsum("bhrtd,bhrtde,bhrte->bhrt", h, r, t)
@@ -607,14 +607,14 @@ def rotate_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the RotatE interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, 2*dim)
+    :param h: shape: (*batch_dims, 2*dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, 2*dim)
+    :param r: shape: (*batch_dims, 2*dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, 2*dim)
+    :param t: shape: (*batch_dims, 2*dim)
         The tail representations.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # r expresses a rotation in complex plane.
@@ -645,22 +645,22 @@ def simple_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the SimplE interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim, dim)
+    :param r: shape: (*batch_dims, dim, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
-    :param h_inv: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h_inv: shape: (*batch_dims, dim)
         The inverse head representations.
-    :param r_inv: shape: (batch_size, 1, num_relations, 1, dim, dim)
+    :param r_inv: shape: (*batch_dims, dim, dim)
         The relation representations.
-    :param t_inv: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t_inv: shape: (*batch_dims, dim)
         The tail representations.
     :param clamp:
         Clamp the scores to the given range.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     scores = 0.5 * (distmult_interaction(h=h, r=r, t=t) + distmult_interaction(h=h_inv, r=r_inv, t=t_inv))
@@ -685,20 +685,20 @@ def se_interaction(
     .. math ::
         f(h, r, t) = -\|R_h h - R_t t\|
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r_h: shape: (batch_size, 1, num_relations, 1, rel_dim, dim)
+    :param r_h: shape: (*batch_dims, rel_dim, dim)
         The relation-specific head projection.
-    :param r_t: shape: (batch_size, 1, num_relations, 1, rel_dim, dim)
+    :param r_t: shape: (*batch_dims, rel_dim, dim)
         The relation-specific tail projection.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param p:
         The p for the norm. cf. :func:`torch.linalg.vector_norm`.
     :param power_norm:
         Whether to return the powered norm.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return negative_norm(
@@ -720,18 +720,18 @@ def toruse_interaction(
     .. note ::
         This only implements the two L_p norm based variants.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param p:
         The p for the norm.
     :param power_norm:
         Whether to return the powered norm.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     d = tensor_sum(h, r, -t)
@@ -752,24 +752,24 @@ def transd_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the TransD interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, d_e)
+    :param h: shape: (*batch_dims, d_e)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, d_r)
+    :param r: shape: (*batch_dims, d_r)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, d_e)
+    :param t: shape: (*batch_dims, d_e)
         The tail representations.
-    :param h_p: shape: (batch_size, num_heads, 1, 1, d_e)
+    :param h_p: shape: (*batch_dims, d_e)
         The head projections.
-    :param r_p: shape: (batch_size, 1, num_relations, 1, d_r)
+    :param r_p: shape: (*batch_dims, d_r)
         The relation projections.
-    :param t_p: shape: (batch_size, 1, 1, num_tails, d_e)
+    :param t_p: shape: (*batch_dims, d_e)
         The tail projections.
     :param p:
         The parameter p for selecting the norm.
     :param power_norm:
         Whether to return the powered norm instead.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # Project entities
@@ -795,18 +795,18 @@ def transe_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the TransE interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param p:
         The p for the norm.
     :param power_norm:
         Whether to return the powered norm.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return negative_norm_of_sum(h, r, -t, p=p, power_norm=power_norm)
@@ -819,14 +819,14 @@ def transf_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the TransF interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return batched_dot(h + r, t) + batched_dot(h, t - r)
@@ -842,20 +842,20 @@ def transh_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the DistMult interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param w_r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param w_r: shape: (*batch_dims, dim)
         The relation normal vector representations.
-    :param d_r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param d_r: shape: (*batch_dims, dim)
         The relation difference vector representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param p:
         The p for the norm. cf. :func:`torch.linalg.vector_norm`.
     :param power_norm:
         Whether to return $|x-y|_p^p$.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return negative_norm_of_sum(
@@ -882,20 +882,20 @@ def transr_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the TransR interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, d_e)
+    :param h: shape: (*batch_dims, d_e)
         Head embeddings.
-    :param r: shape: (batch_size, 1, num_relations, 1, d_r)
+    :param r: shape: (*batch_dims, d_r)
         Relation embeddings.
-    :param m_r: shape: (batch_size, 1, num_relations, 1, d_e, d_r)
+    :param m_r: shape: (*batch_dims, d_e, d_r)
         The relation specific linear transformations.
-    :param t: shape: (batch_size, 1, 1, num_tails, d_e)
+    :param t: shape: (*batch_dims, d_e)
         Tail embeddings.
     :param p:
         The parameter p for selecting the norm.
     :param power_norm:
         Whether to return the powered norm instead.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # project to relation specific subspace and ensure constraints
@@ -925,11 +925,11 @@ def tucker_interaction(
 
     where BN denotes BatchNorm and DO denotes Dropout
 
-    :param h: shape: (batch_size, num_heads, 1, 1, d_e)
+    :param h: shape: (*batch_dims, d_e)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, d_r)
+    :param r: shape: (*batch_dims, d_r)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, d_e)
+    :param t: shape: (*batch_dims, d_e)
         The tail representations.
     :param core_tensor: shape: (d_e, d_r, d_e)
         The core tensor.
@@ -944,7 +944,7 @@ def tucker_interaction(
     :param bn_hr:
         The second batch normalization layer.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return extended_einsum(
@@ -991,24 +991,24 @@ def mure_interaction(
     .. math ::
         -\|Rh + r - t\| + b_h + b_t
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param b_h: shape: (batch_size, num_heads, 1, 1)
+    :param b_h: shape: batch_dims
         The head entity bias.
-    :param r_vec: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r_vec: shape: (*batch_dims, dim)
         The relation vector.
-    :param r_mat: shape: (batch_size, 1, num_relations, 1, dim,)
+    :param r_mat: shape: (*batch_dims, dim,)
         The diagonal relation matrix.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
-    :param b_t: shape: (batch_size, 1, 1, num_tails)
+    :param b_t: shape: batch_dims
         The tail entity bias.
     :param p:
         The parameter p for selecting the norm, cf. :func:`torch.linalg.vector_norm`.
     :param power_norm:
         Whether to return the powered norm instead.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return (
@@ -1032,16 +1032,16 @@ def um_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the SimplE interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param p:
         The parameter p for selecting the norm.
     :param power_norm:
         Whether to return the powered norm instead.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return negative_norm(h - t, p=p, power_norm=power_norm)
@@ -1060,20 +1060,20 @@ def pair_re_interaction(
     .. math ::
         -\|h \odot r_h - t \odot r_t \|
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
-    :param r_h: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r_h: shape: (*batch_dims, dim)
         The head part of the relation representations.
-    :param r_t: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r_t: shape: (*batch_dims, dim)
         The tail part of the relation representations.
     :param p:
         The parameter p for selecting the norm.
     :param power_norm:
         Whether to return the powered norm instead.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return negative_norm_of_sum(
@@ -1113,11 +1113,11 @@ def quat_e_interaction(
     .. note ::
         dim has to be divisible by 4.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The head representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
 
     :return: shape: (...)
@@ -1161,13 +1161,13 @@ def cross_e_interaction(
         multiple competing variants how to break the ties. More information on this can be found in the documentation of
         rank-based evaluation.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param c_r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param c_r: shape: (*batch_dims, dim)
         The relation-specific interaction vector.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param bias: shape: (1, 1, 1, 1, dim)
         The combination bias.
@@ -1176,7 +1176,7 @@ def cross_e_interaction(
     :param dropout:
         Dropout applied after the combination.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
 
     .. seealso:: https://github.com/wencolani/CrossE
@@ -1223,27 +1223,27 @@ def boxe_interaction(
         this interaction relies on Abboud's point-to-box distance
         :func:`pykeen.utils.point_to_box_distance`.
 
-    :param h_pos: shape: (batch_size, num_heads, 1, 1, d)
+    :param h_pos: shape: (*batch_dims, d)
         the head entity position
-    :param h_bump: shape: (batch_size, num_heads, 1, 1, d)
+    :param h_bump: shape: (*batch_dims, d)
         the head entity bump
 
-    :param rh_base: shape: (batch_size, 1, num_relations, 1, d)
+    :param rh_base: shape: (*batch_dims, d)
         the relation-specific head box base position
-    :param rh_delta: shape: (batch_size, 1, num_relations, 1, d)
+    :param rh_delta: shape: (*batch_dims, d)
         # the relation-specific head box base shape (normalized to have a volume of 1):
-    :param rh_size: shape: (batch_size, 1, num_relations, 1, 1)
+    :param rh_size: shape: (*batch_dims, 1)
         the relation-specific head box size (a scalar)
-    :param rt_base: shape: (batch_size, 1, num_relations, 1, d)
+    :param rt_base: shape: (*batch_dims, d)
         the relation-specific tail box base position
-    :param rt_delta: shape: (batch_size, 1, num_relations, 1, d)
+    :param rt_delta: shape: (*batch_dims, d)
         # the relation-specific tail box base shape (normalized to have a volume of 1):
-    :param rt_size: shape: (batch_size, 1, num_relations, 1, d)
+    :param rt_size: shape: (*batch_dims, d)
         the relation-specific tail box size
 
-    :param t_pos: shape: (batch_size, 1, 1, num_tails, d)
+    :param t_pos: shape: (*batch_dims, d)
         the tail entity position
-    :param t_bump: shape: (batch_size, 1, 1, num_tails, d)
+    :param t_bump: shape: (*batch_dims, d)
         the tail entity bump
 
     :param tanh_map:
@@ -1253,7 +1253,7 @@ def boxe_interaction(
     :param power_norm:
         whether to use the p-th power of the p-norm instead
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return sum(
@@ -1279,14 +1279,14 @@ def cp_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the Canonical Tensor Decomposition interaction function.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, rank, dim)
+    :param h: shape: (*batch_dims, rank, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, rank, dim)
+    :param r: shape: (*batch_dims, rank, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, rank, dim)
+    :param t: shape: (*batch_dims, rank, dim)
         The tail representations.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     return extended_einsum(
@@ -1322,15 +1322,15 @@ def triple_re_interaction(
         For equivalence to the paper version, `h` and `t` should be normalized to unit
         Euclidean length, and `p` and `power_norm` be kept at their default values.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, rank, dim)
+    :param h: shape: (*batch_dims, rank, dim)
         The head representations.
-    :param r_head: shape: (batch_size, 1, num_relations, 1, rank, dim)
+    :param r_head: shape: (*batch_dims, rank, dim)
         The relation-specific head multiplicator representations.
-    :param r_mid: shape: (batch_size, 1, num_relations, 1, rank, dim)
+    :param r_mid: shape: (*batch_dims, rank, dim)
         The relation representations.
-    :param r_tail: shape: (batch_size, 1, num_relations, 1, rank, dim)
+    :param r_tail: shape: (*batch_dims, rank, dim)
         The relation-specific tail multiplicator representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, rank, dim)
+    :param t: shape: (*batch_dims, rank, dim)
         The tail representations.
     :param u:
         the relation factor offset. If u is not None or 0, this corresponds to TripleREv2.
@@ -1339,7 +1339,7 @@ def triple_re_interaction(
     :param power_norm:
         Whether to return the powered norm.
 
-    :return: shape: (batch_size, num_heads, num_relations, num_tails)
+    :return: shape: batch_dims
         The scores.
     """
     # note: normalization should be done from the representations
@@ -1388,11 +1388,11 @@ def auto_sf_interaction(
       $\mathcal{C} = \{(0, 0, 0, 1), (0, 1, 1, 1), (1, 0, 1, -1), (1, 0, 1, 1)\}$
     - :class:`pykeen.models.SimplE`: two blocks: $\mathcal{C} = \{(0, 0, 1, 1), (1, 1, 0, 1)\}$
 
-    :param h: each shape: (batch_size, num_heads, 1, 1, rank, dim)
+    :param h: each shape: (*batch_dims, rank, dim)
         The list of head representations.
-    :param r: each shape: (batch_size, 1, num_relations, 1, rank, dim)
+    :param r: each shape: (*batch_dims, rank, dim)
         The list of relation representations.
-    :param t: each shape: (batch_size, 1, 1, num_tails, rank, dim)
+    :param t: each shape: (*batch_dims, rank, dim)
         The list of tail representations.
     :param coefficients:
         the coefficients, in order:
@@ -1420,11 +1420,11 @@ def transformer_interaction(
         \textit{score}(h, r, t) =
             \textit{Linear}(\textit{SumPooling}(\textit{Transformer}([h + pe[0]; r + pe[1]])))^T t
 
-    :param h: shape: (batch_size, num_heads, 1, 1, dim)
+    :param h: shape: (*batch_dims, dim)
         The head representations.
-    :param r: shape: (batch_size, 1, num_relations, 1, dim)
+    :param r: shape: (*batch_dims, dim)
         The relation representations.
-    :param t: shape: (batch_size, 1, 1, num_tails, dim)
+    :param t: shape: (*batch_dims, dim)
         The tail representations.
     :param transformer:
         the transformer encoder

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -25,7 +25,6 @@ from ..utils import (
     clamp_norm,
     compute_box,
     estimate_cost_of_sequence,
-    extended_einsum,
     is_cudnn_error,
     negative_norm,
     negative_norm_of_sum,

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -515,16 +515,17 @@ def ntn_interaction(
     :return: shape: batch_dims
         The scores.
     """
-    x = activation(
-        tensor_sum(
-            extended_einsum("bhrtd,bhrtkde,bhrte->bhrtk", h, w, t),
-            (vh @ h.unsqueeze(dim=-1)).squeeze(dim=-1),
-            (vt @ t.unsqueeze(dim=-1)).squeeze(dim=-1),
-            b,
+    return (
+        u
+        * activation(
+            tensor_sum(
+                torch.einsum("...d,...kde,...e->...k", h, w, t),  # shape: (*batch_dims, k)
+                torch.einsum("...d, ...kd->...k", h, vh),
+                torch.einsum("...d, ...kd->...k", t, vt),
+                b,
+            )
         )
-    )
-    u = u.transpose(-2, -1)
-    return (x @ u).squeeze(dim=-1)
+    ).sum(dim=-1)
 
 
 def proje_interaction(

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -380,8 +380,8 @@ def ermlpe_interaction(
     x = broadcast_cat([h, r], dim=-1)
 
     # Predict t embedding, shape: (*batch_dims, d)
-    shape = x.shape
-    x = mlp(x.view(-1, shape[-1])).view(*shape[:-1], -1)
+    *batch_dims, dim = x.shape
+    x = mlp(x.view(-1, dim)).view(*batch_dims, -1)
 
     # dot product
     return (x * t).sum(dim=-1)

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -312,6 +312,10 @@ def dist_ma_interaction(
     return batched_dot(h, r) + batched_dot(r, t) + batched_dot(h, t)
 
 
+def _make_ones_like(prefix: Sequence) -> Sequence[int]:
+    return [1 for _ in prefix]
+
+
 def ermlp_interaction(
     h: torch.FloatTensor,
     r: torch.FloatTensor,
@@ -346,8 +350,7 @@ def ermlp_interaction(
 
     # split, shape: (embedding_dim, hidden_dim)
     head_to_hidden, rel_to_hidden, tail_to_hidden = hidden.weight.t().split(dim)
-    prefix = [1 for _ in prefix]
-    bias = hidden.bias.view(*prefix, -1)
+    bias = hidden.bias.view(*_make_ones_like(prefix), -1)
     h = torch.einsum("...i,ij->...j", h, head_to_hidden)
     r = torch.einsum("...i,ij->...j", r, rel_to_hidden)
     t = torch.einsum("...i,ij->...j", t, tail_to_hidden)

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -378,15 +378,12 @@ def ermlpe_interaction(
     # repeat if necessary, and concat head and relation, (batch_size, num_heads, num_relations, 1, 2 * embedding_dim)
     x = broadcast_cat([h, r], dim=-1)
 
-    # Predict t embedding, shape: (b, h, r, 1, d)
+    # Predict t embedding, shape: (*batch_dims, d)
     shape = x.shape
     x = mlp(x.view(-1, shape[-1])).view(*shape[:-1], -1)
 
-    # transpose t, (b, 1, 1, d, t)
-    t = t.transpose(-2, -1)
-
-    # dot product, (b, h, r, 1, t)
-    return (x @ t).squeeze(dim=-2)
+    # dot product
+    return (x * t).sum(dim=-1)
 
 
 def hole_interaction(

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -122,11 +122,11 @@ def complex_interaction(
     .. math ::
         Re(\langle h, r, conj(t) \rangle)
 
-    :param h: shape: (*batch_dims, `2*dim`)
+    :param h: shape: (`*batch_dims`, `2*dim`)
         The complex head representations.
-    :param r: shape: (*batch_dims, 2*dim)
+    :param r: shape: (`*batch_dims`, 2*dim)
         The complex relation representations.
-    :param t: shape: (*batch_dims, 2*dim)
+    :param t: shape: (`*batch_dims`, 2*dim)
         The complex tail representations.
 
     :return: shape: batch_dims
@@ -149,13 +149,13 @@ def conve_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the ConvE interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
-    :param t_bias: shape: (*batch_dims, 1)
+    :param t_bias: shape: (`*batch_dims`, 1)
         The tail entity bias.
     :param input_channels:
         The number of input channels.
@@ -215,11 +215,11 @@ def convkb_interaction(
     .. math::
         W_L drop(act(W_C \ast ([h; r; t]) + b_C)) + b_L
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param conv:
         The 3x1 convolution.
@@ -276,11 +276,11 @@ def distmult_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the DistMult interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
 
     :return: shape: batch_dims
@@ -299,11 +299,11 @@ def dist_ma_interaction(
     .. math ::
         \langle h, r\rangle + \langle r, t\rangle + \langle h, t\rangle
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
 
     :return: shape: batch_dims
@@ -322,11 +322,11 @@ def ermlp_interaction(
 ) -> torch.FloatTensor:
     r"""Evaluate the ER-MLP interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param hidden:
         The first linear layer.
@@ -362,11 +362,11 @@ def ermlpe_interaction(
 ) -> torch.FloatTensor:
     r"""Evaluate the ER-MLPE interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param mlp:
         The MLP.
@@ -392,11 +392,11 @@ def hole_interaction(
 ) -> torch.FloatTensor:  # noqa: D102
     """Evaluate the HolE interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
 
     :return: shape: batch_dims
@@ -450,17 +450,17 @@ def kg2e_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the KG2E interaction function.
 
-    :param h_mean: shape: (*batch_dims, d)
+    :param h_mean: shape: (`*batch_dims`, d)
         The head entity distribution mean.
-    :param h_var: shape: (*batch_dims, d)
+    :param h_var: shape: (`*batch_dims`, d)
         The head entity distribution variance.
-    :param r_mean: shape: (*batch_dims, d)
+    :param r_mean: shape: (`*batch_dims`, d)
         The relation distribution mean.
-    :param r_var: shape: (*batch_dims, d)
+    :param r_var: shape: (`*batch_dims`, d)
         The relation distribution variance.
-    :param t_mean: shape: (*batch_dims, d)
+    :param t_mean: shape: (`*batch_dims`, d)
         The tail entity distribution mean.
-    :param t_var: shape: (*batch_dims, d)
+    :param t_var: shape: (`*batch_dims`, d)
         The tail entity distribution variance.
     :param similarity:
         The similarity measures for gaussian distributions. From {"KL", "EL"}.
@@ -494,19 +494,19 @@ def ntn_interaction(
 
         f(h,r,t) = u_r^T act(h W_r t + V_r h + V_r' t + b_r)
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param w: shape: (*batch_dims, k, dim, dim)
+    :param w: shape: (`*batch_dims`, k, dim, dim)
         The relation specific transformation matrix W_r.
-    :param vh: shape: (*batch_dims, k, dim)
+    :param vh: shape: (`*batch_dims`, k, dim)
         The head transformation matrix V_h.
-    :param vt: shape: (*batch_dims, k, dim)
+    :param vt: shape: (`*batch_dims`, k, dim)
         The tail transformation matrix V_h.
-    :param b: shape: (*batch_dims, k)
+    :param b: shape: (`*batch_dims`, k)
         The relation specific offset b_r.
-    :param u: shape: (*batch_dims, k)
+    :param u: shape: (`*batch_dims`, k)
         The relation specific final linear transformation b_r.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param activation:
         The activation function.
@@ -543,11 +543,11 @@ def proje_interaction(
 
         f(h, r, t) = g(t z(D_e h + D_r r + b_c) + b_p)
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param d_e: shape: (dim,)
         Global entity projection.
@@ -582,11 +582,11 @@ def rescal_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the RESCAL interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim, dim)
+    :param r: shape: (`*batch_dims`, dim, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
 
     :return: shape: batch_dims
@@ -602,11 +602,11 @@ def rotate_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the RotatE interaction function.
 
-    :param h: shape: (*batch_dims, 2*dim)
+    :param h: shape: (`*batch_dims`, 2*dim)
         The head representations.
-    :param r: shape: (*batch_dims, 2*dim)
+    :param r: shape: (`*batch_dims`, 2*dim)
         The relation representations.
-    :param t: shape: (*batch_dims, 2*dim)
+    :param t: shape: (`*batch_dims`, 2*dim)
         The tail representations.
 
     :return: shape: batch_dims
@@ -640,17 +640,17 @@ def simple_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the SimplE interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim, dim)
+    :param r: shape: (`*batch_dims`, dim, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
-    :param h_inv: shape: (*batch_dims, dim)
+    :param h_inv: shape: (`*batch_dims`, dim)
         The inverse head representations.
-    :param r_inv: shape: (*batch_dims, dim, dim)
+    :param r_inv: shape: (`*batch_dims`, dim, dim)
         The relation representations.
-    :param t_inv: shape: (*batch_dims, dim)
+    :param t_inv: shape: (`*batch_dims`, dim)
         The tail representations.
     :param clamp:
         Clamp the scores to the given range.
@@ -680,13 +680,13 @@ def se_interaction(
     .. math ::
         f(h, r, t) = -\|R_h h - R_t t\|
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r_h: shape: (*batch_dims, rel_dim, dim)
+    :param r_h: shape: (`*batch_dims`, rel_dim, dim)
         The relation-specific head projection.
-    :param r_t: shape: (*batch_dims, rel_dim, dim)
+    :param r_t: shape: (`*batch_dims`, rel_dim, dim)
         The relation-specific tail projection.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param p:
         The p for the norm. cf. :func:`torch.linalg.vector_norm`.
@@ -715,11 +715,11 @@ def toruse_interaction(
     .. note ::
         This only implements the two L_p norm based variants.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param p:
         The p for the norm.
@@ -747,17 +747,17 @@ def transd_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the TransD interaction function.
 
-    :param h: shape: (*batch_dims, d_e)
+    :param h: shape: (`*batch_dims`, d_e)
         The head representations.
-    :param r: shape: (*batch_dims, d_r)
+    :param r: shape: (`*batch_dims`, d_r)
         The relation representations.
-    :param t: shape: (*batch_dims, d_e)
+    :param t: shape: (`*batch_dims`, d_e)
         The tail representations.
-    :param h_p: shape: (*batch_dims, d_e)
+    :param h_p: shape: (`*batch_dims`, d_e)
         The head projections.
-    :param r_p: shape: (*batch_dims, d_r)
+    :param r_p: shape: (`*batch_dims`, d_r)
         The relation projections.
-    :param t_p: shape: (*batch_dims, d_e)
+    :param t_p: shape: (`*batch_dims`, d_e)
         The tail projections.
     :param p:
         The parameter p for selecting the norm.
@@ -790,11 +790,11 @@ def transe_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the TransE interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param p:
         The p for the norm.
@@ -814,11 +814,11 @@ def transf_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the TransF interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
 
     :return: shape: batch_dims
@@ -837,13 +837,13 @@ def transh_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the DistMult interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param w_r: shape: (*batch_dims, dim)
+    :param w_r: shape: (`*batch_dims`, dim)
         The relation normal vector representations.
-    :param d_r: shape: (*batch_dims, dim)
+    :param d_r: shape: (`*batch_dims`, dim)
         The relation difference vector representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param p:
         The p for the norm. cf. :func:`torch.linalg.vector_norm`.
@@ -877,13 +877,13 @@ def transr_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the TransR interaction function.
 
-    :param h: shape: (*batch_dims, d_e)
+    :param h: shape: (`*batch_dims`, d_e)
         Head embeddings.
-    :param r: shape: (*batch_dims, d_r)
+    :param r: shape: (`*batch_dims`, d_r)
         Relation embeddings.
-    :param m_r: shape: (*batch_dims, d_e, d_r)
+    :param m_r: shape: (`*batch_dims`, d_e, d_r)
         The relation specific linear transformations.
-    :param t: shape: (*batch_dims, d_e)
+    :param t: shape: (`*batch_dims`, d_e)
         Tail embeddings.
     :param p:
         The parameter p for selecting the norm.
@@ -920,11 +920,11 @@ def tucker_interaction(
 
     where BN denotes BatchNorm and DO denotes Dropout
 
-    :param h: shape: (*batch_dims, d_e)
+    :param h: shape: (`*batch_dims`, d_e)
         The head representations.
-    :param r: shape: (*batch_dims, d_r)
+    :param r: shape: (`*batch_dims`, d_r)
         The relation representations.
-    :param t: shape: (*batch_dims, d_e)
+    :param t: shape: (`*batch_dims`, d_e)
         The tail representations.
     :param core_tensor: shape: (d_e, d_r, d_e)
         The core tensor.
@@ -984,15 +984,15 @@ def mure_interaction(
     .. math ::
         -\|Rh + r - t\| + b_h + b_t
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
     :param b_h: shape: batch_dims
         The head entity bias.
-    :param r_vec: shape: (*batch_dims, dim)
+    :param r_vec: shape: (`*batch_dims`, dim)
         The relation vector.
-    :param r_mat: shape: (*batch_dims, dim,)
+    :param r_mat: shape: (`*batch_dims`, dim,)
         The diagonal relation matrix.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param b_t: shape: batch_dims
         The tail entity bias.
@@ -1025,9 +1025,9 @@ def um_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the SimplE interaction function.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param p:
         The parameter p for selecting the norm.
@@ -1053,13 +1053,13 @@ def pair_re_interaction(
     .. math ::
         -\|h \odot r_h - t \odot r_t \|
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
-    :param r_h: shape: (*batch_dims, dim)
+    :param r_h: shape: (`*batch_dims`, dim)
         The head part of the relation representations.
-    :param r_t: shape: (*batch_dims, dim)
+    :param r_t: shape: (`*batch_dims`, dim)
         The tail part of the relation representations.
     :param p:
         The parameter p for selecting the norm.
@@ -1106,11 +1106,11 @@ def quat_e_interaction(
     .. note ::
         dim has to be divisible by 4.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The head representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
 
     :return: shape: (...)
@@ -1154,13 +1154,13 @@ def cross_e_interaction(
         multiple competing variants how to break the ties. More information on this can be found in the documentation of
         rank-based evaluation.
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param c_r: shape: (*batch_dims, dim)
+    :param c_r: shape: (`*batch_dims`, dim)
         The relation-specific interaction vector.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param bias: shape: (dim,)
         The combination bias.
@@ -1216,27 +1216,27 @@ def boxe_interaction(
         this interaction relies on Abboud's point-to-box distance
         :func:`pykeen.utils.point_to_box_distance`.
 
-    :param h_pos: shape: (*batch_dims, d)
+    :param h_pos: shape: (`*batch_dims`, d)
         the head entity position
-    :param h_bump: shape: (*batch_dims, d)
+    :param h_bump: shape: (`*batch_dims`, d)
         the head entity bump
 
-    :param rh_base: shape: (*batch_dims, d)
+    :param rh_base: shape: (`*batch_dims`, d)
         the relation-specific head box base position
-    :param rh_delta: shape: (*batch_dims, d)
+    :param rh_delta: shape: (`*batch_dims`, d)
         # the relation-specific head box base shape (normalized to have a volume of 1):
-    :param rh_size: shape: (*batch_dims, 1)
+    :param rh_size: shape: (`*batch_dims`, 1)
         the relation-specific head box size (a scalar)
-    :param rt_base: shape: (*batch_dims, d)
+    :param rt_base: shape: (`*batch_dims`, d)
         the relation-specific tail box base position
-    :param rt_delta: shape: (*batch_dims, d)
+    :param rt_delta: shape: (`*batch_dims`, d)
         # the relation-specific tail box base shape (normalized to have a volume of 1):
-    :param rt_size: shape: (*batch_dims, d)
+    :param rt_size: shape: (`*batch_dims`, d)
         the relation-specific tail box size
 
-    :param t_pos: shape: (*batch_dims, d)
+    :param t_pos: shape: (`*batch_dims`, d)
         the tail entity position
-    :param t_bump: shape: (*batch_dims, d)
+    :param t_bump: shape: (`*batch_dims`, d)
         the tail entity bump
 
     :param tanh_map:
@@ -1272,11 +1272,11 @@ def cp_interaction(
 ) -> torch.FloatTensor:
     """Evaluate the Canonical Tensor Decomposition interaction function.
 
-    :param h: shape: (*batch_dims, rank, dim)
+    :param h: shape: (`*batch_dims`, rank, dim)
         The head representations.
-    :param r: shape: (*batch_dims, rank, dim)
+    :param r: shape: (`*batch_dims`, rank, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, rank, dim)
+    :param t: shape: (`*batch_dims`, rank, dim)
         The tail representations.
 
     :return: shape: batch_dims
@@ -1310,15 +1310,15 @@ def triple_re_interaction(
         For equivalence to the paper version, `h` and `t` should be normalized to unit
         Euclidean length, and `p` and `power_norm` be kept at their default values.
 
-    :param h: shape: (*batch_dims, rank, dim)
+    :param h: shape: (`*batch_dims`, rank, dim)
         The head representations.
-    :param r_head: shape: (*batch_dims, rank, dim)
+    :param r_head: shape: (`*batch_dims`, rank, dim)
         The relation-specific head multiplicator representations.
-    :param r_mid: shape: (*batch_dims, rank, dim)
+    :param r_mid: shape: (`*batch_dims`, rank, dim)
         The relation representations.
-    :param r_tail: shape: (*batch_dims, rank, dim)
+    :param r_tail: shape: (`*batch_dims`, rank, dim)
         The relation-specific tail multiplicator representations.
-    :param t: shape: (*batch_dims, rank, dim)
+    :param t: shape: (`*batch_dims`, rank, dim)
         The tail representations.
     :param u:
         the relation factor offset. If u is not None or 0, this corresponds to TripleREv2.
@@ -1376,11 +1376,11 @@ def auto_sf_interaction(
       $\mathcal{C} = \{(0, 0, 0, 1), (0, 1, 1, 1), (1, 0, 1, -1), (1, 0, 1, 1)\}$
     - :class:`pykeen.models.SimplE`: two blocks: $\mathcal{C} = \{(0, 0, 1, 1), (1, 1, 0, 1)\}$
 
-    :param h: each shape: (*batch_dims, rank, dim)
+    :param h: each shape: (`*batch_dims`, rank, dim)
         The list of head representations.
-    :param r: each shape: (*batch_dims, rank, dim)
+    :param r: each shape: (`*batch_dims`, rank, dim)
         The list of relation representations.
-    :param t: each shape: (*batch_dims, rank, dim)
+    :param t: each shape: (`*batch_dims`, rank, dim)
         The list of tail representations.
     :param coefficients:
         the coefficients, in order:
@@ -1408,11 +1408,11 @@ def transformer_interaction(
         \textit{score}(h, r, t) =
             \textit{Linear}(\textit{SumPooling}(\textit{Transformer}([h + pe[0]; r + pe[1]])))^T t
 
-    :param h: shape: (*batch_dims, dim)
+    :param h: shape: (`*batch_dims`, dim)
         The head representations.
-    :param r: shape: (*batch_dims, dim)
+    :param r: shape: (`*batch_dims`, dim)
         The relation representations.
-    :param t: shape: (*batch_dims, dim)
+    :param t: shape: (`*batch_dims`, dim)
         The tail representations.
     :param transformer:
         the transformer encoder

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -1424,12 +1424,12 @@ def transformer_interaction(
     :param final:
         the final (linear) transformation
     """
-    # stack h & r (+ broadcast) => shape: (2, batch_size', num_heads, num_relations, 1, *dims)
+    # stack h & r (+ broadcast) => shape: (2, *batch_dims, dim)
     x = torch.stack(broadcast_tensors(h, r), dim=0)
 
     # remember shape for output, but reshape for transformer
     hr_shape = x.shape
-    x = x.view(2, -1, *hr_shape[5:])
+    x = x.view(2, -1, hr_shape[-1])
 
     # get position embeddings, shape: (seq_len, dim)
     # Now we are position-dependent w.r.t qualifier pairs.
@@ -1445,6 +1445,6 @@ def transformer_interaction(
     x = final(x)
 
     # reshape
-    x = x.view(*hr_shape[1:5], x.shape[-1])
+    x = x.view(*hr_shape[1:-1], x.shape[-1])
 
-    return (x @ t.transpose(-1, -2)).squeeze(dim=-2)
+    return (x * t).sum(dim=-1)

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -403,14 +403,11 @@ def hole_interaction(
     :return: shape: batch_dims
         The scores.
     """
-    # composite: (b, h, 1, t, d)
+    # composite: (*batch_dims, d)
     composite = circular_correlation(h, t)
 
-    # transpose composite: (b, h, 1, d, t)
-    composite = composite.transpose(-2, -1)
-
     # inner product with relation embedding
-    return (r @ composite).squeeze(dim=-2)
+    return (r * composite).sum(dim=-1)
 
 
 def circular_correlation(

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -593,7 +593,7 @@ def rescal_interaction(
     :return: shape: batch_dims
         The scores.
     """
-    return extended_einsum("bhrtd,bhrtde,bhrte->bhrt", h, r, t)
+    return torch.einsum("...d,...de,...e->...", h, r, t)
 
 
 def rotate_interaction(

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1361,11 +1361,14 @@ class MonotonicAffineTransformationInteraction(
 
         # The parameters of the affine transformation: bias
         self.bias = nn.Parameter(torch.empty(size=tuple()), requires_grad=trainable_bias)
-        self.initial_bias = torch.as_tensor(data=[initial_bias], dtype=torch.get_default_dtype())
+        self.initial_bias = torch.as_tensor(data=[initial_bias], dtype=torch.get_default_dtype()).squeeze()
 
         # scale. We model this as log(scale) to ensure scale > 0, and thus monotonicity
         self.log_scale = nn.Parameter(torch.empty(size=tuple()), requires_grad=trainable_scale)
-        self.initial_log_scale = torch.as_tensor(data=[math.log(initial_scale)], dtype=torch.get_default_dtype())
+        self.initial_log_scale = torch.as_tensor(
+            data=[math.log(initial_scale)],
+            dtype=torch.get_default_dtype(),
+        ).squeeze()
 
     def reset_parameters(self):  # noqa: D102
         self.bias.data = self.initial_bias.to(device=self.bias.device)

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -875,7 +875,7 @@ class ProjEInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTens
         self.b_c = nn.Parameter(torch.empty(embedding_dim), requires_grad=True)
 
         # Global combination bias
-        self.b_p = nn.Parameter(torch.empty(1), requires_grad=True)
+        self.b_p = nn.Parameter(torch.empty(tuple()), requires_grad=True)
 
         if inner_non_linearity is None:
             inner_non_linearity = nn.Tanh()

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -34,11 +34,17 @@ from torch.nn.init import xavier_normal_
 
 from . import functional as pkf
 from .combinations import Combination
-from ..typing import HeadRepresentation, HintOrType, Initializer, RelationRepresentation, Sign, TailRepresentation
+from ..typing import (
+    HeadRepresentation,
+    HintOrType,
+    Initializer,
+    RelationRepresentation,
+    Representation,
+    Sign,
+    TailRepresentation,
+)
 from ..utils import (
-    CANONICAL_DIMENSIONS,
     activation_resolver,
-    convert_to_canonical_shape,
     ensure_tuple,
     unpack_singletons,
     upgrade_to_sequence,
@@ -109,6 +115,12 @@ def parallel_slice_batches(
     batch_of_unpacked_tuples = unpack_singletons(*batch_of_tuples)
 
     yield from batch_of_unpacked_tuples
+
+
+def unsqueeze(x: Representation, dim: int) -> Representation:
+    x = upgrade_to_sequence(x)
+    x = [xx.unsqueeze(dim=dim) for xx in x]
+    return x[0] if len(x) == 1 else x
 
 
 class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation, TailRepresentation], ABC):
@@ -245,9 +257,9 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
             The scores.
         """
         return self.score(
-            h=all_entities.unsqueeze(dim=0),
-            r=r.unsqueeze(dim=1),
-            t=t.unsqueeze(dim=1),
+            h=unsqueeze(all_entities, dim=0),
+            r=unsqueeze(r, dim=1),
+            t=unsqueeze(t, dim=1),
             slice_size=slice_size,
         )
 
@@ -273,9 +285,9 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
             The scores.
         """
         return self.score(
-            h=h.unsqueeze(dim=1),
-            r=all_relations.unsqueeze(dim=0),
-            t=t.unsqueeze(dim=1),
+            h=unsqueeze(h, dim=1),
+            r=unsqueeze(all_relations, dim=0),
+            t=unsqueeze(t, dim=1),
             slice_size=slice_size,
         )
 
@@ -301,9 +313,9 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
             The scores.
         """
         return self.score(
-            h=h.unsqueeze(dim=1),
-            r=r.unsqueeze(dim=1),
-            t=all_entities.unsqueeze(dim=0),
+            h=unsqueeze(h, dim=1),
+            r=unsqueeze(r, dim=1),
+            t=unsqueeze(all_entities, dim=0),
             slice_size=slice_size,
         )
 

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -153,11 +153,11 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
     ) -> torch.FloatTensor:
         """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
 
-        :param h: shape: (`*batch_dims`, *dims)
+        :param h: shape: (`*batch_dims`, `*dims`)
             The head representations.
-        :param r: shape: (`*batch_dims`, *dims)
+        :param r: shape: (`*batch_dims`, `*dims`)
             The relation representations.
-        :param t: shape: (`*batch_dims`, *dims)
+        :param t: shape: (`*batch_dims`, `*dims`)
             The tail representations.
 
         :return: shape: batch_dims
@@ -179,11 +179,11 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
 
         # TODO: we could change that to slicing along multiple dimensions, if necessary
 
-        :param h: shape: (`*batch_dims`, *dims)
+        :param h: shape: (`*batch_dims`, `*dims`)
             The head representations.
-        :param r: shape: (`*batch_dims`, *dims)
+        :param r: shape: (`*batch_dims`, `*dims`)
             The relation representations.
-        :param t: shape: (`*batch_dims`, *dims)
+        :param t: shape: (`*batch_dims`, `*dims`)
             The tail representations.
         :param slice_size:
             The slice size.
@@ -360,11 +360,11 @@ class LiteralInteraction(
     ) -> torch.FloatTensor:
         """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
 
-        :param h: shape: (`*batch_dims`, *dims)
+        :param h: shape: (`*batch_dims`, `*dims`)
             The head representations.
-        :param r: shape: (`*batch_dims`, *dims)
+        :param r: shape: (`*batch_dims`, `*dims`)
             The relation representations.
-        :param t: shape: (`*batch_dims`, *dims)
+        :param t: shape: (`*batch_dims`, `*dims`)
             The tail representations.
 
         :return: shape: batch_dims
@@ -394,11 +394,11 @@ class FunctionalInteraction(Interaction, Generic[HeadRepresentation, RelationRep
     ) -> torch.FloatTensor:
         """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
 
-        :param h: shape: (`*batch_dims`, *dims)
+        :param h: shape: (`*batch_dims`, `*dims`)
             The head representations.
-        :param r: shape: (`*batch_dims`, *dims)
+        :param r: shape: (`*batch_dims`, `*dims`)
             The relation representations.
-        :param t: shape: (`*batch_dims`, *dims)
+        :param t: shape: (`*batch_dims`, `*dims`)
             The tail representations.
 
         :return: shape: batch_dims

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1392,7 +1392,7 @@ class CrossEInteraction(FunctionalInteraction[FloatTensor, Tuple[FloatTensor, Fl
             combination_activation,
             pos_kwargs=combination_activation_kwargs,
         )
-        self.combination_bias = nn.Parameter(data=torch.zeros(1, 1, 1, 1, embedding_dim))
+        self.combination_bias = nn.Parameter(data=torch.zeros(embedding_dim))
         self.combination_dropout = nn.Dropout(combination_dropout) if combination_dropout else None
 
     def _prepare_state_for_functional(self) -> MutableMapping[str, Any]:  # noqa: D102

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -153,11 +153,11 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
     ) -> torch.FloatTensor:
         """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
 
-        :param h: shape: (*batch_dims, *dims)
+        :param h: shape: (`*batch_dims`, *dims)
             The head representations.
-        :param r: shape: (*batch_dims, *dims)
+        :param r: shape: (`*batch_dims`, *dims)
             The relation representations.
-        :param t: shape: (*batch_dims, *dims)
+        :param t: shape: (`*batch_dims`, *dims)
             The tail representations.
 
         :return: shape: batch_dims
@@ -179,11 +179,11 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
 
         # TODO: we could change that to slicing along multiple dimensions, if necessary
 
-        :param h: shape: (*batch_dims, *dims)
+        :param h: shape: (`*batch_dims`, *dims)
             The head representations.
-        :param r: shape: (*batch_dims, *dims)
+        :param r: shape: (`*batch_dims`, *dims)
             The relation representations.
-        :param t: shape: (*batch_dims, *dims)
+        :param t: shape: (`*batch_dims`, *dims)
             The tail representations.
         :param slice_size:
             The slice size.
@@ -360,11 +360,11 @@ class LiteralInteraction(
     ) -> torch.FloatTensor:
         """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
 
-        :param h: shape: (*batch_dims, *dims)
+        :param h: shape: (`*batch_dims`, *dims)
             The head representations.
-        :param r: shape: (*batch_dims, *dims)
+        :param r: shape: (`*batch_dims`, *dims)
             The relation representations.
-        :param t: shape: (*batch_dims, *dims)
+        :param t: shape: (`*batch_dims`, *dims)
             The tail representations.
 
         :return: shape: batch_dims
@@ -394,11 +394,11 @@ class FunctionalInteraction(Interaction, Generic[HeadRepresentation, RelationRep
     ) -> torch.FloatTensor:
         """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
 
-        :param h: shape: (*batch_dims, *dims)
+        :param h: shape: (`*batch_dims`, *dims)
             The head representations.
-        :param r: shape: (*batch_dims, *dims)
+        :param r: shape: (`*batch_dims`, *dims)
             The relation representations.
-        :param t: shape: (*batch_dims, *dims)
+        :param t: shape: (`*batch_dims`, *dims)
             The tail representations.
 
         :return: shape: batch_dims

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -10,20 +10,7 @@ import math
 from abc import ABC, abstractmethod
 from collections import Counter
 from operator import itemgetter
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    Iterable,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Generic, Iterable, Mapping, MutableMapping, Optional, Sequence, Set, Tuple, Union
 
 import more_itertools
 import numpy
@@ -98,6 +85,16 @@ def parallel_slice_batches(
 ) -> Iterable[Sequence[Representation]]:
     """
     Slice representations along the given dimension.
+
+    :param representations:
+        the representations to slice
+    :param split_size:
+        the slice size
+    :param dim:
+        the dimension along which to slice
+
+    :yield:
+        batches of sliced representations
     """
     # normalize input
     rs: Sequence[Sequence[torch.FloatTensor]] = ensure_tuple(*representations)

--- a/src/pykeen/nn/sim.py
+++ b/src/pykeen/nn/sim.py
@@ -185,7 +185,7 @@ def _vectorized_kl_divergence(
     terms.append(batched_dot(mu.pow(2), r_var_safe_reciprocal))
     # 3. Component
     if exact:
-        terms.append(-torch.as_tensor(data=[h.mean.shape[-1]], device=mu.device))
+        terms.append(-torch.as_tensor(data=[h.mean.shape[-1]], device=mu.device).squeeze())
     # 4. Component
     # ln (det(\Sigma_1) / det(\Sigma_0))
     # = ln det Sigma_1 - ln det Sigma_0

--- a/src/pykeen/typing.py
+++ b/src/pykeen/typing.py
@@ -67,6 +67,7 @@ DeviceHint = Hint[torch.device]
 #: A hint for a :class:`torch.Generator`
 TorchRandomHint = Union[None, int, torch.Generator]
 
+Representation = TypeVar("Representation", bound=OneOrSequence[torch.FloatTensor])
 #: A type variable for head representations used in :class:`pykeen.models.Model`,
 #: :class:`pykeen.nn.modules.Interaction`, etc.
 HeadRepresentation = TypeVar("HeadRepresentation", bound=OneOrSequence[torch.FloatTensor])

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -67,7 +67,6 @@ __all__ = [
     "fix_dataclass_init_docs",
     "get_benchmark",
     "extended_einsum",
-    "strip_dim",
     "upgrade_to_sequence",
     "ensure_tuple",
     "unpack_singletons",
@@ -789,16 +788,6 @@ def convert_to_canonical_shape(
     dim = _normalize_dim(dim=dim)
     shape[dim] = num
     return x.view(*shape, *suffix_shape)
-
-
-def strip_dim(*tensors: torch.FloatTensor, n: int = 4) -> Sequence[torch.FloatTensor]:
-    """Strip the first dimensions.
-
-    :param tensors: The tensors whose first ``n`` dimensions should be independently stripped
-    :param n: The number of initial dimensions to strip
-    :return: A tuple of the reduced tensors
-    """
-    return tuple(tensor.view(tensor.shape[n:]) for tensor in tensors)
 
 
 def upgrade_to_sequence(x: Union[X, Sequence[X]]) -> Sequence[X]:

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -748,9 +748,11 @@ def project_entity(
     return e_bot
 
 
+# TODO delete when deleting _normalize_dim (below)
 CANONICAL_DIMENSIONS = dict(h=1, r=2, t=3)
 
 
+# TODO delete when deleting convert_to_canonical_shape (below)
 def _normalize_dim(dim: Union[int, str]) -> int:
     """Normalize the dimension selection."""
     if isinstance(dim, int):
@@ -758,6 +760,7 @@ def _normalize_dim(dim: Union[int, str]) -> int:
     return CANONICAL_DIMENSIONS[dim.lower()[0]]
 
 
+# TODO delete? See note in test_sim.py on its only usage
 def convert_to_canonical_shape(
     x: torch.FloatTensor,
     dim: Union[int, str],

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -606,7 +606,7 @@ def _reorder(
         return tensors
     # determine optimal processing order
     shapes = tuple(tuple(t.shape) for t in tensors)
-    if len(set(s[0] for s in shapes)) < 2:
+    if len(set(s[0] for s in shapes if s)) < 2:
         # heuristic
         return tensors
     order = get_optimal_sequence(*shapes)[1]

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1386,7 +1386,6 @@ class RepresentationTestCase(GenericTestCase[RepresentationModule]):
         """Test forward and canonical shape for indices."""
         self._test_forward(indices=indices)
         self._test_canonical_shape(indices=indices)
-        self._test_more_canonical_shape(indices=indices)
 
     def test_no_indices(self):
         """Test without indices."""

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -38,6 +38,7 @@ from torch.nn import functional
 from torch.optim import SGD, Adagrad
 
 import pykeen.models
+from pykeen.models.nbase import ERModel
 import pykeen.nn.message_passing
 import pykeen.nn.weighting
 from pykeen.datasets import Nations
@@ -1200,6 +1201,8 @@ Traceback
 
     def test_score_h_with_score_hrt_equality(self) -> None:
         """Test the equality of the model's  ``score_h()`` and ``score_hrt()`` function."""
+        if isinstance(self.instance, ERModel):
+            raise SkipTest("ERModel fulfils this by design.")
         batch = self.factory.mapped_triples[: self.batch_size, 1:].to(self.instance.device)
         self.instance.eval()
         # assert batch comprises (relation, tail) pairs
@@ -1222,6 +1225,8 @@ Traceback
 
     def test_score_r_with_score_hrt_equality(self) -> None:
         """Test the equality of the model's  ``score_r()`` and ``score_hrt()`` function."""
+        if isinstance(self.instance, ERModel):
+            raise SkipTest("ERModel fulfils this by design.")
         batch = self.factory.mapped_triples[: self.batch_size, [0, 2]].to(self.instance.device)
         self.instance.eval()
         # assert batch comprises (relation, tail) pairs
@@ -1244,6 +1249,8 @@ Traceback
 
     def test_score_t_with_score_hrt_equality(self) -> None:
         """Test the equality of the model's  ``score_t()`` and ``score_hrt()`` function."""
+        if isinstance(self.instance, ERModel):
+            raise SkipTest("ERModel fulfils this by design.")
         batch = self.factory.mapped_triples[: self.batch_size, :-1].to(self.instance.device)
         self.instance.eval()
         # assert batch comprises (relation, tail) pairs

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -389,7 +389,7 @@ class InteractionTestCase(
         shape_kwargs.setdefault("d", self.dim)
         result = tuple(
             tuple(
-                torch.rand(*prefix_shape, *(shape_kwargs[dim] for dim in weight_shape), requires_grad=True)
+                torch.rand(size=tuple(prefix_shape) + tuple(shape_kwargs[dim] for dim in weight_shape), requires_grad=True)
                 for weight_shape in weight_shapes
             )
             for prefix_shape, weight_shapes in zip(

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -543,13 +543,12 @@ class InteractionTestCase(
         rs: Tuple[int, ...],
         ts: Tuple[int, ...],
     ) -> Tuple[int, ...]:
-        return tuple(max(ds) for ds in zip(hs, rs, ts))
-        # # TODO:
-        # if len(self.instance.entity_shape) == 0:
-        #     result[1] = result[3] = 1
-        # if len(self.instance.relation_shape) == 0:
-        #     result[2] = 1
-        # return tuple(result)
+        components = []
+        if self.instance.entity_shape:
+            components.extend((hs, ts))
+        if self.instance.relation_shape:
+            components.append(rs)
+        return tuple(max(ds) for ds in zip(*components))
 
     def test_forward(self):
         """Test forward."""

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1382,22 +1382,6 @@ class RepresentationTestCase(GenericTestCase[RepresentationModule]):
             raise AssertionError(indices.shape)
         self._check_result(x=x, prefix_shape=prefix_shape)
 
-    def _test_more_canonical_shape(self, indices: Optional[torch.LongTensor]):
-        """Test more canonical shape."""
-        for i, dim in enumerate(("h", "r", "t"), start=1):
-            x = self.instance.get_in_more_canonical_shape(dim=dim, indices=indices)
-            prefix_shape = [1, 1, 1, 1]
-            if indices is None:
-                prefix_shape[i] = self.instance.max_id
-            elif indices.ndimension() == 1:
-                prefix_shape[0] = indices.shape[0]
-            elif indices.ndimension() == 2:
-                prefix_shape[0] = indices.shape[0]
-                prefix_shape[i] = indices.shape[1]
-            else:
-                raise AssertionError(indices.shape)
-            self._check_result(x=x, prefix_shape=tuple(prefix_shape))
-
     def _test_indices(self, indices: Optional[torch.LongTensor]):
         """Test forward and canonical shape for indices."""
         self._test_forward(indices=indices)

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -544,7 +544,7 @@ class InteractionTestCase(
         ts: Tuple[int, ...],
     ) -> Tuple[int, ...]:
         return tuple(max(ds) for ds in zip(hs, rs, ts))
-        # # TODO: 
+        # # TODO:
         # if len(self.instance.entity_shape) == 0:
         #     result[1] = result[3] = 1
         # if len(self.instance.relation_shape) == 0:
@@ -554,7 +554,7 @@ class InteractionTestCase(
     def test_forward(self):
         """Test forward."""
         for hs, rs, ts in self._get_test_shapes():
-            if get_batchnorm_modules(self.instance) and max(numpy.prod(s) for s in (hs, rs, ts)) == 1:
+            if get_batchnorm_modules(self.instance) and any(numpy.prod(s) == 1 for s in (hs, rs, ts)):
                 logger.warning(
                     f"Skipping test for shapes {hs}, {rs}, {ts} because too small batch size for batch norm",
                 )

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -28,8 +28,8 @@ from typing import (
 from unittest.case import SkipTest
 from unittest.mock import patch
 
-import pytest
 import numpy
+import pytest
 import torch
 import unittest_templates
 from click.testing import CliRunner, Result
@@ -38,7 +38,6 @@ from torch.nn import functional
 from torch.optim import SGD, Adagrad
 
 import pykeen.models
-from pykeen.models.nbase import ERModel
 import pykeen.nn.message_passing
 import pykeen.nn.weighting
 from pykeen.datasets import Nations
@@ -49,6 +48,7 @@ from pykeen.evaluation import Evaluator, MetricResults
 from pykeen.losses import Loss, PairwiseLoss, PointwiseLoss, SetwiseLoss, UnsupportedLabelSmoothingError
 from pykeen.models import RESCAL, EntityRelationEmbeddingModel, Model, TransE
 from pykeen.models.cli import build_cli_from_cls
+from pykeen.models.nbase import ERModel
 from pykeen.nn.emb import RepresentationModule
 from pykeen.nn.modules import FunctionalInteraction, Interaction, LiteralInteraction
 from pykeen.optimizers import optimizer_resolver
@@ -390,7 +390,9 @@ class InteractionTestCase(
         shape_kwargs.setdefault("d", self.dim)
         result = tuple(
             tuple(
-                torch.rand(size=tuple(prefix_shape) + tuple(shape_kwargs[dim] for dim in weight_shape), requires_grad=True)
+                torch.rand(
+                    size=tuple(prefix_shape) + tuple(shape_kwargs[dim] for dim in weight_shape), requires_grad=True
+                )
                 for weight_shape in weight_shapes
             )
             for prefix_shape, weight_shapes in zip(

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -210,8 +210,7 @@ class ProjETests(cases.InteractionTestCase):
     )
 
     def _exp_score(self, h, r, t, d_e, d_r, b_c, b_p, activation) -> torch.FloatTensor:
-        # f(h, r, t) = g(t z(D_e h + D_r r + b_c) + b_p)
-        h, r, t = strip_dim(h, r, t)
+        # f(h, r, t) = g(t z(D_e h + D_r r + b_c) + b_p)        
         return (t * activation((d_e * h) + (d_r * r) + b_c)).sum() + b_p
 
 

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -116,7 +116,6 @@ class CrossETests(cases.InteractionTestCase):
     )
 
     def _exp_score(self, h, r, c_r, t, bias, activation, dropout) -> torch.FloatTensor:  # noqa: D102
-        h, r, c_r, t, bias = strip_dim(h, r, c_r, t, bias)
         return (dropout(activation(h * c_r + h * r * c_r + bias)) * t).sum()
 
 

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -242,7 +242,6 @@ class KG2ETests(cases.InteractionTestCase):
 
     def _exp_score(self, exact, h_mean, h_var, r_mean, r_var, similarity, t_mean, t_var):
         assert similarity == "KL"
-        h_mean, h_var, r_mean, r_var, t_mean, t_var = strip_dim(h_mean, h_var, r_mean, r_var, t_mean, t_var)
         e_mean, e_var = h_mean - t_mean, h_var + t_var
         p = torch.distributions.MultivariateNormal(loc=e_mean, covariance_matrix=torch.diag(e_var))
         q = torch.distributions.MultivariateNormal(loc=r_mean, covariance_matrix=torch.diag(r_var))
@@ -401,7 +400,7 @@ class UMTests(cases.TranslationalInteractionTests):
     def _exp_score(self, h, t, p, power_norm) -> torch.FloatTensor:
         assert power_norm
         # -\|h - t\|
-        h, t = strip_dim(h, t)
+        # h, t = strip_dim(h, t)
         return -(h - t).pow(p).sum()
 
 
@@ -643,7 +642,4 @@ class AutoSFTests(cases.InteractionTestCase):
         coefficients: Sequence[Tuple[int, int, int, Sign]],
     ) -> torch.FloatTensor:  # noqa: D102
         h, r, t = ensure_tuple(h, r, t)
-        h = strip_dim(*h)
-        r = strip_dim(*r)
-        t = strip_dim(*t)
         return sum(s * (h[i] * r[j] * t[k]).sum(dim=-1) for i, j, k, s in coefficients)

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -537,7 +537,6 @@ class TransformerTests(cases.InteractionTestCase):
         position_embeddings: torch.FloatTensor,
         final: nn.Module,
     ) -> torch.FloatTensor:  # noqa: D102
-        h, r, t = strip_dim(h, r, t)
         x = torch.stack([h, r], dim=0) + position_embeddings
         x = transformer(src=x.unsqueeze(dim=1))
         x = x.sum(dim=0)

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -190,8 +190,6 @@ class NTNTests(cases.InteractionTestCase):
     def _exp_score(self, h, t, w, vt, vh, b, u, activation) -> torch.FloatTensor:
         # f(h,r,t) = u_r^T act(h W_r t + V_r h + V_r t + b_r)
         # shapes: w: (k, dim, dim), vh/vt: (k, dim), b/u: (k,), h/t: (dim,)
-        # remove batch/num dimension
-        # h, t, w, vt, vh, b, u = strip_dim(h, t, w, vt, vh, b, u)
         score = 0.0
         for i in range(u.shape[-1]):
             first_part = h.view(1, self.dim) @ w[i] @ t.view(self.dim, 1)
@@ -210,7 +208,7 @@ class ProjETests(cases.InteractionTestCase):
     )
 
     def _exp_score(self, h, r, t, d_e, d_r, b_c, b_p, activation) -> torch.FloatTensor:
-        # f(h, r, t) = g(t z(D_e h + D_r r + b_c) + b_p)        
+        # f(h, r, t) = g(t z(D_e h + D_r r + b_c) + b_p)
         return (t * activation((d_e * h) + (d_r * r) + b_c)).sum() + b_p
 
 
@@ -396,7 +394,6 @@ class UMTests(cases.TranslationalInteractionTests):
     def _exp_score(self, h, t, p, power_norm) -> torch.FloatTensor:
         assert power_norm
         # -\|h - t\|
-        # h, t = strip_dim(h, t)
         return -(h - t).pow(p).sum()
 
 

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -552,13 +552,13 @@ class InteractionTestsTestCase(unittest_templates.MetaTestCase[pykeen.nn.modules
 class ParallelSliceBatchesTest(unittest.TestCase):
     """Tests for parallel_slice_batches."""
 
-    @staticmethod
     def _verify(
+        self,
         z: Representation,
         z_batch: Representation,
         dim: int,
         split_size: int,
-    ):
+    ) -> None:
         """Verify a sliced representations."""
         if torch.is_tensor(z):
             assert torch.is_tensor(z_batch)
@@ -573,10 +573,10 @@ class ParallelSliceBatchesTest(unittest.TestCase):
             assert not torch.is_tensor(z_batch)
             assert len(z) == len(z_batch)
             for y, y_batch in zip(z, z_batch):
-                ParallelSliceBatchesTest._verify(z=y, z_batch=y_batch, dim=dim, split_size=split_size)
+                self._verify(z=y, z_batch=y_batch, dim=dim, split_size=split_size)
 
-    @staticmethod
     def _generate(
+        self,
         shape: Union[Tuple[int, ...], Sequence[Tuple[int, ...]]],
     ) -> Representation:
         """Generate dummy representations for the given shape(s)."""
@@ -584,7 +584,7 @@ class ParallelSliceBatchesTest(unittest.TestCase):
             return []
         if isinstance(shape[0], tuple):
             # multiple
-            return [ParallelSliceBatchesTest._generate(s) for s in shape]
+            return [self._generate(s) for s in shape]
         # single
         return torch.empty(size=shape, device="meta")
 

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -232,7 +232,6 @@ class RESCALTests(cases.InteractionTestCase):
 
     def _exp_score(self, h, r, t) -> torch.FloatTensor:
         # f(h, r, t) = h @ r @ t
-        h, r, t = strip_dim(h, r, t)
         return h.view(1, -1) @ r @ t.view(-1, 1)
 
 

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -259,7 +259,6 @@ class TuckerTests(cases.InteractionTestCase):
 
     def _exp_score(self, bn_h, bn_hr, core_tensor, do_h, do_r, do_hr, h, r, t) -> torch.FloatTensor:
         # DO_{hr}(BN_{hr}(DO_h(BN_h(h)) x_1 DO_r(W x_2 r))) x_3 t
-        h, r, t = strip_dim(h, r, t)
         a = do_r((core_tensor * r[None, :, None]).sum(dim=1, keepdims=True))  # shape: (embedding_dim, 1, embedding_dim)
         b = do_h(bn_h(h.view(1, -1))).view(-1)  # shape: (embedding_dim)
         c = (b[:, None, None] * a).sum(dim=0, keepdims=True)  # shape: (1, 1, embedding_dim)

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -191,7 +191,7 @@ class NTNTests(cases.InteractionTestCase):
         # f(h,r,t) = u_r^T act(h W_r t + V_r h + V_r t + b_r)
         # shapes: w: (k, dim, dim), vh/vt: (k, dim), b/u: (k,), h/t: (dim,)
         # remove batch/num dimension
-        h, t, w, vt, vh, b, u = strip_dim(h, t, w, vt, vh, b, u)
+        # h, t, w, vt, vh, b, u = strip_dim(h, t, w, vt, vh, b, u)
         score = 0.0
         for i in range(u.shape[-1]):
             first_part = h.view(1, self.dim) @ w[i] @ t.view(self.dim, 1)

--- a/tests/test_nn/test_sim.py
+++ b/tests/test_nn/test_sim.py
@@ -25,6 +25,8 @@ class KullbackLeiblerTests(unittest.TestCase):
         dims = dict(h=self.num_heads, r=self.num_relations, t=self.num_tails)
         (self.h_mean, self.r_mean, self.t_mean), (self.h_var, self.r_var, self.t_var) = [
             [
+                # TODO this is the only place this function is used.
+                #  Is there an alternative so we can remove it?
                 convert_to_canonical_shape(
                     x=torch.rand(self.batch_size, num, self.d),
                     dim=dim,


### PR DESCRIPTION
This PR is a draft to change the format from the "more canonical" shape `(batch_size, num_heads, num_relations, num_tails, *dims)` to an arbitrary number of batch dimensions `(*batch_dims, *dims)`, This should avoid some of the unnecessary dimension expansion and reductions, which *may* be the cause of the performance issue observed in #735 .

In particular it allows `score_hrt` from shape `(batch_size, dim)` instead of the expansion to `(batch_size, 1, 1, 1, dim)`.