### PR TITLE
✏️🇮🇳 Rename inductive representation methods

### DIFF
--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -168,12 +168,14 @@ class InductiveNodePiece(ERModel):
     def _get_entity_representations_from_inductive_mode(
         self, *, mode: Optional[InductiveMode]
     ) -> Sequence[Representation]:  # noqa: D102
-        if mode is None:
-            raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
         if mode == TRAINING:
             return self.entity_representations
-        else:
+        elif mode == TESTING or mode == VALIDATION:
             return self.inference_representation
+        elif mode is None:
+            raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
 
     # docstr-coverage: inherited
     def _get_entity_len(self, *, mode: Optional[InductiveMode]) -> Optional[int]:  # noqa: D102

--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -3,7 +3,7 @@
 """A wrapper which combines an interaction function with NodePiece entity representations."""
 
 import logging
-from typing import Any, Callable, ClassVar, Mapping, Optional
+from typing import Any, Callable, ClassVar, Mapping, Optional, Sequence
 
 import torch
 from class_resolver import Hint, HintOrType, OptionalKwargs
@@ -14,6 +14,7 @@ from ...nn import (
     DistMultInteraction,
     Interaction,
     NodePieceRepresentation,
+    Representation,
     SubsetRepresentation,
     representation_resolver,
 )
@@ -163,14 +164,18 @@ class InductiveNodePiece(ERModel):
             self.num_valid_entities = validation_factory.num_entities
             self.num_test_entities = test_factory.num_entities
 
-    def _entity_representation_from_mode(self, *, mode: Optional[InductiveMode]):
+    # docstr-coverage: inherited
+    def _get_entity_representations_from_inductive_mode(
+        self, *, mode: Optional[InductiveMode]
+    ) -> Sequence[Representation]:  # noqa: D102
         assert mode is not None, "Inductive mode must be explicitly set for inductive models"
         if mode == TRAINING:
             return self.entity_representations
         else:
             return self.inference_representation
 
-    def _get_entity_len(self, *, mode: Optional[InductiveMode]) -> Optional[int]:
+    # docstr-coverage: inherited
+    def _get_entity_len(self, *, mode: Optional[InductiveMode]) -> Optional[int]:  # noqa: D102
         if mode == TRAINING:
             return self.num_train_entities
         elif mode == TESTING:

--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -168,7 +168,8 @@ class InductiveNodePiece(ERModel):
     def _get_entity_representations_from_inductive_mode(
         self, *, mode: Optional[InductiveMode]
     ) -> Sequence[Representation]:  # noqa: D102
-        assert mode is not None, "Inductive mode must be explicitly set for inductive models"
+        if mode is None:
+            raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
         if mode == TRAINING:
             return self.entity_representations
         else:

--- a/src/pykeen/models/inductive/inductive_nodepiece_gnn.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece_gnn.py
@@ -9,7 +9,7 @@ import torch
 from torch import nn
 
 from .inductive_nodepiece import InductiveNodePiece
-from ...nn.representation import CompGCNLayer
+from ...nn.representation import CompGCNLayer, Representation
 from ...typing import HeadRepresentation, InductiveMode, RelationRepresentation, TailRepresentation
 from ...utils import get_edge_index
 
@@ -109,7 +109,7 @@ class InductiveNodePieceGNN(InductiveNodePiece):
         mode: InductiveMode = None,
     ) -> Tuple[HeadRepresentation, RelationRepresentation, TailRepresentation]:
         """Get representations for head, relation and tails, in canonical shape with a GNN encoder."""
-        entity_representations = self._entity_representation_from_mode(mode=mode)
+        entity_representations = self._get_entity_representations_from_inductive_mode(mode=mode)
 
         # Extract all entity and relation representations
         x_e, x_r = entity_representations[0](), self.relation_representations[0]()

--- a/src/pykeen/models/inductive/inductive_nodepiece_gnn.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece_gnn.py
@@ -9,7 +9,7 @@ import torch
 from torch import nn
 
 from .inductive_nodepiece import InductiveNodePiece
-from ...nn.representation import CompGCNLayer, Representation
+from ...nn.representation import CompGCNLayer
 from ...typing import HeadRepresentation, InductiveMode, RelationRepresentation, TailRepresentation
 from ...utils import get_edge_index
 

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -502,7 +502,7 @@ class ERModel(
         :param mode:
             the inductive mode
 
-        :raises NotImplementedError:
+        :raises ValueError:
             if the model does not support the given inductive mode, e.g.,
             because it is purely transductive
 
@@ -510,7 +510,7 @@ class ERModel(
             the entity representations for the given inductive mode
         """
         if mode is not None:
-            raise NotImplementedError
+            raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
         return self.entity_representations
 
     def _get_entity_len(self, *, mode: Optional[InductiveMode]) -> Optional[int]:  # noqa:D105

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -493,12 +493,40 @@ class ERModel(
             num=self.num_relations,
         )
 
-    def _entity_representation_from_mode(self, *, mode: Optional[InductiveMode]):
+    def _get_entity_representations_from_inductive_mode(
+        self, *, mode: Optional[InductiveMode]
+    ) -> Sequence[Representation]:
+        """
+        Return the entity representations for the given inductive mode.
+
+        :param mode:
+            the inductive mode
+
+        :raises NotImplementedError:
+            if the model does not support the given inductive mode, e.g.,
+            because it is purely transductive
+
+        :return:
+            the entity representations for the given inductive mode
+        """
         if mode is not None:
             raise NotImplementedError
         return self.entity_representations
 
     def _get_entity_len(self, *, mode: Optional[InductiveMode]) -> Optional[int]:  # noqa:D105
+        """
+        Return the number of entities for the given inductive mode.
+
+        :param mode:
+            the inductive mode
+
+        :raises NotImplementedError:
+            if the model does not support the given inductive mode, e.g.,
+            because it is purely transductive
+
+        :return:
+            the number of entities in the given inductive mode
+        """
         if mode is not None:
             raise NotImplementedError
         return self.num_entities
@@ -512,7 +540,7 @@ class ERModel(
         mode: Optional[InductiveMode],
     ) -> Tuple[HeadRepresentation, RelationRepresentation, TailRepresentation]:
         """Get representations for head, relation and tails."""
-        head_representations = tail_representations = self._entity_representation_from_mode(mode=mode)
+        head_representations = tail_representations = self._get_entity_representations_from_inductive_mode(mode=mode)
         head_representations = [head_representations[i] for i in self.interaction.head_indices()]
         tail_representations = [tail_representations[i] for i in self.interaction.tail_indices()]
         hr, rr, tr = [


### PR DESCRIPTION
This PR 
* renames helper methods for getting inductive representations
*  adds docstrings
* raises a more meaningful error message when an inappropriate inductive mode is passed