### PR TITLE
🚛®️ Update TuckER to ERModel

### DIFF
--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -22,7 +22,7 @@ from ..nn.representation import Representation
 from ..regularizers import Regularizer
 from ..triples import CoreTriplesFactory
 from ..typing import HeadRepresentation, InductiveMode, RelationRepresentation, TailRepresentation
-from ..utils import check_shapes
+from ..utils import check_shapes, get_batchnorm_modules
 
 __all__ = [
     "_NewAbstractModel",
@@ -406,6 +406,13 @@ class ERModel(
         h, r, t = self._get_representations(h=hrt_batch[:, 0], r=hrt_batch[:, 1], t=hrt_batch[:, 2], mode=mode)
         return self.interaction.score_hrt(h=h, r=r, t=t)
 
+    def _check_slicing(self, slice_size: Optional[int]) -> None:
+        """Raise an error, if slicing is requested, but the model does not support it."""
+        if not slice_size:
+            return
+        if get_batchnorm_modules(self):  # if there are any, this is truthy
+            raise ValueError("This model does not support slicing, since it has batch normalization layers.")
+
     def score_t(
         self, hr_batch: torch.LongTensor, *, slice_size: Optional[int] = None, mode: Optional[InductiveMode] = None
     ) -> torch.FloatTensor:
@@ -424,6 +431,7 @@ class ERModel(
         :return: shape: (batch_size, num_entities), dtype: float
             For each h-r pair, the scores for all possible tails.
         """
+        self._check_slicing(slice_size=slice_size)
         h, r, t = self._get_representations(h=hr_batch[:, 0], r=hr_batch[:, 1], t=None, mode=mode)
         return repeat_if_necessary(
             scores=self.interaction.score_t(h=h, r=r, all_entities=t, slice_size=slice_size),
@@ -449,6 +457,7 @@ class ERModel(
         :return: shape: (batch_size, num_entities), dtype: float
             For each r-t pair, the scores for all possible heads.
         """
+        self._check_slicing(slice_size=slice_size)
         h, r, t = self._get_representations(h=None, r=rt_batch[:, 0], t=rt_batch[:, 1], mode=mode)
         return repeat_if_necessary(
             scores=self.interaction.score_h(all_entities=h, r=r, t=t, slice_size=slice_size),
@@ -474,6 +483,7 @@ class ERModel(
         :return: shape: (batch_size, num_relations), dtype: float
             For each h-t pair, the scores for all possible relations.
         """
+        self._check_slicing(slice_size=slice_size)
         h, r, t = self._get_representations(h=ht_batch[:, 0], r=None, t=ht_batch[:, 1], mode=mode)
         return repeat_if_necessary(
             scores=self.interaction.score_r(h=h, all_relations=r, t=t, slice_size=slice_size),

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -4,9 +4,7 @@
 
 from typing import Any, ClassVar, Mapping, Optional, Type
 
-import torch.autograd
 from class_resolver import OptionalKwargs
-from torch import nn
 
 from ..nbase import ERModel
 from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
@@ -18,17 +16,6 @@ from ...typing import Hint, Initializer
 __all__ = [
     "TuckER",
 ]
-
-
-def _apply_bn_to_tensor(
-    batch_norm: nn.BatchNorm1d,
-    tensor: torch.FloatTensor,
-) -> torch.FloatTensor:
-    shape = tensor.shape
-    tensor = tensor.view(-1, shape[-1])
-    tensor = batch_norm(tensor)
-    tensor = tensor.view(*shape)
-    return tensor
 
 
 class TuckER(ERModel):

--- a/src/pykeen/models/unimodal/tucker.py
+++ b/src/pykeen/models/unimodal/tucker.py
@@ -4,13 +4,14 @@
 
 from typing import Any, ClassVar, Mapping, Optional, Type
 
-import torch
 import torch.autograd
+from class_resolver import OptionalKwargs
 from torch import nn
 
-from ..base import EntityRelationEmbeddingModel
+from ..nbase import ERModel
 from ...constants import DEFAULT_DROPOUT_HPO_RANGE, DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import BCEAfterSigmoidLoss, Loss
+from ...nn import TuckerInteraction
 from ...nn.init import xavier_normal_
 from ...typing import Hint, Initializer
 
@@ -30,7 +31,7 @@ def _apply_bn_to_tensor(
     return tensor
 
 
-class TuckER(EntityRelationEmbeddingModel):
+class TuckER(ERModel):
     r"""An implementation of TuckEr from [balazevic2019]_.
 
     TuckER is a linear model that is based on the tensor factorization method Tucker in which a three-mode tensor
@@ -101,115 +102,30 @@ class TuckER(EntityRelationEmbeddingModel):
         apply_batch_normalization: bool = True,
         entity_initializer: Hint[Initializer] = xavier_normal_,
         relation_initializer: Hint[Initializer] = xavier_normal_,
+        core_tensor_initializer: Hint[Initializer] = None,
+        core_tensor_initializer_kwargs: OptionalKwargs = None,
         **kwargs,
     ) -> None:
+        relation_dim = relation_dim or embedding_dim
         super().__init__(
+            interaction=TuckerInteraction,
+            interaction_kwargs=dict(
+                embedding_dim=embedding_dim,
+                relation_dim=relation_dim,
+                head_dropout=dropout_0,  # TODO: rename
+                relation_dropout=dropout_1,
+                head_relation_dropout=dropout_2,
+                apply_batch_normalization=apply_batch_normalization,
+                core_initializer=core_tensor_initializer,
+                core_initializer_kwargs=core_tensor_initializer_kwargs,
+            ),
             entity_representations_kwargs=dict(
                 shape=embedding_dim,
                 initializer=entity_initializer,
             ),
             relation_representations_kwargs=dict(
-                shape=relation_dim or embedding_dim,
+                shape=relation_dim,
                 initializer=relation_initializer,
             ),
             **kwargs,
         )
-
-        # Core tensor
-        # Note: we use a different dimension permutation as in the official implementation to match the paper.
-        self.core_tensor = nn.Parameter(
-            torch.empty(self.embedding_dim, self.relation_dim, self.embedding_dim, device=self.device),
-            requires_grad=True,
-        )
-
-        # Dropout
-        self.input_dropout = nn.Dropout(dropout_0)
-        self.hidden_dropout_1 = nn.Dropout(dropout_1)
-        self.hidden_dropout_2 = nn.Dropout(dropout_2)
-
-        self.apply_batch_normalization = apply_batch_normalization
-
-        if self.apply_batch_normalization:
-            self.bn_0 = nn.BatchNorm1d(self.embedding_dim)
-            self.bn_1 = nn.BatchNorm1d(self.embedding_dim)
-
-    def _reset_parameters_(self):  # noqa: D102
-        super()._reset_parameters_()
-        # Initialize core tensor, cf. https://github.com/ibalazevic/TuckER/blob/master/model.py#L12
-        nn.init.uniform_(self.core_tensor, -1.0, 1.0)
-
-    def _scoring_function(
-        self,
-        h: torch.FloatTensor,
-        r: torch.FloatTensor,
-        t: torch.FloatTensor,
-    ) -> torch.FloatTensor:
-        """
-        Evaluate the scoring function.
-
-        :param h: shape: (batch_size, 1, embedding_dim) or (1, num_entities, embedding_dim)
-        :param r: shape: (batch_size, relation_dim)
-        :param t: shape: (1, num_entities, embedding_dim) or (batch_size, 1, embedding_dim)
-        :return: shape: (batch_size, num_entities) or (batch_size, 1)
-        """
-        # Abbreviation
-        w = self.core_tensor
-        d_e = self.embedding_dim
-        d_r = self.relation_dim
-
-        # Compute h_n = DO(BN(h))
-        if self.apply_batch_normalization:
-            h = _apply_bn_to_tensor(batch_norm=self.bn_0, tensor=h)
-
-        h = self.input_dropout(h)
-
-        # Compute wr = DO(W x_2 r)
-        w = w.view(1, d_e, d_r, d_e)
-        r = r.view(-1, 1, 1, d_r)
-        wr = r @ w
-        wr = self.hidden_dropout_1(wr)
-
-        # compute whr = DO(BN(h_n x_1 wr))
-        wr = wr.view(-1, d_e, d_e)
-        whr = h @ wr
-        if self.apply_batch_normalization:
-            whr = _apply_bn_to_tensor(batch_norm=self.bn_1, tensor=whr)
-        whr = self.hidden_dropout_2(whr)
-
-        # Compute whr x_3 t
-        scores = torch.sum(whr * t, dim=-1)
-
-        return scores
-
-    def score_hrt(self, hrt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=hrt_batch[:, 0]).unsqueeze(1)
-        r = self.relation_embeddings(indices=hrt_batch[:, 1])
-        t = self.entity_embeddings(indices=hrt_batch[:, 2]).unsqueeze(1)
-
-        # Compute scores
-        scores = self._scoring_function(h=h, r=r, t=t)
-
-        return scores
-
-    def score_t(self, hr_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=hr_batch[:, 0]).unsqueeze(1)
-        r = self.relation_embeddings(indices=hr_batch[:, 1])
-        t = self.entity_embeddings(indices=None).unsqueeze(0)
-
-        # Compute scores
-        scores = self._scoring_function(h=h, r=r, t=t)
-
-        return scores
-
-    def score_h(self, rt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=None).unsqueeze(0)
-        r = self.relation_embeddings(indices=rt_batch[:, 0])
-        t = self.entity_embeddings(indices=rt_batch[:, 1]).unsqueeze(1)
-
-        # Compute scores
-        scores = self._scoring_function(h=h, r=r, t=t)
-
-        return scores

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -940,7 +940,7 @@ class TuckerInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
 
     # default core tensor initialization
     # cf. https://github.com/ibalazevic/TuckER/blob/master/model.py#L12
-    default_core_initializer: ClassVar[Type[Initializer]] = nn.init.uniform_
+    default_core_initializer: ClassVar[Type[Initializer]] = staticmethod(nn.init.uniform_)
     default_core_initializer_kwargs: Mapping[str, Any] = {"a": -1.0, "b": 1.0}
 
     def __init__(

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -22,7 +22,6 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    Type,
     Union,
 )
 

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -29,7 +29,7 @@ from typing import (
 import more_itertools
 import numpy
 import torch
-from class_resolver import ClassResolver, OptionalKwargs
+from class_resolver import ClassResolver, Hint, OptionalKwargs
 from class_resolver.contrib.torch import activation_resolver
 from docdata import parse_docdata
 from torch import FloatTensor, nn
@@ -940,7 +940,7 @@ class TuckerInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
 
     # default core tensor initialization
     # cf. https://github.com/ibalazevic/TuckER/blob/master/model.py#L12
-    default_core_initializer: ClassVar[Type[Initializer]] = staticmethod(nn.init.uniform_)
+    default_core_initializer: ClassVar[Initializer] = staticmethod(nn.init.uniform_)  # type: ignore
     default_core_initializer_kwargs: Mapping[str, Any] = {"a": -1.0, "b": 1.0}
 
     def __init__(
@@ -951,7 +951,7 @@ class TuckerInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
         relation_dropout: float = 0.4,
         head_relation_dropout: float = 0.5,
         apply_batch_normalization: bool = True,
-        core_initializer: HintOrType[Initializer] = default_core_initializer,
+        core_initializer: Hint[Initializer] = None,
         core_initializer_kwargs: OptionalKwargs = None,
     ):
         """Initialize the Tucker interaction function.


### PR DESCRIPTION
This PR updates TuckER to new-style ERModel.

#### Performance Comparison
Running
```console
pykeen experiments reproduce tucker balazevic2019 fb15k237
``` 
with this env

| Key             | Value                    |
|-----------------|--------------------------|
| OS              | posix                    |
| Platform        | Linux                    |
| Release         | 5.4.0-90-generic         |
| Time            | Wed Apr  6 11:53:48 2022 |
| Python          | 3.8.10                   |
| PyKEEN          | 1.8.1-dev                |
| PyKEEN Hash     | *                 |
| PyKEEN Branch   | * |
| PyTorch         | 1.10.0+cu113             |
| CUDA Available? | true                     |
| CUDA Version    | 11.3                     |
| cuDNN Version   | 8200                     |

on both branches yields

| Branch | batch/s | 
| --| --| 
| master | 14.8 | 
| update-tucker-to-ermodel (61502647) | 30.8  |
