### PR TITLE
✨🦜 Upgrade TransR to ERModel

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -783,11 +783,6 @@ class EntityRelationEmbeddingModel(_OldAbstractModel, ABC, autoreset=False):
         return self.entity_embeddings.embedding_dim
 
     @property
-    def relation_dim(self) -> int:  # noqa:D401
-        """The relation embedding dimension."""
-        return self.relation_embeddings.embedding_dim
-
-    @property
     def entity_representations(self) -> Sequence[Representation]:  # noqa:D401
         """The entity representations.
 

--- a/src/pykeen/models/unimodal/trans_r.py
+++ b/src/pykeen/models/unimodal/trans_r.py
@@ -8,11 +8,10 @@ from typing import Any, ClassVar, Mapping
 import torch
 import torch.autograd
 import torch.nn.init
-from torch import linalg
 
-from ..base import EntityRelationEmbeddingModel
+from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
-from ...nn import representation_resolver
+from ...nn import TransRInteraction
 from ...nn.init import xavier_uniform_, xavier_uniform_norm_
 from ...typing import Constrainer, Hint, Initializer
 from ...utils import clamp_norm
@@ -32,7 +31,7 @@ def _projection_initializer(
     return torch.nn.init.xavier_uniform_(x.view(num_relations, embedding_dim, relation_dim)).view(x.shape)
 
 
-class TransR(EntityRelationEmbeddingModel):
+class TransR(ERModel):
     r"""An implementation of TransR from [lin2015]_.
 
     TransR is an extension of :class:`pykeen.models.TransH` that explicitly considers entities and relations as
@@ -88,98 +87,37 @@ class TransR(EntityRelationEmbeddingModel):
         **kwargs,
     ) -> None:
         """Initialize the model."""
+        # TODO: Initialize from TransE
         super().__init__(
+            interaction=TransRInteraction,
+            interaction_kwargs=dict(
+                p=scoring_fct_norm,
+            ),
             entity_representations_kwargs=dict(
                 shape=embedding_dim,
                 initializer=entity_initializer,
                 constrainer=entity_constrainer,
                 constrainer_kwargs=dict(maxnorm=1.0, p=2, dim=-1),
             ),
-            relation_representations_kwargs=dict(
-                shape=(relation_dim,),
-                initializer=relation_initializer,
-                constrainer=relation_constrainer,
-                constrainer_kwargs=dict(maxnorm=1.0, p=2, dim=-1),
-            ),
+            relation_representations_kwargs=[
+                # relation embedding
+                dict(
+                    shape=(relation_dim,),
+                    initializer=relation_initializer,
+                    constrainer=relation_constrainer,
+                    constrainer_kwargs=dict(maxnorm=1.0, p=2, dim=-1),
+                ),
+                # relation projection
+                dict(
+                    shape=(relation_dim * embedding_dim,),
+                    max_id=self.num_relations,
+                    initializer=partial(
+                        _projection_initializer,
+                        num_relations=self.num_relations,
+                        embedding_dim=self.embedding_dim,
+                        relation_dim=self.relation_dim,
+                    ),
+                ),
+            ],
             **kwargs,
         )
