### PR TITLE
👣 📚 Correct typos in "First Steps" tutorial 

### DIFF
--- a/docs/source/tutorial/first_steps.rst
+++ b/docs/source/tutorial/first_steps.rst
@@ -30,7 +30,7 @@ with datasets, triples factories, and models using the labels
 of the entities and relations.
 
 We can map a triples factory's entities to identifiers using
-:data:`TriplesFactory.entity_to_ids` like in the following
+:data:`TriplesFactory.entities_to_ids` like in the following
 example:
 
 .. code-block:: python
@@ -40,7 +40,7 @@ example:
     triples_factory = Nations().training
 
     # Get tensor of entity identifiers
-    entity_ids = torch.as_tensor(triples_factory.entity_to_ids(["china", "egypt"]))
+    entity_ids = torch.as_tensor(triples_factory.entities_to_ids(["china", "egypt"]))
 
 Similarly, we can map a triples factory's relations to identifiers
 using :data:`TriplesFactory.relation_to_ids` like in the following

--- a/docs/source/tutorial/first_steps.rst
+++ b/docs/source/tutorial/first_steps.rst
@@ -30,7 +30,7 @@ with datasets, triples factories, and models using the labels
 of the entities and relations.
 
 We can map a triples factory's entities to identifiers using
-:data:`TriplesFactory.entities_to_ids` like in the following
+:func:`TriplesFactory.entities_to_ids` like in the following
 example:
 
 .. code-block:: python

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -628,14 +628,30 @@ class CoreTriplesFactory:
         ]
 
     def entities_to_ids(self, entities: Union[Collection[int], Collection[str]]) -> Collection[int]:
-        """Normalize entities to IDs."""
+        """Normalize entities to IDs.
+
+        :param entities: A collection of either integer identifiers for entities or
+            string labels for entities (that will get auto-converted)
+        :returns: Integer identifiers for entities
+        :raises ValueError: If the ``entities`` passed are string labels
+            and this triples factory does not have an entity label to identifier mapping
+            (e.g., it's just a base :class:`CoreTriplesFactory` instance)
+        """
         for e in entities:
             if not isinstance(e, int):
                 raise ValueError(f"{self.__class__.__name__} cannot convert entity IDs from {type(e)} to int.")
         return cast(Collection[int], entities)
 
     def relations_to_ids(self, relations: Union[Collection[int], Collection[str]]) -> Collection[int]:
-        """Normalize relations to IDs."""
+        """Normalize relations to IDs.
+
+        :param relations: A collection of either integer identifiers for relations or
+            string labels for relations (that will get auto-converted)
+        :returns: Integer identifiers for relations
+        :raises ValueError: If the ``relations`` passed are string labels
+            and this triples factory does not have a relation label to identifier mapping
+            (e.g., it's just a base :class:`CoreTriplesFactory` instance)
+        """
         for e in relations:
             if not isinstance(e, int):
                 raise ValueError(f"{self.__class__.__name__} cannot convert relation IDs from {type(e)} to int.")


### PR DESCRIPTION
Closes https://github.com/pykeen/pykeen/issues/845

First_steps.rst, lines 33 and 43

[Link to the relevant Bug(s)](https://github.com/pykeen/pykeen/blob/master/docs/source/tutorial/first_steps.rst)
Description of the Change
Just corrected a method that was not spelled properly
Possible Drawbacks
Not many
Verification Process
Release Notes


