### PR TITLE
🔧✈️ Fix TransH

### DIFF
--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -1315,7 +1315,7 @@ class TransHInteraction(NormBasedInteraction[FloatTensor, Tuple[FloatTensor, Flo
         r: RelationRepresentation,
         t: TailRepresentation,
     ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
-        return dict(h=h, w_r=r[0], d_r=r[1], t=t)
+        return dict(h=h, w_r=r[1], d_r=r[0], t=t)
 
 
 class MuREInteraction(


### PR DESCRIPTION
This PR fixes a typo which confused TransH's normal and offset vectors. This makes a difference in expressiveness, since there is a (soft) constraint on the normal vector, but none on the offset.