### PR TITLE
Add the PrimeKG dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The full documentation can be found at https://pykeen.readthedocs.io.
 Below are the models, datasets, training modes, evaluators, and metrics implemented
 in ``pykeen``.
 
-### Datasets (34)
+### Datasets (35)
 
 The following datasets are built in to PyKEEN. The citation for each dataset corresponds to either the paper
 describing the dataset, the first paper published using the dataset with knowledge graph embedding models,
@@ -143,6 +143,7 @@ have a suggestion for another dataset to include in PyKEEN, please let us know
 | OpenEA Family                      | [`pykeen.datasets.OpenEA`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.OpenEA.html)                 | [Sun *et al*., 2020](http://www.vldb.org/pvldb/vol13/p2326-sun.pdf)                                                     |      15000 |         248 |     38265 |
 | PharmKG                            | [`pykeen.datasets.PharmKG`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.PharmKG.html)               | [Zheng *et al*., 2020](https://doi.org/10.1093/bib/bbaa344)                                                             |     188296 |          39 |   1093236 |
 | PharmKG8k                          | [`pykeen.datasets.PharmKG8k`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.PharmKG8k.html)           | [Zheng *et al*., 2020](https://doi.org/10.1093/bib/bbaa344)                                                             |       7247 |          28 |    485787 |
+| PrimeKG                            | [`pykeen.datasets.PrimeKG`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.PrimeKG.html)               | [Chandak *et al*., 2022](https://doi.org/10.1101/2022.05.01.489928)            |     129375 |          30 |   8100498 |
 | Unified Medical Language System    | [`pykeen.datasets.UMLS`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.UMLS.html)                     | [`ZhenfengLei/KGDatasets`](https://github.com/ZhenfengLei/KGDatasets)                                                   |        135 |          46 |      6529 |
 | WD50K (triples)                    | [`pykeen.datasets.WD50KT`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.WD50KT.html)                 | [Galkin *et al*., 2020](https://www.aclweb.org/anthology/2020.emnlp-main.596/)                                          |      40107 |         473 |    232344 |
 | Wikidata5M                         | [`pykeen.datasets.Wikidata5M`](https://pykeen.readthedocs.io/en/latest/api/pykeen.datasets.Wikidata5M.html)         | [Wang *et al*., 2019](https://arxiv.org/abs/1911.06136)                                                                 |    4594149 |         822 |  20624239 |

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -110,3 +110,6 @@ References
 
 .. [hoyt2022] Hoyt, C.T., *et al.* (2022) `A Unified Framework for Rank-based Evaluation Metrics for
    Link Prediction in Knowledge Graphs <https://arxiv.org/abs/2203.07544>`_. *arXiv*, 2203.07544.
+
+.. [chandak2022] Chandak, P., *et al* (2022). `Building a knowledge graph to enable precision medicine
+   <https://doi.org/10.1101/2022.05.01.489928>`_. *bioRxiv*, 2022.05.01.489928.

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -45,6 +45,7 @@ from .nations import Nations
 from .ogb import OGBBioKG, OGBLoader, OGBWikiKG2
 from .openbiolink import OpenBioLink, OpenBioLinkLQ
 from .pharmkg import PharmKG, PharmKG8k
+from .primekg import PrimeKG
 from .umls import UMLS
 from .utils import get_dataset
 from .wd50k import WD50KT
@@ -93,6 +94,7 @@ __all__ = [
     "Wikidata5M",
     "PharmKG8k",
     "PharmKG",
+    "PrimeKG",
 ]
 
 logger = logging.getLogger(__name__)

--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -894,6 +894,7 @@ class SingleTabbedDataset(TabbedDataset):
         eager: bool = False,
         create_inverse_triples: bool = False,
         random_state: TorchRandomHint = None,
+        download_kwargs: Optional[Dict[str, Any]] = None,
         read_csv_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """Initialize dataset.
@@ -908,6 +909,7 @@ class SingleTabbedDataset(TabbedDataset):
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         :param random_state: An optional random state to make the training/testing/validation split reproducible.
+        :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
         :param read_csv_kwargs: Keyword arguments to pass through to :func:`pandas.read_csv`.
 
         :raises ValueError: if there's no URL specified and there is no data already at the calculated path
@@ -921,6 +923,7 @@ class SingleTabbedDataset(TabbedDataset):
 
         self.name = name or name_from_url(url)
 
+        self.download_kwargs = download_kwargs or {}
         self.read_csv_kwargs = read_csv_kwargs or {}
         self.read_csv_kwargs.setdefault("sep", "\t")
 
@@ -937,7 +940,7 @@ class SingleTabbedDataset(TabbedDataset):
     def _get_df(self) -> pd.DataFrame:
         if not self._get_path().is_file():
             logger.info("downloading data from %s to %s", self.url, self._get_path())
-            download(url=self.url, path=self._get_path())  # noqa:S310
+            download(url=self.url, path=self._get_path(), **self.download_kwargs)  # noqa:S310
         df = pd.read_csv(self._get_path(), **self.read_csv_kwargs)
 
         usecols = self.read_csv_kwargs.get("usecols")

--- a/src/pykeen/datasets/primekg.py
+++ b/src/pykeen/datasets/primekg.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+"""The PrimeKG dataset.
+
+Get a summary with ``python -m pykeen.datasets.primekg``
+"""
+
+import click
+from docdata import parse_docdata
+from more_click import verbose_option
+
+from .base import SingleTabbedDataset
+from ..typing import TorchRandomHint
+
+__all__ = [
+    "PrimeKG",
+]
+
+URL = "https://dataverse.harvard.edu/api/access/datafile/6180620"
+
+
+@parse_docdata
+class PrimeKG(SingleTabbedDataset):
+    """The Precision Medicine Knowledge Graph (PrimeKG) dataset from [chandak2022]_.
+
+    ---
+    name: PrimeKG
+    citation:
+        author: Chandak
+        year: 2022
+        link: https://doi.org/10.1101/2022.05.01.489928
+        github: mims-harvard/PrimeKG
+    single: true
+    statistics:
+        entities: 129375
+        relations: 30
+        triples: 8100498
+    """
+
+    def __init__(
+        self,
+        create_inverse_triples: bool = False,
+        random_state: TorchRandomHint = 0,
+        **kwargs,
+    ):
+        """Initialize the PrimeKG dataset from [chandak2022]_.
+
+        :param create_inverse_triples: Should inverse triples be created? Defaults to false.
+        :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
+        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.SingleTabbedDataset`.
+        """
+        super().__init__(
+            url=URL,
+            name="primekg.csv",
+            create_inverse_triples=create_inverse_triples,
+            random_state=random_state,
+            read_csv_kwargs=dict(
+                usecols=["x_name", "relation", "y_name"],
+                sep=",",
+            ),
+            **kwargs,
+        )
+
+
+@click.command()
+@verbose_option
+def _main():
+    from pykeen.datasets import get_dataset
+
+    ds = get_dataset(dataset=PrimeKG)
+    ds.summarize()
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/pykeen/datasets/primekg.py
+++ b/src/pykeen/datasets/primekg.py
@@ -54,6 +54,9 @@ class PrimeKG(SingleTabbedDataset):
             name="primekg.csv",
             create_inverse_triples=create_inverse_triples,
             random_state=random_state,
+            download_kwargs=dict(
+                backend="requests",
+            ),
             read_csv_kwargs=dict(
                 usecols=["x_name", "relation", "y_name"],
                 sep=",",


### PR DESCRIPTION
### Current Issues:

The dataset is hosted on Harvard Dataverse and this seems to not like the current header used by pystow when sending the download request and results in a 403. I was able to fix this by switching the user agent in the header by adding the following lines to the `download` function in pystow's `utils.py`:

``` python

opener = urllib.request.build_opener()
opener.addheaders = [("User-agent", "Mozilla/5.0")]
urllib.request.install_opener(opener)
```
I was wondering if I am missing something or if there is a better way to do this that does not require altering pystow's source code?

### Link to the relevant data request

Closes #914

### Verification Process

After the fix in pystow, I was able to use the dataset in pipeline-based training.

### Release Notes

Added the PrimeKG dataset from Chandak et al 2022. 
