### PR TITLE
🍭🧑‍🚀 Update remaining einsum usages

### DIFF
--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -33,6 +33,7 @@ def _batched_dot_einsum(
     a: torch.FloatTensor,
     b: torch.FloatTensor,
 ) -> torch.FloatTensor:
+    # TODO switch to einsum
     return torch.einsum("...i,...i->...", a, b)
 
 

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -80,7 +80,7 @@ def _complex_direct(
     )
 
 
-# TODO benchmark
+# TODO unused
 def _complex_einsum(
     h: torch.FloatTensor,
     r: torch.FloatTensor,

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -5,7 +5,7 @@
 import numpy
 import torch
 
-from ..utils import einsum, extended_einsum, split_complex, tensor_product, view_complex, view_complex_native
+from ..utils import einsum, split_complex, tensor_product, view_complex, view_complex_native
 
 __all__ = [
     "batched_dot",
@@ -77,27 +77,6 @@ def _complex_direct(
         + (h_re * r_im * t_im).sum(dim=-1)
         + (h_im * r_re * t_im).sum(dim=-1)
         - (h_im * r_im * t_re).sum(dim=-1)
-    )
-
-
-# TODO unused
-def _complex_einsum(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-) -> torch.FloatTensor:
-    """Use einsum."""
-    x = h.new_zeros(2, 2, 2)
-    x[0, 0, 0] = 1
-    x[0, 1, 1] = 1
-    x[1, 0, 1] = 1
-    x[1, 1, 0] = -1
-    return extended_einsum(
-        "ijk,bhrtdi,bhrtdj,bhrtdk->bhrt",
-        x,
-        h.view(*h.shape[:-1], -1, 2),
-        r.view(*r.shape[:-1], -1, 2),
-        t.view(*t.shape[:-1], -1, 2),
     )
 
 

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -5,7 +5,7 @@
 import numpy
 import torch
 
-from ..utils import extended_einsum, split_complex, tensor_product, view_complex, view_complex_native
+from ..utils import einsum, extended_einsum, split_complex, tensor_product, view_complex, view_complex_native
 
 __all__ = [
     "batched_dot",
@@ -34,7 +34,7 @@ def _batched_dot_einsum(
     b: torch.FloatTensor,
 ) -> torch.FloatTensor:
     # TODO switch to einsum
-    return torch.einsum("...i,...i->...", a, b)
+    return einsum("...i,...i->...", a, b)
 
 
 def batched_dot(

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -33,7 +33,6 @@ def _batched_dot_einsum(
     a: torch.FloatTensor,
     b: torch.FloatTensor,
 ) -> torch.FloatTensor:
-    # TODO switch to einsum
     return einsum("...i,...i->...", a, b)
 
 

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -845,12 +845,12 @@ def transh_interaction(
     return negative_norm_of_sum(
         # h projection to hyperplane
         h,
-        -(h * w_r).sum(dim=-1, keepdims=True) * w_r,
+        -torch.einsum("...i, ...i, ...j -> ...j", h, w_r, w_r),
         # r
         d_r,
         # -t projection to hyperplane
         -t,
-        (t * w_r).sum(dim=-1, keepdims=True) * w_r,
+        torch.einsum("...i, ...i, ...j -> ...j", t, w_r, w_r),
         p=p,
         power_norm=power_norm,
     )

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -846,12 +846,12 @@ def transh_interaction(
     return negative_norm_of_sum(
         # h projection to hyperplane
         h,
-        -torch.einsum("...i, ...i, ...j -> ...j", h, w_r, w_r),
+        -einsum("...i, ...i, ...j -> ...j", h, w_r, w_r),
         # r
         d_r,
         # -t projection to hyperplane
         -t,
-        torch.einsum("...i, ...i, ...j -> ...j", t, w_r, w_r),
+        einsum("...i, ...i, ...j -> ...j", t, w_r, w_r),
         p=p,
         power_norm=power_norm,
     )

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -701,8 +701,7 @@ def extended_einsum(
     r_keep_dims = set("".join(mod_ops))
     m_rhs = "".join(c for c in rhs if c in r_keep_dims)
     m_eq = f"{m_lhs}->{m_rhs}"
-    # TODO switch to new einsum
-    mod_r = torch.einsum(m_eq, *mod_t)
+    mod_r = einsum(m_eq, *mod_t)
     # unsqueeze
     for i, c in enumerate(rhs):
         if c not in r_keep_dims:

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -701,6 +701,7 @@ def extended_einsum(
     r_keep_dims = set("".join(mod_ops))
     m_rhs = "".join(c for c in rhs if c in r_keep_dims)
     m_eq = f"{m_lhs}->{m_rhs}"
+    # TODO switch to new einsum
     mod_r = torch.einsum(m_eq, *mod_t)
     # unsqueeze
     for i, c in enumerate(rhs):

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -77,7 +77,6 @@ __all__ = [
     "Result",
     "fix_dataclass_init_docs",
     "get_benchmark",
-    "extended_einsum",
     "upgrade_to_sequence",
     "ensure_tuple",
     "unpack_singletons",
@@ -674,40 +673,6 @@ def negative_norm(
         return -(x.abs() ** p).sum(dim=-1)
 
     return -x.norm(p=p, dim=-1)
-
-
-# TODO: deprecated? It's only used in pykeen.nn.compute_kernel._complex_einsum(),
-#  which is itself unused
-def extended_einsum(
-    eq: str,
-    *tensors,
-) -> torch.FloatTensor:
-    """Drop dimensions of size 1 to allow broadcasting."""
-    # TODO: check if einsum is still very slow.
-    lhs, rhs = eq.split("->")
-    mod_ops, mod_t = [], []
-    for op, t in zip(lhs.split(","), tensors):
-        mod_op = ""
-        if len(op) != len(t.shape):
-            raise ValueError(f"Shapes not equal: op={op} and t.shape={t.shape}")
-        # TODO: t_shape = list(t.shape); del t_shape[i]; t.view(*shape) -> only one reshape operation
-        for i, c in reversed(list(enumerate(op))):
-            if t.shape[i] == 1:
-                t = t.squeeze(dim=i)
-            else:
-                mod_op = c + mod_op
-        mod_ops.append(mod_op)
-        mod_t.append(t)
-    m_lhs = ",".join(mod_ops)
-    r_keep_dims = set("".join(mod_ops))
-    m_rhs = "".join(c for c in rhs if c in r_keep_dims)
-    m_eq = f"{m_lhs}->{m_rhs}"
-    mod_r = einsum(m_eq, *mod_t)
-    # unsqueeze
-    for i, c in enumerate(rhs):
-        if c not in r_keep_dims:
-            mod_r = mod_r.unsqueeze(dim=i)
-    return mod_r
 
 
 def project_entity(

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -676,7 +676,8 @@ def negative_norm(
     return -x.norm(p=p, dim=-1)
 
 
-# TODO: deprecated?
+# TODO: deprecated? It's only used in pykeen.nn.compute_kernel._complex_einsum(),
+#  which is itself unused
 def extended_einsum(
     eq: str,
     *tensors,

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -562,6 +562,7 @@ class MultiLinearTuckerInteractionTests(cases.InteractionTestCase):
         return kwargs
 
     def _exp_score(self, core_tensor, h, r, t) -> torch.FloatTensor:
+        # TODO update einsum
         return torch.einsum("ijk,i,j,k", core_tensor, h, r, t)
 
 

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -18,7 +18,7 @@ import pykeen.utils
 from pykeen.models.unimodal.quate import quaternion_normalizer
 from pykeen.nn.functional import distmult_interaction
 from pykeen.typing import Representation, Sign
-from pykeen.utils import clamp_norm, complex_normalize, ensure_tuple, project_entity
+from pykeen.utils import clamp_norm, complex_normalize, einsum, ensure_tuple, project_entity
 from tests import cases
 
 logger = logging.getLogger(__name__)
@@ -562,8 +562,7 @@ class MultiLinearTuckerInteractionTests(cases.InteractionTestCase):
         return kwargs
 
     def _exp_score(self, core_tensor, h, r, t) -> torch.FloatTensor:
-        # TODO update einsum
-        return torch.einsum("ijk,i,j,k", core_tensor, h, r, t)
+        return einsum("ijk,i,j,k", core_tensor, h, r, t)
 
 
 class InteractionTestsTestCase(unittest_templates.MetaTestCase[pykeen.nn.modules.Interaction]):


### PR DESCRIPTION
As a follow-up to #1058, this PR updates four remaining usages of `torch.einsum`:

1. TransH to use einsum for the projection operation. For FB15k-237 evaluation, I observed a slight speed-up. With #1058 , we might see more, or at least defer the contraction path decision from the hard-coded left-to-right to a library.
2. Deletes the unused `extended_einsum` code, which seems itself to be unused outside of a single unused function on complex dot product stacking
3. Update an unused instance in complex dot product stacking
4. Update a test