### PR TITLE
⚓🧍 NodePiece Anchor Searching via PPR

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ install_requires =
     more_itertools
     pystow>=0.1.5
     docdata
-    class_resolver>=0.3.8
+    class_resolver>=0.3.9
     pyyaml
     rexmex
 

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -41,6 +41,7 @@ from .metrics.utils import Metric
 from .models import ComplExLiteral, DistMultLiteral, DistMultLiteralGated, model_resolver
 from .models.cli import build_cli_from_cls
 from .nn.modules import LiteralInteraction, interaction_resolver
+from .nn.node_piece.cli import tokenize
 from .optimizers import optimizer_resolver
 from .regularizers import regularizer_resolver
 from .sampling import negative_sampler_resolver
@@ -661,6 +662,9 @@ for cls in model_resolver.lookup_dict.values():
 # Add HPO command
 main.add_command(optimize)
 main.add_command(experiments)
+
+# Add NodePiece tokenization command
+main.add_command(tokenize)
 
 if __name__ == "__main__":
     main()

--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -22,6 +22,7 @@ from .typing import (
 __all__ = [
     "PYKEEN_HOME",
     "PYKEEN_DATASETS",
+    "PYKEEN_DATASETS_MODULE",
     "PYKEEN_BENCHMARKS",
     "PYKEEN_EXPERIMENTS",
     "PYKEEN_CHECKPOINTS",
@@ -37,6 +38,7 @@ PYKEEN_MODULE: pystow.Module = pystow.module("pykeen")
 PYKEEN_HOME: Path = PYKEEN_MODULE.base
 #: A subdirectory of the PyKEEN data folder for datasets, defaults to ``~/.data/pykeen/datasets``
 PYKEEN_DATASETS: Path = PYKEEN_MODULE.join("datasets")
+PYKEEN_DATASETS_MODULE: pystow.Module = PYKEEN_MODULE.submodule("datasets")
 #: A subdirectory of the PyKEEN data folder for benchmarks, defaults to ``~/.data/pykeen/benchmarks``
 PYKEEN_BENCHMARKS: Path = PYKEEN_MODULE.join("benchmarks")
 #: A subdirectory of the PyKEEN data folder for experiments, defaults to ``~/.data/pykeen/experiments``

--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -22,7 +22,6 @@ from .typing import (
 __all__ = [
     "PYKEEN_HOME",
     "PYKEEN_DATASETS",
-    "PYKEEN_DATASETS_MODULE",
     "PYKEEN_BENCHMARKS",
     "PYKEEN_EXPERIMENTS",
     "PYKEEN_CHECKPOINTS",
@@ -38,7 +37,6 @@ PYKEEN_MODULE: pystow.Module = pystow.module("pykeen")
 PYKEEN_HOME: Path = PYKEEN_MODULE.base
 #: A subdirectory of the PyKEEN data folder for datasets, defaults to ``~/.data/pykeen/datasets``
 PYKEEN_DATASETS: Path = PYKEEN_MODULE.join("datasets")
-PYKEEN_DATASETS_MODULE: pystow.Module = PYKEEN_MODULE.submodule("datasets")
 #: A subdirectory of the PyKEEN data folder for benchmarks, defaults to ``~/.data/pykeen/benchmarks``
 PYKEEN_BENCHMARKS: Path = PYKEEN_MODULE.join("benchmarks")
 #: A subdirectory of the PyKEEN data folder for experiments, defaults to ``~/.data/pykeen/experiments``

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -15,7 +15,7 @@ to the set of tokens, usually using the graph structure of the KG.
 One way of tokenization, is tokenization by :class:`AnchorTokenizer`, which selects some anchor
 entities from the graph as vocabulary. The anchor selection process is controlled by an
 :class:`AnchorSelection` instance. In order to obtain the assignment, some measure of graph
-distance is used. To this end, a :class:`AnchorSeracher` instance calculates the closest 
+distance is used. To this end, a :class:`AnchorSeracher` instance calculates the closest
 anchor entities from the vocabulary for each of the entities in the graph.
 
 Since some tokenizations are expensive to compute, we offer a mechanism to use precomputed tokenizations via

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -15,7 +15,7 @@ to the set of tokens, usually using the graph structure of the KG.
 One way of tokenization, is tokenization by :class:`AnchorTokenizer`, which selects some anchor
 entities from the graph as vocabulary. The anchor selection process is controlled by an
 :class:`AnchorSelection` instance. In order to obtain the assignment, some measure of graph
-distance is used. To this end, a :class:`AnchorSeracher` instance calculates the closest
+distance is used. To this end, a :class:`AnchorSearcher` instance calculates the closest
 anchor entities from the vocabulary for each of the entities in the graph.
 
 Since some tokenizations are expensive to compute, we offer a mechanism to use precomputed tokenizations via
@@ -27,7 +27,7 @@ you can use the command
 
     pykeen tokenize
 
-It usage is explained by passing the `--help` flag.
+Its usage is explained by passing the ``--help`` flag.
 """
 
 from .anchor_search import (

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -2,7 +2,13 @@
 
 """NodePiece modules."""
 
-from .anchor_search import AnchorSearcher, CSGraphAnchorSearcher, ScipySparseAnchorSearcher, anchor_searcher_resolver
+from .anchor_search import (
+    AnchorSearcher,
+    CSGraphAnchorSearcher,
+    PersonalizedPageRankAnchorSearcher,
+    ScipySparseAnchorSearcher,
+    anchor_searcher_resolver,
+)
 from .anchor_selection import (
     AnchorSelection,
     DegreeAnchorSelection,
@@ -22,6 +28,7 @@ __all__ = [
     "AnchorSearcher",
     "ScipySparseAnchorSearcher",
     "CSGraphAnchorSearcher",
+    "PersonalizedPageRankAnchorSearcher",
     # Anchor Selection
     "anchor_selection_resolver",
     "AnchorSelection",

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -18,7 +18,12 @@ from .anchor_selection import (
     SingleSelection,
     anchor_selection_resolver,
 )
-from .loader import GalkinPrecomputedTokenizerLoader, PrecomputedTokenizerLoader, precomputed_tokenizer_loader_resolver
+from .loader import (
+    GalkinPrecomputedTokenizerLoader,
+    PrecomputedTokenizerLoader,
+    TorchPrecomputedTokenizerLoader,
+    precomputed_tokenizer_loader_resolver,
+)
 from .representations import NodePieceRepresentation, TokenizationRepresentation
 from .tokenization import AnchorTokenizer, PrecomputedPoolTokenizer, RelationTokenizer, Tokenizer, tokenizer_resolver
 
@@ -47,6 +52,7 @@ __all__ = [
     "precomputed_tokenizer_loader_resolver",
     "PrecomputedTokenizerLoader",
     "GalkinPrecomputedTokenizerLoader",
+    "TorchPrecomputedTokenizerLoader",
     # Representations
     "TokenizationRepresentation",
     "NodePieceRepresentation",

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -1,6 +1,23 @@
 # -*- coding: utf-8 -*-
 
-"""NodePiece modules."""
+"""
+NodePiece modules.
+
+A :class:`NodePieceRepresentation` contains a collection of :class:`TokenizationRepresentation`.
+A :class:`TokenizationRepresentation` is defined as :class:`Representation` module mapping token
+indices to representations, also called the `vocabulary` in resemblance of token representations
+known from NLP applications, and an assignment from entities to (multiple) tokens.
+
+In order to obtain the vocabulary and assignment, multiple options are available, which often
+follow a two-step approach of first selecting a vocabulary, and afterwards assigning the entities
+to the set of tokens, usually using the graph structure of the KG.
+
+One way of tokenization, is tokenization by :class:`AnchorTokenizer`, which selects some anchor
+entities from the graph as vocabulary. The anchor selection process is controlled by an
+:class:`AnchorSelection` instance. In order to obtain the assignment, some measure of graph
+distance is used. To this end, a :class:`AnchorSeracher` instance calculates the closest 
+anchor entities from the vocabulary for each of the entities in the graph.
+"""
 
 from .anchor_search import (
     AnchorSearcher,

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -17,6 +17,17 @@ entities from the graph as vocabulary. The anchor selection process is controlle
 :class:`AnchorSelection` instance. In order to obtain the assignment, some measure of graph
 distance is used. To this end, a :class:`AnchorSeracher` instance calculates the closest 
 anchor entities from the vocabulary for each of the entities in the graph.
+
+Since some tokenizations are expensive to compute, we offer a mechanism to use precomputed tokenizations via
+:class:`PrecomputedPoolTokenizer`. To enable loading from different formats, a loader subclassing from
+:class:`PrecomputedTokenizerLoader` can be selected accordingly. To precompute anchor-based tokenizations,
+you can use the command
+
+.. code-block:: console
+
+    pykeen tokenize
+
+It usage is explained by passing the `--help` flag.
 """
 
 from .anchor_search import (

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -220,7 +220,12 @@ class ScipySparseAnchorSearcher(AnchorSearcher):
 
 
 class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
-    """Select closest anchors as the nodes with the largest personalized page rank."""
+    """
+    Select closest anchors as the nodes with the largest personalized page rank.
+
+    .. seealso::
+        http://web.stanford.edu/class/cs224w/slides/04-pagerank.pdf
+    """
 
     def __init__(self, batch_size: int = 1, use_tqdm: bool = False, page_rank_kwargs: OptionalKwargs = None):
         """

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -237,6 +237,11 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
         self.page_rank_kwargs = page_rank_kwargs or {}
         self.use_tqdm = use_tqdm
 
+    def extra_repr(self) -> Iterable[str]:  # noqa: D102
+        yield f"batch_size={self.batch_size}"
+        yield f"use_tqdm={self.use_tqdm}"
+        yield f"page_rank_kwargs={self.page_rank_kwargs}"
+
     def __call__(self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int) -> numpy.ndarray:  # noqa: D102
         # prepare adjacency matrix only once
         adj = prepare_page_rank_adjacency(edge_index=edge_index)

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -284,7 +284,7 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
         :param anchors: shape: `(num_anchors,)`
             the anchor IDs.
 
-        :yields: shape: (batch_size, num_anchor)
+        :yields: shape: (batch_size, num_anchors)
             batches of anchor PPRs.
         """
         # prepare adjacency matrix only once

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -269,7 +269,7 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
         result = numpy.full(shape=(n, k), fill_value=-1)
         i = 0
         for batch_ppr in self._iter_ppr(edge_index=edge_index, anchors=anchors):
-            batch_size = batch_ppr.shape[1]
+            batch_size = batch_ppr.shape[0]
             # select k anchors with largest ppr, shape: (batch_size, k)
             result[i : i + batch_size, :] = numpy.argpartition(-batch_ppr, kth=k, axis=-1)[:, :k]
             i += batch_size

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -244,7 +244,7 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
 
     def precalculate_anchor_ppr(self, edge_index: numpy.ndarray, anchors: numpy.ndarray) -> numpy.ndarray:
         """
-        Calculate PPR values from each node for each anchor.
+        Sort anchors nodes by PPR values from each node.
 
         :param edge_index: shape: (2, m)
             the edge index.
@@ -254,7 +254,15 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
         :return: shape: `(num_entities, num_anchors)`
             the PPR values for each anchor
         """
-        return numpy.concatenate(list(self._iter_ppr(edge_index=edge_index, anchors=anchors)))
+        return numpy.concatenate(
+            [
+                numpy.argsort(ppr_batch, axis=-1)
+                for ppr_batch in self._iter_ppr(
+                    edge_index=edge_index,
+                    anchors=anchors,
+                )
+            ]
+        )[:, ::-1]
 
     def __call__(self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int) -> numpy.ndarray:  # noqa: D102
         n = edge_index.max().item() + 1
@@ -263,11 +271,22 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
         for batch_ppr in self._iter_ppr(edge_index=edge_index, anchors=anchors):
             batch_size = batch_ppr.shape[1]
             # select k anchors with largest ppr, shape: (batch_size, k)
-            result[i : i + batch_size, :] = numpy.argpartition(-batch_ppr, kth=k, axis=0)[:k].T
+            result[i : i + batch_size, :] = numpy.argpartition(-batch_ppr, kth=k, axis=-1)[:, :k]
             i += batch_size
         return result
 
     def _iter_ppr(self, edge_index: numpy.ndarray, anchors: numpy.ndarray) -> Iterable[numpy.ndarray]:
+        """
+        Yield batches of PPR values for each anchor from each entities' perspective.
+
+        :param edge_index: shape: (2, m)
+            the edge index.
+        :param anchors: shape: `(num_anchors,)`
+            the anchor IDs.
+
+        :yields: shape: (batch_size, num_anchor)
+            batches of anchor PPRs.
+        """
         # prepare adjacency matrix only once
         adj = prepare_page_rank_adjacency(edge_index=edge_index)
         # prepare result
@@ -286,7 +305,7 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
             # run page-rank calculation, shape: (batch_size, n)
             ppr = page_rank(adj=adj, x0=x0, **self.page_rank_kwargs)
             # select PPR values for the anchors, shape: (num_anchors, batch_size)
-            yield ppr[anchors]
+            yield ppr[anchors].T
 
 
 anchor_searcher_resolver: ClassResolver[AnchorSearcher] = ClassResolver.from_subclasses(

--- a/src/pykeen/nn/node_piece/anchor_selection.py
+++ b/src/pykeen/nn/node_piece/anchor_selection.py
@@ -157,43 +157,27 @@ class PageRankAnchorSelection(SingleSelection):
     def __init__(
         self,
         num_anchors: int = 32,
-        max_iter: int = 1_000,
-        alpha: float = 0.05,
-        epsilon: float = 1.0e-04,
+        **kwargs,
     ) -> None:
         """
         Initialize the selection strategy.
 
         :param num_anchors:
             the number of anchors to select
-        :param max_iter:
-            the maximum number of power iterations
-        :param alpha:
-            the smoothing value / teleport probability
-        :param epsilon:
-            a constant to check for convergence
+        :param kwargs:
+            additional keyword-based parameters passed to :func:`page_rank`.
         """
         super().__init__(num_anchors=num_anchors)
-        self.max_iter = max_iter
-        self.alpha = alpha
-        self.epsilon = epsilon
+        self.kwargs = kwargs
 
     def extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().extra_repr()
-        yield f"max_iter={self.max_iter}"
-        yield f"alpha={self.alpha}"
-        yield f"epsilon={self.epsilon}"
+        for key, value in self.kwargs.items():
+            yield f"{key}={value}"
 
     def rank(self, edge_index: numpy.ndarray) -> numpy.ndarray:  # noqa: D102
         # sort by decreasing page rank
-        return numpy.argsort(
-            page_rank(
-                edge_index=edge_index,
-                max_iter=self.max_iter,
-                alpha=self.alpha,
-                epsilon=self.epsilon,
-            ),
-        )[::-1]
+        return numpy.argsort(page_rank(edge_index=edge_index, **self.kwargs))[::-1]
 
 
 class RandomAnchorSelection(SingleSelection):

--- a/src/pykeen/nn/node_piece/anchor_selection.py
+++ b/src/pykeen/nn/node_piece/anchor_selection.py
@@ -158,7 +158,12 @@ class DegreeAnchorSelection(SingleSelection):
 
 
 class PageRankAnchorSelection(SingleSelection):
-    """Select entities according to their page rank."""
+    """
+    Select entities according to their page rank.
+
+    .. seealso::
+        http://web.stanford.edu/class/cs224w/slides/04-pagerank.pdf
+    """
 
     def __init__(
         self,

--- a/src/pykeen/nn/node_piece/anchor_selection.py
+++ b/src/pykeen/nn/node_piece/anchor_selection.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 
-"""Anchor selection for NodePiece."""
+"""
+Anchor selection for NodePiece.
+
+An anchor selection method selects a given number of entities from the KG which serve as *anchors* to describe other
+entities. Most of these methods rely on some form of
+`(graph) centrality measure <https://en.wikipedia.org/wiki/Centrality>`_ to select central entities.
+"""
 
 import logging
 from abc import ABC, abstractmethod

--- a/src/pykeen/nn/node_piece/cli.py
+++ b/src/pykeen/nn/node_piece/cli.py
@@ -20,9 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @click.command()
-# TODO: no default results in error in class_resolver:
-# ValueError: no default given either from resolver or explicitly
-@dataset_resolver.get_option("-d", "--dataset", as_string=True, default="nations")
+@dataset_resolver.get_option("-d", "--dataset", as_string=True, required=True)
 @click.option("-c", "--configuration-path", type=pathlib.Path, default=None)
 @click.option("-k", "--num-tokens", type=int, default=None)
 @click.option("-a", "--num-anchors", type=int, default=None)

--- a/src/pykeen/nn/node_piece/cli.py
+++ b/src/pykeen/nn/node_piece/cli.py
@@ -59,7 +59,7 @@ def tokenize(
         configuration = {}
     else:
         logger.info(f"Loading tokenization configuration from {configuration_path}")
-        configuration = load_configuration(configuration_path)
+        configuration = dict(load_configuration(configuration_path))
 
     if output_path is None:
         # calculate configuration digest

--- a/src/pykeen/nn/node_piece/cli.py
+++ b/src/pykeen/nn/node_piece/cli.py
@@ -74,7 +74,7 @@ def tokenize(
     if output_path.exists():
         logger.warning(f"Output path exists: {output_path}")
         if not force:
-            logger.info(f"Existing file will not be overwritten. To enforce this, pass `--force`")
+            logger.info("Existing file will not be overwritten. To enforce this, pass `--force`")
             quit()
 
     # create anchor selection instance

--- a/src/pykeen/nn/node_piece/cli.py
+++ b/src/pykeen/nn/node_piece/cli.py
@@ -1,4 +1,5 @@
 """Command-Line Interface for pre-computing tokenizations for NodePiece."""
+import copy
 import logging
 import math
 import pathlib
@@ -62,7 +63,10 @@ def tokenize(
 
     if output_path is None:
         # calculate configuration digest
-        digest = _digest_kwargs(configuration)
+        _configuration = copy.deepcopy(configuration)
+        _configuration["num_anchors"] = num_anchors
+        _configuration["num_tokens"] = num_tokens
+        digest = _digest_kwargs(_configuration)
         output_path = PYKEEN_MODULE.join(__name__.replace(".cli", ""), dataset_resolver.normalize(dataset)).joinpath(
             f"{digest}.pt"
         )

--- a/src/pykeen/nn/node_piece/cli.py
+++ b/src/pykeen/nn/node_piece/cli.py
@@ -1,0 +1,105 @@
+"""Command-Line Interface for pre-computing tokenizations for NodePiece."""
+import logging
+import math
+import pathlib
+from typing import Optional
+
+import click
+import more_click
+
+from .anchor_search import anchor_searcher_resolver
+from .anchor_selection import anchor_selection_resolver
+from .loader import TorchPrecomputedTokenizerLoader
+from ...constants import PYKEEN_MODULE
+from ...datasets import dataset_resolver
+from ...datasets.utils import _digest_kwargs
+from ...utils import load_configuration
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+# TODO: no default results in error in class_resolver:
+# ValueError: no default given either from resolver or explicitly
+@dataset_resolver.get_option("-d", "--dataset", as_string=True, default="nations")
+@click.option("-c", "--configuration-path", type=pathlib.Path, default=None)
+@click.option("-k", "--num-tokens", type=int, default=None)
+@click.option("-a", "--num-anchors", type=int, default=None)
+@click.option("-o", "--output-path", type=pathlib.Path, default=None)
+@more_click.log_level_option()
+@click.option("--force", is_flag=True)
+def tokenize(
+    dataset: str,
+    configuration_path: pathlib.Path,
+    num_tokens: Optional[int],
+    num_anchors: Optional[int],
+    output_path: Optional[pathlib.Path],
+    log_level: str,
+    force: bool,
+):
+    """Pre-compute tokenization."""
+    logging.basicConfig(level=log_level)
+
+    logger.info(f"Loading dataset: {dataset}")
+    dataset_instance = dataset_resolver.make(dataset)
+
+    # heuristic
+    if num_anchors is None:
+        num_anchors = max(2, int(math.ceil(math.sqrt(dataset_instance.num_entities))))
+        logger.info(f"Inferred number of anchors using sqrt(num_entities) heuristic: {num_anchors}")
+
+    # heuristic
+    if num_tokens is None:
+        num_tokens = max(2, int(math.ceil(math.sqrt(num_anchors))))
+        logger.info(f"Inferred number of tokens using sqrt(num_anchors) heuristic: {num_tokens}")
+
+    if configuration_path is None:
+        logger.warning("No configuration path provided. Will use defaults.")
+        configuration = {}
+    else:
+        logger.info(f"Loading tokenization configuration from {configuration_path}")
+        configuration = load_configuration(configuration_path)
+
+    if output_path is None:
+        # calculate configuration digest
+        digest = _digest_kwargs(configuration)
+        output_path = PYKEEN_MODULE.join(__name__.replace(".cli", ""), dataset_resolver.normalize(dataset)).joinpath(
+            f"{digest}.pt"
+        )
+        logger.info(f"Inferred output path: {output_path}")
+    if output_path.exists():
+        logger.warning(f"Output path exists: {output_path}")
+        if not force:
+            logger.info(f"Existing file will not be overwritten. To enforce this, pass `--force`")
+            quit()
+
+    # create anchor selection instance
+    anchor_selection_config = configuration.pop("anchor_selection", {})
+    anchor_selection = anchor_selection_config.pop("class", None)  # TODO: better key?
+    anchor_selection_instance = anchor_selection_resolver.make(
+        anchor_selection, pos_kwargs=anchor_selection_config, num_anchors=num_anchors
+    )
+    logger.info(f"Created anchor selection instance: {anchor_selection_instance}")
+
+    # select anchors
+    edge_index = dataset_instance.training.mapped_triples[:, [0, 2]].numpy().T
+    anchors = anchor_selection_instance(edge_index=edge_index)
+    logger.info(f"Selected {len(anchors)} anchors")
+
+    # anchor search (=anchor assignment?)
+    anchor_searcher_config = configuration.pop("anchor_searcher", {})
+    anchor_searcher = anchor_searcher_config.pop("class", None)
+    anchor_searcher_instance = anchor_searcher_resolver.make(anchor_searcher, pos_kwargs=anchor_searcher_config)
+    logger.info(f"Created anchor searcher instance: {anchor_searcher_instance}")
+
+    # assign anchors
+    sorted_anchor_ids = anchor_searcher_instance(edge_index=edge_index, anchors=anchors, k=num_tokens)
+
+    # save
+    TorchPrecomputedTokenizerLoader.save(
+        path=output_path,
+        order=sorted_anchor_ids,
+        anchor_ids=anchors,
+    )
+
+    logger.info(f"Saved tokenization to {output_path}")

--- a/src/pykeen/nn/node_piece/loader.py
+++ b/src/pykeen/nn/node_piece/loader.py
@@ -56,6 +56,22 @@ class GalkinPrecomputedTokenizerLoader(PrecomputedTokenizerLoader):
         }, len(anchor_map)
 
 
+class TorchPrecomputedTokenizerLoader(PrecomputedTokenizerLoader):
+    """A loader via torch.load."""
+
+    def __call__(self, path: pathlib.Path) -> Tuple[Mapping[int, Collection[int]], int]:  # noqa: D102
+        c = torch.load(path)
+        # anchor_ids = c["anchors"]  # ignored for now
+        order = c["order"]
+        logger.info(f"Loaded precomputed pools of shape {order.shape}.")
+        # TODO: since we save a contiguous array of (num_entities, num_anchors),
+        # it would be more efficient to not convert to a mapping, but directly select from the tensor
+        return {
+            i: list(anchor_ids)
+            for i, anchor_ids in enumerate(order)
+        }
+
+
 precomputed_tokenizer_loader_resolver: ClassResolver[PrecomputedTokenizerLoader] = ClassResolver.from_subclasses(
     base=PrecomputedTokenizerLoader,
     default=GalkinPrecomputedTokenizerLoader,

--- a/src/pykeen/nn/node_piece/loader.py
+++ b/src/pykeen/nn/node_piece/loader.py
@@ -20,6 +20,7 @@ __all__ = [
     "PrecomputedTokenizerLoader",
     # Concrete classes
     "GalkinPrecomputedTokenizerLoader",
+    "TorchPrecomputedTokenizerLoader",
 ]
 
 logger = logging.getLogger(__name__)

--- a/src/pykeen/nn/node_piece/loader.py
+++ b/src/pykeen/nn/node_piece/loader.py
@@ -92,7 +92,7 @@ class TorchPrecomputedTokenizerLoader(PrecomputedTokenizerLoader):
         num_anchors = c["anchors"].shape[0]
         # TODO: since we save a contiguous array of (num_entities, num_anchors),
         # it would be more efficient to not convert to a mapping, but directly select from the tensor
-        return {i: anchor_ids.tolist() for i, anchor_ids in enumerate(order)}, num_anchors   # type: ignore
+        return {i: anchor_ids.tolist() for i, anchor_ids in enumerate(order)}, num_anchors  # type: ignore
 
 
 precomputed_tokenizer_loader_resolver: ClassResolver[PrecomputedTokenizerLoader] = ClassResolver.from_subclasses(

--- a/src/pykeen/nn/node_piece/loader.py
+++ b/src/pykeen/nn/node_piece/loader.py
@@ -89,9 +89,10 @@ class TorchPrecomputedTokenizerLoader(PrecomputedTokenizerLoader):
         c = torch.load(path)
         order = c["order"]
         logger.info(f"Loaded precomputed pools of shape {order.shape}.")
+        num_anchors = c["anchors"].shape[0]
         # TODO: since we save a contiguous array of (num_entities, num_anchors),
         # it would be more efficient to not convert to a mapping, but directly select from the tensor
-        return {i: anchor_ids.tolist() for i, anchor_ids in enumerate(order)}  # type: ignore
+        return {i: anchor_ids.tolist() for i, anchor_ids in enumerate(order)}, num_anchors   # type: ignore
 
 
 precomputed_tokenizer_loader_resolver: ClassResolver[PrecomputedTokenizerLoader] = ClassResolver.from_subclasses(

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -23,6 +23,7 @@ def page_rank(
     alpha: float = 0.05,
     epsilon: float = 1.0e-04,
     x0: Optional[numpy.ndarray] = None,
+    use_tqdm: bool = False,
 ) -> numpy.ndarray:
     """
     Compute page-rank vector by power iteration.
@@ -37,6 +38,8 @@ def page_rank(
         a (small) constant to check for convergence
     :param x0: shape: `(n,)`, or `(n, batch_size)`
         the initial value for $x$. If None, set to a constant $1/n$ vector.
+    :param use_tqdm:
+        whether to use a tqdm progress bar
 
     :return: shape: `(n,)`
         the page-rank vector, i.e., a score between 0 and 1 for each node.
@@ -61,7 +64,10 @@ def page_rank(
     # power iteration
     x_old = x = x0
     beta = 1.0 - alpha
-    for i in range(max_iter):
+    progress = range(max_iter)
+    if use_tqdm:
+        progress = tqdm(progress, unit_scale=True, leave=False)
+    for i in progress:
         x = beta * adj.dot(x) + alpha * x0
         if numpy.linalg.norm(x - x_old, ord=float("+inf")) < epsilon:
             logger.debug(f"Converged after {i} iterations up to {epsilon}.")

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -66,7 +66,10 @@ def page_rank(
         progress = tqdm(progress, unit_scale=True, leave=False)
     for i in progress:
         x = beta * adj.dot(x) + alpha * x0
-        if numpy.linalg.norm(x - x_old, ord=float("+inf")) < epsilon:
+        max_diff = numpy.linalg.norm(x - x_old, ord=float("+inf"))
+        if use_tqdm:
+            progress.set_postfix(max_diff=max_diff)
+        if max_diff < epsilon:
             logger.debug(f"Converged after {i} iterations up to {epsilon}.")
             break
         x_old = x

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -35,10 +35,10 @@ def page_rank(
         the smoothing value / teleport probability
     :param epsilon: $>0$
         a (small) constant to check for convergence
-    :param x0:
+    :param x0: shape: `(n,)`, or `(n, batch_size)`
         the initial value for $x$. If None, set to a constant $1/n$ vector.
 
-    :return: shape: (n,)
+    :return: shape: `(n,)`
         the page-rank vector, i.e., a score between 0 and 1 for each node.
     """
     # convert to sparse matrix, shape: (n, n)

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -57,6 +57,10 @@ def page_rank(
     if x0 is None:
         n = adj.shape[0]
         x0 = numpy.full(shape=(n,), fill_value=1.0 / n)
+    else:
+        numpy.testing.assert_allclose(x0.sum(axis=0), 1.0)
+        assert (x0 >= 0.0).all()
+        assert (x0 <= 1.0).all()
 
     # power iteration
     x_old = x = x0
@@ -66,7 +70,7 @@ def page_rank(
         progress = tqdm(progress, unit_scale=True, leave=False)
     for i in progress:
         x = beta * adj.dot(x) + alpha * x0
-        max_diff = numpy.linalg.norm(x - x_old, ord=float("+inf"))
+        max_diff = numpy.linalg.norm(x - x_old, ord=float("+inf"), axis=0).max()
         if use_tqdm:
             progress.set_postfix(max_diff=max_diff)
         if max_diff < epsilon:

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -47,6 +47,9 @@ def page_rank(
 
     :return: shape: `(n,)`
         the page-rank vector, i.e., a score between 0 and 1 for each node.
+
+    :raises ValueError:
+        if neither `adj` nor `edge_index` are provided
     """
     if adj is None:
         if edge_index is None:
@@ -72,6 +75,7 @@ def page_rank(
         x = beta * adj.dot(x) + alpha * x0
         max_diff = numpy.linalg.norm(x - x_old, ord=float("+inf"), axis=0).max()
         if use_tqdm:
+            assert isinstance(progress, tqdm)  # for mypy
             progress.set_postfix(max_diff=max_diff)
         if max_diff < epsilon:
             logger.debug(f"Converged after {i} iterations up to {epsilon}.")

--- a/tests/test_nn/test_node_piece.py
+++ b/tests/test_nn/test_node_piece.py
@@ -91,6 +91,12 @@ class ScipySparseAnchorSearcherTests(cases.AnchorSearcherTestCase):
         numpy.testing.assert_array_equal(pool, exp_pool)
 
 
+class PersonalizedPageRankAnchorSearcherTests(cases.AnchorSearcherTestCase):
+    """Tests for anchor search via PPR."""
+
+    cls = pykeen.nn.node_piece.PersonalizedPageRankAnchorSearcher
+
+
 class AnchorSearcherMetaTestCase(unittest_templates.MetaTestCase[pykeen.nn.node_piece.AnchorSearcher]):
     """Test for tests for anchor search strategies."""
 


### PR DESCRIPTION
This PR adds

* [x] another searcher, which uses PPR values instead of the shortest path distance to select the "closest" anchors
* [x] a CLI command to pre-compute tokenizations for NodePiece
* [x] a loader of precomputed pools from a more condensed array-based serialization format

#### Example
* default anchor selection and search strategy
```console
pykeen tokenize -d fb15k237
```
* using a configuration file
```console
pykeen tokenize -d fb15k237 -c ./config.yaml
```
with `./config.yaml` containing
```yaml
selection:
   class: page-rank
   alpha: 0.2
search:
   class: personalized-page-rank
   use_tqdm: true
   batch_size: 256
```