### PR TITLE
🐸🫖 Fix QuatE

### DIFF
--- a/src/pykeen/models/unimodal/quate.py
+++ b/src/pykeen/models/unimodal/quate.py
@@ -93,7 +93,7 @@ class QuatE(ERModel):
         relation_initializer: Hint[Initializer] = init_quaternions,
         relation_regularizer: Hint[Regularizer] = LpRegularizer,
         relation_regularizer_kwargs: Optional[Mapping[str, Any]] = None,
-        relation_constrainer: Hint[Constrainer] = quaternion_normalizer,
+        relation_normalizer: Hint[Constrainer] = quaternion_normalizer,
         **kwargs,
     ) -> None:
         """Initialize QuatE.
@@ -121,8 +121,8 @@ class QuatE(ERModel):
         :param relation_regularizer_kwargs:
             The keyword arguments passed to the relation regularizer. Defaults to
             :data:`QuatE.regularizer_default_kwargs` if not specified.
-        :param relation_constrainer:
-            The constrainer to use for the relation embeddings.
+        :param relation_normalizer:
+            The normalizer to use for the relation embeddings.
         :param kwargs:
             Additional keyword based arguments passed to :class:`pykeen.models.ERModel`. Must not contain
             "interaction", "entity_representations", or "relation_representations".
@@ -130,16 +130,16 @@ class QuatE(ERModel):
         super().__init__(
             interaction=QuatEInteraction,
             entity_representations_kwargs=dict(
-                shape=(4 * embedding_dim,),
+                shape=(embedding_dim, 4),  # quaternions
                 initializer=entity_initializer,
                 dtype=torch.float,
                 regularizer=entity_regularizer,
                 regularizer_kwargs=entity_regularizer_kwargs or self.regularizer_default_kwargs,
             ),
             relation_representations_kwargs=dict(
-                shape=(4 * embedding_dim,),
+                shape=(embedding_dim, 4),  # quaternions
                 initializer=relation_initializer,
-                constrainer=relation_constrainer,
+                normalizer=relation_normalizer,
                 dtype=torch.float,
                 regularizer=relation_regularizer,
                 regularizer_kwargs=relation_regularizer_kwargs or self.regularizer_default_kwargs,

--- a/src/pykeen/nn/algebra.py
+++ b/src/pykeen/nn/algebra.py
@@ -1,5 +1,6 @@
 """Utilities for handling exoctic algebras such as quaternions."""
 from functools import lru_cache
+
 import torch
 
 __all__ = [

--- a/src/pykeen/nn/algebra.py
+++ b/src/pykeen/nn/algebra.py
@@ -1,0 +1,46 @@
+"""Utilities for handling exoctic algebras such as quaternions."""
+from functools import lru_cache
+import torch
+
+__all__ = [
+    "quaterion_multiplication_table",
+]
+
+
+@lru_cache(1)
+def quaterion_multiplication_table() -> torch.Tensor:
+    """
+    Create the quaternion basis multiplication table.
+
+    :return: shape: (4, 4, 4)
+        the table of products of basis elements.
+
+    ..seealso:: https://en.wikipedia.org/wiki/Quaternion#Multiplication_of_basis_elements
+    """
+    _1, _i, _j, _k = 0, 1, 2, 3
+    table = torch.zeros(4, 4, 4)
+    for i, j, k, v in [
+        # 1 * ? = ?; ? * 1 = ?
+        (_1, _1, _1, 1),
+        (_1, _i, _i, 1),
+        (_1, _j, _j, 1),
+        (_1, _k, _k, 1),
+        (_i, _1, _i, 1),
+        (_j, _1, _j, 1),
+        (_k, _1, _k, 1),
+        # i**2 = j**2 = k**2 = -1
+        (_i, _i, _1, -1),
+        (_j, _j, _1, -1),
+        (_k, _k, _1, -1),
+        # i * j = k; i * k = -j
+        (_i, _j, _k, 1),
+        (_i, _k, _j, -1),
+        # j * i = -k, j * k = i
+        (_j, _i, _k, -1),
+        (_j, _k, _i, 1),
+        # k * i = j; k * j = -i
+        (_k, _i, _j, 1),
+        (_k, _j, _i, -1),
+    ]:
+        table[i, j, k] = v
+    return table

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -1082,53 +1082,29 @@ def pair_re_interaction(
     )
 
 
-def _rotate_quaternion(qa: torch.FloatTensor, qb: torch.FloatTensor) -> torch.FloatTensor:
-    # Rotate (=Hamilton product in quaternion space).
-    return torch.stack(
-        [
-            qa[0] * qb[0] - qa[1] * qb[1] - qa[2] * qb[2] - qa[3] * qb[3],
-            qa[0] * qb[1] + qa[1] * qb[0] + qa[2] * qb[3] - qa[3] * qb[2],
-            qa[0] * qb[2] - qa[1] * qb[3] + qa[2] * qb[0] + qa[3] * qb[1],
-            qa[0] * qb[3] + qa[1] * qb[2] - qa[2] * qb[1] + qa[3] * qb[0],
-        ],
-        dim=-1,
-    )
-
-
-def _split_quaternion(x: torch.FloatTensor) -> torch.FloatTensor:
-    return torch.chunk(x, chunks=4, dim=-1)
-
-
 def quat_e_interaction(
     h: torch.FloatTensor,
     r: torch.FloatTensor,
     t: torch.FloatTensor,
+    table: torch.FloatTensor,
 ):
     """Evaluate the interaction function of QuatE for given embeddings.
 
     The embeddings have to be in a broadcastable shape.
 
