### PR TITLE
💾💽 Change serialization format

### DIFF
--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -34,9 +34,9 @@ from .instances import Instances, LCWAInstances, SLCWAInstances
 from .splitting import split
 from .utils import TRIPLES_DF_COLUMNS, get_entities, get_relations, load_triples, tensor_to_df, triple_tensor_to_set
 from ..typing import (
-    COLUMN_HEAD,
-    COLUMN_RELATION,
-    COLUMN_TAIL,
+    LABEL_HEAD,
+    LABEL_RELATION,
+    LABEL_TAIL,
     EntityMapping,
     LabeledTriples,
     MappedTriples,
@@ -751,7 +751,7 @@ class CoreTriplesFactory:
         # store numeric triples
         pd.DataFrame(
             data=self.mapped_triples.numpy(),
-            columns=[COLUMN_HEAD, COLUMN_RELATION, COLUMN_TAIL],
+            columns=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL],
         ).to_csv(path.joinpath("numeric_triples.tsv.gz"), sep="\t", index=False)
 
         # store metadata

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -778,6 +778,9 @@ class CoreTriplesFactory:
 class TriplesFactory(CoreTriplesFactory):
     """Create instances given the path to triples."""
 
+    file_name_entity_to_id: ClassVar[str] = "entity_to_id"
+    file_name_relation_to_id: ClassVar[str] = "relation_to_id"
+
     def __init__(
         self,
         mapped_triples: MappedTriples,
@@ -956,10 +959,10 @@ class TriplesFactory(CoreTriplesFactory):
     def to_path_binary(self, path: Union[str, pathlib.Path, TextIO]) -> pathlib.Path:  # noqa: D102
         path = super().to_path_binary(path=path)
         # store entity/relation to ID
-        for name, data in dict(
-            entity_to_id=self.entity_to_id,
-            relation_to_id=self.relation_to_id,
-        ).items():
+        for name, data in (
+            (self.file_name_entity_to_id, self.entity_to_id,),
+            (self.file_name_relation_to_id, self.relation_to_id,),
+        ):
             pd.DataFrame(data=data.items(), columns=["label", "id"],).sort_values(by="id").set_index("id").to_csv(
                 path.joinpath(f"{name}.tsv.gz"),
                 sep="\t",
@@ -970,7 +973,7 @@ class TriplesFactory(CoreTriplesFactory):
     def _from_path_binary(cls, path: pathlib.Path) -> MutableMapping[str, Any]:
         data = super()._from_path_binary(path)
         # load entity/relation to ID
-        for name in ["entity_to_id", "relation_to_id"]:
+        for name in [cls.file_name_entity_to_id, cls.file_name_relation_to_id]:
             df = pd.read_csv(
                 path.joinpath(f"{name}.tsv.gz"),
                 sep="\t",

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -752,7 +752,7 @@ class CoreTriplesFactory:
         pd.DataFrame(
             data=self.mapped_triples.numpy(),
             columns=[COLUMN_HEAD, COLUMN_RELATION, COLUMN_TAIL],
-        ).to_csv(path.joinpath("numeric_triples.tsv.gz"), sep="\t")
+        ).to_csv(path.joinpath("numeric_triples.tsv.gz"), sep="\t", index=False)
 
         # store metadata
         torch.save(self._get_binary_state(), path.joinpath("state.pth"))

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -960,8 +960,14 @@ class TriplesFactory(CoreTriplesFactory):
         path = super().to_path_binary(path=path)
         # store entity/relation to ID
         for name, data in (
-            (self.file_name_entity_to_id, self.entity_to_id,),
-            (self.file_name_relation_to_id, self.relation_to_id,),
+            (
+                self.file_name_entity_to_id,
+                self.entity_to_id,
+            ),
+            (
+                self.file_name_relation_to_id,
+                self.relation_to_id,
+            ),
         ):
             pd.DataFrame(data=data.items(), columns=["label", "id"],).sort_values(by="id").set_index("id").to_csv(
                 path.joinpath(f"{name}.tsv.gz"),

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -730,7 +730,7 @@ class CoreTriplesFactory:
         data = dict(torch.load(path.joinpath("state.pth")))
         # load numeric triples
         data["mapped_triples"] = torch.as_tensor(
-            pd.read_csv(path.joinpath("numeric_triples.tsv.gz"), sep="\t").values,
+            pd.read_csv(path.joinpath("numeric_triples.tsv.gz"), sep="\t", dtype=int).values,
             dtype=torch.long,
         )
         return data

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -532,15 +532,16 @@ class TestUtils(unittest.TestCase):
         self.assertIsInstance(tf, tf_cls)
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory)
-            self.assertFalse(any(p.is_file() for p in path.iterdir()))
+            # serialize
             tf.to_path_binary(path)
-            self.assertTrue(any(p.is_file() for p in path.iterdir()))
-
+            # de-serialize
             tf2 = tf_cls.from_path_binary(path)
+            # check for equality
             self.assert_tf_equal(tf, tf2)
 
     def assert_tf_equal(self, tf1, tf2) -> None:
         """Check two triples factories have all of the same stuff."""
+        # TODO: this could be (Core)TriplesFactory.__equal__
         self.assertEqual(type(tf1), type(tf2))
         self.assertEqual(tf1.entity_ids, tf2.entity_ids)
         self.assertEqual(tf1.relation_ids, tf2.relation_ids)

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -531,10 +531,10 @@ class TestUtils(unittest.TestCase):
         """Check the triples factory can be written and reloaded properly."""
         self.assertIsInstance(tf, tf_cls)
         with tempfile.TemporaryDirectory() as directory:
-            path = Path(directory) / "training.pt"
-            self.assertFalse(path.is_file())
+            path = Path(directory)
+            self.assertFalse(any(p.is_file() for p in path.iterdir()))
             tf.to_path_binary(path)
-            self.assertTrue(path.is_file())
+            self.assertTrue(any(p.is_file() for p in path.iterdir()))
 
             tf2 = tf_cls.from_path_binary(path)
             self.assert_tf_equal(tf, tf2)


### PR DESCRIPTION
This PR changes the serialization format of the triples factory to store the key components, triples (and label to ID mappings), in a compressed, but human-readable format. This allows easy inspection outside of PyKEEN.

For FB15k237, I saw that the total file size was also significantly reduced (from `6.9MiB` on ef769a8c3145d48d9f136a2e4729781097c8d9c9 = `master` to `1.1MiB` for bf47eb5)

Based upon https://github.com/pykeen/pykeen/pull/655#issuecomment-996715410