### PR TITLE
🪡💻 Fix typo in ConsoleTracker.log_metrics

### DIFF
--- a/src/pykeen/datasets/openea.py
+++ b/src/pykeen/datasets/openea.py
@@ -50,7 +50,7 @@ class OpenEA(LazyDataset):
     DROPBOX_LINK: str = "https://www.dropbox.com/s/xfehqm4pcd9yw0v/OpenEA_dataset_v2.0.zip?dl=1"
 
     #: The hex digest for the zip file
-    SHA512: str = "c1589f185f86e05c497de147b4d6c243c66775cb4b50c6b41ecc71b36cfafb4c9f86fbee94e1e78a7ee056dd69df1ce3fc210ae07dc64955ad2bfda7450545ef"
+    SHA512: str = "c1589f185f86e05c497de147b4d6c243c66775cb4b50c6b41ecc71b36cfafb4c9f86fbee94e1e78a7ee056dd69df1ce3fc210ae07dc64955ad2bfda7450545ef"  # noqa: E501
 
     def __init__(
         self,

--- a/src/pykeen/experiments/inverse_stability.py
+++ b/src/pykeen/experiments/inverse_stability.py
@@ -17,7 +17,7 @@ import seaborn as sns
 
 import pykeen.evaluation.evaluator
 from pykeen.constants import PYKEEN_EXPERIMENTS
-from pykeen.datasets import Dataset, dataset_resolver, get_dataset
+from pykeen.datasets import Dataset, get_dataset
 from pykeen.models import Model, model_resolver
 from pykeen.pipeline import pipeline
 from pykeen.typing import InductiveMode

--- a/src/pykeen/experiments/inverse_stability.py
+++ b/src/pykeen/experiments/inverse_stability.py
@@ -17,7 +17,7 @@ import seaborn as sns
 
 import pykeen.evaluation.evaluator
 from pykeen.constants import PYKEEN_EXPERIMENTS
-from pykeen.datasets import Dataset, get_dataset
+from pykeen.datasets import Dataset, dataset_resolver, get_dataset
 from pykeen.models import Model, model_resolver
 from pykeen.pipeline import pipeline
 from pykeen.typing import InductiveMode

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -186,7 +186,7 @@ class ConsoleResultTracker(ResultTracker):
         self.write(f"Step: {step}")
         for key, value in flatten_dictionary(dictionary=metrics, prefix=prefix).items():
             if not self.metric_filter or self.metric_filter.match(key):
-                self.write(f"Parameter: {key} = {value}")
+                self.write(f"Metric: {key} = {value}")
 
     def end_run(self, success: bool = True) -> None:  # noqa: D102
         if not success:


### PR DESCRIPTION
This PR fixes a small typo in `ConsoleTracker`'s `log_metrics`, as well as fixing the failing pipeline.