### PR TITLE
📏🕳️ Move normalization to base representation

### DIFF
--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -749,7 +749,7 @@ class RGCNRepresentation(Representation):
 
         return x
 
-    def _real_forward(
+    def _plain_forward(
         self,
         indices: Optional[torch.LongTensor] = None,
     ) -> torch.FloatTensor:

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -14,7 +14,6 @@ from torch import nn
 from .init import uniform_norm_p1_
 from .representation import LowRankRepresentation, Representation
 from .weighting import EdgeWeighting, edge_weight_resolver
-from ..regularizers import Regularizer, regularizer_resolver
 from ..triples import CoreTriplesFactory
 
 __all__ = [
@@ -601,8 +600,7 @@ class RGCNRepresentation(Representation):
         edge_weighting: Hint[EdgeWeighting] = None,
         decomposition: Hint[Decomposition] = None,
         decomposition_kwargs: Optional[Mapping[str, Any]] = None,
-        regularizer: Hint[Regularizer] = None,
-        regularizer_kwargs: Optional[Mapping[str, Any]] = None,
+        **kwargs,
     ):
         """Instantiate the R-GCN encoder.
 
@@ -635,10 +633,8 @@ class RGCNRepresentation(Representation):
             The decomposition, cf. :class:`pykeen.nn.message_passing.Decomposition`.
         :param decomposition_kwargs:
             Additional keyword based arguments passed to the decomposition upon instantiation.
-        :param regularizer:
-            A regularizer, which is applied to the selected embeddings in forward pass
-        :param regularizer_kwargs:
-            Additional keyword arguments passed to the regularizer
+        :param kwargs:
+            additional keyword-based parameters passed to super.__init__
         """
         if max_id:
             assert max_id == triples_factory.num_entities
@@ -651,7 +647,7 @@ class RGCNRepresentation(Representation):
             max_id=triples_factory.num_entities,
             pos_kwargs=entity_representations_kwargs,
         )
-        super().__init__(max_id=base_embeddings.max_id, shape=shape or base_embeddings.shape)
+        super().__init__(max_id=base_embeddings.max_id, shape=shape or base_embeddings.shape, **kwargs)
         self.entity_embeddings = base_embeddings
 
         if triples_factory.create_inverse_triples:
@@ -693,10 +689,6 @@ class RGCNRepresentation(Representation):
         # buffering of enriched representations
         self.enriched_embeddings = None
 
-        if regularizer is not None:
-            regularizer = regularizer_resolver.make(regularizer, pos_kwargs=regularizer_kwargs)
-        self.regularizer = regularizer
-
     def post_parameter_update(self) -> None:  # noqa: D102
         super().post_parameter_update()
 
@@ -712,7 +704,7 @@ class RGCNRepresentation(Representation):
             elif any(p.requires_grad for p in m.parameters()):
                 logger.warning("Layers %s has parameters, but no reset_parameters.", m)
 
-    def _real_forward(self) -> torch.FloatTensor:
+    def _real_forward_all(self) -> torch.FloatTensor:
         if self.enriched_embeddings is not None:
             return self.enriched_embeddings
 
@@ -757,14 +749,12 @@ class RGCNRepresentation(Representation):
 
         return x
 
-    def forward(
+    def _real_forward(
         self,
         indices: Optional[torch.LongTensor] = None,
     ) -> torch.FloatTensor:
         """Enrich the entity embeddings of the decoder using R-GCN message propagation."""
-        x = self._real_forward()
+        x = self._real_forward_all()
         if indices is not None:
             x = x[indices]
-        if self.regularizer is not None:
-            self.regularizer.update(x)
         return x

--- a/src/pykeen/nn/node_piece.py
+++ b/src/pykeen/nn/node_piece.py
@@ -846,7 +846,7 @@ class TokenizationRepresentation(Representation):
             )
         )
 
