### PR TITLE
🔍📈 Fix MacroRankBasedEvaluator share precomputed weights for different triples

### DIFF
--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -3,7 +3,7 @@
 """Constants for PyKEEN."""
 
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Tuple
 
 import pystow
 import torch
@@ -66,3 +66,5 @@ TARGET_TO_INDEX: Mapping[Target, TargetColumn] = {
     LABEL_RELATION: COLUMN_RELATION,
     LABEL_TAIL: COLUMN_TAIL,
 }
+
+COLUMN_LABELS: Tuple[Target, Target, Target] = (LABEL_HEAD, LABEL_RELATION, LABEL_TAIL)

--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -68,3 +68,4 @@ TARGET_TO_INDEX: Mapping[Target, TargetColumn] = {
 }
 
 COLUMN_LABELS: Tuple[Target, Target, Target] = (LABEL_HEAD, LABEL_RELATION, LABEL_TAIL)
+TARGET_TO_KEYS = {target: [TARGET_TO_INDEX[c] for c in COLUMN_LABELS if c != target] for target in COLUMN_LABELS}

--- a/src/pykeen/constants.py
+++ b/src/pykeen/constants.py
@@ -68,4 +68,5 @@ TARGET_TO_INDEX: Mapping[Target, TargetColumn] = {
 }
 
 COLUMN_LABELS: Tuple[Target, Target, Target] = (LABEL_HEAD, LABEL_RELATION, LABEL_TAIL)
-TARGET_TO_KEYS = {target: [TARGET_TO_INDEX[c] for c in COLUMN_LABELS if c != target] for target in COLUMN_LABELS}
+TARGET_TO_KEY_LABELS = {target: [c for c in COLUMN_LABELS if c != target] for target in COLUMN_LABELS}
+TARGET_TO_KEYS = {target: [TARGET_TO_INDEX[c] for c in cs] for target, cs in TARGET_TO_KEY_LABELS.items()}

--- a/src/pykeen/datasets/cli.py
+++ b/src/pykeen/datasets/cli.py
@@ -20,7 +20,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 from .base import Dataset
 from .utils import dataset_regex_option, iter_dataset_instances, max_triples_option, min_triples_option
