### PR TITLE
⏩🛌 fix dtype forwarding in Embedding

### DIFF
--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -312,7 +312,7 @@ class Embedding(RepresentationModule):
             _embedding_dim = _embedding_dim * 2
             # note: this seems to work, as finfo returns the datatype of the underlying floating
             # point dtype, rather than the combined complex one
-            dtype = torch.finfo(dtype).dtype
+            dtype = getattr(torch, torch.finfo(dtype).dtype)
 
         super().__init__(
             max_id=num_embeddings,

--- a/src/pykeen/nn/emb.py
+++ b/src/pykeen/nn/emb.py
@@ -310,6 +310,9 @@ class Embedding(RepresentationModule):
         if dtype.is_complex:
             shape = tuple(shape[:-1]) + (2 * shape[-1],)
             _embedding_dim = _embedding_dim * 2
+            # note: this seems to work, as finfo returns the datatype of the underlying floating
+            # point dtype, rather than the combined complex one
+            dtype = torch.finfo(dtype).dtype
 
         super().__init__(
             max_id=num_embeddings,
@@ -326,6 +329,7 @@ class Embedding(RepresentationModule):
         self._embeddings = torch.nn.Embedding(
             num_embeddings=num_embeddings,
             embedding_dim=_embedding_dim,
+            dtype=dtype,
         )
         self._embeddings.requires_grad_(trainable)
         self.dropout = None if dropout is None else nn.Dropout(dropout)


### PR DESCRIPTION
This small PR fixes the `dtype` usage in `pykeen.nn.emb.Embedding`