-    def _real_forward(
+    def _plain_forward(
         self,
         indices: Optional[torch.LongTensor] = None,
     ) -> torch.FloatTensor:  # noqa: D102
@@ -971,7 +971,7 @@ class NodePieceRepresentation(Representation):
         aggregation_str = self.aggregation.__name__ if hasattr(self.aggregation, "__name__") else str(self.aggregation)
         return f"aggregation={aggregation_str}, "
 
-    def _real_forward(
+    def _plain_forward(
         self,
         indices: Optional[torch.LongTensor] = None,
     ) -> torch.FloatTensor:  # noqa: D102

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -75,7 +75,7 @@ class Representation(nn.Module, ABC):
     normalizer: Optional[Normalizer]
 
     #: a regularizer for individual representations
-    regularizer: Optional[Normalizer]
+    regularizer: Optional[Regularizer]
 
     #: dropout
     dropout: Optional[nn.Dropout]

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -281,15 +281,10 @@ class Embedding(Representation):
         shape: Union[None, int, Sequence[int]] = None,
         initializer: Hint[Initializer] = None,
         initializer_kwargs: Optional[Mapping[str, Any]] = None,
-        normalizer: Hint[Normalizer] = None,
-        normalizer_kwargs: Optional[Mapping[str, Any]] = None,
         constrainer: Hint[Constrainer] = None,
         constrainer_kwargs: Optional[Mapping[str, Any]] = None,
-        regularizer: Hint[Regularizer] = None,
-        regularizer_kwargs: Optional[Mapping[str, Any]] = None,
         trainable: bool = True,
         dtype: Optional[torch.dtype] = None,
-        dropout: Optional[float] = None,
         **kwargs,
     ):
         """Instantiate an embedding with extended functionality.

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -263,7 +263,7 @@ class CombinedRegularizer(Regularizer):
         return self.normalization_factor * sum(r.weight * r.forward(x) for r in self.regularizers)
 
 
-regularizer_resolver = ClassResolver.from_subclasses(
+regularizer_resolver: ClassResolver[Regularizer] = ClassResolver.from_subclasses(
     base=Regularizer,
     default=NoRegularizer,
 )

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -38,7 +38,7 @@ from click.testing import CliRunner, Result
 from docdata import get_docdata
 from torch import optim
 from torch.nn import functional
-from torch.optim import Adagrad, SGD
+from torch.optim import SGD, Adagrad
 
 import pykeen.models
 import pykeen.nn.message_passing
@@ -53,7 +53,7 @@ from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH
 from pykeen.evaluation import Evaluator, MetricResults
 from pykeen.losses import Loss, PairwiseLoss, PointwiseLoss, SetwiseLoss, UnsupportedLabelSmoothingError
 from pykeen.metrics.ranking import RankBasedMetric
-from pykeen.models import EntityRelationEmbeddingModel, Model, RESCAL, TransE
+from pykeen.models import RESCAL, EntityRelationEmbeddingModel, Model, TransE
 from pykeen.models.cli import build_cli_from_cls
 from pykeen.models.nbase import ERModel
 from pykeen.nn.modules import FunctionalInteraction, Interaction, LiteralInteraction
@@ -68,14 +68,14 @@ from pykeen.triples.splitting import Cleaner, Splitter
 from pykeen.triples.triples_factory import CoreTriplesFactory
 from pykeen.triples.utils import get_entities
 from pykeen.typing import (
+    LABEL_HEAD,
+    LABEL_TAIL,
+    TRAINING,
     HeadRepresentation,
     InductiveMode,
     Initializer,
-    LABEL_HEAD,
-    LABEL_TAIL,
     MappedTriples,
     RelationRepresentation,
-    TRAINING,
     TailRepresentation,
 )
 from pykeen.utils import (

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -24,7 +24,7 @@ class CustomRepresentation(Representation):
         super().__init__(max_id=num_entities, shape=shape)
         self.x = nn.Parameter(torch.rand(*shape))
 
-    def forward(self, indices: Optional[torch.LongTensor] = None) -> torch.FloatTensor:  # noqa:D102
+    def _real_forward(self, indices: Optional[torch.LongTensor] = None) -> torch.FloatTensor:  # noqa:D102
         n = self.max_id if indices is None else indices.shape[0]
         return self.x.unsqueeze(dim=0).repeat(n, *(1 for _ in self.shape))
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -24,7 +24,7 @@ class CustomRepresentation(Representation):
         super().__init__(max_id=num_entities, shape=shape)
         self.x = nn.Parameter(torch.rand(*shape))
 
-    def _real_forward(self, indices: Optional[torch.LongTensor] = None) -> torch.FloatTensor:  # noqa:D102
+    def _plain_forward(self, indices: Optional[torch.LongTensor] = None) -> torch.FloatTensor:  # noqa:D102
         n = self.max_id if indices is None else indices.shape[0]
         return self.x.unsqueeze(dim=0).repeat(n, *(1 for _ in self.shape))
 

--- a/tests/test_nn/test_representation.py
+++ b/tests/test_nn/test_representation.py
@@ -37,20 +37,6 @@ class EmbeddingTests(cases.RepresentationTestCase):
         embedding_dim = int(numpy.prod(self.instance.shape))
         assert self.instance.shape == (embedding_dim,)
 
-    def test_dropout(self):
-        """Test dropout layer."""
-        # create a new instance with guaranteed dropout
-        kwargs = self.instance_kwargs
-        kwargs.pop("dropout", None)
-        dropout_instance = self.cls(**kwargs, dropout=0.1)
-        # set to training mode
-        dropout_instance.train()
-        # check for different output
-        indices = torch.arange(2)
-        first = dropout_instance(indices)
-        second = dropout_instance(indices)
-        assert not torch.allclose(first, second)
-
 
 class LowRankEmbeddingRepresentationTests(cases.RepresentationTestCase):
     """Tests for low-rank embedding representations."""


### PR DESCRIPTION
~This should have been the PR to move normalization, regularization and dropout to the base representation. I accidentally pushed it already to `master`.~

This PR moves normalization, regularization and dropout to the base representation class, allowing us to use them with other representations, too.