### PR TITLE
⛔💠 Remove get in canonical shape

### DIFF
--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -9,20 +9,20 @@ import torch
 import torch.autograd
 from torch.nn.init import uniform_
 
-from ..base import EntityRelationEmbeddingModel
+from pykeen.nn.modules import KG2EInteraction
+
+from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...nn.emb import Embedding, EmbeddingSpecification
+from ...nn.emb import EmbeddingSpecification
 from ...typing import Constrainer, Hint, Initializer
-from ...utils import at_least_eps, clamp_norm
+from ...utils import clamp_norm
 
 __all__ = [
     "KG2E",
 ]
 
-_LOG_2_PI = math.log(2.0 * math.pi)
 
-
-class KG2E(EntityRelationEmbeddingModel):
+class KG2E(ERModel):
     r"""An implementation of KG2E from [he2015]_.
 
     KG2E aims to explicitly model (un)certainties in entities and relations (e.g. influenced by the number of triples
@@ -97,199 +97,41 @@ class KG2E(EntityRelationEmbeddingModel):
         :raises ValueError: if an illegal ``dist_similarity`` is given
         """
         super().__init__(
-            entity_representations=EmbeddingSpecification(
-                embedding_dim=embedding_dim,
-                initializer=entity_initializer,
-                constrainer=entity_constrainer,
-                constrainer_kwargs=entity_constrainer_kwargs or self.constrainer_default_kwargs,
+            interaction=KG2EInteraction,
+            interaction_kwargs=dict(
+                similarity=dist_similarity,
             ),
-            relation_representations=EmbeddingSpecification(
-                embedding_dim=embedding_dim,
-                initializer=relation_initializer,
-                constrainer=relation_constrainer,
-                constrainer_kwargs=relation_constrainer_kwargs or self.constrainer_default_kwargs,
-            ),
+            entity_representations=[
+                # mean
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    initializer=entity_initializer,
+                    constrainer=entity_constrainer,
+                    constrainer_kwargs=entity_constrainer_kwargs or self.constrainer_default_kwargs,
+                ),
+                # diagonal covariance
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    # Ensure positive definite covariances matrices and appropriate size by clamping
+                    constrainer=torch.clamp,
+                    constrainer_kwargs=dict(min=c_min, max=c_max),
+                ),
+            ],
+            relation_representations=[
+                # mean
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    initializer=relation_initializer,
+                    constrainer=relation_constrainer,
+                    constrainer_kwargs=relation_constrainer_kwargs or self.constrainer_default_kwargs,
+                ),
+                # diagonal covariance
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    # Ensure positive definite covariances matrices and appropriate size by clamping
+                    constrainer=torch.clamp,
+                    constrainer_kwargs=dict(min=self.c_min, max=self.c_max),
+                ),
+            ],
             **kwargs,
         )
