### PR TITLE
✨🤖 Update DistMult to ERModel

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -121,7 +121,7 @@ class TestDistMult(cases.ModelTestCase):
 
         Entity embeddings have to have unit L2 norm.
         """
-        entity_norms = self.instance.entity_embeddings(indices=None).norm(p=2, dim=-1)
+        entity_norms = self.instance.entity_representations[0](indices=None).norm(p=2, dim=-1)
         assert torch.allclose(entity_norms, torch.ones_like(entity_norms))
 
     def _test_score_all_triples(self, k: Optional[int], batch_size: int = 16):


### PR DESCRIPTION
This PR updates `DistMult` to `ERModel`.

#### Benchmark

**TL;DR**: Overall comparable runtime; in training slightly slower; in some evaluation settings faster.

<details>

| Key             | Value                    |
|-----------------|--------------------------|
| OS              | posix                    |
| Platform        | Linux                    |
| Release         | 5.4.0-81-generic         |
| Time            | Sat Apr 16 18:12:51 2022 |
| Python          | 3.8.10                   |
| PyKEEN          | 1.8.1-dev                |
| PyKEEN Hash     | *                 |
| PyKEEN Branch   | *                   |
| PyTorch         | 1.10.0+cu113             |
| CUDA Available? | true                     |
| CUDA Version    | 11.3                     |
| cuDNN Version   | 8200                     |

```console
pykeen experiments reproduce distmult yang2014 fb15k
```
| commit | train | eval |
| -- | -- | -- |
| 661b0eb5244d1906c1353fae50ffb5af6bac78cf (`master`) | 3.04s* | 12.90s** |
| a7bc64e (`update-distmult-to-ermodel`) | 3.10s* | 11.63s** |

* `*`: `sub_batch_size=24155`
* `**`: `batch_size=2048.`

```console
pykeen experiments reproduce distmult yang2014 wn18
```

| commit | train | eval |
| -- | -- | -- |
| 661b0eb5244d1906c1353fae50ffb5af6bac78cf (`master`) | 1.03s* | 2.12s** |
| a7bc64e (`update-distmult-to-ermodel`) | 1.04s* | 1.43s** |


* `*`: `sub_batch_size=24155`
* `**`: `batch_size=1024.`

```console
pykeen train distmult --embedding-dim 128 --training-loop lcwa --create-inverse-triples --dataset fb15k237 --batch-size 1024
```
| commit | train | eval |
| -- | -- | -- |
| 661b0eb5244d1906c1353fae50ffb5af6bac78cf (`master`) | 51.87s | 3.27s* |
| a7bc64e (`update-distmult-to-ermodel`) | 51.90s | 3.29s* |

* `*`: `batch_size=2048`

</details>