### PR TITLE
🚚🗽 Add transformed representation

### DIFF
--- a/src/pykeen/nn/__init__.py
+++ b/src/pykeen/nn/__init__.py
@@ -68,6 +68,7 @@ from .representation import (
     Representation,
     SubsetRepresentation,
     TextRepresentation,
+    TransformedRepresentation,
     WikidataTextRepresentation,
 )
 
@@ -90,6 +91,7 @@ __all__ = [
     "FeaturizedMessagePassingRepresentation",
     "CombinedRepresentation",
     "TextRepresentation",
+    "TransformedRepresentation",
     "WikidataTextRepresentation",
     "tokenizer_resolver",
     "representation_resolver",

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1460,7 +1460,7 @@ class TransformedRepresentation(Representation):
     >>> from pykeen.nn import TransformedRepresentation
     >>> r = TransformedRepresentation(
     ...     transformation=mlp,
-    ...     base_kwargs=dict(max_id=dataset.num_entities, shape=(dim), initializer=initializer, trainable=False),
+    ...     base_kwargs=dict(max_id=dataset.num_entities, shape=(dim,), initializer=initializer, trainable=False),
     ... )
     """
 

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -43,6 +43,7 @@ __all__ = [
     "SubsetRepresentation",
     "CombinedRepresentation",
     "TextRepresentation",
+    "TransformedRepresentation",
     "WikidataTextRepresentation",
     # Utils
     "constrainer_resolver",
@@ -1472,7 +1473,7 @@ class TransformedRepresentation(Representation):
         base: Representation, transformation: nn.Module, indices: Optional[torch.LongTensor]
     ) -> torch.FloatTensor:
         """
-        A small wrapper for obtaining base representations and applying the transformation.
+        Obtain base representations and apply the transformation.
 
         :param base:
             the base representation module

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1398,3 +1398,94 @@ class BackfillRepresentation(PartitionRepresentation):
         assignment[mask, 1] = torch.arange(backfill.max_id)
 
         super().__init__(assignment=assignment, bases=[base, backfill], **kwargs)
+
+
+class TransformedRepresentation(Representation):
+    """
+    A (learnable) transformation upon base representations.
+
+    In the following example, we create representations which are obtained from a trainable transformation of fixed
+    random walk encoding features. We first load the dataset, here Nations:
+
+    >>> from pykeen.datasets import get_dataset
+    >>> dataset = get_dataset(dataset="nations")
+
+    Next, we create a random-walk positional encoding of dimension 32:
+
+    >>> from pykeen.nn import init
+    >>> dim = 32
+    >>> initializer = RandomWalkPositionalEncoding(triples_factory=dataset.training)
+
+    For the transformation, we use a simple 2-layer MLP
+
+    >>> from torch import nn
+    >>> hidden = 64
+    >>> mlp = nn.Sequential(
+    ...     nn.Linear(in_features=dim, out_features=hidden),
+    ...     nn.ReLU(),
+    ...     nn.Linear(in_features=hidden, out_features=dim),
+    ... )
+
+    Finally, the transformed representation is given as
+
+    >>> from pykeen.nn import TransformedRepresentation
+    >>> r = TransformedRepresentation(
+    ...     transformation=mlp,
+    ...     base_kwargs=dict(max_id=dataset.num_entities, shape=(dim), initializer=initializer, trainable=False),
+    ... )
+    """
+
+    def __init__(
+        self,
+        transformation: nn.Module,
+        base: HintOrType[Representation] = None,
+        base_kwargs: OptionalKwargs = None,
+        **kwargs,
+    ):
+        """
+        Initialize the representation.
+
+        :param transformation:
+            the transformation
+        :param base:
+            the base representation, or a hint thereof, cf. `representation_resolver`
+        :param base_kwargs:
+            keyword-based parameters used to instantiate the base representation
+        :param kwargs:
+            additional keyword-based parameters passed to :meth:`Representation.__init__`.
+        """
+        # import here to avoid cyclic import
+        from . import representation_resolver
+
+        base = representation_resolver.make(base, base_kwargs)
+
+        # infer shape
+        shape = self._help_forward(
+            transformation=transformation, indices=torch.zeros(1, dtype=torch.long, device=base.device)
+        ).shape[1:]
+        super().__init__(max_id=base.max_id, shape=shape, **kwargs)
+        self.transformation = transformation
+        self.base = base
+
+    @staticmethod
+    def _help_forward(
+        base: Representation, transformation: nn.Module, indices: Optional[torch.LongTensor]
+    ) -> torch.FloatTensor:
+        """
+        A small wrapper for obtaining base representations and applying the transformation.
+
+        :param base:
+            the base representation module
+        :param transformation:
+            the transformation
+        :param indices:
+            the indices
+
+        :return:
+            the transformed base representations
+        """
+        return transformation(base(indices=indices))
+
+    # docstr-coverage: inherited
+    def _plain_forward(self, indices: Optional[torch.LongTensor] = None) -> torch.FloatTensor:  # noqa: D102
+        return self._help_forward(base=self.base, transformation=self.transformation, indices=indices)

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1443,7 +1443,9 @@ class TransformedRepresentation(Representation):
 
     >>> from pykeen.nn import init
     >>> dim = 32
-    >>> initializer = RandomWalkPositionalEncoding(triples_factory=dataset.training)
+    >>> initializer = init.RandomWalkPositionalEncoding(triples_factory=dataset.training, dim=dim+1)
+    We used dim+1 for the RWPE initializion as by default it doesn't return the first dimension of 0's
+    That is, in the default setup, dim = 33 would return a 32d vector
 
     For the transformation, we use a simple 2-layer MLP
 

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1488,6 +1488,9 @@ class TransformedRepresentation(Representation):
             keyword-based parameters used to instantiate the base representation
         :param kwargs:
             additional keyword-based parameters passed to :meth:`Representation.__init__`.
+
+        :raises ValueError:
+            if the max_id or shape does not match
         """
         # import here to avoid cyclic import
         from . import representation_resolver

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1461,7 +1461,7 @@ class TransformedRepresentation(Representation):
 
         # infer shape
         shape = self._help_forward(
-            transformation=transformation, indices=torch.zeros(1, dtype=torch.long, device=base.device)
+            base=base, transformation=transformation, indices=torch.zeros(1, dtype=torch.long, device=base.device)
         ).shape[1:]
         super().__init__(max_id=base.max_id, shape=shape, **kwargs)
         self.transformation = transformation

--- a/tests/test_nn/test_representation.py
+++ b/tests/test_nn/test_representation.py
@@ -335,6 +335,22 @@ class BackfillRepresentationTests(cases.RepresentationTestCase):
     )
 
 
+class TransformedRepresentationTest(cases.RepresentationTestCase):
+    """Tests for transformed representations."""
+
+    cls = pykeen.nn.representation.TransformedRepresentation
+    kwargs = dict(
+        base_kwargs=dict(shape=(5,)),
+    )
+
+    # docstr-coverage: inherited
+    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
+        kwargs = super()._pre_instantiation_hook(kwargs)
+        kwargs["transformation"] = torch.nn.Linear(5, 7)
+        kwargs["base_kwargs"]["max_id"] = kwargs.pop("max_id")
+        return kwargs
+
+
 class RepresentationModuleMetaTestCase(unittest_templates.MetaTestCase[pykeen.nn.representation.Representation]):
     """Test that there are tests for all representation modules."""
 


### PR DESCRIPTION
This PR adds a small wrapper around base representations which allow a transformation by a `nn.Module`, e.g., an MLP.

#### Dependencies
* [x] #983