### PR TITLE
🌋 🗺️ Switch evaluator from dataclass to dict

### DIFF
--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -414,16 +414,16 @@ METRIC_NAMES = {
 
 
 def _get_metrics_lines(tablefmt: str):
-    for field, name, value in get_metric_list():
-        if field.name in {"rank_std", "rank_var", "rank_mad", "rank_count"}:
+    for key, metadata, name, value in get_metric_list():
+        if key in {"rank_std", "rank_var", "rank_mad", "rank_count"}:
             continue
-        label = field.metadata["name"]
-        link = field.metadata["link"]
+        label = metadata["name"]
+        link = metadata["link"]
         yv = [
             f"[{label}]({link})",
-            field.metadata["range"],
-            "📈" if field.metadata["increasing"] else "📉",
-            field.metadata["doc"],
+            metadata["range"],
+            "📈" if metadata["increasing"] else "📉",
+            metadata["doc"],
             METRIC_NAMES[name],
         ]
         if tablefmt != "github":

--- a/src/pykeen/evaluation/__init__.py
+++ b/src/pykeen/evaluation/__init__.py
@@ -2,9 +2,6 @@
 
 """Evaluation."""
 
-import dataclasses
-from typing import Set, Type
-
 from class_resolver import ClassResolver
 
 from .classification_evaluator import ClassificationEvaluator, ClassificationMetricResults
@@ -29,16 +26,7 @@ evaluator_resolver: ClassResolver[Evaluator] = ClassResolver.from_subclasses(
     default=RankBasedEvaluator,
 )
 
-_METRICS_SUFFIX = "MetricResults"
-_METRICS: Set[Type[MetricResults]] = {
-    RankBasedMetricResults,
-    ClassificationMetricResults,
-}
-metric_resolver = ClassResolver(
-    _METRICS,
-    suffix=_METRICS_SUFFIX,
-    base=MetricResults,
-)
+metric_resolver: ClassResolver[MetricResults] = ClassResolver.from_subclasses(MetricResults)
 
 
 def get_metric_list():

--- a/src/pykeen/evaluation/__init__.py
+++ b/src/pykeen/evaluation/__init__.py
@@ -44,7 +44,7 @@ metric_resolver = ClassResolver(
 def get_metric_list():
     """Get info about all metrics across all evaluators."""
     return [
-        (field, name, value)
-        for name, value in metric_resolver.lookup_dict.items()
-        for field in dataclasses.fields(value)
+        (key, metadata, resolver_name, resolver_cls)
+        for resolver_name, resolver_cls in metric_resolver.lookup_dict.items()
+        for key, metadata in resolver_cls.metadata.items()
     ]

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -40,7 +40,7 @@ class ClassificationMetricResults(MetricResults):
     def from_scores(cls, y_true, y_score):
         """Return an instance of these metrics from a given set of true and scores."""
         return ClassificationMetricResults(
-            {metadata["name"]: metadata["f"](y_true, y_score) for metadata in CLASSIFICATION_FIELDS.values()}
+            {key: metadata["f"](y_true, y_score) for key, metadata in CLASSIFICATION_FIELDS.items()}
         )
 
     def get_metric(self, name: str) -> float:  # noqa: D102

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -44,7 +44,7 @@ class ClassificationMetricResults(MetricResults):
         )
 
     def get_metric(self, name: str) -> float:  # noqa: D102
-        return self.results[name]
+        return self.data[name]
 
 
 class ClassificationEvaluator(Evaluator):

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -60,9 +60,10 @@ class MetricResults:
         self.data = data
 
     def __getattr__(self, item):  # noqa:D105
-        if item in self.data:
-            return self.data[item]
-        return getattr(self, item)
+        # TODO remove this, it makes code much harder to reason about
+        if item not in self.data:
+            raise AttributeError
+        return self.data[item]
 
     def get_metric(self, name: str) -> float:
         """Get the given metric from the results.
@@ -72,9 +73,13 @@ class MetricResults:
         """
         raise NotImplementedError
 
+    def to_dict(self):
+        """Get the results as a dictionary."""
+        return self.data
+
     def to_flat_dict(self) -> Mapping[str, Any]:
         """Get the results as a flattened dictionary."""
-        return self.data
+        return self.to_dict()
 
 
 class Evaluator(ABC):

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -60,7 +60,9 @@ class MetricResults:
         self.results = results
 
     def __getattr__(self, item):  # noqa:D105
-        return self.results[item]
+        if item in self.results:
+            return self.results[item]
+        return getattr(self, item)
 
     def get_metric(self, name: str) -> float:
         """Get the given metric from the results.

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -7,15 +7,13 @@ import logging
 import timeit
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from dataclasses import dataclass
 from math import ceil
 from textwrap import dedent
-from typing import Any, Collection, Iterable, List, Mapping, Optional, Tuple, Union, cast
+from typing import Any, ClassVar, Collection, Iterable, List, Mapping, Optional, Tuple, Union, cast
 
 import numpy as np
 import pandas
 import torch
-from dataclasses_json import DataClassJsonMixin
 from tqdm.autonotebook import tqdm
 
 from ..constants import TARGET_TO_INDEX
@@ -52,9 +50,17 @@ def optional_context_manager(condition, context_manager):
         yield
 
 
-@dataclass
-class MetricResults(DataClassJsonMixin):
+class MetricResults:
     """Results from computing metrics."""
+
+    metadata: ClassVar[Mapping[str, Any]]
+
+    def __init__(self, results):
+        """Initialize the result wrapper."""
+        self.results = results
+
+    def __getattr__(self, item):  # noqa:D105
+        return self.results[item]
 
     def get_metric(self, name: str) -> float:
         """Get the given metric from the results.
@@ -66,7 +72,7 @@ class MetricResults(DataClassJsonMixin):
 
     def to_flat_dict(self) -> Mapping[str, Any]:
         """Get the results as a flattened dictionary."""
-        return self.to_dict()
+        return self.results()
 
 
 class Evaluator(ABC):

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -55,13 +55,13 @@ class MetricResults:
 
     metadata: ClassVar[Mapping[str, Any]]
 
-    def __init__(self, results):
+    def __init__(self, data):
         """Initialize the result wrapper."""
-        self.results = results
+        self.data = data
 
     def __getattr__(self, item):  # noqa:D105
-        if item in self.results:
-            return self.results[item]
+        if item in self.data:
+            return self.data[item]
         return getattr(self, item)
 
     def get_metric(self, name: str) -> float:
@@ -74,7 +74,7 @@ class MetricResults:
 
     def to_flat_dict(self) -> Mapping[str, Any]:
         """Get the results as a flattened dictionary."""
-        return self.results()
+        return self.data
 
 
 class Evaluator(ABC):

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -7,13 +7,11 @@ import logging
 import math
 import random
 from collections import defaultdict
-from dataclasses import dataclass, field, fields
 from typing import DefaultDict, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
 import torch
-from dataclasses_json import dataclass_json
 
 from .evaluator import Evaluator, MetricResults, prepare_filter_triples
 from .metrics import (
@@ -50,7 +48,6 @@ from ..typing import (
     RankType,
     Target,
 )
-from ..utils import fix_dataclass_init_docs
 
 __all__ = [
     "RankBasedEvaluator",
@@ -59,155 +56,112 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+RANKING_FIELDS = dict(
+    arithmetic_mean_rank=dict(
+        name="Mean Rank (MR)",
+        increasing=False,
+        range="[1, inf)",
+        doc="The arithmetic mean over all ranks.",
+        link="https://pykeen.readthedocs.io/en/stable/tutorial/understanding_evaluation.html#mean-rank",
+    ),
+    geometric_mean_rank=dict(
+        name="Geometric Mean Rank (GMR)",
+        increasing=False,
+        range="[1, inf)",
+        doc="The geometric mean over all ranks.",
+        link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
+    ),
+    median_rank=dict(
+        name="Median Rank",
+        increasing=False,
+        range="[1, inf)",
+        doc="The median over all ranks.",
+        link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
+    ),
+    harmonic_mean_rank=dict(
+        name="Harmonic Mean Rank (HMR)",
+        increasing=False,
+        range="[1, inf)",
+        doc="The harmonic mean over all ranks.",
+        link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
+    ),
+    inverse_arithmetic_mean_rank=dict(
+        name="Inverse Arithmetic Mean Rank (IAMR)",
+        increasing=True,
+        range="(0, 1]",
+        doc="The inverse of the arithmetic mean over all ranks.",
+        link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
+    ),
+    inverse_geometric_mean_rank=dict(
+        name="Inverse Geometric Mean Rank (IGMR)",
+        increasing=True,
+        range="(0, 1]",
+        doc="The inverse of the geometric mean over all ranks.",
+        link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
+    ),
+    inverse_harmonic_mean_rank=dict(
+        name="Mean Reciprocal Rank (MRR)",
+        increasing=True,
+        range="(0, 1]",
+        doc="The inverse of the harmonic mean over all ranks.",
+        link="https://en.wikipedia.org/wiki/Mean_reciprocal_rank",
+    ),
+    inverse_median_rank=dict(
+        name="Inverse Median Rank",
+        increasing=True,
+        range="(0, 1]",
+        doc="The inverse of the median over all ranks.",
+        link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
+    ),
+    rank_count=dict(
+        name="Rank Count",
+        doc="The number of considered ranks, a non-negative number. Low numbers may indicate unreliable results.",
+    ),
+    rank_std=dict(
+        name="Rank Standard Deviation",
+        range="[0, inf)",
+        increasing=False,
+        doc="The standard deviation over all ranks.",
+    ),
+    rank_var=dict(
+        name="Rank Variance",
+        range="[0, inf)",
+        increasing=False,
+        doc="The variance over all ranks.",
+    ),
+    rank_mad=dict(
+        name="Rank Median Absolute Deviation",
+        range="[0, inf)",
+        doc="The median absolute deviation over all ranks.",
+    ),
+    hits_at_k=dict(
+        name="Hits @ K",
+        range="[0, 1]",
+        increasing=True,
+        doc="The relative frequency of ranks not larger than a given k.",
+        link="https://pykeen.readthedocs.io/en/stable/tutorial/understanding_evaluation.html#hits-k",
+    ),
+    adjusted_arithmetic_mean_rank=dict(
+        name="Adjusted Arithmetic Mean Rank (AAMR)",
+        increasing=False,
+        range="(0, 2)",
+        doc="The mean over all chance-adjusted ranks.",
+        link="https://arxiv.org/abs/2002.06914",
+    ),
+    adjusted_arithmetic_mean_rank_index=dict(
+        name="Adjusted Arithmetic Mean Rank Index (AAMRI)",
+        increasing=True,
+        range="[-1, 1]",
+        doc="The re-indexed adjusted mean rank (AAMR)",
+        link="https://arxiv.org/abs/2002.06914",
+    ),
+)
 
-@fix_dataclass_init_docs
-@dataclass_json
-@dataclass
+
 class RankBasedMetricResults(MetricResults):
     """Results from computing metrics."""
 
-    arithmetic_mean_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Mean Rank (MR)",
-            increasing=False,
-            range="[1, inf)",
-            doc="The arithmetic mean over all ranks.",
-            link="https://pykeen.readthedocs.io/en/stable/tutorial/understanding_evaluation.html#mean-rank",
-        )
-    )
-
-    geometric_mean_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Geometric Mean Rank (GMR)",
-            increasing=False,
-            range="[1, inf)",
-            doc="The geometric mean over all ranks.",
-            link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
-        )
-    )
-
-    median_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Median Rank",
-            increasing=False,
-            range="[1, inf)",
-            doc="The median over all ranks.",
-            link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
-        )
-    )
-
-    harmonic_mean_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Harmonic Mean Rank (HMR)",
-            increasing=False,
-            range="[1, inf)",
-            doc="The harmonic mean over all ranks.",
-            link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
-        )
-    )
-
-    inverse_arithmetic_mean_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Inverse Arithmetic Mean Rank (IAMR)",
-            increasing=True,
-            range="(0, 1]",
-            doc="The inverse of the arithmetic mean over all ranks.",
-            link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
-        )
-    )
-
-    inverse_geometric_mean_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Inverse Geometric Mean Rank (IGMR)",
-            increasing=True,
-            range="(0, 1]",
-            doc="The inverse of the geometric mean over all ranks.",
-            link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
-        )
-    )
-
-    inverse_harmonic_mean_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Mean Reciprocal Rank (MRR)",
-            increasing=True,
-            range="(0, 1]",
-            doc="The inverse of the harmonic mean over all ranks.",
-            link="https://en.wikipedia.org/wiki/Mean_reciprocal_rank",
-        )
-    )
-
-    inverse_median_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Inverse Median Rank",
-            increasing=True,
-            range="(0, 1]",
-            doc="The inverse of the median over all ranks.",
-            link="https://cthoyt.com/2021/04/19/pythagorean-mean-ranks.html",
-        )
-    )
-
-    rank_count: Dict[str, Dict[str, int]] = field(
-        metadata=dict(
-            name="Rank Count",
-            doc="The number of considered ranks, a non-negative number. Low numbers may indicate unreliable results.",
-        )
-    )
-
-    rank_std: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Rank Standard Deviation",
-            range="[0, inf)",
-            increasing=False,
-            doc="The standard deviation over all ranks.",
-        )
-    )
-
-    rank_var: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Rank Variance",
-            range="[0, inf)",
-            increasing=False,
-            doc="The variance over all ranks.",
-        )
-    )
-
-    rank_mad: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Rank Median Absolute Deviation",
-            range="[0, inf)",
-            doc="The median absolute deviation over all ranks.",
-        )
-    )
-
-    hits_at_k: Dict[str, Dict[str, Dict[Union[int, float], float]]] = field(
-        metadata=dict(
-            name="Hits @ K",
-            range="[0, 1]",
-            increasing=True,
-            doc="The relative frequency of ranks not larger than a given k.",
-            link="https://pykeen.readthedocs.io/en/stable/tutorial/understanding_evaluation.html#hits-k",
-        )
-    )
-
-    adjusted_arithmetic_mean_rank: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Adjusted Arithmetic Mean Rank (AAMR)",
-            increasing=False,
-            range="(0, 2)",
-            doc="The mean over all chance-adjusted ranks.",
-            link="https://arxiv.org/abs/2002.06914",
-        )
-    )
-
-    adjusted_arithmetic_mean_rank_index: Dict[str, Dict[str, float]] = field(
-        metadata=dict(
-            name="Adjusted Arithmetic Mean Rank Index (AAMRI)",
-            increasing=True,
-            range="[-1, 1]",
-            doc="The re-indexed adjusted mean rank (AAMR)",
-            link="https://arxiv.org/abs/2002.06914",
-        )
-    )
+    metadata = RANKING_FIELDS
 
     def get_metric(self, name: str) -> float:
         """Get the rank-based metric.
@@ -255,9 +209,9 @@ class RankBasedMetricResults(MetricResults):
 
     def _get_metric(self, metric_key: MetricKey) -> float:
         if not metric_key.name.startswith("hits"):
-            return getattr(self, metric_key.name)[metric_key.side][metric_key.rank_type]
+            return self.results[metric_key.name][metric_key.side][metric_key.rank_type]
         assert metric_key.k is not None
-        return self.hits_at_k[metric_key.side][metric_key.rank_type][metric_key.k]
+        return self.results["hits_at_k"][metric_key.side][metric_key.rank_type][metric_key.k]
 
     def to_flat_dict(self):  # noqa: D102
         return {f"{side}.{rank_type}.{metric_name}": value for side, rank_type, metric_name, value in self._iter_rows()}
@@ -268,14 +222,13 @@ class RankBasedMetricResults(MetricResults):
 
     def _iter_rows(self) -> Iterable[Tuple[ExtendedTarget, RankType, str, Union[float, int]]]:
         for side, rank_type in itt.product(SIDES, RANK_TYPES):
-            for k, v in self.hits_at_k[side][rank_type].items():
+            for k, v in self.results["hits_at_k"][side][rank_type].items():
                 yield side, rank_type, f"hits_at_{k}", v
-            for f in fields(self):
-                if f.name == "hits_at_k":
+            for name, side_data in self.results.items():
+                if name == "hits_at_k":
                     continue
-                side_data = getattr(self, f.name)[side]
                 if rank_type in side_data:
-                    yield side, rank_type, f.name, side_data[rank_type]
+                    yield side, rank_type, name, side_data[rank_type]
 
 
 class RankBasedEvaluator(Evaluator):
@@ -389,21 +342,23 @@ class RankBasedEvaluator(Evaluator):
         self.ranks.clear()
 
         return RankBasedMetricResults(
-            arithmetic_mean_rank=dict(asr[ARITHMETIC_MEAN_RANK]),
-            geometric_mean_rank=dict(asr[GEOMETRIC_MEAN_RANK]),
-            harmonic_mean_rank=dict(asr[HARMONIC_MEAN_RANK]),
-            median_rank=dict(asr[MEDIAN_RANK]),
-            inverse_arithmetic_mean_rank=dict(asr[INVERSE_ARITHMETIC_MEAN_RANK]),
-            inverse_geometric_mean_rank=dict(asr[INVERSE_GEOMETRIC_MEAN_RANK]),
-            inverse_harmonic_mean_rank=dict(asr[INVERSE_HARMONIC_MEAN_RANK]),
-            inverse_median_rank=dict(asr[INVERSE_MEDIAN_RANK]),
-            rank_count=dict(asr[RANK_COUNT]),  # type: ignore
-            rank_std=dict(asr[RANK_STD]),
-            rank_mad=dict(asr[RANK_MAD]),
-            rank_var=dict(asr[RANK_VARIANCE]),
-            adjusted_arithmetic_mean_rank=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK]),
-            adjusted_arithmetic_mean_rank_index=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK_INDEX]),
-            hits_at_k=dict(hits_at_k),
+            dict(
+                arithmetic_mean_rank=dict(asr[ARITHMETIC_MEAN_RANK]),
+                geometric_mean_rank=dict(asr[GEOMETRIC_MEAN_RANK]),
+                harmonic_mean_rank=dict(asr[HARMONIC_MEAN_RANK]),
+                median_rank=dict(asr[MEDIAN_RANK]),
+                inverse_arithmetic_mean_rank=dict(asr[INVERSE_ARITHMETIC_MEAN_RANK]),
+                inverse_geometric_mean_rank=dict(asr[INVERSE_GEOMETRIC_MEAN_RANK]),
+                inverse_harmonic_mean_rank=dict(asr[INVERSE_HARMONIC_MEAN_RANK]),
+                inverse_median_rank=dict(asr[INVERSE_MEDIAN_RANK]),
+                rank_count=dict(asr[RANK_COUNT]),  # type: ignore
+                rank_std=dict(asr[RANK_STD]),
+                rank_mad=dict(asr[RANK_MAD]),
+                rank_var=dict(asr[RANK_VARIANCE]),
+                adjusted_arithmetic_mean_rank=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK]),
+                adjusted_arithmetic_mean_rank_index=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK_INDEX]),
+                hits_at_k=dict(hits_at_k),
+            )
         )
 
 

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -163,6 +163,11 @@ class RankBasedMetricResults(MetricResults):
 
     metadata = RANKING_FIELDS
 
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create an instance from kwargs."""
+        return cls(**kwargs)
+
     def get_metric(self, name: str) -> float:
         """Get the rank-based metric.
 

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -214,9 +214,9 @@ class RankBasedMetricResults(MetricResults):
 
     def _get_metric(self, metric_key: MetricKey) -> float:
         if not metric_key.name.startswith("hits"):
-            return self.results[metric_key.name][metric_key.side][metric_key.rank_type]
+            return self.data[metric_key.name][metric_key.side][metric_key.rank_type]
         assert metric_key.k is not None
-        return self.results["hits_at_k"][metric_key.side][metric_key.rank_type][metric_key.k]
+        return self.data["hits_at_k"][metric_key.side][metric_key.rank_type][metric_key.k]
 
     def to_flat_dict(self):  # noqa: D102
         return {f"{side}.{rank_type}.{metric_name}": value for side, rank_type, metric_name, value in self._iter_rows()}
@@ -227,9 +227,9 @@ class RankBasedMetricResults(MetricResults):
 
     def _iter_rows(self) -> Iterable[Tuple[ExtendedTarget, RankType, str, Union[float, int]]]:
         for side, rank_type in itt.product(SIDES, RANK_TYPES):
-            for k, v in self.results["hits_at_k"][side][rank_type].items():
+            for k, v in self.data["hits_at_k"][side][rank_type].items():
                 yield side, rank_type, f"hits_at_{k}", v
-            for name, side_data in self.results.items():
+            for name, side_data in self.data.items():
                 if name == "hits_at_k":
                     continue
                 if rank_type in side_data:

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -166,7 +166,7 @@ class RankBasedMetricResults(MetricResults):
     @classmethod
     def from_dict(cls, **kwargs):
         """Create an instance from kwargs."""
-        return cls(**kwargs)
+        return cls(kwargs)
 
     def get_metric(self, name: str) -> float:
         """Get the rank-based metric.