-
-        # Similarity function used for distributions
-        if dist_similarity is None or dist_similarity.upper() == "KL":
-            self.similarity = self.kullback_leibler_similarity
-        elif dist_similarity.upper() == "EL":
-            self.similarity = self.expected_likelihood
-        else:
-            raise ValueError(f'Unknown distribution similarity: "{dist_similarity}".')
-
-        # element-wise covariance bounds
-        self.c_min = c_min
-        self.c_max = c_max
-
-        # Additional covariance embeddings
-        self.entity_covariances = Embedding.init_with_device(
-            num_embeddings=self.num_entities,
-            embedding_dim=embedding_dim,
-            device=self.device,
-            # Ensure positive definite covariances matrices and appropriate size by clamping
-            constrainer=torch.clamp,
-            constrainer_kwargs=dict(min=self.c_min, max=self.c_max),
-        )
-        self.relation_covariances = Embedding.init_with_device(
-            num_embeddings=self.num_relations,
-            embedding_dim=embedding_dim,
-            device=self.device,
-            # Ensure positive definite covariances matrices and appropriate size by clamping
-            constrainer=torch.clamp,
-            constrainer_kwargs=dict(min=self.c_min, max=self.c_max),
-        )
-
-    def _reset_parameters_(self):  # noqa: D102
-        # Constraints are applied through post_parameter_update
-        super()._reset_parameters_()
-        for emb in [
-            self.entity_covariances,
-            self.relation_covariances,
-        ]:
-            emb.reset_parameters()
-
-    def post_parameter_update(self) -> None:  # noqa: D102
-        super().post_parameter_update()
-        for cov in (
-            self.entity_covariances,
-            self.relation_covariances,
-        ):
-            cov.post_parameter_update()
-
-    def _score(
-        self,
-        h_indices: Optional[torch.LongTensor] = None,
-        r_indices: Optional[torch.LongTensor] = None,
-        t_indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
-        """
-        Compute scores for NTN.
-
-        :param h_indices: shape: (batch_size,)
-        :param r_indices: shape: (batch_size,)
-        :param t_indices: shape: (batch_size,)
-
-        :return: shape: (batch_size, num_entities)
-        """
-        # Get embeddings
-        mu_h = self.entity_embeddings.get_in_canonical_shape(indices=h_indices)
-        mu_r = self.relation_embeddings.get_in_canonical_shape(indices=r_indices)
-        mu_t = self.entity_embeddings.get_in_canonical_shape(indices=t_indices)
-
-        sigma_h = self.entity_covariances.get_in_canonical_shape(indices=h_indices)
-        sigma_r = self.relation_covariances.get_in_canonical_shape(indices=r_indices)
-        sigma_t = self.entity_covariances.get_in_canonical_shape(indices=t_indices)
-
-        # Compute entity distribution
-        mu_e = mu_h - mu_t
-        sigma_e = sigma_h + sigma_t
-        return self.similarity(mu_e=mu_e, mu_r=mu_r, sigma_e=sigma_e, sigma_r=sigma_r)
-
-    def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=hrt_batch[:, 0], r_indices=hrt_batch[:, 1], t_indices=hrt_batch[:, 2]).view(-1, 1)
-
-    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=hr_batch[:, 0], r_indices=hr_batch[:, 1])
-
-    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
-        return self._score(r_indices=rt_batch[:, 0], t_indices=rt_batch[:, 1])
-
-    @staticmethod
-    def expected_likelihood(
-        mu_e: torch.FloatTensor,
-        mu_r: torch.FloatTensor,
-        sigma_e: torch.FloatTensor,
-        sigma_r: torch.FloatTensor,
-    ) -> torch.FloatTensor:
-        r"""Compute the similarity based on expected likelihood.
-
-        .. math::
-
-            D((\mu_e, \Sigma_e), (\mu_r, \Sigma_r)))
-            = \frac{1}{2} \left(
-                (\mu_e - \mu_r)^T(\Sigma_e + \Sigma_r)^{-1}(\mu_e - \mu_r)
-                + \log \det (\Sigma_e + \Sigma_r) + d \log (2 \pi)
-            \right)
-            = \frac{1}{2} \left(
-                \mu^T\Sigma^{-1}\mu
-                + \log \det \Sigma + d \log (2 \pi)
-            \right)
-
-        :param mu_e: torch.Tensor, shape: (s_1, ..., s_k, d)
-            The mean of the first Gaussian.
-        :param mu_r: torch.Tensor, shape: (s_1, ..., s_k, d)
-            The mean of the second Gaussian.
-        :param sigma_e: torch.Tensor, shape: (s_1, ..., s_k, d)
-            The diagonal covariance matrix of the first Gaussian.
-        :param sigma_r: torch.Tensor, shape: (s_1, ..., s_k, d)
-            The diagonal covariance matrix of the second Gaussian.
-
-        :return: torch.Tensor, shape: (s_1, ..., s_k)
-            The similarity.
-        """
-        d = sigma_e.shape[-1]
-        sigma = sigma_r + sigma_e
-        mu = mu_e - mu_r
-
-        #: a = \mu^T\Sigma^{-1}\mu
-        safe_sigma = at_least_eps(sigma)
-        sigma_inv = torch.reciprocal(safe_sigma)
-        a = torch.sum(sigma_inv * mu ** 2, dim=-1)
-
-        #: b = \log \det \Sigma
-        b = safe_sigma.log().sum(dim=-1)
-        return a + b + d * _LOG_2_PI
-
-    @staticmethod
-    def kullback_leibler_similarity(
-        mu_e: torch.FloatTensor,
-        mu_r: torch.FloatTensor,
-        sigma_e: torch.FloatTensor,
-        sigma_r: torch.FloatTensor,
-    ) -> torch.FloatTensor:
-        r"""Compute the similarity based on KL divergence.
-
-        This is done between two Gaussian distributions given by mean mu_* and diagonal covariance matrix sigma_*.
-
-        .. math::
-
-            D((\mu_e, \Sigma_e), (\mu_r, \Sigma_r)))
-            = \frac{1}{2} \left(
-                tr(\Sigma_r^{-1}\Sigma_e)
-                + (\mu_r - \mu_e)^T\Sigma_r^{-1}(\mu_r - \mu_e)
-                - \log \frac{det(\Sigma_e)}{det(\Sigma_r)} - k_e
-            \right)
-
-        Note: The sign of the function has been flipped as opposed to the description in the paper, as the
-              Kullback Leibler divergence is large if the distributions are dissimilar.
-
-        :param mu_e: torch.Tensor, shape: (s_1, ..., s_k, d)
-            The mean of the first Gaussian.
-        :param mu_r: torch.Tensor, shape: (s_1, ..., s_k, d)
-            The mean of the second Gaussian.
-        :param sigma_e: torch.Tensor, shape: (s_1, ..., s_k, d)
-            The diagonal covariance matrix of the first Gaussian.
-        :param sigma_r: torch.Tensor, shape: (s_1, ..., s_k, d)
-            The diagonal covariance matrix of the second Gaussian.
-
-        :return: torch.Tensor, shape: (s_1, ..., s_k)
-            The similarity.
-        """
-        d = mu_e.shape[-1]
-        safe_sigma_r = at_least_eps(sigma_r)
-        sigma_r_inv = torch.reciprocal(safe_sigma_r)
-
-        #: a = tr(\Sigma_r^{-1}\Sigma_e)
-        a = torch.sum(sigma_e * sigma_r_inv, dim=-1)
-
-        #: b = (\mu_r - \mu_e)^T\Sigma_r^{-1}(\mu_r - \mu_e)
-        mu = mu_r - mu_e
-        b = torch.sum(sigma_r_inv * mu ** 2, dim=-1)
-
-        #: c = \log \frac{det(\Sigma_e)}{det(\Sigma_r)}
-        # = sum log (sigma_e)_i - sum log (sigma_r)_i
-        c = at_least_eps(sigma_e).log().sum(dim=-1) - safe_sigma_r.log().sum(dim=-1)
-        return -0.5 * (a + b - c - d)

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -2,18 +2,16 @@
 
 """Implementation of KG2E."""
 
-import math
 from typing import Any, ClassVar, Mapping, Optional
 
 import torch
 import torch.autograd
 from torch.nn.init import uniform_
 
-from pykeen.nn.modules import KG2EInteraction
-
 from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...nn.emb import EmbeddingSpecification
