### PR TITLE
⚽ 🔧 Properly shuttle tensors to CPU in rank-based evaluator

### DIFF
--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -509,7 +509,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         # compute macro weights
         df = pandas.DataFrame(data=evaluation_triples.numpy(), columns=list(self.COLUMNS))
         self.precomputed_weights = dict()
-        self.weights = defaultdict(list)
+        self.weights = {}
         for target in (LABEL_HEAD, LABEL_TAIL):
             key = self._get_key(target)
             counts = df.groupby(by=key).nunique()[target]

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -509,7 +509,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         # compute macro weights
         df = pandas.DataFrame(data=evaluation_triples.numpy(), columns=list(self.COLUMNS))
         self.precomputed_weights = dict()
-        self.weights = {}
+        self.weights = defaultdict(list)
         for target in (LABEL_HEAD, LABEL_TAIL):
             key = self._get_key(target)
             counts = df.groupby(by=key).nunique()[target]
@@ -539,7 +539,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
             dense_positive_mask=dense_positive_mask,
         )
         key_list = (
-            hrt_batch[:, [TARGET_TO_INDEX[key] for key in self._get_key(target=target)]].detach().numpy().tolist()
+            hrt_batch[:, [TARGET_TO_INDEX[key] for key in self._get_key(target=target)]].detach().cpu().numpy().tolist()
         )
         keys = cast(List[Tuple[int, int]], list(map(tuple, key_list)))
         self.weights[target].append(numpy.asarray([self.precomputed_weights[target][k] for k in keys]))


### PR DESCRIPTION
### Link to the relevant Bug(s)

References #1061

### Description of the Change

Originally, this PR was moviated by the following:

> Use `defaultdict(list)` in `MacroRankBasedEvaluator` to allow reuse of evaluator after `finalize` is called.
> move `hrt_batch` to cpu in `process_scores` after calling detach

See also #1079 for follow-up changes since the PyKEEN team couldn't make edits on this branch

### Possible Drawbacks

After further experimentation i have found there is still a problem with using MacroRankBasedEvaluator in the pipeline with  early stopping as the pipeline ensures one Evaluator instance is used this means that if:
- validation set is used as `evaluation_factory` then we start evaluating on test set post training the evaluator is initialised with weights from the validation set and then a key error will be raised. 
- if we use the test set as the `evaluation_factory` then early stopping will error as the pipeline defaults to using the validation set.

Despite these i think these changes are still relevant to the `MacroRankBasedEvaluator` so i have continued with the PR.

I have also seen the PR put up for refactoring the pipeline https://github.com/pykeen/pykeen/pull/1075 which i will take a look at as it may be relevant here!



### Verification Process

Tested without early stopping using test dataset as evaluation.

```python
from src.pykeen.pipeline import pipeline
from src.pykeen.datasets import Nations

dataset = Nations()

pipeline_result = pipeline(
    dataset=dataset,
    model="TransE",
    evaluator="macrorankbased",
    evaluator_kwargs=dict(evaluation_factory=dataset.testing),
    training_kwargs=dict(num_epochs=10),
)
```


### Release Notes

Fixed an issue where MacroRankBasedEvaluator couldnt be reused after finalize call.