-        self.scoring_fct_norm = scoring_fct_norm
-
-        # TODO: Initialize from TransE
-
-        # embeddings
-        self.relation_projections = representation_resolver.make(
-            query=None,
-            shape=(relation_dim * embedding_dim,),
-            max_id=self.num_relations,
-            initializer=partial(
-                _projection_initializer,
-                num_relations=self.num_relations,
-                embedding_dim=self.embedding_dim,
-                relation_dim=self.relation_dim,
-            ),
-        )
-
-    def _reset_parameters_(self):  # noqa: D102
-        super()._reset_parameters_()
-        self.relation_projections.reset_parameters()
-
-    @staticmethod
-    def interaction_function(
-        h: torch.FloatTensor,
-        r: torch.FloatTensor,
-        t: torch.FloatTensor,
-        m_r: torch.FloatTensor,
-    ) -> torch.FloatTensor:
-        """Evaluate the interaction function for given embeddings.
-
-        The embeddings have to be in a broadcastable shape.
-
-        :param h: shape: (batch_size, num_entities, d_e)
-            Head embeddings.
-        :param r: shape: (batch_size, num_entities, d_r)
-            Relation embeddings.
-        :param t: shape: (batch_size, num_entities, d_e)
-            Tail embeddings.
-        :param m_r: shape: (batch_size, num_entities, d_e, d_r)
-            The relation specific linear transformations.
-
-        :return: shape: (batch_size, num_entities)
-            The scores.
-        """
-        # project to relation specific subspace, shape: (b, e, d_r)
-        h_bot = h @ m_r
-        t_bot = t @ m_r
-        # ensure constraints
-        h_bot = clamp_norm(h_bot, p=2, dim=-1, maxnorm=1.0)
-        t_bot = clamp_norm(t_bot, p=2, dim=-1, maxnorm=1.0)
-
-        # evaluate score function, shape: (b, e)
-        return -linalg.vector_norm(h_bot + r - t_bot, dim=-1) ** 2
-
-    def score_hrt(self, hrt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=hrt_batch[:, 0]).unsqueeze(dim=1)
-        r = self.relation_embeddings(indices=hrt_batch[:, 1]).unsqueeze(dim=1)
-        t = self.entity_embeddings(indices=hrt_batch[:, 2]).unsqueeze(dim=1)
-        m_r = self.relation_projections(indices=hrt_batch[:, 1]).view(-1, self.embedding_dim, self.relation_dim)
-
-        return self.interaction_function(h=h, r=r, t=t, m_r=m_r).view(-1, 1)
-
-    def score_t(self, hr_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=hr_batch[:, 0]).unsqueeze(dim=1)
-        r = self.relation_embeddings(indices=hr_batch[:, 1]).unsqueeze(dim=1)
-        t = self.entity_embeddings(indices=None).unsqueeze(dim=0)
-        m_r = self.relation_projections(indices=hr_batch[:, 1]).view(-1, self.embedding_dim, self.relation_dim)
-
-        return self.interaction_function(h=h, r=r, t=t, m_r=m_r)
-
-    def score_h(self, rt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=None).unsqueeze(dim=0)
-        r = self.relation_embeddings(indices=rt_batch[:, 0]).unsqueeze(dim=1)
-        t = self.entity_embeddings(indices=rt_batch[:, 1]).unsqueeze(dim=1)
-        m_r = self.relation_projections(indices=rt_batch[:, 0]).view(-1, self.embedding_dim, self.relation_dim)
-
-        return self.interaction_function(h=h, r=r, t=t, m_r=m_r)

--- a/src/pykeen/models/unimodal/trans_r.py
+++ b/src/pykeen/models/unimodal/trans_r.py
@@ -2,7 +2,6 @@
 
 """Implementation of TransR."""
 
-from functools import partial
 from typing import Any, ClassVar, Mapping
 
 import torch
@@ -19,16 +18,6 @@ from ...utils import clamp_norm
 __all__ = [
     "TransR",
 ]
-
-
-def _projection_initializer(
-    x: torch.FloatTensor,
-    num_relations: int,
-    embedding_dim: int,
-    relation_dim: int,
-) -> torch.FloatTensor:
-    """Initialize by Glorot."""
-    return torch.nn.init.xavier_uniform_(x.view(num_relations, embedding_dim, relation_dim)).view(x.shape)
 
 
 class TransR(ERModel):
@@ -109,14 +98,8 @@ class TransR(ERModel):
                 ),
                 # relation projection
                 dict(
-                    shape=(relation_dim * embedding_dim,),
-                    max_id=self.num_relations,
-                    initializer=partial(
-                        _projection_initializer,
-                        num_relations=self.num_relations,
-                        embedding_dim=self.embedding_dim,
-                        relation_dim=self.relation_dim,
-                    ),
+                    shape=(embedding_dim, relation_dim),
+                    initializer=torch.nn.init.xavier_uniform_,
                 ),
             ],
             **kwargs,

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -892,15 +892,12 @@ def transr_interaction(
     :return: shape: batch_dims
         The scores.
     """
-    # h_bot = clamp_norm((h.unsqueeze(dim=-2) @ m_r), p=2, dim=-1, maxnorm=1.0).squeeze(dim=-2)
-    # t_bot = clamp_norm((t.unsqueeze(dim=-2) @ m_r), p=2, dim=-1, maxnorm=1.0).squeeze(dim=-2)
     # project to relation specific subspace
     h_bot = torch.einsum("...e, ...er -> ...r", h, m_r)
     t_bot = torch.einsum("...e, ...er -> ...r", t, m_r)
     # ensure constraints
     h_bot = clamp_norm(h_bot, p=2, dim=-1, maxnorm=1.0)
     t_bot = clamp_norm(t_bot, p=2, dim=-1, maxnorm=1.0)
-    # return -linalg.vector_norm(h_bot + r - t_bot, dim=-1) ** 2
     return negative_norm_of_sum(h_bot, r, -t_bot, p=p, power_norm=power_norm)
 
 

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -892,9 +892,15 @@ def transr_interaction(
     :return: shape: batch_dims
         The scores.
     """
-    # project to relation specific subspace and ensure constraints
-    h_bot = clamp_norm((h.unsqueeze(dim=-2) @ m_r), p=2, dim=-1, maxnorm=1.0).squeeze(dim=-2)
-    t_bot = clamp_norm((t.unsqueeze(dim=-2) @ m_r), p=2, dim=-1, maxnorm=1.0).squeeze(dim=-2)
+    # h_bot = clamp_norm((h.unsqueeze(dim=-2) @ m_r), p=2, dim=-1, maxnorm=1.0).squeeze(dim=-2)
+    # t_bot = clamp_norm((t.unsqueeze(dim=-2) @ m_r), p=2, dim=-1, maxnorm=1.0).squeeze(dim=-2)
+    # project to relation specific subspace
+    h_bot = torch.einsum("...e, ...er -> ...r", h, m_r)
+    t_bot = torch.einsum("...e, ...er -> ...r", t, m_r)
+    # ensure constraints
+    h_bot = clamp_norm(h_bot, p=2, dim=-1, maxnorm=1.0)
+    t_bot = clamp_norm(t_bot, p=2, dim=-1, maxnorm=1.0)
+    # return -linalg.vector_norm(h_bot + r - t_bot, dim=-1) ** 2
     return negative_norm_of_sum(h_bot, r, -t_bot, p=p, power_norm=power_norm)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -639,51 +639,12 @@ class TestTransR(cases.DistanceModelTestCase):
         "relation_dim": 4,
     }
 