-    .. note ::
-        dim has to be divisible by 4.
-
-    :param h: shape: (`*batch_dims`, dim)
+    :param h: shape: (`*batch_dims`, dim, 4)
         The head representations.
-    :param r: shape: (`*batch_dims`, dim)
+    :param r: shape: (`*batch_dims`, dim, 4)
         The head representations.
-    :param t: shape: (`*batch_dims`, dim)
+    :param t: shape: (`*batch_dims`, dim, 4)
         The tail representations.
+    :param table:
+        the quaternion multiplication table.
 
     :return: shape: (...)
         The scores.
     """
-    return -(
-        # Rotation in quaternion space
-        _rotate_quaternion(
-            _split_quaternion(h),
-            _split_quaternion(r),
-        )
-        * t.view(*t.shape[:-1], -1, 4)
-    ).sum(dim=(-2, -1))
+    return torch.einsum("...di, ...dj, ...dk, ijk -> ...", h, r, t, table)
 
 
 def cross_e_interaction(

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -1104,7 +1104,8 @@ def quat_e_interaction(
     :return: shape: (...)
         The scores.
     """
-    return torch.einsum("...di, ...dj, ...dk, ijk -> ...", h, r, t, table)
+    # TODO: this sign is in the official code, too, but why do we need it?
+    return -torch.einsum("...di, ...dj, ...dk, ijk -> ...", h, r, t, table)
 
 
 def cross_e_interaction(

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -1084,7 +1084,7 @@ def pair_re_interaction(
 
 def _rotate_quaternion(qa: torch.FloatTensor, qb: torch.FloatTensor) -> torch.FloatTensor:
     # Rotate (=Hamilton product in quaternion space).
-    return torch.cat(
+    return torch.stack(
         [
             qa[0] * qb[0] - qa[1] * qb[1] - qa[2] * qb[2] - qa[3] * qb[3],
             qa[0] * qb[1] + qa[1] * qb[0] + qa[2] * qb[3] - qa[3] * qb[2],
@@ -1127,8 +1127,8 @@ def quat_e_interaction(
             _split_quaternion(h),
             _split_quaternion(r),
         )
-        * t
-    ).sum(dim=-1)
+        * t.view(*t.shape[:-1], -1, 4)
+    ).sum(dim=(-2, -1))
 
 
 def cross_e_interaction(

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -1093,7 +1093,7 @@ def quat_e_interaction(
         The scores.
     """
     # TODO: this sign is in the official code, too, but why do we need it?
-    return -torch.einsum("...di, ...dj, ...dk, ijk -> ...", h, r, t, table)
+    return -einsum("...di, ...dj, ...dk, ijk -> ...", h, r, t, table)
 
 
 def cross_e_interaction(

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -168,11 +168,19 @@ uniform_norm_p1_ = compose(
 def init_quaternions(
     x: torch.FloatTensor,
 ) -> torch.FloatTensor:
-    """Initialize quaternion."""
-    num_elements, dim = x.shape
-    if dim % 4 != 0:
-        raise ValueError(f"Quaternions have four components, but dimension {dim} is not divisible by four.")
-    dim //= 4
+    """
+    Initialize quaternion.
+
+    :param x: shape: (..., d, 4)
+        the quaternions
+
+    :return: shape: (..., d, 4)
+        uniform quaternions
+    """
+    if x.shape[-1] != 4:
+        raise ValueError(f"Quaternions have four components, but the dimension of {x.shape} is equal to four.")
+    *shape, dim = x.shape[:-1]
+    num_elements = math.prod(shape)
     # scaling factor
     s = 1.0 / math.sqrt(2 * num_elements)
     # modulus ~ Uniform[-s, s]

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -174,6 +174,9 @@ def init_quaternions(
     :param x: shape: (..., d, 4)
         the quaternions
 
+    :raises ValueError:
+        if the shape's last dimension is not 4.
+
     :return: shape: (..., d, 4)
         uniform quaternions
     """

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -180,8 +180,8 @@ def init_quaternions(
     :return: shape: (..., d, 4)
         uniform quaternions
     """
-    if x.shape[-1] != 4:
-        raise ValueError(f"Quaternions have four components, but the dimension of {x.shape} is equal to four.")
+    if x.ndim < 2 or x.shape[-1] != 4:
+        raise ValueError(f"shape must be (..., 4) but is {x.shape}.")
     *shape, dim = x.shape[:-1]
     num_elements = math.prod(shape)
     # scaling factor
@@ -196,8 +196,7 @@ def init_quaternions(
     imag = torch.rand(num_elements, dim, 3)
     imag = functional.normalize(imag, p=2, dim=-1)
     imag = imag * (modulus * phase.sin()).unsqueeze(dim=-1)
-    x = torch.cat([real, imag], dim=-1)
-    return x.view(num_elements, 4 * dim)
+    return torch.cat([real, imag], dim=-1)
 
 
 class PretrainedInitializer:

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -9,6 +9,7 @@ import logging
 import math
 from abc import ABC, abstractmethod
 from collections import Counter
+from functools import lru_cache
 from operator import itemgetter
 from typing import (
     Any,
@@ -1409,6 +1410,7 @@ class PairREInteraction(NormBasedInteraction[FloatTensor, Tuple[FloatTensor, Flo
         return dict(h=h, r_h=r[0], r_t=r[1], t=t)
 
 
+@lru_cache(1)
 def quaterion_multiplication_table() -> torch.Tensor:
     """
     Create the quaternion basis multiplication table.

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1465,6 +1465,7 @@ class QuatEInteraction(
     func = pkf.quat_e_interaction
 
     def __init__(self) -> None:
+        """Initialize the interaction module."""
         super().__init__()
         self.register_buffer(name="table", tensor=quaterion_multiplication_table())
 

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -9,7 +9,6 @@ import logging
 import math
 from abc import ABC, abstractmethod
 from collections import Counter
-from functools import lru_cache
 from operator import itemgetter
 from typing import (
     Any,
@@ -38,6 +37,7 @@ from torch import FloatTensor, nn
 from torch.nn.init import xavier_normal_
 
 from . import functional as pkf
+from .algebra import quaterion_multiplication_table
 from .init import initializer_resolver
 from ..typing import (
     HeadRepresentation,
@@ -1408,45 +1408,6 @@ class PairREInteraction(NormBasedInteraction[FloatTensor, Tuple[FloatTensor, Flo
         t: TailRepresentation,
     ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
         return dict(h=h, r_h=r[0], r_t=r[1], t=t)
-
-
-@lru_cache(1)
-def quaterion_multiplication_table() -> torch.Tensor:
-    """
-    Create the quaternion basis multiplication table.
-
-    :return: shape: (4, 4, 4)
-        the table of products of basis elements.
-
-    ..seealso:: https://en.wikipedia.org/wiki/Quaternion#Multiplication_of_basis_elements
-    """
-    _1, _i, _j, _k = 0, 1, 2, 3
-    table = torch.zeros(4, 4, 4)
-    for i, j, k, v in [
-        # 1 * ? = ?; ? * 1 = ?
-        (_1, _1, _1, 1),
-        (_1, _i, _i, 1),
-        (_1, _j, _j, 1),
-        (_1, _k, _k, 1),
-        (_i, _1, _i, 1),
-        (_j, _1, _j, 1),
-        (_k, _1, _k, 1),
-        # i**2 = j**2 = k**2 = -1
-        (_i, _i, _1, -1),
-        (_j, _j, _1, -1),
-        (_k, _k, _1, -1),
-        # i * j = k; i * k = -j
-        (_i, _j, _k, 1),
-        (_i, _k, _j, -1),
-        # j * i = -k, j * k = i
-        (_j, _i, _k, -1),
-        (_j, _k, _i, 1),
-        # k * i = j; k * j = -i
-        (_k, _i, _j, 1),
-        (_k, _j, _i, -1),
-    ]:
-        table[i, j, k] = v
-    return table
 
 
 class QuatEInteraction(

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1409,6 +1409,44 @@ class PairREInteraction(NormBasedInteraction[FloatTensor, Tuple[FloatTensor, Flo
         return dict(h=h, r_h=r[0], r_t=r[1], t=t)
 
 
+def quaterion_multiplication_table() -> torch.Tensor:
+    """
+    Create the quaternion basis multiplication table.
+
+    :return: shape: (4, 4, 4)
+        the table of products of basis elements.
+
+    ..seealso:: https://en.wikipedia.org/wiki/Quaternion#Multiplication_of_basis_elements
+    """
+    _1, _i, _j, _k = 0, 1, 2, 3
+    table = torch.zeros(4, 4, 4)
+    for i, j, k, v in [
+        # 1 * ? = ?; ? * 1 = ?
+        (_1, _1, _1, 1),
+        (_1, _i, _i, 1),
+        (_1, _j, _j, 1),
+        (_1, _k, _k, 1),
+        (_i, _1, _i, 1),
+        (_j, _1, _j, 1),
+        (_k, _1, _k, 1),
+        # i**2 = j**2 = k**2 = -1
+        (_i, _i, _1, -1),
+        (_j, _j, _1, -1),
+        (_k, _k, _1, -1),
+        # i * j = k; i * k = -j
+        (_i, _j, _k, 1),
+        (_i, _k, _j, -1),
+        # j * i = -k, j * k = i
+        (_j, _i, _k, -1),
+        (_j, _k, _i, 1),
+        # k * i = j; k * j = -i
+        (_k, _i, _j, 1),
+        (_k, _j, _i, -1),
+    ]:
+        table[i, j, k] = v
+    return table
+
+
 class QuatEInteraction(
     FunctionalInteraction[
         torch.FloatTensor,
@@ -1421,7 +1459,17 @@ class QuatEInteraction(
     .. seealso:: :func:`pykeen.nn.functional.quat_e_interaction`
     """
 
+    # with k=4
+    entity_shape: Sequence[str] = ("dk",)
+    relation_shape: Sequence[str] = ("dk",)
     func = pkf.quat_e_interaction
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_buffer(name="table", tensor=quaterion_multiplication_table())
+
+    def _prepare_state_for_functional(self) -> MutableMapping[str, Any]:
+        return dict(table=self.table)
 
 
 class MonotonicAffineTransformationInteraction(

--- a/tests/test_nn/test_algebra.py
+++ b/tests/test_nn/test_algebra.py
@@ -1,0 +1,24 @@
+"""Tests for algebraic utilities."""
+
+import pykeen.nn.algebra
+import torch
+
+
+def _test_multiplication_table(t: torch.Tensor):
+    """Generic test for multiplication tables."""
+    # check type
+    assert torch.is_tensor(t)
+    # check size
+    assert t.ndim == 3
+    n = t.shape[0]
+    assert t.shape == (n, n, n)
+    # check value range
+    cond = torch.zeros_like(t, dtype=torch.bool)
+    for v in {-1, 0, 1}:
+        cond |= torch.isclose(t, torch.full_like(t, fill_value=v))
+    assert cond.all()
+
+
+def test_quaternion_multiplication_table():
+    """Test quaternion multiplication table."""
+    _test_multiplication_table(pykeen.nn.algebra.quaterion_multiplication_table())

--- a/tests/test_nn/test_algebra.py
+++ b/tests/test_nn/test_algebra.py
@@ -1,7 +1,8 @@
 """Tests for algebraic utilities."""
 
-import pykeen.nn.algebra
 import torch
+
+import pykeen.nn.algebra
 
 
 def _test_multiplication_table(t: torch.Tensor):

--- a/tests/test_nn/test_algebra.py
+++ b/tests/test_nn/test_algebra.py
@@ -6,7 +6,7 @@ import pykeen.nn.algebra
 
 
 def _test_multiplication_table(t: torch.Tensor):
-    """Generic test for multiplication tables."""
+    """Test properties of multiplication tables."""
     # check type
     assert torch.is_tensor(t)
     # check size

--- a/tests/test_nn/test_init.py
+++ b/tests/test_nn/test_init.py
@@ -64,8 +64,8 @@ class QuaternionTestCase(cases.InitializerTestCase):
     """Tests for quaternion initialization."""
 
     initializer = staticmethod(pykeen.nn.init.init_quaternions)
-    # quaternion needs dim divisible by 4
-    shape = (4,)
+    # quaternion needs shape to end on 4
+    shape = (2, 4)
 
     def _verify_initialization(self, x: torch.FloatTensor) -> None:
         # check value range (actually [-s, +s] with s = 1/sqrt(2*n))

--- a/tests/test_nn/test_init.py
+++ b/tests/test_nn/test_init.py
@@ -3,12 +3,14 @@
 """Tests for initializers."""
 
 import unittest
+from typing import ClassVar
 
 import torch
+from class_resolver import HintOrType
 
 import pykeen.nn.init
 from pykeen.datasets import Nations
-from pykeen.nn.modules import ComplExInteraction
+from pykeen.nn.modules import ComplExInteraction, Interaction, QuatEInteraction
 from tests import cases
 
 try:
@@ -66,6 +68,7 @@ class QuaternionTestCase(cases.InitializerTestCase):
     initializer = staticmethod(pykeen.nn.init.init_quaternions)
     # quaternion needs shape to end on 4
     shape = (2, 4)
+    interaction: ClassVar[HintOrType[Interaction]] = QuatEInteraction
 
     def _verify_initialization(self, x: torch.FloatTensor) -> None:
         # check value range (actually [-s, +s] with s = 1/sqrt(2*n))

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -225,8 +225,12 @@ class QuatETests(cases.InteractionTestCase):
     cls = pykeen.nn.modules.QuatEInteraction
     shape_kwargs = dict(k=4)  # quaternions
 
-    def _exp_score(self, h, r, t, table) -> torch.FloatTensor:  # noqa: D102
-        return (_rotate_quaternion(*(x.unbind(dim=-1) for x in [h, r])) * t).sum()
+    def _exp_score(
+        self, h: torch.Tensor, r: torch.Tensor, t: torch.Tensor, table: torch.Tensor
+    ) -> torch.FloatTensor:  # noqa: D102
+        # we calculate the scores using the hard-coded formula, instead of utilizing table + einsum
+        x = _rotate_quaternion(*(x.unbind(dim=-1) for x in [h, r]))
+        return -(x * t).sum()
 
     def _get_hrt(self, *shapes):
         h, r, t = super()._get_hrt(*shapes)

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -12,10 +12,10 @@ import torch
 import torch.nn.functional
 import unittest_templates
 from torch import nn
-from pykeen.models.unimodal.quate import quaternion_normalizer
 
 import pykeen.nn.modules
 import pykeen.utils
+from pykeen.models.unimodal.quate import quaternion_normalizer
 from pykeen.nn.functional import _rotate_quaternion, _split_quaternion, distmult_interaction
 from pykeen.typing import Representation, Sign
 from pykeen.utils import clamp_norm, complex_normalize, ensure_tuple, project_entity


### PR DESCRIPTION
This PR fixes a dimension mismatch caused by using `cat` rather than `stack`, as well as using a constrainer instead of a normalizer.

It also replaces the implementation by a more efficient variant based on einsum (see also #1058 ).

## Blocked by 

- [x] https://github.com/pykeen/pykeen/pull/1058