### PR TITLE
👯‍♂️👯‍♀️ Unique hashes in the NodePiece representation

### DIFF
--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -52,7 +52,7 @@ from .loader import (
     TorchPrecomputedTokenizerLoader,
     precomputed_tokenizer_loader_resolver,
 )
-from .representations import NodePieceRepresentation, TokenizationRepresentation, RatioInfo
+from .representations import DiversityInfo, NodePieceRepresentation, TokenizationRepresentation
 from .tokenization import AnchorTokenizer, PrecomputedPoolTokenizer, RelationTokenizer, Tokenizer, tokenizer_resolver
 
 __all__ = [
@@ -85,7 +85,7 @@ __all__ = [
     "TokenizationRepresentation",
     "NodePieceRepresentation",
     # Data containers
-    "RatioInfo",
+    "DiversityInfo",
 ]
 
 # TODO: use graph library, such as igraph, graph-tool, or networkit

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -52,7 +52,7 @@ from .loader import (
     TorchPrecomputedTokenizerLoader,
     precomputed_tokenizer_loader_resolver,
 )
-from .representations import NodePieceRepresentation, TokenizationRepresentation
+from .representations import NodePieceRepresentation, TokenizationRepresentation, RatioInfo
 from .tokenization import AnchorTokenizer, PrecomputedPoolTokenizer, RelationTokenizer, Tokenizer, tokenizer_resolver
 
 __all__ = [
@@ -84,6 +84,8 @@ __all__ = [
     # Representations
     "TokenizationRepresentation",
     "NodePieceRepresentation",
+    # Data containers
+    "RatioInfo",
 ]
 
 # TODO: use graph library, such as igraph, graph-tool, or networkit

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -52,7 +52,7 @@ from .loader import (
     TorchPrecomputedTokenizerLoader,
     precomputed_tokenizer_loader_resolver,
 )
-from .representations import DiversityInfo, NodePieceRepresentation, TokenizationRepresentation
+from .representations import HashDiversityInfo, NodePieceRepresentation, TokenizationRepresentation
 from .tokenization import AnchorTokenizer, PrecomputedPoolTokenizer, RelationTokenizer, Tokenizer, tokenizer_resolver
 
 __all__ = [
@@ -85,7 +85,7 @@ __all__ = [
     "TokenizationRepresentation",
     "NodePieceRepresentation",
     # Data containers
-    "DiversityInfo",
+    "HashDiversityInfo",
 ]
 
 # TODO: use graph library, such as igraph, graph-tool, or networkit

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -3,7 +3,7 @@
 """Representation modules for NodePiece."""
 
 import logging
-from typing import Callable, Optional, Sequence, Union, Tuple, List
+from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 import torch
 from class_resolver import HintOrType, OneOrManyHintOrType, OneOrManyOptionalKwargs, OptionalKwargs
@@ -302,7 +302,7 @@ class NodePieceRepresentation(Representation):
     def ratio_unique_hashes(self) -> Tuple[List[float], float]:
         """
         Return the ratio of unique hashes in the total pool.
-        
+
         :return:
             A pair `unique_per_repr, unique_total`, where `unique_per_repr` is a list with
             the percentage of unique hashes for each token representation, and `unique_total`
@@ -322,4 +322,3 @@ class NodePieceRepresentation(Representation):
             dim=0
         ).shape[0]
         return uniques_per_representation, uniques_total / self.max_id
-

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -310,8 +310,7 @@ class NodePieceRepresentation(Representation):
         """
         # unique hashes per representation
         uniques_per_representation = [
-            tokens.assignment.unique(dim=0).shape[0] / self.max_id
-            for tokens in self.token_representations
+            tokens.assignment.unique(dim=0).shape[0] / self.max_id for tokens in self.token_representations
         ]
 
         # unique hashes if we concat all representations together

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -323,7 +323,16 @@ class NodePieceRepresentation(Representation):
         :return:
             A ratio information tuple
 
-        .. todo:: @migalkin explain why you would want to calculate this
+        Tokenization strategies might produce exactly the same hashes for
+        several nodes depending on the graph structure and tokenization
+        parameters. Same hashes will result in same node representations
+        and, hence, might inhibit the downstream performance.
+        This function comes handy when you need to estimate the diversity
+        of built node hashes under a certain tokenization strategy - ideally,
+        you'd want every node to have a unique hash.
+        The function computes how many node hashes are unique in each
+        representation and overall (if we concat all of them in a single row).
+        1.0 means that all nodes have unique hashes.
 
         Example usage:
 

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -3,7 +3,7 @@
 """Representation modules for NodePiece."""
 
 import logging
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Union, Tuple, List
 
 import torch
 from class_resolver import HintOrType, OneOrManyHintOrType, OneOrManyOptionalKwargs, OptionalKwargs
@@ -298,3 +298,23 @@ class NodePieceRepresentation(Representation):
             ),
             self.aggregation_index,
         )
+
+    def unique_hashes(self) -> Tuple[List[float], float]:
+        # returns the ratio of unique hashes in token_representations in the total pool
+        num_nodes = self.token_representations[0].assignment.shape[0]
+
+        # unique hashes per representation
+        uniques_per_representation = [
+            tokens.assignment.unique(dim=0).shape[0] / num_nodes
+            for tokens in self.token_representations
+        ]
+
+        # unique hashes is we concat all representations together
+        uniques_total = torch.unique(
+            torch.cat(
+                [tokens.assignment for tokens in self.token_representations], dim=-1
+            ),
+            dim=0
+        ).shape[0]
+        return uniques_per_representation, uniques_total / num_nodes
+

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -299,7 +299,7 @@ class NodePieceRepresentation(Representation):
             self.aggregation_index,
         )
 