-from ..constants import PYKEEN_DATASETS
+from ..constants import COLUMN_LABELS, PYKEEN_DATASETS
 from ..evaluation.evaluator import get_candidate_set_size
 from ..metrics.ranking import (
     ArithmeticMeanRank,
@@ -366,7 +366,7 @@ def expected_metrics(
 
 
 def _summarize_degree_distribution(factory: CoreTriplesFactory) -> Iterable[List]:
-    df = pd.DataFrame(data=factory.mapped_triples.numpy(), columns=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL])
+    df = pd.DataFrame(data=factory.mapped_triples.numpy(), columns=COLUMN_LABELS)
     for target in [LABEL_HEAD, LABEL_TAIL]:
         key = [LABEL_TAIL if target == LABEL_HEAD else LABEL_HEAD, LABEL_RELATION]
         unique_targets = df.groupby(by=key)[target].nunique()

--- a/src/pykeen/datasets/ea/openea.py
+++ b/src/pykeen/datasets/ea/openea.py
@@ -17,9 +17,9 @@ from more_click import verbose_option
 from pystow.utils import read_zipfile_csv
 
 from .base import EADataset
-from ...constants import PYKEEN_DATASETS_MODULE
+from ...constants import COLUMN_LABELS, PYKEEN_DATASETS_MODULE
 from ...triples import TriplesFactory
-from ...typing import EA_SIDE_LEFT, EA_SIDES, LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, EASide
+from ...typing import EA_SIDE_LEFT, EA_SIDES, EASide
 
 __all__ = [
     "OpenEA",
@@ -131,7 +131,7 @@ class OpenEA(EADataset):
                 path=self.zip_path,
                 inner_path=str(self.inner_path.joinpath(file_name)),
                 header=None,
-                names=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL],
+                names=COLUMN_LABELS,
                 sep="\t",
                 encoding="utf8",
                 dtype=str,

--- a/src/pykeen/datasets/ea/wk3l.py
+++ b/src/pykeen/datasets/ea/wk3l.py
@@ -18,9 +18,9 @@ from more_click import verbose_option
 from pystow.utils import read_zipfile_csv
 
 from .base import EADataset
-from ...constants import PYKEEN_DATASETS_MODULE
+from ...constants import COLUMN_LABELS, PYKEEN_DATASETS_MODULE
 from ...triples import TriplesFactory
-from ...typing import EA_SIDE_LEFT, EA_SIDE_RIGHT, EA_SIDES, LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, EASide
+from ...typing import EA_SIDE_LEFT, EA_SIDE_RIGHT, EA_SIDES, LABEL_HEAD, LABEL_TAIL, EASide
 
 __all__ = [
     "MTransEDataset",
@@ -108,7 +108,7 @@ class MTransEDataset(EADataset, ABC):
     # docstr-coverage: inherited
     def _load_graph(self, side: EASide) -> TriplesFactory:  # noqa: D102
         logger.info(f"Loading graph for side: {side}")
-        df = self._load_df(key=side, names=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL])
+        df = self._load_df(key=side, names=COLUMN_LABELS)
         # create triples factory
         return TriplesFactory.from_labeled_triples(
             triples=df.values, metadata=dict(graph_pair=self.graph_pair, side=side)
@@ -121,9 +121,7 @@ class MTransEDataset(EADataset, ABC):
         # load mappings for both sides
         dfs = [self._load_df(key=key, names=list(key)) for key in (EA_SIDES, EA_SIDES_R)]
         # load triple alignments
-        df = self._load_df(
-            key=None, names=[(side, column) for side in EA_SIDES for column in [LABEL_HEAD, LABEL_RELATION, LABEL_TAIL]]
-        )
+        df = self._load_df(key=None, names=[(side, column) for side in EA_SIDES for column in COLUMN_LABELS])
         # extract entity alignments
         # (h1, r1, t1) = (h2, r2, t2) => h1 = h2 and t1 = t2
         for column in [LABEL_HEAD, LABEL_TAIL]:

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -17,10 +17,10 @@ from torch_max_mem import MemoryUtilizationMaximizer
 from tqdm.auto import tqdm
 
 from .evaluator import Evaluator, MetricResults, filter_scores_
-from ..constants import TARGET_TO_INDEX
+from ..constants import COLUMN_LABELS, TARGET_TO_INDEX
 from ..models import Model
 from ..triples import CoreTriplesFactory
-from ..typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, InductiveMode, MappedTriples, OneOrSequence, Target
+from ..typing import LABEL_HEAD, LABEL_TAIL, InductiveMode, MappedTriples, OneOrSequence, Target
 from ..utils import upgrade_to_sequence
 
 logger = logging.getLogger(__name__)
@@ -232,7 +232,7 @@ class FilterIndex:
             a filter index object
         """
         # input verification
-        expected_columns = {LABEL_HEAD, LABEL_RELATION, LABEL_TAIL}
+        expected_columns = set(COLUMN_LABELS)
         if not expected_columns.issubset(df.columns):
             raise ValueError(f"Missing columns: {sorted(expected_columns.difference(df.columns))}")
 
@@ -344,7 +344,7 @@ class LCWAEvaluationDataset(Dataset[Mapping[Target, Tuple[MappedTriples, Optiona
                         *(get_mapped_triples(x) for x in upgrade_to_sequence(additional_filter_triples or [])),
                     ]
                 ),
-                columns=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL],
+                columns=COLUMN_LABELS,
             )
             self.filter_indices = {target: FilterIndex.from_df(df=df, target=target) for target in targets}
         else:

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -15,7 +15,7 @@ import pandas
 import torch
 from tqdm.autonotebook import tqdm
 
-from ..constants import TARGET_TO_INDEX
+from ..constants import COLUMN_LABELS, TARGET_TO_INDEX, TARGET_TO_KEYS
 from ..metrics.utils import Metric
 from ..models import Model
 from ..triples.triples_factory import restrict_triples
@@ -842,10 +842,9 @@ def get_candidate_set_size(
     )
 
     # evaluation triples as dataframe
-    columns = [LABEL_HEAD, LABEL_RELATION, LABEL_TAIL]
     df_eval = pandas.DataFrame(
         data=mapped_triples.numpy(),
-        columns=columns,
+        columns=COLUMN_LABELS,
     ).reset_index()
 
     # determine filter triples
@@ -869,14 +868,14 @@ def get_candidate_set_size(
     )
     df_filter = pandas.DataFrame(
         data=filter_triples.numpy(),
-        columns=columns,
+        columns=COLUMN_LABELS,
     )
 
     # compute candidate set sizes for different targets
     # TODO: extend to relations?
     for target in [LABEL_HEAD, LABEL_TAIL]:
         total = num_entities
-        group_keys = [c for c in columns if c != target]
+        group_keys = TARGET_TO_KEYS[target]
         df_count = df_filter.groupby(by=group_keys).agg({target: "count"})
         column = f"{target}_candidates"
         df_count[column] = total - df_count[target]

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -15,7 +15,7 @@ import pandas
 import torch
 from tqdm.autonotebook import tqdm
 
-from ..constants import COLUMN_LABELS, TARGET_TO_INDEX, TARGET_TO_KEYS
+from ..constants import COLUMN_LABELS, TARGET_TO_INDEX, TARGET_TO_KEY_LABELS
 from ..metrics.utils import Metric
 from ..models import Model
 from ..triples.triples_factory import restrict_triples
@@ -875,7 +875,7 @@ def get_candidate_set_size(
     # TODO: extend to relations?
     for target in [LABEL_HEAD, LABEL_TAIL]:
         total = num_entities
-        group_keys = TARGET_TO_KEYS[target]
+        group_keys = TARGET_TO_KEY_LABELS[target]
         df_count = df_filter.groupby(by=group_keys).agg({target: "count"})
         column = f"{target}_candidates"
         df_count[column] = total - df_count[target]

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -35,7 +35,6 @@ from ..typing import (
     MappedTriples,
     RankType,
     Target,
-    TargetColumn,
 )
 
 __all__ = [

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -2,12 +2,12 @@
 
 """Implementation of ranked based evaluator."""
 
-from functools import lru_cache
 import itertools
 import logging
 import math
 import random
 from collections import defaultdict
+from functools import lru_cache
 from typing import Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
 
 import numpy as np

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -7,7 +7,6 @@ import logging
 import math
 import random
 from collections import defaultdict
-from functools import lru_cache
 from typing import Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Type, TypeVar, Union, cast
 
 import numpy as np
@@ -475,10 +474,7 @@ class SampledRankBasedEvaluator(RankBasedEvaluator):
         self.num_entities = num_entities
 
 
-@lru_cache(maxsize=3)
-def _get_key(target: Target) -> List[TargetColumn]:
-    """Get the IDs of all columns except the target."""
-    return [TARGET_TO_INDEX[c] for c in COLUMN_LABELS if c != target]
+TARGET_TO_KEYS = {target: [TARGET_TO_INDEX[c] for c in COLUMN_LABELS if c != target] for target in COLUMN_LABELS}
 
 
 class MacroRankBasedEvaluator(RankBasedEvaluator):
@@ -532,7 +528,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
             dense_positive_mask=dense_positive_mask,
         )
         # store keys for calculating macro weights
-        self.keys[target].append(hrt_batch[:, _get_key(target=target)].detach().cpu().numpy())
+        self.keys[target].append(hrt_batch[:, TARGET_TO_KEYS[target]].detach().cpu().numpy())
 
     # docstr-coverage: inherited
     def finalize(self) -> RankBasedMetricResults:  # noqa: D102

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -18,13 +18,12 @@ from class_resolver import HintOrType, OptionalKwargs
 from .evaluator import Evaluator, MetricResults, prepare_filter_triples
 from .ranking_metric_lookup import MetricKey
 from .ranks import Ranks
-from ..constants import TARGET_TO_KEYS
+from ..constants import COLUMN_LABELS, TARGET_TO_KEYS
 from ..metrics.ranking import HITS_METRICS, RankBasedMetric, rank_based_metric_resolver
 from ..metrics.utils import Metric
 from ..triples.triples_factory import CoreTriplesFactory
 from ..typing import (
     LABEL_HEAD,
-    LABEL_RELATION,
     LABEL_TAIL,
     RANK_OPTIMISTIC,
     RANK_PESSIMISTIC,
@@ -334,16 +333,15 @@ def sample_negatives(
         additional_filter_triples=additional_filter_triples,
     )
     num_entities = num_entities or (additional_filter_triples[:, [0, 2]].max().item() + 1)
-    columns = [LABEL_HEAD, LABEL_RELATION, LABEL_TAIL]
     num_triples = evaluation_triples.shape[0]
-    df = pd.DataFrame(data=evaluation_triples.numpy(), columns=columns)
-    all_df = pd.DataFrame(data=additional_filter_triples.numpy(), columns=columns)
+    df = pd.DataFrame(data=evaluation_triples.numpy(), columns=COLUMN_LABELS)
+    all_df = pd.DataFrame(data=additional_filter_triples.numpy(), columns=COLUMN_LABELS)
     id_df = df.reset_index()
     all_ids = set(range(num_entities))
     negatives = {}
     for side in [LABEL_HEAD, LABEL_TAIL]:
         this_negatives = cast(torch.FloatTensor, torch.empty(size=(num_triples, num_samples), dtype=torch.long))
-        other = [c for c in columns if c != side]
+        other = TARGET_TO_KEYS[side]
         for _, group in pd.merge(id_df, all_df, on=other, suffixes=["_eval", "_all"]).groupby(
             by=other,
         ):

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -18,7 +18,7 @@ from class_resolver import HintOrType, OptionalKwargs
 from .evaluator import Evaluator, MetricResults, prepare_filter_triples
 from .ranking_metric_lookup import MetricKey
 from .ranks import Ranks
-from ..constants import COLUMN_LABELS, TARGET_TO_INDEX
+from ..constants import TARGET_TO_KEYS
 from ..metrics.ranking import HITS_METRICS, RankBasedMetric, rank_based_metric_resolver
 from ..metrics.utils import Metric
 from ..triples.triples_factory import CoreTriplesFactory
@@ -472,9 +472,6 @@ class SampledRankBasedEvaluator(RankBasedEvaluator):
         # write back correct num_entities
         # TODO: should we give num_entities in the constructor instead of inferring it every time ranks are processed?
         self.num_entities = num_entities
-
-
-TARGET_TO_KEYS = {target: [TARGET_TO_INDEX[c] for c in COLUMN_LABELS if c != target] for target in COLUMN_LABELS}
 
 
 class MacroRankBasedEvaluator(RankBasedEvaluator):

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -509,7 +509,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         # compute macro weights
         df = pandas.DataFrame(data=evaluation_triples.numpy(), columns=list(self.COLUMNS))
         self.precomputed_weights = dict()
-        self.weights = {}
+        self.weights = defaultdict(list)
         for target in (LABEL_HEAD, LABEL_TAIL):
             key = self._get_key(target)
             counts = df.groupby(by=key).nunique()[target]
@@ -539,7 +539,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
             dense_positive_mask=dense_positive_mask,
         )
         key_list = (
-            hrt_batch[:, [TARGET_TO_INDEX[key] for key in self._get_key(target=target)]].detach().numpy().tolist()
+            hrt_batch[:, [TARGET_TO_INDEX[key] for key in self._get_key(target=target)]].detach().cpu().numpy().tolist()
         )
         keys = cast(List[Tuple[int, int]], list(map(tuple, key_list)))
         self.weights[target].append(numpy.asarray([self.precomputed_weights[target][k] for k in keys]))

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -538,7 +538,8 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         if self.num_entities is None:
             raise ValueError
         # compute macro weights
-        weights = {target: self._calculate_weights(keys=keys) for target, keys in self.keys.items()}
+        # note: we wrap the array into a list to be able to re-use _iter_ranks
+        weights = {target: [self._calculate_weights(keys=keys)] for target, keys in self.keys.items()}
         # calculate weighted metrics
         result = RankBasedMetricResults.from_ranks(
             metrics=self.metrics,

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -18,7 +18,7 @@ from class_resolver import HintOrType, OptionalKwargs
 from .evaluator import Evaluator, MetricResults, prepare_filter_triples
 from .ranking_metric_lookup import MetricKey
 from .ranks import Ranks
-from ..constants import COLUMN_LABELS, TARGET_TO_KEYS
+from ..constants import COLUMN_LABELS, TARGET_TO_KEY_LABELS, TARGET_TO_KEYS
 from ..metrics.ranking import HITS_METRICS, RankBasedMetric, rank_based_metric_resolver
 from ..metrics.utils import Metric
 from ..triples.triples_factory import CoreTriplesFactory
@@ -341,7 +341,7 @@ def sample_negatives(
     negatives = {}
     for side in [LABEL_HEAD, LABEL_TAIL]:
         this_negatives = cast(torch.FloatTensor, torch.empty(size=(num_triples, num_samples), dtype=torch.long))
-        other = TARGET_TO_KEYS[side]
+        other = TARGET_TO_KEY_LABELS[side]
         for _, group in pd.merge(id_df, all_df, on=other, suffixes=["_eval", "_all"]).groupby(
             by=other,
         ):

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -2,6 +2,7 @@
 
 """Implementation of ranked based evaluator."""
 
+from functools import lru_cache
 import itertools
 import logging
 import math
@@ -478,49 +479,40 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
     """Macro-average rank-based evaluation."""
 
     COLUMNS = (LABEL_HEAD, LABEL_RELATION, LABEL_TAIL)
-    precomputed_weights: Mapping[Target, Mapping[Tuple[int, int], float]]
     weights: MutableMapping[Target, List[numpy.ndarray]]
 
-    def __init__(
-        self,
-        *,
-        evaluation_factory: Optional[CoreTriplesFactory] = None,
-        evaluation_triples: Optional[MappedTriples] = None,
-        **kwargs,
-    ):
+    def __init__(self, **kwargs):
         """
         Initialize the evaluator.
 
-        :param evaluation_factory:
-            the evaluation triples' factory. Must be provided, if no explicit triples are provided.
-        :param evaluation_triples:
-            the evaluation triples. If given, takes precedence over extracting triples from a factory.
         :param kwargs:
             additional keyword-based parameters passed to :meth:`RankBasedEvaluator.__init__`.
-
-        :raises ValueError:
-            if neither evaluation triples nor a factory are provided
         """
         super().__init__(**kwargs)
-        if evaluation_triples is None:
-            if evaluation_factory is None:
-                raise ValueError("Need to provide either evaluation_triples or evaluation_factory.")
-            evaluation_triples = evaluation_factory.mapped_triples
-        # compute macro weights
-        df = pandas.DataFrame(data=evaluation_triples.numpy(), columns=list(self.COLUMNS))
-        self.precomputed_weights = dict()
-        self.weights = defaultdict(list)
-        for target in (LABEL_HEAD, LABEL_TAIL):
-            key = self._get_key(target)
-            counts = df.groupby(by=key).nunique()[target]
-            key_list = cast(Iterable[Tuple[int, int]], map(tuple, counts.index.tolist()))
-            self.precomputed_weights[target] = dict(
-                zip(key_list, numpy.reciprocal(counts.values.astype(float)).tolist())
-            )
-            self.weights[target] = []
+        self.keys = defaultdict(list)
 
-    def _get_key(self, target: Target) -> List[Target]:
-        return [c for c in self.COLUMNS if c != target]
+    @lru_cache(maxsize=3)
+    def _get_key(self, target: Target) -> List[int]:
+        return [TARGET_TO_INDEX[c] for c in self.COLUMNS if c != target]
+
+    @staticmethod
+    def _calculate_weights(keys: Iterable[np.ndarray]) -> np.ndarray:
+        """Calculate macro weights, i.e., weights inversely proportional to the key frequency.
+
+        :param keys:
+            the keys, in batches
+
+        :return: shape: (n,)
+            the weights
+        """
+        # combine key batches
+        keys = np.concatenate(list(keys), axis=0)
+        # calculate key frequency
+        inverse, counts = np.unique(keys, axis=0, return_inverse=True, return_counts=True)[1:]
+        # weight = inverse frequency
+        weights = np.reciprocal(counts)
+        # broadcast to samples
+        return weights[inverse]
 
     # docstr-coverage: inherited
     def process_scores_(
@@ -538,22 +530,22 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
             true_scores=true_scores,
             dense_positive_mask=dense_positive_mask,
         )
-        key_list = (
-            hrt_batch[:, [TARGET_TO_INDEX[key] for key in self._get_key(target=target)]].detach().cpu().numpy().tolist()
-        )
-        keys = cast(List[Tuple[int, int]], list(map(tuple, key_list)))
-        self.weights[target].append(numpy.asarray([self.precomputed_weights[target][k] for k in keys]))
+        # store keys for calculating macro weights
+        self.keys[target].append(hrt_batch[:, self._get_key(target=target)].detach().cpu().numpy())
 
     # docstr-coverage: inherited
     def finalize(self) -> RankBasedMetricResults:  # noqa: D102
         if self.num_entities is None:
             raise ValueError
+        # compute macro weights
+        weights = {target: self._calculate_weights(keys=keys) for target, keys in self.keys.items()}
+        # calculate weighted metrics
         result = RankBasedMetricResults.from_ranks(
             metrics=self.metrics,
-            rank_and_candidates=_iter_ranks(ranks=self.ranks, num_candidates=self.num_candidates, weights=self.weights),
+            rank_and_candidates=_iter_ranks(ranks=self.ranks, num_candidates=self.num_candidates, weights=weights),
         )
         # Clear buffers
-        self.weights.clear()
+        self.keys.clear()
         self.ranks.clear()
         self.num_candidates.clear()
 

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -510,7 +510,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         # calculate key frequency
         inverse, counts = np.unique(keys, axis=0, return_inverse=True, return_counts=True)[1:]
         # weight = inverse frequency
-        weights = np.reciprocal(counts)
+        weights = np.reciprocal(counts, dtype=float)
         # broadcast to samples
         return weights[inverse]
 

--- a/src/pykeen/triples/analysis.py
+++ b/src/pykeen/triples/analysis.py
@@ -13,7 +13,7 @@ import pandas as pd
 from tqdm.auto import tqdm
 
 from . import TriplesFactory
-from ..constants import TARGET_TO_INDEX
+from ..constants import COLUMN_LABELS, TARGET_TO_INDEX
 from ..typing import COLUMN_HEAD, COLUMN_RELATION, COLUMN_TAIL, LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, MappedTriples
 
 logger = logging.getLogger(__name__)
@@ -404,7 +404,7 @@ def iter_relation_cardinality_types(
 def _help_iter_relation_cardinality_types(
     mapped_triples: Collection[Tuple[int, int, int]],
 ) -> Iterable[Tuple[int, int, float, float]]:
-    df = pd.DataFrame(data=mapped_triples, columns=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL])
+    df = pd.DataFrame(data=mapped_triples, columns=COLUMN_LABELS)
     for relation, group in df.groupby(by=LABEL_RELATION):
         n_unique_heads, head_injective_conf = _is_injective_mapping(df=group, source=LABEL_HEAD, target=LABEL_TAIL)
         n_unique_tails, tail_injective_conf = _is_injective_mapping(df=group, source=LABEL_TAIL, target=LABEL_HEAD)
@@ -683,7 +683,7 @@ def get_relation_functionality(
     :return:
         A dataframe with columns ( functionality | inverse_functionality )
     """
-    df = pd.DataFrame(data=mapped_triples, columns=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL])
+    df = pd.DataFrame(data=mapped_triples, columns=COLUMN_LABELS)
     df = df.groupby(by=LABEL_RELATION).agg({LABEL_HEAD: ["nunique", COUNT_COLUMN_NAME], LABEL_TAIL: "nunique"})
     df[FUNCTIONALITY_COLUMN_NAME] = df[(LABEL_HEAD, "nunique")] / df[(LABEL_HEAD, COUNT_COLUMN_NAME)]
     df[INVERSE_FUNCTIONALITY_COLUMN_NAME] = df[(LABEL_TAIL, "nunique")] / df[(LABEL_HEAD, COUNT_COLUMN_NAME)]

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -12,6 +12,7 @@ import pandas
 import torch
 from class_resolver.api import ClassResolver, HintOrType
 
+from ..constants import COLUMN_LABELS
 from ..typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, MappedTriples, Target, TorchRandomHint
 from ..utils import ensure_torch_random_state
 
@@ -88,10 +89,7 @@ def _get_cover_deterministic(triples: MappedTriples) -> torch.BoolTensor:
     :return: shape: (n,)
         A boolean mask indicating whether the triple is part of the cover.
     """
-    df = pandas.DataFrame(
-        data=triples.numpy(),
-        columns=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL],
-    ).reset_index()
+    df = pandas.DataFrame(data=triples.numpy(), columns=COLUMN_LABELS).reset_index()
 
     # select one triple per relation
     chosen = _get_cover_for_column(df=df, column=LABEL_RELATION)

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -36,16 +36,8 @@ from torch.utils.data import Dataset
 from .instances import BatchedSLCWAInstances, LCWAInstances, SubGraphSLCWAInstances
 from .splitting import split
 from .utils import TRIPLES_DF_COLUMNS, load_triples, tensor_to_df
-from ..typing import (
-    LABEL_HEAD,
-    LABEL_RELATION,
-    LABEL_TAIL,
-    EntityMapping,
-    LabeledTriples,
-    MappedTriples,
-    RelationMapping,
-    TorchRandomHint,
-)
+from ..constants import COLUMN_LABELS
+from ..typing import EntityMapping, LabeledTriples, MappedTriples, RelationMapping, TorchRandomHint
 from ..utils import (
     ExtraReprMixin,
     compact_mapping,
@@ -846,7 +838,7 @@ class CoreTriplesFactory(KGInfo):
         # store numeric triples
         pd.DataFrame(
             data=self.mapped_triples.numpy(),
-            columns=[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL],
+            columns=COLUMN_LABELS,
         ).to_csv(path.joinpath(self.triples_file_name), sep="\t", index=False)
 
         # store metadata

--- a/tests/test_evaluation/test_evaluators.py
+++ b/tests/test_evaluation/test_evaluators.py
@@ -16,6 +16,7 @@ import torch
 import unittest_templates
 from more_itertools import pairwise
 
+from pykeen.constants import COLUMN_LABELS
 from pykeen.datasets import Nations
 from pykeen.evaluation import Evaluator, MetricResults, RankBasedEvaluator, RankBasedMetricResults
 from pykeen.evaluation.classification_evaluator import (
@@ -579,10 +580,7 @@ class CandidateSetSizeTests(unittest.TestCase):
         # value range
         if not restrict_entities_to and not restrict_relations_to:
             numpy.testing.assert_array_equal(df["index"], numpy.arange(mapped_triples.shape[0]))
-            numpy.testing.assert_array_equal(
-                df[[LABEL_HEAD, LABEL_RELATION, LABEL_TAIL]].values,
-                mapped_triples.numpy(),
-            )
+            numpy.testing.assert_array_equal(df[list(COLUMN_LABELS)].values, mapped_triples.numpy())
         for candidate_column in (f"{LABEL_HEAD}_candidates", f"{LABEL_TAIL}_candidates"):
             numpy.testing.assert_array_less(-1, df[candidate_column])
             numpy.testing.assert_array_less(df[candidate_column], self.dataset.num_entities)

--- a/tests/test_evaluation/test_evaluators.py
+++ b/tests/test_evaluation/test_evaluators.py
@@ -100,11 +100,6 @@ class MacroRankBasedEvaluatorTests(RankBasedEvaluatorTests):
 
     cls = MacroRankBasedEvaluator
 
-    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
-        kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
-        kwargs["evaluation_factory"] = self.factory
-        return kwargs
-
 
 class ClassificationEvaluatorTest(cases.EvaluatorTestCase):
     """Unittest for the ClassificationEvaluator."""


### PR DESCRIPTION
This PR removes the pre-calculation of macro weights, and do this during finalization (of one evaluation round) instead. This should fix the problem with validation weights overlapping with test weights.


#### Dependencies
* [x] #1076 