### PR TITLE
🩹💯 Fix typo in OpenEA graph size

### DIFF
--- a/src/pykeen/datasets/ea/openea.py
+++ b/src/pykeen/datasets/ea/openea.py
@@ -40,7 +40,7 @@ GRAPH_PAIRS: Tuple[GraphPair, ...] = (D_W, D_Y, EN_DE, EN_FR)
 # graph sizes
 GraphSize = Literal["15K", "100K"]
 SIZE_15K: GraphSize = "15K"
-SIZE_100K: GraphSize = "15K"
+SIZE_100K: GraphSize = "100K"
 GRAPH_SIZES = (SIZE_15K, SIZE_100K)
 
 # graph versions


### PR DESCRIPTION
Fixes wrong size of 100K version of OpenEA dataset

## Contributing to bug fixes

 - Fill out the template below
 - The pull request should only fix existing bug reports
 - The pull request should comply with these points mentioned in [the contribution guidelines](https://github.com/pykeen/pykeen/blob/master/.github/CONTRIBUTING.md#pull-request)


### Link to the relevant Bug(s)

OpenEA dataset graph size variable `SIZE_100K` is set to `"15K"`


### Description of the Change

Change the string to `"100K"`


### Possible Drawbacks

None


### Verification Process

I changed the variable and checked that `OpenEA(size="100K")` can be run (which was previously not possible)


### Release Notes

- Fixed graph size bug in OpenEA dataset
