### PR TITLE
➕🌍 Add option to add all default rank-based metrics

### DIFF
--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -212,6 +212,7 @@ class RankBasedEvaluator(Evaluator):
         filtered: bool = True,
         metrics: Optional[Sequence[HintOrType[RankBasedMetric]]] = None,
         metrics_kwargs: OptionalKwargs = None,
+        add_defaults: bool = True,
         **kwargs,
     ):
         """Initialize rank-based evaluator.
@@ -223,6 +224,8 @@ class RankBasedEvaluator(Evaluator):
             the rank-based metrics to compute
         :param metrics_kwargs:
             additional keyword parameter
+        :param add_defaults:
+            whether to add all default metrics besides the ones specified by `metrics` / `metrics_kwargs`.
         :param kwargs: Additional keyword arguments that are passed to the base class.
         """
         super().__init__(
@@ -231,7 +234,10 @@ class RankBasedEvaluator(Evaluator):
             **kwargs,
         )
         if metrics is None:
-            assert metrics_kwargs is None
+            add_defaults = True
+            metrics = []
+        self.metrics = rank_based_metric_resolver.make_many(metrics, metrics_kwargs)
+        if add_defaults:
             hits_at_k_keys = ["hits_at_k", "z_hits_at_k", "adjusted_hits_at_k"]
             ks = (1, 3, 5, 10)
             metrics = [key for key in rank_based_metric_resolver.options if key not in hits_at_k_keys]
@@ -239,8 +245,7 @@ class RankBasedEvaluator(Evaluator):
             for hits_at_k_key in hits_at_k_keys:
                 metrics += [hits_at_k_key] * len(ks)
                 metrics_kwargs += [dict(k=k) for k in ks]
-
-        self.metrics = rank_based_metric_resolver.make_many(metrics, metrics_kwargs)
+            self.metrics.extend(rank_based_metric_resolver.make_many(metrics, metrics_kwargs))
         self.ranks = defaultdict(list)
         self.num_candidates = defaultdict(list)
         self.num_entities = None

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -18,7 +18,7 @@ from class_resolver import HintOrType, OptionalKwargs
 from .evaluator import Evaluator, MetricResults, prepare_filter_triples
 from .ranking_metric_lookup import MetricKey
 from .ranks import Ranks
-from ..metrics.ranking import AdjustedHitsAtK, HitsAtK, RankBasedMetric, ZHitsAtK, rank_based_metric_resolver
+from ..metrics.ranking import HITS_METRICS, RankBasedMetric, rank_based_metric_resolver
 from ..metrics.utils import Metric
 from ..triples.triples_factory import CoreTriplesFactory
 from ..typing import (
@@ -238,9 +238,7 @@ class RankBasedEvaluator(Evaluator):
             metrics = []
         self.metrics = rank_based_metric_resolver.make_many(metrics, metrics_kwargs)
         if add_defaults:
-            hits_at_k_keys = [
-                rank_based_metric_resolver.normalize_cls(cls) for cls in (HitsAtK, ZHitsAtK, AdjustedHitsAtK)
-            ]
+            hits_at_k_keys = [rank_based_metric_resolver.normalize_cls(cls) for cls in HITS_METRICS]
             ks = (1, 3, 5, 10)
             metrics = [key for key in rank_based_metric_resolver.lookup_dict if key not in hits_at_k_keys]
             metrics_kwargs = [None] * len(metrics)

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -18,7 +18,7 @@ from class_resolver import HintOrType, OptionalKwargs
 from .evaluator import Evaluator, MetricResults, prepare_filter_triples
 from .ranking_metric_lookup import MetricKey
 from .ranks import Ranks
-from ..metrics.ranking import RankBasedMetric, rank_based_metric_resolver
+from ..metrics.ranking import AdjustedHitsAtK, HitsAtK, RankBasedMetric, ZHitsAtK, rank_based_metric_resolver
 from ..metrics.utils import Metric
 from ..triples.triples_factory import CoreTriplesFactory
 from ..typing import (
@@ -238,10 +238,11 @@ class RankBasedEvaluator(Evaluator):
             metrics = []
         self.metrics = rank_based_metric_resolver.make_many(metrics, metrics_kwargs)
         if add_defaults:
-            hits_at_k_keys = ["hits_at_k", "z_hits_at_k", "adjusted_hits_at_k"]
+            hits_at_k_keys = [
+                rank_based_metric_resolver.normalize_cls(cls) for cls in (HitsAtK, ZHitsAtK, AdjustedHitsAtK)
+            ]
             ks = (1, 3, 5, 10)
-            # TODO: options contains synonyms!
-            metrics = [key for key in rank_based_metric_resolver.options if key not in hits_at_k_keys]
+            metrics = [key for key in rank_based_metric_resolver.lookup_dict if key not in hits_at_k_keys]
             metrics_kwargs = [None] * len(metrics)
             for hits_at_k_key in hits_at_k_keys:
                 metrics += [hits_at_k_key] * len(ks)

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -240,6 +240,7 @@ class RankBasedEvaluator(Evaluator):
         if add_defaults:
             hits_at_k_keys = ["hits_at_k", "z_hits_at_k", "adjusted_hits_at_k"]
             ks = (1, 3, 5, 10)
+            # TODO: options contains synonyms!
             metrics = [key for key in rank_based_metric_resolver.options if key not in hits_at_k_keys]
             metrics_kwargs = [None] * len(metrics)
             for hits_at_k_key in hits_at_k_keys:

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -4,7 +4,7 @@
 
 import math
 from abc import abstractmethod
-from typing import ClassVar, Collection, Iterable, Optional
+from typing import ClassVar, Collection, Iterable, Optional, Tuple, Type
 
 import numpy as np
 from class_resolver import ClassResolver
@@ -48,6 +48,8 @@ __all__ = [
     "StandardDeviation",
     "Variance",
     "Count",
+    #
+    "HITS_METRICS",
 ]
 EPSILON = 1.0e-12
 
@@ -805,3 +807,5 @@ rank_based_metric_resolver: ClassResolver[RankBasedMetric] = ClassResolver.from_
     default=InverseHarmonicMeanRank,  # mrr
     skip={BaseZMixin, IncreasingZMixin, DecreasingZMixin, ExpectationNormalizedMixin, ReindexMixin},
 )
+
+HITS_METRICS: Tuple[Type[RankBasedMetric], ...] = (HitsAtK, ZHitsAtK, AdjustedHitsAtK)

--- a/src/pykeen/metrics/utils.py
+++ b/src/pykeen/metrics/utils.py
@@ -118,5 +118,5 @@ class Metric:
     def _extra_repr(self) -> Iterable[str]:
         return []
 
-    def __str__(self) -> str:  # noqa:D105
+    def __repr__(self) -> str:  # noqa:D105
         return f"{self.__class__.__name__}({', '.join(self._extra_repr())})"


### PR DESCRIPTION
Since https://github.com/pykeen/pykeen/pull/786 it has become difficult to specify non-default `k` for Hits@k, while still keeping all the default metrics. This PR fixes that.

It also fixes an issue where the same metric object was created for each of its synonyms.