-    def test_score_hrt_manual(self):
-        """Manually test interaction function of TransR."""
-        # entity embeddings
-        weights = torch.as_tensor(data=[[2.0, 2.0], [3.0, 3.0]], dtype=torch.float)
-        entity_embeddings = Embedding(
-            num_embeddings=2,
-            embedding_dim=2,
-        )
-        entity_embeddings._embeddings.weight.data.copy_(weights)
-        self.instance.entity_embeddings = entity_embeddings
-
-        # relation embeddings
-        relation_weights = torch.as_tensor(data=[[4.0, 4], [5.0, 5.0]], dtype=torch.float)
-        relation_embeddings = Embedding(
-            num_embeddings=2,
-            embedding_dim=2,
-        )
-        relation_embeddings._embeddings.weight.data.copy_(relation_weights)
-        self.instance.relation_embeddings = relation_embeddings
-
-        relation_projection_weights = torch.as_tensor(
-            data=[[5.0, 5.0, 6.0, 6.0], [7.0, 7.0, 8.0, 8.0]], dtype=torch.float
-        )
-        relation_projection_embeddings = Embedding(
-            num_embeddings=2,
-            embedding_dim=4,
-        )
-        relation_projection_embeddings._embeddings.weight.data.copy_(relation_projection_weights)
-        self.instance.relation_projections = relation_projection_embeddings
-
-        # Compute Scores
-        batch = torch.as_tensor(data=[[0, 0, 0], [0, 0, 1]], dtype=torch.long)
-        scores = self.instance.score_hrt(hrt_batch=batch)
-        self.assertEqual(scores.shape[0], 2)
-        self.assertEqual(scores.shape[1], 1)
-        first_score = scores[0].item()
-        # second_score = scores[1].item()
-        self.assertAlmostEqual(first_score, -32, delta=0.01)
-
     def _check_constraints(self):
         """Check model constraints.
 
         Entity and relation embeddings have to have at most unit L2 norm.
         """
-        for emb in (self.instance.entity_embeddings, self.instance.relation_embeddings):
+        for emb in (self.instance.entity_representations[0], self.instance.relation_representations[0]):
             assert all_in_bounds(emb(indices=None).norm(p=2, dim=-1), high=1.0, a_tol=1.0e-06)
 
 


### PR DESCRIPTION
This PR updates TransR to new-style `ERModel`.

It also removes the now obsolete `relation_dim` property.

#### Benchmark

| commit | train epoch | evaluation |
| -- | --: | --: |
| 8f3e74f4 (master) | 1.67s | 34.09s (batch_size=512) |
| ce86912b | 1.86s | 201.60s (batch_size=64) |
| 1058560d (upgrade-transr-to-er-model) | 1.86s | 38.88s (batch_size=512) |



<details>

```console
pykeen experiments reproduce transr li2015 fb15k
```

GPU: NVIDIA GeForce GTX 1080 Ti

| Key             | Value                      |
|-----------------|----------------------------|
| OS              | posix                      |
| Platform        | Linux                      |
| Release         | 5.4.0-107-generic          |
| Time            | Mon Apr 11 13:52:56 2022   |
| Python          | 3.8.10                     |
| PyKEEN          | 1.8.1-dev                  |
| PyKEEN Hash     | *                   |
| PyKEEN Branch   | * |
| PyTorch         | 1.10.0+cu113               |
| CUDA Available? | true                       |
| CUDA Version    | 11.3                       |
| cuDNN Version   | 8200                       |

</details>