@@ -346,24 +346,22 @@ class RankBasedEvaluator(Evaluator):
         # Clear buffers
         self.ranks.clear()
 
-        return RankBasedMetricResults(
-            dict(
-                arithmetic_mean_rank=dict(asr[ARITHMETIC_MEAN_RANK]),
-                geometric_mean_rank=dict(asr[GEOMETRIC_MEAN_RANK]),
-                harmonic_mean_rank=dict(asr[HARMONIC_MEAN_RANK]),
-                median_rank=dict(asr[MEDIAN_RANK]),
-                inverse_arithmetic_mean_rank=dict(asr[INVERSE_ARITHMETIC_MEAN_RANK]),
-                inverse_geometric_mean_rank=dict(asr[INVERSE_GEOMETRIC_MEAN_RANK]),
-                inverse_harmonic_mean_rank=dict(asr[INVERSE_HARMONIC_MEAN_RANK]),
-                inverse_median_rank=dict(asr[INVERSE_MEDIAN_RANK]),
-                rank_count=dict(asr[RANK_COUNT]),  # type: ignore
-                rank_std=dict(asr[RANK_STD]),
-                rank_mad=dict(asr[RANK_MAD]),
-                rank_var=dict(asr[RANK_VARIANCE]),
-                adjusted_arithmetic_mean_rank=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK]),
-                adjusted_arithmetic_mean_rank_index=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK_INDEX]),
-                hits_at_k=dict(hits_at_k),
-            )
+        return RankBasedMetricResults.from_dict(
+            arithmetic_mean_rank=dict(asr[ARITHMETIC_MEAN_RANK]),
+            geometric_mean_rank=dict(asr[GEOMETRIC_MEAN_RANK]),
+            harmonic_mean_rank=dict(asr[HARMONIC_MEAN_RANK]),
+            median_rank=dict(asr[MEDIAN_RANK]),
+            inverse_arithmetic_mean_rank=dict(asr[INVERSE_ARITHMETIC_MEAN_RANK]),
+            inverse_geometric_mean_rank=dict(asr[INVERSE_GEOMETRIC_MEAN_RANK]),
+            inverse_harmonic_mean_rank=dict(asr[INVERSE_HARMONIC_MEAN_RANK]),
+            inverse_median_rank=dict(asr[INVERSE_MEDIAN_RANK]),
+            rank_count=dict(asr[RANK_COUNT]),  # type: ignore
+            rank_std=dict(asr[RANK_STD]),
+            rank_mad=dict(asr[RANK_MAD]),
+            rank_var=dict(asr[RANK_VARIANCE]),
+            adjusted_arithmetic_mean_rank=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK]),
+            adjusted_arithmetic_mean_rank_index=dict(asr[ADJUSTED_ARITHMETIC_MEAN_RANK_INDEX]),
+            hits_at_k=dict(hits_at_k),
         )
 
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -50,7 +50,7 @@ class MockEvaluator(Evaluator):
         hits = next(self.losses_iter)
         dummy_1 = {side: {rank_type: 10.0 for rank_type in RANK_TYPES} for side in SIDES}
         dummy_2 = {side: {rank_type: 1.0 for rank_type in RANK_TYPES} for side in SIDES}
