### PR TITLE
🎯🪜 Update default batch size HPO range

### DIFF
--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -125,7 +125,7 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
 
     hpo_default = dict(
         num_epochs=dict(type=int, low=100, high=1000, q=100),
-        batch_size=dict(type=int, low=32, high=4000, q=100),
+        batch_size=dict(type=int, low=4, high=12, scale="power_two"),  # [16, 4096]
     )
 
     def __init__(


### PR DESCRIPTION
This PR changes the default HPO range for the `batch_size` parameter.

Thereby, it silences the following warning
```
./venv/lib/python3.9/site-packages/optuna/distributions.py:560: UserWarning: The distribution is specified by [32, 4000] and step=100, but the range is not divisible by `step`. It will be replaced by [32, 3932].
```
and also makes the default range search uniformly over powers of two, rather than uniformly over a given plain interval.