### PR TITLE
🖇️ 📊 Use Figshare link for OpenEA dataset

### DIFF
--- a/src/pykeen/datasets/openea.py
+++ b/src/pykeen/datasets/openea.py
@@ -50,7 +50,7 @@ class OpenEA(LazyDataset):
     """
 
     #: The link to the zip file
-    DROPBOX_LINK: str = "https://www.dropbox.com/s/xfehqm4pcd9yw0v/OpenEA_dataset_v2.0.zip?dl=1"
+    FIGSHARE_LINK: str = "https://figshare.com/ndownloader/files/34234391"
 
     #: The hex digest for the zip file
     SHA512: str = "c1589f185f86e05c497de147b4d6c243c66775cb4b50c6b41ecc71b36cfafb4c9f86fbee94e1e78a7ee056dd69df1ce3fc210ae07dc64955ad2bfda7450545ef"  # noqa: E501
@@ -133,8 +133,8 @@ class OpenEA(LazyDataset):
 
         # ensure file is present
         if not path.is_file() or self.force:
-            logger.info(f"Downloading file from Dropbox (Link: {self.__class__.DROPBOX_LINK})")
-            download(url=self.__class__.DROPBOX_LINK, path=path, hexdigests={"sha512": self.SHA512})
+            logger.info(f"Downloading file from Figshare (Link: {self.__class__.FIGSHARE_LINK})")
+            download(url=self.__class__.FIGSHARE_LINK, path=path, hexdigests={"sha512": self.SHA512})
 
         df = read_zipfile_csv(
             path=path,


### PR DESCRIPTION
There is no right template for this and it is a minimal change.
As discussed in #783 using an alternative storage than Dropbox is preferred. The authors of OpenEA have uploaded the dataset to figshare and I adapted the link.
