### PR TITLE
♻️☎️ Re-use optimized batch-size in evaluation callback

### DIFF
--- a/src/pykeen/training/callbacks.py
+++ b/src/pykeen/training/callbacks.py
@@ -248,6 +248,7 @@ class EvaluationTrainingCallback(TrainingCallback):
         self.evaluator = evaluator_resolver.make(evaluator, evaluator_kwargs)
         self.prefix = prefix
         self.kwargs = kwargs
+        self.batch_size = self.kwargs.pop("batch_size", None)
 
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         if epoch % self.frequency:
@@ -256,6 +257,7 @@ class EvaluationTrainingCallback(TrainingCallback):
             model=self.model,
             mapped_triples=self.evaluation_triples,
             device=self.training_loop.device,
+            batch_size=self.evaluator.batch_size or self.batch_size,
             **self.kwargs,
         )
         self.result_tracker.log_metrics(metrics=result.to_flat_dict(), step=epoch, prefix=self.prefix)

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -69,7 +69,7 @@ from pykeen.optimizers import optimizer_resolver
 from pykeen.pipeline import pipeline
 from pykeen.regularizers import LpRegularizer, Regularizer
 from pykeen.trackers import ResultTracker
-from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop, TrainingLoop
+from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop, TrainingLoop, TrainingCallback
 from pykeen.triples import Instances, TriplesFactory, generation
 from pykeen.triples.instances import BaseBatchedSLCWAInstances, SLCWABatch
 from pykeen.triples.splitting import Cleaner, Splitter
@@ -2283,4 +2283,23 @@ class BatchSLCWATrainingInstancesTestCase(unittest_templates.GenericTestCase[Bas
                 )
             ),
             self.factory.num_triples,
+        )
+
+
+class TrainingCallbackTestCase(unittest_templates.GenericTestCase[TrainingCallback]):
+    """Base test case for training callbacks."""
+
+    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
+        kwargs = super()._pre_instantiation_hook(kwargs)
+        self.dataset = Nations()
+        return kwargs
+
+    def test_pipeline(self):
+        """Test running a small pipeline with the provided callback."""
+        pipeline(
+            dataset=self.dataset,
+            model="distmult",
+            training_kwargs=dict(
+                callbacks=self.instance,
+            ),
         )

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -69,7 +69,7 @@ from pykeen.optimizers import optimizer_resolver
 from pykeen.pipeline import pipeline
 from pykeen.regularizers import LpRegularizer, Regularizer
 from pykeen.trackers import ResultTracker
-from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop, TrainingLoop, TrainingCallback
+from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop, TrainingCallback, TrainingLoop
 from pykeen.triples import Instances, TriplesFactory, generation
 from pykeen.triples.instances import BaseBatchedSLCWAInstances, SLCWABatch
 from pykeen.triples.splitting import Cleaner, Splitter

--- a/tests/test_training/test_callbacks.py
+++ b/tests/test_training/test_callbacks.py
@@ -1,7 +1,15 @@
 """Tests for training callbacks."""
+import unittest
 from typing import Any, MutableMapping
-from .. import cases
+from unittest import mock
+
+import torch
+
+from pykeen.evaluation.evaluator import Evaluator
+from pykeen.pipeline import pipeline
 from pykeen.training.callbacks import EvaluationTrainingCallback
+
+from .. import cases
 
 
 class EvaluationTrainingCallbackTestCase(cases.TrainingCallbackTestCase):
@@ -13,3 +21,20 @@ class EvaluationTrainingCallbackTestCase(cases.TrainingCallbackTestCase):
         kwargs = super()._pre_instantiation_hook(kwargs)
         kwargs["evaluation_triples"] = self.dataset.validation.mapped_triples
         return kwargs
+
+    @unittest.skipIf(
+        condition=not torch.cuda.is_available(),
+        reason="automatic memory optimization only active for GPU",
+    )
+    def test_batch_size(self):
+        """Test batch size gets updated by automatic memory optimization."""
+        assert isinstance(self.instance, EvaluationTrainingCallback)
+        with mock.patch.object(Evaluator, "evaluate", side_effect=self.instance.evaluator.evaluate) as mock_evaluate:
+            pipeline(
+                dataset="nations",
+                model="distmult",
+                training_kwargs=dict(
+                    callbacks=self.instance,
+                ),
+            )
+            assert {c.kwargs.get("batch_size", None) for c in mock_evaluate.call_args_list} != {None}

--- a/tests/test_training/test_callbacks.py
+++ b/tests/test_training/test_callbacks.py
@@ -1,0 +1,15 @@
+"""Tests for training callbacks."""
+from typing import Any, MutableMapping
+from .. import cases
+from pykeen.training.callbacks import EvaluationTrainingCallback
+
+
+class EvaluationTrainingCallbackTestCase(cases.TrainingCallbackTestCase):
+    """Test for evaluation callback."""
+
+    cls = EvaluationTrainingCallback
+
+    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
+        kwargs = super()._pre_instantiation_hook(kwargs)
+        kwargs["evaluation_triples"] = self.dataset.validation.mapped_triples
+        return kwargs


### PR DESCRIPTION
In the evaluation training callback, we do not re-use the stored optimized batch size of the evaluator instance, but rather re-optimize it each time the callback is called.