### PR TITLE
Extend HPO-Sampling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     click
     click_default_group
     sklearn
-    torch>=1.10; platform_system != "Windows"
+    torch>=1.9; platform_system != "Windows"
     tqdm
     requests
     optuna>=2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     click
     click_default_group
     sklearn
-    torch>=1.9; platform_system != "Windows"
+    torch>=1.10; platform_system != "Windows"
     tqdm
     requests
     optuna>=2.0.0

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -176,8 +176,8 @@ class Objective:
             kwargs_ranges=self.model_kwargs_ranges,
         )
 
-        # 2.1 Entity representations
         if self.entity_representation_kwargs is not None:
+            # 2.1 Entity representations
             _entity_representation_kwargs = _get_kwargs(
                 trial=trial,
                 prefix='entity_representation',

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -220,8 +220,6 @@ class Objective:
             )
             if interaction_resolver.lookup(self.interaction) is TransformerInteraction:
                 assert 'embedding_dim' in _model_kwargs
-            if 'embedding_dim' in _interaction_kwargs:
-                logging.warning('\'embedding_dim\' in \'interaction_kwargs\' will be overwritten.')
             # The Transformer Interaction expects as input dimension the embedding dimension.
             _interaction_kwargs['input_dim'] = _model_kwargs['embedding_dim']
 


### PR DESCRIPTION
In this PR, we extend the HPO-sampling, so that parameters of the `entity_representation`, `relation_representation`, and `interaction` modules can be sampled.