-    def unique_hashes(self) -> Tuple[List[float], float]:
+    def num_unique_hashes(self) -> Tuple[List[float], float]:
         # returns the ratio of unique hashes in token_representations in the total pool
         num_nodes = self.token_representations[0].assignment.shape[0]
 

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -301,7 +301,7 @@ class NodePieceRepresentation(Representation):
 
     def num_unique_hashes(self) -> Tuple[List[float], float]:
         # returns the ratio of unique hashes in token_representations in the total pool
-        num_nodes = self.token_representations[0].assignment.shape[0]
+        num_nodes = self.max_id
 
         # unique hashes per representation
         uniques_per_representation = [

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -17,7 +17,7 @@ from ...utils import broadcast_upgrade_to_sequences
 
 __all__ = [
     "TokenizationRepresentation",
-    "DiversityInfo",
+    "HashDiversityInfo",
     "NodePieceRepresentation",
 ]
 
@@ -167,7 +167,7 @@ class TokenizationRepresentation(Representation):
         return self.vocabulary(token_ids)
 
 
-class DiversityInfo(NamedTuple):
+class HashDiversityInfo(NamedTuple):
     """A ratio information object.
 
     A pair `unique_per_repr, unique_total`, where `unique_per_repr` is a list with
@@ -316,7 +316,7 @@ class NodePieceRepresentation(Representation):
             self.aggregation_index,
         )
 
-    def estimate_diversity(self) -> DiversityInfo:
+    def estimate_diversity(self) -> HashDiversityInfo:
         """
         Estimate the diversity of the tokens via their hashes.
 
@@ -362,7 +362,7 @@ class NodePieceRepresentation(Representation):
         unnormalized_uniques_total = torch.unique(
             torch.cat([tokens.assignment for tokens in self.token_representations], dim=-1), dim=0
         ).shape[0]
-        return DiversityInfo(
+        return HashDiversityInfo(
             uniques_per_representation=uniques_per_representation,
             uniques_total=unnormalized_uniques_total / self.max_id,
         )

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -349,7 +349,7 @@ class NodePieceRepresentation(Representation):
                 relation_constrainer="complex_normalize",
                 entity_initializer="xavier_uniform_",
             )
-            print(model.entity_representations[0].num_unique_hashes())
+            print(model.entity_representations[0].estimate_diversity())
 
         .. seealso:: https://github.com/pykeen/pykeen/pull/896
         """

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -309,7 +309,7 @@ class NodePieceRepresentation(Representation):
             for tokens in self.token_representations
         ]
 
-        # unique hashes is we concat all representations together
+        # unique hashes if we concat all representations together
         uniques_total = torch.unique(
             torch.cat(
                 [tokens.assignment for tokens in self.token_representations], dim=-1

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -299,13 +299,18 @@ class NodePieceRepresentation(Representation):
             self.aggregation_index,
         )
 
-    def num_unique_hashes(self) -> Tuple[List[float], float]:
-        # returns the ratio of unique hashes in token_representations in the total pool
-        num_nodes = self.max_id
-
+    def ratio_unique_hashes(self) -> Tuple[List[float], float]:
+        """
+        Return the ratio of unique hashes in the total pool.
+        
+        :return:
+            A pair `unique_per_repr, unique_total`, where `unique_per_repr` is a list with
+            the percentage of unique hashes for each token representation, and `unique_total`
+            the frequency of unique hashes when we concatenate all token representations.
+        """
         # unique hashes per representation
         uniques_per_representation = [
-            tokens.assignment.unique(dim=0).shape[0] / num_nodes
+            tokens.assignment.unique(dim=0).shape[0] / self.max_id
             for tokens in self.token_representations
         ]
 
@@ -316,5 +321,5 @@ class NodePieceRepresentation(Representation):
             ),
             dim=0
         ).shape[0]
-        return uniques_per_representation, uniques_total / num_nodes
+        return uniques_per_representation, uniques_total / self.max_id
 

--- a/src/pykeen/nn/node_piece/representations.py
+++ b/src/pykeen/nn/node_piece/representations.py
@@ -3,7 +3,7 @@
 """Representation modules for NodePiece."""
 
 import logging
-from typing import Callable, List, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import Callable, List, NamedTuple, Optional, Sequence, Union
 
 import torch
 from class_resolver import HintOrType, OneOrManyHintOrType, OneOrManyOptionalKwargs, OptionalKwargs


### PR DESCRIPTION
This PR adds a small function `num_unique_hashes` that computes the ratio of unique node hashes to the total number of nodes. Returns two values:
* a list with ratios per representation in their creation order, eg `[0.58, 0.82]` for AnchorTokenization and RelationTokenization
* a scalar ratio of unique rows when combining all representations into one matrix, eg `0.95`

Can be called after creating a model:

```python
model = NodePiece(
    triples_factory=dataset.training,
    tokenizers=["AnchorTokenizer", "RelationTokenizer"],
    num_tokens=[20, 12],
    embedding_dim=64,
    interaction="rotate",
    relation_constrainer="complex_normalize",
    entity_initializer="xavier_uniform_",
)

print(model.entity_representations[0].num_unique_hashes())
```

This will come handy when designing and comparing new token representation mechanisms, eg, a PPR-based one proposed in #870 