### PR TITLE
✨🤖 Update ProjE to ERModel

### DIFF
--- a/src/pykeen/models/unimodal/proj_e.py
+++ b/src/pykeen/models/unimodal/proj_e.py
@@ -74,9 +74,9 @@ class ProjE(ERModel):
                 inner_non_linearity=inner_non_linearity,
             ),
             entity_representations_kwargs=dict(
-                    shape=embedding_dim,
-                    initializer=entity_initializer,
-                ),,
+                shape=embedding_dim,
+                initializer=entity_initializer,
+            ),
             relation_representations_kwargs=dict(
                 shape=embedding_dim,
                 initializer=relation_initializer,

--- a/src/pykeen/models/unimodal/proj_e.py
+++ b/src/pykeen/models/unimodal/proj_e.py
@@ -4,15 +4,13 @@
 
 from typing import Any, ClassVar, Mapping, Optional, Type
 
-import numpy
-import torch
-import torch.autograd
 from torch import nn
 
-from ..base import EntityRelationEmbeddingModel
+from ..nbase import ERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...losses import BCEWithLogitsLoss, Loss
 from ...nn.init import xavier_uniform_
+from ...nn.modules import ProjEInteraction
 from ...typing import Hint, Initializer
 
 __all__ = [
@@ -20,7 +18,7 @@ __all__ = [
 ]
 
 
-class ProjE(EntityRelationEmbeddingModel):
+class ProjE(ERModel):
     r"""An implementation of ProjE from [shi2017]_.
 
     ProjE is a neural network-based approach with a *combination* and a *projection* layer. The interaction model
@@ -70,76 +68,18 @@ class ProjE(EntityRelationEmbeddingModel):
         **kwargs,
     ) -> None:
         super().__init__(
-            entity_representations_kwargs=dict(
-                shape=embedding_dim,
-                initializer=entity_initializer,
+            interaction=ProjEInteraction,
+            interaction_kwargs=dict(
+                embedding_dim=embedding_dim,
+                inner_non_linearity=inner_non_linearity,
             ),
+            entity_representations_kwargs=dict(
+                    shape=embedding_dim,
+                    initializer=entity_initializer,
+                ),,
             relation_representations_kwargs=dict(
                 shape=embedding_dim,
                 initializer=relation_initializer,
             ),
             **kwargs,
         )
-
-        # Global entity projection
-        self.d_e = nn.Parameter(torch.empty(self.embedding_dim, device=self.device), requires_grad=True)
-
-        # Global relation projection
-        self.d_r = nn.Parameter(torch.empty(self.embedding_dim, device=self.device), requires_grad=True)
-
-        # Global combination bias
-        self.b_c = nn.Parameter(torch.empty(self.embedding_dim, device=self.device), requires_grad=True)
-
-        # Global combination bias
-        self.b_p = nn.Parameter(torch.empty(1, device=self.device), requires_grad=True)
-
-        if inner_non_linearity is None:
-            inner_non_linearity = nn.Tanh()
-        self.inner_non_linearity = inner_non_linearity
-
-    def _reset_parameters_(self):  # noqa: D102
-        super()._reset_parameters_()
-        bound = numpy.sqrt(6) / self.embedding_dim
-        nn.init.uniform_(self.d_e, a=-bound, b=bound)
-        nn.init.uniform_(self.d_r, a=-bound, b=bound)
-        nn.init.uniform_(self.b_c, a=-bound, b=bound)
-        nn.init.uniform_(self.b_p, a=-bound, b=bound)
-
-    def score_hrt(self, hrt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=hrt_batch[:, 0])
-        r = self.relation_embeddings(indices=hrt_batch[:, 1])
-        t = self.entity_embeddings(indices=hrt_batch[:, 2])
-
-        # Compute score
-        hidden = self.inner_non_linearity(self.d_e[None, :] * h + self.d_r[None, :] * r + self.b_c[None, :])
-        scores = torch.sum(hidden * t, dim=-1, keepdim=True) + self.b_p
-
-        return scores
-
-    def score_t(self, hr_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=hr_batch[:, 0])
-        r = self.relation_embeddings(indices=hr_batch[:, 1])
-        t = self.entity_embeddings(indices=None)
-
-        # Rank against all entities
-        hidden = self.inner_non_linearity(self.d_e[None, :] * h + self.d_r[None, :] * r + self.b_c[None, :])
-        scores = torch.sum(hidden[:, None, :] * t[None, :, :], dim=-1) + self.b_p
-
-        return scores
-
-    def score_h(self, rt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
-        # Get embeddings
-        h = self.entity_embeddings(indices=None)
-        r = self.relation_embeddings(indices=rt_batch[:, 0])
-        t = self.entity_embeddings(indices=rt_batch[:, 1])
-
-        # Rank against all entities
-        hidden = self.inner_non_linearity(
-            self.d_e[None, None, :] * h[None, :, :]
-            + (self.d_r[None, None, :] * r[:, None, :] + self.b_c[None, None, :]),
-        )
-        scores = torch.sum(hidden * t[:, None, :], dim=-1) + self.b_p
-
-        return scores

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -563,8 +563,8 @@ def proje_interaction(
         The scores.
     """
     # global projections
-    h = h * d_e.view(*make_ones_like(h.shape[:-1]), -1)
-    r = r * d_r.view(*make_ones_like(h.shape[:-1]), -1)
+    h = torch.einsum("...d, d -> ...d", h, d_e)
+    r = torch.einsum("...d, d -> ...d", r, d_r)
 
     # combination, shape: (*batch_dims, d)
     x = activation(tensor_sum(h, r, b_c))

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -570,7 +570,7 @@ def proje_interaction(
     x = activation(tensor_sum(h, r, b_c))
 
     # dot product with t
-    return (x * t).sum(dim=-1) + b_p
+    return torch.einsum("...d, ...d -> ...", x, t) + b_p
 
 
 def rescal_interaction(


### PR DESCRIPTION
This PR updates `ProjE` to new-style `ERModel`.

#### Benchmark

**TL;DR**: in LCWA, the new version is almost twice as fast. In sLCWA (with 1 negative sample only), it is slower in training (but faster in evaluation, cf. LCWA)

<details>

| Key             | Value                    |
|-----------------|--------------------------|
| OS              | posix                    |
| Platform        | Linux                    |
| Release         | 5.4.0-81-generic         |
| Time            | Sat Apr 16 18:12:51 2022 |
| Python          | 3.8.10                   |
| PyKEEN          | 1.8.1-dev                |
| PyKEEN Hash     | *                 |
| PyKEEN Branch   | *                   |
| PyTorch         | 1.10.0+cu113             |
| CUDA Available? | true                     |
| CUDA Version    | 11.3                     |
| cuDNN Version   | 8200                     |

Since there is no experiment configuration available, we use some exemplary `pykeen train` calls.
```console
pykeen train proje --embedding-dim 256 --dataset fb15k237 --create-inverse-triples --training-loop lcwa
```

| commit | train | eval |
| -- | -- | -- |
| f47ee602573c87f6dace277ff656d2b12eeb5430 (`master`) | 67.68s | 4.90s* |
| bb67147c23e569e41a9a3cae725db8d8f036cdde (`update-proje-to-ermodel`) | 36.92s | 1.69s** |

* `*` with `batch_size=1024`
* `**` with `batch_size=4096`

```console
pykeen train proje --embedding-dim 256 --dataset fb15k237
```

| commit | train | eval |
| -- | -- | -- |
| f47ee602573c87f6dace277ff656d2b12eeb5430 (`master`) | 2.85s | 7.10s* |
| bb67147c23e569e41a9a3cae725db8d8f036cdde (`update-proje-to-ermodel`) | 4.05s | 4.40s* |

* `*` with `batch_size=1024`

</details>