### PR TITLE
📿 🧩 Support disconnected nodes in the Relation tokenizer

### DIFF
--- a/src/pykeen/nn/node_piece/tokenization.py
+++ b/src/pykeen/nn/node_piece/tokenization.py
@@ -334,7 +334,7 @@ class PrecomputedPoolTokenizer(Tokenizer):
         if num_entities != len(self.pool):
             raise ValueError(f"Invalid number of entities ({num_entities}); expected {len(self.pool)}")
         if self.randomize_selection:
-            assignment = random_sample_no_replacement(pool=self.pool, num_tokens=num_tokens)
+            assignment = random_sample_no_replacement(pool=self.pool, num_tokens=num_tokens, num_entities=num_entities)
         else:
             # choose first num_tokens
             assignment = torch.full(

--- a/src/pykeen/nn/node_piece/tokenization.py
+++ b/src/pykeen/nn/node_piece/tokenization.py
@@ -95,7 +95,9 @@ class RelationTokenizer(Tokenizer):
             e2r[e].add(r_)
 
         # randomly sample without replacement num_tokens relations for each entity
-        return 2 * num_relations + 1, random_sample_no_replacement(pool=e2r, num_tokens=num_tokens)
+        return 2 * num_relations + 1, random_sample_no_replacement(
+            pool=e2r, num_tokens=num_tokens, num_entities=num_entities
+        )
 
 
 class AnchorTokenizer(Tokenizer):

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def random_sample_no_replacement(
     pool: Mapping[int, Collection[int]],
     num_tokens: int,
-    num_entities: int,
+    num_entities: Optional[int] = None,
 ) -> torch.LongTensor:
     """Sample randomly without replacement num_tokens relations for each entity.
 
@@ -30,11 +30,14 @@ def random_sample_no_replacement(
     :param num_tokens:
         the number of tokens to sample for each entity
     :param num_entities:
-        the total number of nodes in the graph, might be bigger than the pool size for graphs with disconnected nodes
+        the total number of nodes in the graph, might be bigger than the pool size for graphs with disconnected nodes.
+        If not given, is calculated based the length of ``pool``.
 
     :return: shape: (num_entities, num_tokens), -1 <= res < vocabulary_size
         the selected relation IDs for each entity. -1 is used as a padding token.
     """
+    if num_entities is None:
+        num_entities = len(pool)
     assignment = torch.full(
         size=(num_entities, num_tokens),
         dtype=torch.long,

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -19,10 +19,13 @@ logger = logging.getLogger(__name__)
 def random_sample_no_replacement(
     pool: Mapping[int, Collection[int]],
     num_tokens: int,
+    num_entities: int,
 ) -> torch.LongTensor:
-    """Sample randomly without replacement num_tokens relations for each entity."""
+    """Sample randomly without replacement num_tokens relations for each entity.
+    If a graph has disconnected nodes, then num_entities > number of rows in the pool
+    """
     assignment = torch.full(
-        size=(len(pool), num_tokens),
+        size=(num_entities, num_tokens),
         dtype=torch.long,
         fill_value=-1,
     )

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -21,8 +21,8 @@ def random_sample_no_replacement(
     num_tokens: int,
     num_entities: int,
 ) -> torch.LongTensor:
-    """
-    Sample randomly without replacement num_tokens relations for each entity.
+    """Sample randomly without replacement num_tokens relations for each entity.
+
     If a graph has disconnected nodes, then num_entities > number of rows in the pool.
 
     :param pool:

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -21,8 +21,19 @@ def random_sample_no_replacement(
     num_tokens: int,
     num_entities: int,
 ) -> torch.LongTensor:
-    """Sample randomly without replacement num_tokens relations for each entity.
-    If a graph has disconnected nodes, then num_entities > number of rows in the pool
+    """
+    Sample randomly without replacement num_tokens relations for each entity.
+    If a graph has disconnected nodes, then num_entities > number of rows in the pool.
+
+    :param pool:
+        a dictionary of entity: [relations]
+    :param num_tokens:
+        the number of tokens to sample for each entity
+    :param num_entities:
+        the total number of nodes in the graph, might be bigger than the pool size for graphs with disconnected nodes
+
+    :return: shape: (num_entities, num_tokens), -1 <= res < vocabulary_size
+        the selected relation IDs for each entity. -1 is used as a padding token.
     """
     assignment = torch.full(
         size=(num_entities, num_tokens),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,6 +21,7 @@ from pykeen.models.predict import get_all_prediction_df, predict
 from pykeen.nn import Embedding, NodePieceRepresentation
 from pykeen.nn.combination import ConcatAggregationCombination
 from pykeen.nn.perceptron import ConcatMLP
+from pykeen.triples.triples_factory import CoreTriplesFactory
 from pykeen.utils import all_in_bounds, extend_batch
 from tests import cases
 from tests.constants import EPSILON
@@ -227,6 +228,16 @@ class TestKG2EWithEL(cases.BaseKG2ETest):
 
 class TestNodePiece(cases.BaseNodePieceTest):
     """Test the NodePiece model."""
+
+    def test_disconnected(self):
+        """Test handling of disconnected entities."""
+        edges = torch.tensor(
+            [[0, 0, 1], [1, 1, 0], [3, 1, 0], [3, 2, 1]], dtype=torch.long
+        )  # node ID 2 is missing as a disconnected node
+        factory = CoreTriplesFactory.create(
+            mapped_triples=edges, num_entities=4, num_relations=3, create_inverse_triples=True
+        )
+        pykeen.models.NodePiece(triples_factory=factory, num_tokens=2)
 
 
 class TestNodePieceMLP(cases.BaseNodePieceTest):


### PR DESCRIPTION
A quick fix for the sampler in relation tokenizer to support graphs where `num_entities` is larger than `pool` size.

A script to reproduce the error before/after the fix

```python
import torch.nn
from pykeen.models import NodePiece
from pykeen.triples import CoreTriplesFactory

edges = torch.tensor([
    [0, 0, 1],
    [1, 1, 0],
    [3, 1, 0],
    [3, 2, 1]
], dtype=torch.long)  # node ID 2 is missing as a disconnected node

factory = CoreTriplesFactory.create(mapped_triples=edges, num_entities=4, num_relations=3, create_inverse_triples=True)
model = NodePiece(triples_factory=factory, num_tokens=2)
```

Generally, taking care of disconnected nodes in NodePiece in more complex scenarios might take much more effort