+from ...nn.modules import KG2EInteraction
 from ...typing import Constrainer, Hint, Initializer
 from ...utils import clamp_norm
 

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -130,7 +130,7 @@ class KG2E(ERModel):
                     embedding_dim=embedding_dim,
                     # Ensure positive definite covariances matrices and appropriate size by clamping
                     constrainer=torch.clamp,
-                    constrainer_kwargs=dict(min=self.c_min, max=self.c_max),
+                    constrainer_kwargs=dict(min=c_min, max=c_max),
                 ),
             ],
             **kwargs,

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -89,10 +89,7 @@ class KG2E(ERModel):
         :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.uniform_`
         :param relation_constrainer: Relation constrainer function. Defaults to :func:`pykeen.utils.clamp_norm`
         :param relation_constrainer_kwargs: Keyword arguments to be used when calling the relation constrainer
-        :param kwargs:
-            Remaining keyword arguments to forward to :class:`pykeen.models.EntityRelationEmbeddingModel`
-
-        :raises ValueError: if an illegal ``dist_similarity`` is given
+        :param kwargs: Remaining keyword arguments to forward to :class:`pykeen.models.ERModel`
         """
         super().__init__(
             interaction=KG2EInteraction,

--- a/src/pykeen/models/unimodal/simple.py
+++ b/src/pykeen/models/unimodal/simple.py
@@ -4,6 +4,8 @@
 
 from typing import Any, ClassVar, Mapping, Optional, Tuple, Type, Union
 
+from class_resolver import OptionalKwargs
+
 from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
@@ -74,6 +76,8 @@ class SimplE(ERModel):
         clamp_score: Optional[Union[float, Tuple[float, float]]] = None,
         entity_initializer: Hint[Initializer] = None,
         relation_initializer: Hint[Initializer] = None,
+        regularizer: Hint[Regularizer] = None,
+        regularizer_kwargs: OptionalKwargs = None,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -84,12 +88,15 @@ class SimplE(ERModel):
                 EmbeddingSpecification(
                     embedding_dim=embedding_dim,
                     initializer=entity_initializer,
-                    # TODO: regularizer?
+                    regularizer=regularizer,
+                    regularizer_kwargs=regularizer_kwargs,
                 ),
                 # tail entity
                 EmbeddingSpecification(
                     embedding_dim=embedding_dim,
                     initializer=entity_initializer,
+                    regularizer=regularizer,
+                    regularizer_kwargs=regularizer_kwargs,
                 ),
             ],
             relation_representations=[
@@ -97,11 +104,15 @@ class SimplE(ERModel):
                 EmbeddingSpecification(
                     embedding_dim=embedding_dim,
                     initializer=relation_initializer,
+                    regularizer=regularizer,
+                    regularizer_kwargs=regularizer_kwargs,
                 ),
                 # inverse relations
                 EmbeddingSpecification(
                     embedding_dim=embedding_dim,
                     initializer=relation_initializer,
+                    regularizer=regularizer,
+                    regularizer_kwargs=regularizer_kwargs,
                 ),
             ],
             **kwargs,

--- a/src/pykeen/models/unimodal/simple.py
+++ b/src/pykeen/models/unimodal/simple.py
@@ -11,7 +11,7 @@ from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
 from ...nn.emb import EmbeddingSpecification
 from ...nn.modules import SimplEInteraction
-from ...regularizers import PowerSumRegularizer, Regularizer
+from ...regularizers import PowerSumRegularizer, Regularizer, regularizer_resolver
 from ...typing import Hint, Initializer
 
 __all__ = [
@@ -80,6 +80,7 @@ class SimplE(ERModel):
         regularizer_kwargs: OptionalKwargs = None,
         **kwargs,
     ) -> None:
+        regularizer = regularizer_resolver.make_safe(regularizer, pos_kwargs=regularizer_kwargs)
         super().__init__(
             interaction=SimplEInteraction,
             interaction_kwargs=dict(clamp_score=clamp_score),
@@ -89,14 +90,12 @@ class SimplE(ERModel):
                     embedding_dim=embedding_dim,
                     initializer=entity_initializer,
                     regularizer=regularizer,
-                    regularizer_kwargs=regularizer_kwargs,
                 ),
                 # tail entity
                 EmbeddingSpecification(
                     embedding_dim=embedding_dim,
                     initializer=entity_initializer,
                     regularizer=regularizer,
-                    regularizer_kwargs=regularizer_kwargs,
                 ),
             ],
             relation_representations=[
@@ -105,14 +104,12 @@ class SimplE(ERModel):
                     embedding_dim=embedding_dim,
                     initializer=relation_initializer,
                     regularizer=regularizer,
-                    regularizer_kwargs=regularizer_kwargs,
                 ),
                 # inverse relations
                 EmbeddingSpecification(
                     embedding_dim=embedding_dim,
                     initializer=relation_initializer,
                     regularizer=regularizer,
-                    regularizer_kwargs=regularizer_kwargs,
                 ),
             ],
             **kwargs,

--- a/src/pykeen/models/unimodal/simple.py
+++ b/src/pykeen/models/unimodal/simple.py
@@ -4,12 +4,11 @@
 
 from typing import Any, ClassVar, Mapping, Optional, Tuple, Type, Union
 
-import torch.autograd
-
-from ..base import EntityRelationEmbeddingModel
+from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import Loss, SoftplusLoss
-from ...nn.emb import Embedding, EmbeddingSpecification
+from ...nn.emb import EmbeddingSpecification
+from ...nn.modules import SimplEInteraction
 from ...regularizers import PowerSumRegularizer, Regularizer
 from ...typing import Hint, Initializer
 
@@ -18,7 +17,7 @@ __all__ = [
 ]
 
 
-class SimplE(EntityRelationEmbeddingModel):
+class SimplE(ERModel):
     r"""An implementation of SimplE [kazemi2018]_.
 
     SimplE is an extension of canonical polyadic (CP), an early tensor factorization approach in which each entity
@@ -78,78 +77,32 @@ class SimplE(EntityRelationEmbeddingModel):
         **kwargs,
     ) -> None:
         super().__init__(
-            entity_representations=EmbeddingSpecification(
-                embedding_dim=embedding_dim,
-                initializer=entity_initializer,
-            ),
-            relation_representations=EmbeddingSpecification(
-                embedding_dim=embedding_dim,
-                initializer=relation_initializer,
-            ),
+            interaction=SimplEInteraction,
+            interaction_kwargs=dict(clamp_score=clamp_score),
+            entity_representations=[
+                # (head) entity
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    initializer=entity_initializer,
+                    # TODO: regularizer?
+                ),
+                # tail entity
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    initializer=entity_initializer,
+                ),
+            ],
+            relation_representations=[
+                # relations
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    initializer=relation_initializer,
+                ),
+                # inverse relations
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    initializer=relation_initializer,
+                ),
+            ],
             **kwargs,
         )
-
-        # extra embeddings
-        self.tail_entity_embeddings = Embedding.init_with_device(
-            num_embeddings=self.num_entities,
-            embedding_dim=embedding_dim,
-            device=self.device,
-        )
-        self.inverse_relation_embeddings = Embedding.init_with_device(
-            num_embeddings=self.num_relations,
-            embedding_dim=embedding_dim,
-            device=self.device,
-        )
-
-        if isinstance(clamp_score, float):
-            clamp_score = (-clamp_score, clamp_score)
-        self.clamp = clamp_score
-
-    def _reset_parameters_(self):  # noqa: D102
-        super()._reset_parameters_()
-        for emb in [
-            self.tail_entity_embeddings,
-            self.inverse_relation_embeddings,
-        ]:
-            emb.reset_parameters()
-
-    def _score(
-        self,
-        h_indices: Optional[torch.LongTensor],
-        r_indices: Optional[torch.LongTensor],
-        t_indices: Optional[torch.LongTensor],
-    ) -> torch.FloatTensor:  # noqa: D102
-        # forward model
-        h = self.entity_embeddings.get_in_canonical_shape(indices=h_indices)
-        r = self.relation_embeddings.get_in_canonical_shape(indices=r_indices)
-        t = self.tail_entity_embeddings.get_in_canonical_shape(indices=t_indices)
-        scores = (h * r * t).sum(dim=-1)
-
-        # Regularization
-        self.regularize_if_necessary(h, r, t)
-
-        # backward model
-        h = self.entity_embeddings.get_in_canonical_shape(indices=t_indices)
-        r = self.inverse_relation_embeddings.get_in_canonical_shape(indices=r_indices)
-        t = self.tail_entity_embeddings.get_in_canonical_shape(indices=h_indices)
-        scores = 0.5 * (scores + (h * r * t).sum(dim=-1))
-
-        # Regularization
-        self.regularize_if_necessary(h, r, t)
-
-        # Note: In the code in their repository, the score is clamped to [-20, 20].
-        #       That is not mentioned in the paper, so it is omitted here.
-        if self.clamp is not None:
-            min_, max_ = self.clamp
-            scores = scores.clamp(min=min_, max=max_)
-
-        return scores
-
-    def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=hrt_batch[:, 0], r_indices=hrt_batch[:, 1], t_indices=hrt_batch[:, 2]).view(-1, 1)
-
-    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=hr_batch[:, 0], r_indices=hr_batch[:, 1], t_indices=None)
-
-    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=None, r_indices=rt_batch[:, 0], t_indices=rt_batch[:, 1])

--- a/src/pykeen/models/unimodal/trans_d.py
+++ b/src/pykeen/models/unimodal/trans_d.py
@@ -2,16 +2,15 @@
 
 """Implementation of TransD."""
 
-from typing import Any, ClassVar, Mapping, Optional
+from typing import Any, ClassVar, Mapping
 
-import torch
-import torch.autograd
-from torch import linalg
+from class_resolver import OptionalKwargs
 
-from ..base import EntityRelationEmbeddingModel
+from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...nn.emb import Embedding, EmbeddingSpecification
+from ...nn.emb import EmbeddingSpecification
 from ...nn.init import xavier_normal_, xavier_uniform_, xavier_uniform_norm_
+from ...nn.modules import TransDInteraction
 from ...typing import Constrainer, Hint, Initializer
 from ...utils import clamp_norm
 
@@ -20,54 +19,7 @@ __all__ = [
 ]
 
 
-def _project_entity(
-    e: torch.FloatTensor,
-    e_p: torch.FloatTensor,
-    r: torch.FloatTensor,
-    r_p: torch.FloatTensor,
-) -> torch.FloatTensor:
-    r"""Project entity relation-specific.
-
-    .. math::
-
-        e_{\bot} = M_{re} e
-                 = (r_p e_p^T + I^{d_r \times d_e}) e
-                 = r_p e_p^T e + I^{d_r \times d_e} e
-                 = r_p (e_p^T e) + e'
-
-    and additionally enforces
-
-    .. math::
-
-        \|e_{\bot}\|_2 \leq 1
-
-    :param e: shape: (batch_size, num_entities, d_e)
-        The entity embedding.
-    :param e_p: shape: (batch_size, num_entities, d_e)
-        The entity projection.
-    :param r: shape: (batch_size, num_entities, d_r)
-        The relation embedding.
-    :param r_p: shape: (batch_size, num_entities, d_r)
-        The relation projection.
-
-    :return: shape: (batch_size, num_entities, d_r)
-
-    """
-    # The dimensions affected by e'
-    change_dim = min(e.shape[-1], r.shape[-1])
-
-    # Project entities
-    # r_p (e_p.T e) + e'
-    e_bot = r_p * torch.sum(e_p * e, dim=-1, keepdim=True)
-    e_bot[:, :, :change_dim] += e[:, :, :change_dim]
-
-    # Enforce constraints
-    e_bot = clamp_norm(e_bot, p=2, dim=-1, maxnorm=1)
-
-    return e_bot
-
-
-class TransD(EntityRelationEmbeddingModel):
+class TransD(ERModel):
     r"""An implementation of TransD from [ji2015]_.
 
     TransD is an extension of :class:`pykeen.models.TransR` that, like TransR, considers entities and relations
@@ -110,16 +62,12 @@ class TransD(EntityRelationEmbeddingModel):
         relation_dim=DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE,
     )
 
-    #: Secondary embeddings for entities
-    entity_projections: Embedding
-    #: Secondary embeddings for relations
-    relation_projections: Embedding
-
     def __init__(
         self,
         *,
         embedding_dim: int = 50,
         relation_dim: int = 30,
+        interaction_kwargs: OptionalKwargs = None,
         entity_initializer: Hint[Initializer] = xavier_uniform_,
         relation_initializer: Hint[Initializer] = xavier_uniform_norm_,
         entity_constrainer: Hint[Constrainer] = clamp_norm,  # type: ignore
@@ -127,110 +75,31 @@ class TransD(EntityRelationEmbeddingModel):
         **kwargs,
     ) -> None:
         super().__init__(
-            entity_representations=EmbeddingSpecification(
-                embedding_dim=embedding_dim,
-                initializer=entity_initializer,
-                constrainer=entity_constrainer,
-                constrainer_kwargs=dict(maxnorm=1.0, p=2, dim=-1),
-            ),
-            relation_representations=EmbeddingSpecification(
-                embedding_dim=relation_dim,
-                initializer=relation_initializer,
-                constrainer=relation_constrainer,
-                constrainer_kwargs=dict(maxnorm=1.0, p=2, dim=-1),
-            ),
+            interaction=TransDInteraction,
+            interaction_kwargs=interaction_kwargs,
+            entity_representations=[
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    initializer=entity_initializer,
+                    constrainer=entity_constrainer,
+                    constrainer_kwargs=dict(maxnorm=1.0, p=2, dim=-1),
+                ),
+                EmbeddingSpecification(
+                    embedding_dim=embedding_dim,
+                    initializer=xavier_normal_,
+                ),
+            ],
+            relation_representations=[
+                EmbeddingSpecification(
+                    embedding_dim=relation_dim,
+                    initializer=relation_initializer,
+                    constrainer=relation_constrainer,
+                    constrainer_kwargs=dict(maxnorm=1.0, p=2, dim=-1),
+                ),
+                EmbeddingSpecification(
+                    embedding_dim=relation_dim,
+                    initializer=xavier_normal_,
+                ),
+            ],
             **kwargs,
         )
-
-        self.entity_projections = Embedding.init_with_device(
-            num_embeddings=self.num_entities,
-            embedding_dim=embedding_dim,
-            device=self.device,
-            initializer=xavier_normal_,
-        )
-        self.relation_projections = Embedding.init_with_device(
-            num_embeddings=self.num_relations,
-            embedding_dim=relation_dim,
-            device=self.device,
-            initializer=xavier_normal_,
-        )
-
-    def _reset_parameters_(self):  # noqa: D102
-        super()._reset_parameters_()
-        self.entity_projections.reset_parameters()
-        self.relation_projections.reset_parameters()
-
-    @staticmethod
-    def interaction_function(
-        h: torch.FloatTensor,
-        h_p: torch.FloatTensor,
-        r: torch.FloatTensor,
-        r_p: torch.FloatTensor,
-        t: torch.FloatTensor,
-        t_p: torch.FloatTensor,
-    ) -> torch.FloatTensor:
-        """Evaluate the interaction function for given embeddings.
-
-        The embeddings have to be in a broadcastable shape.
-
-        :param h: shape: (batch_size, num_entities, d_e)
-            Head embeddings.
-        :param h_p: shape: (batch_size, num_entities, d_e)
-            Head projections.
-        :param r: shape: (batch_size, num_entities, d_r)
-            Relation embeddings.
-        :param r_p: shape: (batch_size, num_entities, d_r)
-            Relation projections.
-        :param t: shape: (batch_size, num_entities, d_e)
-            Tail embeddings.
-        :param t_p: shape: (batch_size, num_entities, d_e)
-            Tail projections.
-
-        :return: shape: (batch_size, num_entities)
-            The scores.
-        """
-        # Project entities
-        h_bot = _project_entity(e=h, e_p=h_p, r=r, r_p=r_p)
-        t_bot = _project_entity(e=t, e_p=t_p, r=r, r_p=r_p)
-
-        # score = -||h_bot + r - t_bot||_2^2
-        return -linalg.vector_norm(h_bot + r - t_bot, dim=-1, ord=2) ** 2
-
-    def _score(
-        self,
-        h_indices: Optional[torch.LongTensor] = None,
-        r_indices: Optional[torch.LongTensor] = None,
-        t_indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
-        """
-        Evaluate the interaction function.
-
-        :param h_indices: shape: (batch_size,)
-            The indices of head entities. If None, score against all.
-        :param r_indices: shape: (batch_size,)
-            The indices of relations. If None, score against all.
-        :param t_indices: shape: (batch_size,)
-            The indices of tail entities. If None, score against all.
-
-        :return: The scores, shape: (batch_size, num_entities)
-        """
-        # Head
-        h = self.entity_embeddings.get_in_canonical_shape(indices=h_indices)
-        h_p = self.entity_projections.get_in_canonical_shape(indices=h_indices)
-
-        r = self.relation_embeddings.get_in_canonical_shape(indices=r_indices)
-        r_p = self.relation_projections.get_in_canonical_shape(indices=r_indices)
-
-        t = self.entity_embeddings.get_in_canonical_shape(indices=t_indices)
-        t_p = self.entity_projections.get_in_canonical_shape(indices=t_indices)
-
-        return self.interaction_function(h=h, h_p=h_p, r=r, r_p=r_p, t=t, t_p=t_p)
-
-    def score_hrt(self, hrt_batch: torch.LongTensor) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=hrt_batch[:, 0], r_indices=hrt_batch[:, 1], t_indices=hrt_batch[:, 2])
-
-    def score_t(self, hr_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=hr_batch[:, 0], r_indices=hr_batch[:, 1], t_indices=None)
-
-    def score_h(self, rt_batch: torch.LongTensor, slice_size: Optional[int] = None) -> torch.FloatTensor:  # noqa: D102
-        return self._score(h_indices=None, r_indices=rt_batch[:, 0], t_indices=rt_batch[:, 1])

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -135,31 +135,6 @@ class RepresentationModule(nn.Module, ABC):
     def post_parameter_update(self):
         """Apply constraints which should not be included in gradients."""
 
-    def get_in_canonical_shape(
-        self,
-        indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
-        """Get representations in canonical shape.
-
-        :param indices: None, shape: (b,) or (b, n)
-            The indices. If None, return all representations.
-
-        :return: shape: (b?, n?, d)
-            If indices is None, b=1, n=max_id.
-            If indices is 1-dimensional, b=indices.shape[0] and n=1.
-            If indices is 2-dimensional, b, n = indices.shape
-        """
-        x = self.forward_unique(indices=indices)
-        if indices is None:
-            x = x.unsqueeze(dim=0)
-        elif indices.ndimension() > 2:
-            raise ValueError(
-                f"Undefined canonical shape for more than 2-dimensional index tensors: {indices.shape}",
-            )
-        elif indices.ndimension() == 1:
-            x = x.unsqueeze(dim=1)
-        return x
-
     @property
     def embedding_dim(self) -> int:
         """Return the "embedding dimension". Kept for backward compatibility."""

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1369,19 +1369,6 @@ class RepresentationTestCase(GenericTestCase[RepresentationModule]):
         prefix_shape = (self.instance.max_id,) if indices is None else tuple(indices.shape)
         self._check_result(x=representations, prefix_shape=prefix_shape)
 
-    def _test_canonical_shape(self, indices: Optional[torch.LongTensor]):
-        """Test canonical shape."""
-        x = self.instance.get_in_canonical_shape(indices=indices)
-        if indices is None:
-            prefix_shape = (1, self.instance.max_id)
-        elif indices.ndimension() == 1:
-            prefix_shape = (indices.shape[0], 1)
-        elif indices.ndimension() == 2:
-            prefix_shape = tuple(indices.shape)
-        else:
-            raise AssertionError(indices.shape)
-        self._check_result(x=x, prefix_shape=prefix_shape)
-
     def _test_indices(self, indices: Optional[torch.LongTensor]):
         """Test forward and canonical shape for indices."""
         self._test_forward(indices=indices)

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1372,7 +1372,6 @@ class RepresentationTestCase(GenericTestCase[RepresentationModule]):
     def _test_indices(self, indices: Optional[torch.LongTensor]):
         """Test forward and canonical shape for indices."""
         self._test_forward(indices=indices)
-        self._test_canonical_shape(indices=indices)
 
     def test_no_indices(self):
         """Test without indices."""

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -50,7 +50,7 @@ from pykeen.models import RESCAL, EntityRelationEmbeddingModel, Model, TransE
 from pykeen.models.cli import build_cli_from_cls
 from pykeen.models.nbase import ERModel
 from pykeen.nn.emb import RepresentationModule
-from pykeen.nn.modules import FunctionalInteraction, Interaction, LiteralInteraction
+from pykeen.nn.modules import FunctionalInteraction, Interaction, KG2EInteraction, LiteralInteraction
 from pykeen.optimizers import optimizer_resolver
 from pykeen.pipeline import pipeline
 from pykeen.regularizers import LpRegularizer, Regularizer
@@ -1313,6 +1313,14 @@ class BaseKG2ETest(ModelTestCase):
     """General tests for the KG2E model."""
 
     cls = pykeen.models.KG2E
+    c_min: float = 0.01
+    c_max: float =1.0
+
+    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
+        kwargs["c_min"] = self.c_min
+        kwargs["c_max"] = self.c_max
+        return kwargs
 
     def _check_constraints(self):
         """Check model constraints.
@@ -1320,10 +1328,12 @@ class BaseKG2ETest(ModelTestCase):
         * Entity and relation embeddings have to have at most unit L2 norm.
         * Covariances have to have values between c_min and c_max
         """
-        for embedding in (self.instance.entity_embeddings, self.instance.relation_embeddings):
+        self.instance: ERModel
+        (e_mean, e_cov), (r_mean, r_cov) = self.instance.entity_representations, self.instance.relation_representations
+        for embedding in (e_mean, r_mean):
             assert all_in_bounds(embedding(indices=None).norm(p=2, dim=-1), high=1.0, a_tol=EPSILON)
-        for cov in (self.instance.entity_covariances, self.instance.relation_covariances):
-            assert all_in_bounds(cov(indices=None), low=self.instance.c_min, high=self.instance.c_max)
+        for cov in (e_cov, r_cov):
+            assert all_in_bounds(cov(indices=None), low=self.instance_kwargs["c_min"], high=self.instance_kwargs["c_max"])
 
 
 class BaseRGCNTest(ModelTestCase):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -50,7 +50,7 @@ from pykeen.models import RESCAL, EntityRelationEmbeddingModel, Model, TransE
 from pykeen.models.cli import build_cli_from_cls
 from pykeen.models.nbase import ERModel
 from pykeen.nn.emb import RepresentationModule
-from pykeen.nn.modules import FunctionalInteraction, Interaction, KG2EInteraction, LiteralInteraction
+from pykeen.nn.modules import FunctionalInteraction, Interaction, LiteralInteraction
 from pykeen.optimizers import optimizer_resolver
 from pykeen.pipeline import pipeline
 from pykeen.regularizers import LpRegularizer, Regularizer

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1314,7 +1314,7 @@ class BaseKG2ETest(ModelTestCase):
 
     cls = pykeen.models.KG2E
     c_min: float = 0.01
-    c_max: float =1.0
+    c_max: float = 1.0
 
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
@@ -1333,7 +1333,9 @@ class BaseKG2ETest(ModelTestCase):
         for embedding in (e_mean, r_mean):
             assert all_in_bounds(embedding(indices=None).norm(p=2, dim=-1), high=1.0, a_tol=EPSILON)
         for cov in (e_cov, r_cov):
-            assert all_in_bounds(cov(indices=None), low=self.instance_kwargs["c_min"], high=self.instance_kwargs["c_max"])
+            assert all_in_bounds(
+                cov(indices=None), low=self.instance_kwargs["c_min"], high=self.instance_kwargs["c_max"]
+            )
 
 
 class BaseRGCNTest(ModelTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -387,7 +387,8 @@ class TestTransD(cases.DistanceModelTestCase):
 
         Entity and relation embeddings have to have at most unit L2 norm.
         """
-        for emb in (self.instance.entity_embeddings, self.instance.relation_embeddings):
+        self.instance: ERModel
+        for emb in (self.instance.entity_representations[0], self.instance.relation_representations[0]):
             assert all_in_bounds(emb(indices=None).norm(p=2, dim=-1), high=1.0, a_tol=EPSILON)
 
     def test_score_hrt_manual(self):
@@ -399,7 +400,6 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         entity_embeddings._embeddings.weight.data.copy_(weights)
-        self.instance.entity_embeddings = entity_embeddings
 
         projection_weights = torch.as_tensor(data=[[3.0, 3.0], [2.0, 2.0]], dtype=torch.float)
         entity_projection_embeddings = Embedding(
@@ -407,7 +407,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         entity_projection_embeddings._embeddings.weight.data.copy_(projection_weights)
-        self.instance.entity_projections = entity_projection_embeddings
+        self.instance.entity_representations = torch.nn.ModuleList([entity_embeddings, entity_projection_embeddings])
 
         # relation embeddings
         relation_weights = torch.as_tensor(data=[[4.0], [4.0]], dtype=torch.float)
@@ -416,7 +416,6 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=1,
         )
         relation_embeddings._embeddings.weight.data.copy_(relation_weights)
-        self.instance.relation_embeddings = relation_embeddings
 
         relation_projection_weights = torch.as_tensor(data=[[5.0], [3.0]], dtype=torch.float)
         relation_projection_embeddings = Embedding(
@@ -424,7 +423,9 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=1,
         )
         relation_projection_embeddings._embeddings.weight.data.copy_(relation_projection_weights)
-        self.instance.relation_projections = relation_projection_embeddings
+        self.instance.relation_representations = torch.nn.ModuleList(
+            [relation_embeddings, relation_projection_embeddings]
+        )
 
         # Compute Scores
         batch = torch.as_tensor(data=[[0, 0, 0], [0, 0, 1]], dtype=torch.long)
@@ -442,7 +443,6 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=3,
         )
         relation_embeddings._embeddings.weight.data.copy_(relation_weights)
-        self.instance.relation_embeddings = relation_embeddings
 
         relation_projection_weights = torch.as_tensor(data=[[4.0, 4.0, 4.0], [4.0, 4.0, 4.0]], dtype=torch.float)
         relation_projection_embeddings = Embedding(
@@ -450,7 +450,9 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=3,
         )
         relation_projection_embeddings._embeddings.weight.data.copy_(relation_projection_weights)
-        self.instance.relation_projections = relation_projection_embeddings
+        self.instance.relation_representations = torch.nn.ModuleList(
+            [relation_embeddings, relation_projection_embeddings]
+        )
 
         # Compute Scores
         batch = torch.as_tensor(data=[[0, 0, 0]], dtype=torch.long)
@@ -474,7 +476,6 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=3,
         )
         entity_embeddings._embeddings.weight.data.copy_(weights)
-        self.instance.entity_embeddings = entity_embeddings
 
         projection_weights = torch.as_tensor(data=[[2.0, 2.0, 2.0], [2.0, 2.0, 2.0]], dtype=torch.float)
         entity_projection_embeddings = Embedding(
@@ -482,7 +483,7 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=3,
         )
         entity_projection_embeddings._embeddings.weight.data.copy_(projection_weights)
-        self.instance.entity_projections = entity_projection_embeddings
+        self.instance.entity_representations = torch.nn.ModuleList([entity_embeddings, entity_projection_embeddings])
 
         # relation embeddings
         relation_weights = torch.as_tensor(data=[[3.0, 3.0], [3.0, 3.0]], dtype=torch.float)
@@ -491,7 +492,6 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         relation_embeddings._embeddings.weight.data.copy_(relation_weights)
-        self.instance.relation_embeddings = relation_embeddings
 
         relation_projection_weights = torch.as_tensor(data=[[4.0, 4.0], [4.0, 4.0]], dtype=torch.float)
         relation_projection_embeddings = Embedding(
@@ -499,7 +499,9 @@ class TestTransD(cases.DistanceModelTestCase):
             embedding_dim=2,
         )
         relation_projection_embeddings._embeddings.weight.data.copy_(relation_projection_weights)
-        self.instance.relation_projections = relation_projection_embeddings
+        self.instance.relation_representations = torch.nn.ModuleList(
+            [relation_embeddings, relation_projection_embeddings]
+        )
 
         # Compute Scores
         batch = torch.as_tensor(data=[[0, 0, 0], [0, 0, 0]], dtype=torch.long)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,6 @@ from pykeen.models import (
 from pykeen.models.multimodal.base import LiteralModel
 from pykeen.models.predict import get_all_prediction_df, get_novelty_mask, predict
 from pykeen.models.unimodal.node_piece import _ConcatMLP
-from pykeen.models.unimodal.trans_d import _project_entity
 from pykeen.nn import EmbeddingSpecification
 from pykeen.nn.emb import Embedding, NodePieceRepresentation
 from pykeen.utils import all_in_bounds, clamp_norm, extend_batch
@@ -511,27 +510,6 @@ class TestTransD(cases.DistanceModelTestCase):
         second_score = scores[1].item()
         self.assertAlmostEqual(first_score, -18, delta=0.01)
         self.assertAlmostEqual(second_score, -18, delta=0.01)
-
-    def test_project_entity(self):
-        """Test _project_entity."""
-        # random entity embeddings & projections
-        e = torch.rand(1, self.instance.num_entities, self.embedding_dim, generator=self.generator)
-        e = clamp_norm(e, maxnorm=1, p=2, dim=-1)
-        e_p = torch.rand(1, self.instance.num_entities, self.embedding_dim, generator=self.generator)
-
-        # random relation embeddings & projections
-        r = torch.rand(self.batch_size, 1, self.instance.relation_dim, generator=self.generator)
-        r = clamp_norm(r, maxnorm=1, p=2, dim=-1)
-        r_p = torch.rand(self.batch_size, 1, self.instance.relation_dim, generator=self.generator)
-
-        # project
-        e_bot = _project_entity(e=e, e_p=e_p, r=r, r_p=r_p)
-
-        # check shape:
-        assert e_bot.shape == (self.batch_size, self.instance.num_entities, self.instance.relation_dim)
-
-        # check normalization
-        assert (torch.norm(e_bot, dim=-1, p=2) <= 1.0 + 1.0e-06).all()
 
 
 class TestTransE(cases.DistanceModelTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,7 +30,7 @@ from pykeen.models.predict import get_all_prediction_df, get_novelty_mask, predi
 from pykeen.models.unimodal.node_piece import _ConcatMLP
 from pykeen.nn import EmbeddingSpecification
 from pykeen.nn.emb import Embedding, NodePieceRepresentation
-from pykeen.utils import all_in_bounds, clamp_norm, extend_batch
+from pykeen.utils import all_in_bounds, extend_batch
 from tests import cases
 from tests.constants import EPSILON
 from tests.test_model_mode import SimpleInteractionModel


### PR DESCRIPTION
Fix #739

* [x] remove `pykeen.nn.emb.RepresentationModule.get_in_canonical_shape`

#### KG2E
* [x] upgrade [KG2E](https://github.com/pykeen/pykeen/blob/c10fc2a6ab889e7f0cdd728724539362bcee7b78/src/pykeen/models/unimodal/kg2e.py)
* [x] check for performance regression (using fb15k configuration, `pykeen experiments reproduce kg2e he2015 fb15k`)
  * c10fc2a / `master`: ~3.5s/epoch; ~18s/eval (bs: 512)
  *  1f86ca1 : ~3.5s/epoch; ~17s/eval (bs: 512)

#### SimplE
* [x] upgrade [SimplE](https://github.com/pykeen/pykeen/blob/c10fc2a6ab889e7f0cdd728724539362bcee7b78/src/pykeen/models/unimodal/simple.py)
* [x] check for performance regression (using fb15k configuration, `pykeen experiments reproduce simple kazemi2018 fb15k`)
  * c10fc2a / `master`: 4s/epoch, ~24.5s/eval (bs: 256)
  * 3582752  :  3.2s/epoch, ~20s/eval (bs: 256)

#### TransD
* [x] upgrade [TransD](https://github.com/pykeen/pykeen/blob/c10fc2a6ab889e7f0cdd728724539362bcee7b78/src/pykeen/models/unimodal/trans_d.py)
* [x] check for performance regression (using fb15k configuration, `pykeen experiments reproduce transd ji2015 fb15k`)
  * c10fc2a / `master`: ~27.3s/epoch; ~18.66s/eval (bs: 512)
  * e3cefb4  : 25.8s/epoch; ~22s/eval (bs: 512)