-        return RankBasedMetricResults(
+        return RankBasedMetricResults.from_dict(
             arithmetic_mean_rank=dummy_1,
             geometric_mean_rank=dummy_1,
             harmonic_mean_rank=dummy_1,

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -165,6 +165,7 @@ class ClassificationEvaluatorTest(cases.EvaluatorTestCase):
             with self.subTest(metric=metric):
                 f = metadata["f"]
                 exp_score = f(numpy.array(mask.flat), numpy.array(scores.flat))
+                self.assertIn(metric, result.data)
                 act_score = result.get_metric(metric)
                 if numpy.isnan(exp_score):
                     self.assertTrue(numpy.isnan(act_score))

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -382,24 +382,22 @@ class DummyEvaluator(Evaluator):
             self.counter -= 1
 
     def finalize(self) -> MetricResults:  # noqa: D102
-        return RankBasedMetricResults(
-            dict(
-                arithmetic_mean_rank=self.counter,
-                geometric_mean_rank=None,
-                harmonic_mean_rank=None,
-                median_rank=None,
-                inverse_arithmetic_mean_rank=None,
-                inverse_geometric_mean_rank=None,
-                inverse_harmonic_mean_rank=None,
-                inverse_median_rank=None,
-                rank_std=None,
-                rank_var=None,
-                rank_mad=None,
-                rank_count=None,
-                adjusted_arithmetic_mean_rank=None,
-                adjusted_arithmetic_mean_rank_index=None,
-                hits_at_k=dict(),
-            )
+        return RankBasedMetricResults.from_dict(
+            arithmetic_mean_rank=self.counter,
+            geometric_mean_rank=None,
+            harmonic_mean_rank=None,
+            median_rank=None,
+            inverse_arithmetic_mean_rank=None,
+            inverse_geometric_mean_rank=None,
+            inverse_harmonic_mean_rank=None,
+            inverse_median_rank=None,
+            rank_std=None,
+            rank_var=None,
+            rank_mad=None,
+            rank_count=None,
+            adjusted_arithmetic_mean_rank=None,
+            adjusted_arithmetic_mean_rank_index=None,
+            hits_at_k=dict(),
         )
 
     def __repr__(self):  # noqa: D105


### PR DESCRIPTION
This PR should come before #705 and #744 since it structurally changes the evaluator and metric results without changing any implementations. It simplifies the data model to only use dictionaries and not need hard-coded dataclasses and fields.

Future PRs can do a few things:

1. Better organize how the data is stored in this dictionary
2. Use structured fields to describe metadata for different ranking and classification metrics
3. Clean up some of the `getattr` hacks that are still living here (I didn't want to make the diff any bigger than it had to be)