### PR TITLE
♻️⚙️ Re-use AMO for predict_triples_df

### DIFF
--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -19,7 +19,7 @@ from tqdm.auto import tqdm
 from .evaluator import Evaluator, MetricResults, filter_scores_
 from ..constants import COLUMN_LABELS, TARGET_TO_INDEX
 from ..models import Model
-from ..triples import CoreTriplesFactory
+from ..triples import CoreTriplesFactory, get_mapped_triples
 from ..typing import LABEL_HEAD, LABEL_TAIL, InductiveMode, MappedTriples, OneOrSequence, Target
 from ..utils import upgrade_to_sequence
 
@@ -259,39 +259,6 @@ class FilterIndex:
         key_id = self.triple_id_to_key_id[item]
         low, high = self.bounds[key_id : key_id + 2]
         return self.indices[low:high]
-
-
-def get_mapped_triples(
-    x: Union[None, MappedTriples, CoreTriplesFactory] = None,
-    *,
-    mapped_triples: Optional[MappedTriples] = None,
-    factory: Optional[CoreTriplesFactory] = None,
-) -> MappedTriples:
-    """
-    Get ID-based triples either directly, or from a factory.
-
-    :param x:
-        either of ID-based triples, a factory, or None.
-    :param mapped_triples: shape: (n, 3)
-        the ID-based triples
-    :param factory:
-        the triples factory
-
-    :raises ValueError:
-        if all inputs are None
-
-    :return:
-        the ID-based triples
-    """
-    if x is not None:
-        if isinstance(x, CoreTriplesFactory):
-            return x.mapped_triples
-        return x
-    if mapped_triples is not None:
-        return mapped_triples
-    if factory is None:
-        raise ValueError("Needs at least one of `mapped_triples` and `factory`.")
-    return factory.mapped_triples
 
 
 class LCWAEvaluationDataset(Dataset[Mapping[Target, Tuple[MappedTriples, Optional[torch.Tensor]]]]):

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -1056,9 +1056,6 @@ def predict_triples_df(
     :return: columns: head_id | relation_id | tail_id | score | *
         A dataframe with one row per triple.
 
-    :raises ValueError:
-        If label-based triples have been provided, but the triples factory does not provide a mapping.
-
     The TransE model can be trained and used to predict a given triple.
 
     >>> from pykeen.pipeline import pipeline

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -1068,7 +1068,7 @@ def predict_triples_df(
     ... )
     """
     # normalize input
-    triples = get_mapped_triples(mapped_triples=triples, factory=triples_factory)
+    triples = get_mapped_triples(triples, factory=triples_factory)
     # calculate scores (with automatic memory optimization)
     scores = _predict_triples_batched(
         model=model, mapped_triples=triples, batch_size=batch_size or len(triples), mode=mode

--- a/src/pykeen/models/predict.py
+++ b/src/pykeen/models/predict.py
@@ -19,7 +19,7 @@ from typing_extensions import TypeAlias  # Python <=3.9
 
 from .base import Model
 from ..constants import TARGET_TO_INDEX
-from ..triples import CoreTriplesFactory, TriplesFactory
+from ..triples import CoreTriplesFactory, TriplesFactory, get_mapped_triples
 from ..triples.utils import tensor_to_df
 from ..typing import (
     LABEL_HEAD,
@@ -32,7 +32,7 @@ from ..typing import (
     ScorePack,
     Target,
 )
-from ..utils import is_cuda_oom_error, resolve_device
+from ..utils import resolve_device
 
 __all__ = [
     "predict",
@@ -121,13 +121,6 @@ def _get_input_batch(
     return target, batch, (batch_ids[0], batch_ids[1])
 
 
-def _get_mapped_triples(mapped_triples: Union[CoreTriplesFactory, MappedTriples]):
-    """Get mapped triples."""
-    if isinstance(mapped_triples, CoreTriplesFactory):
-        mapped_triples = mapped_triples.mapped_triples
-    return mapped_triples
-
-
 class PredictionPostProcessor:
     """A post-processor for predictions."""
 
@@ -139,7 +132,7 @@ class PredictionPostProcessor:
             used to derive column names.
         """
         self.filter_triples = {
-            key: _get_mapped_triples(value) for key, value in filter_triples.items() if value is not None
+            key: get_mapped_triples(value) for key, value in filter_triples.items() if value is not None
         }
 
     @abstractmethod
@@ -1010,46 +1003,25 @@ def _build_pack(result: torch.LongTensor, scores: torch.FloatTensor, flatten: bo
     return ScorePack(result=result, scores=scores)
 
 
-@torch.inference_mode()
-def _predict_triples(
+@maximize_memory_utilization(keys=["model"])
+def _predict_triples_batched(
     model: Model,
     mapped_triples: MappedTriples,
-    batch_size: Optional[int] = None,
+    batch_size: int,
     *,
     mode: Optional[InductiveMode],
 ) -> torch.FloatTensor:
-    """Predict scores for triples while dealing with reducing batch size for CUDA OOM."""
-    # base case: infer maximum batch size
-    if batch_size is None:
-        return _predict_triples(
-            model=model, mapped_triples=mapped_triples, batch_size=mapped_triples.shape[0], mode=mode
-        )
-
-    # base case: single batch
-    if batch_size >= mapped_triples.shape[0]:
-        return model.predict_hrt(hrt_batch=mapped_triples, mode=mode)
-
-    if batch_size <= 0:
-        # TODO: this could happen because of AMO
-        raise ValueError("batch_size must be positive.")
-
-    try:
-        return torch.cat(
-            [
-                model.predict_hrt(hrt_batch=hrt_batch, mode=mode)
-                for hrt_batch in mapped_triples.split(split_size=batch_size, dim=0)
-            ],
-            dim=0,
-        )
-    except RuntimeError as error:
-        # TODO: Can we make AMO code re-usable? e.g. like https://gist.github.com/mberr/c37a8068b38cabc98228db2cbe358043
-        if is_cuda_oom_error(error):
-            return _predict_triples(model=model, mapped_triples=mapped_triples, batch_size=batch_size // 2)
-
-        # no OOM error.
-        raise error
+    """Predict scores for triples in batches."""
+    return torch.cat(
+        [
+            model.predict_hrt(hrt_batch=hrt_batch, mode=mode)
+            for hrt_batch in mapped_triples.split(split_size=batch_size, dim=0)
+        ],
+        dim=0,
+    )
 
 
+@torch.inference_mode()
 def predict_triples_df(
     model: Model,
     *,
@@ -1098,28 +1070,12 @@ def predict_triples_df(
     ...     triples_factory=result.training,
     ... )
     """
-    if triples is None:
-        if triples_factory is None:
-            raise ValueError("If no triples are provided, a triples_factory must be provided.")
-
-        triples = triples_factory.mapped_triples
-
-    if not isinstance(triples, torch.Tensor) or triples.dtype != torch.long:
-        if triples_factory is None or not isinstance(triples_factory, TriplesFactory):
-            raise ValueError("If triples are not ID-based, a triples_factory must be provided and label-based.")
-
-        # make sure triples are a numpy array
-        triples = numpy.asanyarray(triples)
-
-        # make sure triples are 2d
-        triples = numpy.atleast_2d(triples)
-
-        # convert to ID-based
-        triples = triples_factory.map_triples(triples)
-
-    assert torch.is_tensor(triples) and triples.dtype == torch.long
-
-    scores = _predict_triples(model=model, mapped_triples=triples, batch_size=batch_size, mode=mode).squeeze(dim=1)
+    # normalize input
+    triples = get_mapped_triples(mapped_triples=triples, factory=triples_factory)
+    # calculate scores (with automatic memory optimization)
+    scores = _predict_triples_batched(
+        model=model, mapped_triples=triples, batch_size=batch_size or len(triples), mode=mode
+    ).squeeze(dim=1)
 
     if triples_factory is None:
         return tensor_to_df(tensor=triples, score=scores)

--- a/src/pykeen/triples/__init__.py
+++ b/src/pykeen/triples/__init__.py
@@ -3,7 +3,14 @@
 """Classes for creating and storing training data from triples."""
 
 from .instances import Instances, LCWAInstances, SLCWAInstances
-from .triples_factory import CoreTriplesFactory, KGInfo, RelationInverter, TriplesFactory, relation_inverter
+from .triples_factory import (
+    CoreTriplesFactory,
+    KGInfo,
+    RelationInverter,
+    TriplesFactory,
+    relation_inverter,
+    get_mapped_triples,
+)
 from .triples_numeric_literals_factory import TriplesNumericLiteralsFactory
 
 __all__ = [
@@ -16,4 +23,5 @@ __all__ = [
     "relation_inverter",
     "TriplesFactory",
     "TriplesNumericLiteralsFactory",
+    "get_mapped_triples",
 ]

--- a/src/pykeen/triples/__init__.py
+++ b/src/pykeen/triples/__init__.py
@@ -8,8 +8,8 @@ from .triples_factory import (
     KGInfo,
     RelationInverter,
     TriplesFactory,
-    relation_inverter,
     get_mapped_triples,
+    relation_inverter,
 )
 from .triples_numeric_literals_factory import TriplesNumericLiteralsFactory
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1351,7 +1351,7 @@ def splits_similarity(a: Sequence[CoreTriplesFactory], b: Sequence[CoreTriplesFa
 
 
 def get_mapped_triples(
-    x: Union[None, MappedTriples, CoreTriplesFactory] = None,
+    x: Union[None, Tuple[str, str, str], Sequence[Tuple[str, str, str]], MappedTriples, CoreTriplesFactory] = None,
     *,
     mapped_triples: Optional[MappedTriples] = None,
     triples: Union[None, LabeledTriples, Tuple[str, str, str], Sequence[Tuple[str, str, str]]] = None,

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1367,9 +1367,11 @@ def get_mapped_triples(
     4. `x`
 
     :param x:
-        either of ID-based triples, a factory, or None.
+        either of label-based triples, ID-based triples, a factory, or None.
     :param mapped_triples: shape: (n, 3)
         the ID-based triples
+    :param triples:
+        the label-based triples
     :param factory:
         the triples factory
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1363,8 +1363,8 @@ def get_mapped_triples(
     Preference order:
     1. `mapped_triples`
     2. `triples` (converted using factory)
-    3. `factory.mapped_triples`
-    4. `x`
+    3. `x`
+    4. `factory.mapped_triples`
 
     :param x:
         either of label-based triples, ID-based triples, a factory, or None.
@@ -1406,7 +1406,7 @@ def get_mapped_triples(
         return factory.map_triples(triples)
 
     # triples factory
-    if factory is not None:
+    if x is None and factory is not None:
         return factory.mapped_triples
 
     # all keyword-based options have been none
@@ -1422,4 +1422,4 @@ def get_mapped_triples(
         return get_mapped_triples(mapped_triples=x.mapped_triples)
 
     # only labeled triples are remaining
-    return get_mapped_triples(triples=x)
+    return get_mapped_triples(triples=x, factory=factory)

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -8,9 +8,10 @@ import tempfile
 import unittest
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
-from typing import Collection, Optional, Tuple
+from typing import Any, Collection, Iterable, Mapping, Optional, Tuple, Union
 from unittest.mock import patch
 
+import numpy
 import numpy as np
 import pytest
 import torch
@@ -19,7 +20,7 @@ from pykeen.datasets import Hetionet, Nations, SingleTabbedDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
 from pykeen.triples import CoreTriplesFactory, LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory
 from pykeen.triples.splitting import splitter_resolver
-from pykeen.triples.triples_factory import INVERSE_SUFFIX, _map_triples_elements_to_ids
+from pykeen.triples.triples_factory import INVERSE_SUFFIX, _map_triples_elements_to_ids, get_mapped_triples
 from pykeen.triples.utils import TRIPLES_DF_COLUMNS, load_triples
 from tests.constants import RESOURCES
 from tests.utils import needs_packages
@@ -560,3 +561,36 @@ def test_core_triples_factory_error_handling(dtype: torch.dtype, size: Tuple[int
         CoreTriplesFactory(
             mapped_triples=torch.randint(33, size=size).to(dtype=dtype), num_entities=..., num_relations=...
         )
+
+
+def _iter_get_mapped_triples_inputs() -> Iterable[Tuple[Any, Mapping[str, Any]]]:
+    """Iterate valid test inputs for get_mapped_triples."""
+    factory = Nations().training
+    # >>> positional argument
+    # mapped_triples
+    yield factory.mapped_triples, {}
+    # triples factory
+    yield factory, {}
+    # labeled triples + factory
+    labeled = [("brazil", "accusation", "burma"), ("brazil", "accusation", "uk")]
+    # single labeled triple
+    yield labeled[0], dict(factory=factory)
+    # multiple labeled triples as list
+    yield labeled, dict(factory=factory)
+    # multiple labeled triples as array
+    yield numpy.asarray(labeled), dict(factory=factory)
+    # >>> keyword only
+    yield None, dict(mapped_triples=factory.mapped_triples)
+    yield None, dict(factory=factory)
+    yield None, dict(triples=labeled, factory=factory)
+    yield None, dict(triples=numpy.asarray(labeled), factory=factory)
+
+
+@pytest.mark.parametrize(["x", "inputs"], _iter_get_mapped_triples_inputs())
+def test_get_mapped_triples(x, inputs: Mapping[str, Any]):
+    """Test get_mapped_triples."""
+    mapped_triples = get_mapped_triples(x, **inputs)
+    assert torch.is_tensor(mapped_triples)
+    assert mapped_triples.dtype == torch.long
+    assert mapped_triples.ndim == 2
+    assert mapped_triples.shape[-1] == 3

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -8,10 +8,9 @@ import tempfile
 import unittest
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
-from typing import Any, Collection, Iterable, Mapping, Optional, Tuple, Union
+from typing import Any, Collection, Iterable, Mapping, Optional, Tuple
 from unittest.mock import patch
 
-import numpy
 import numpy as np
 import pytest
 import torch
@@ -578,12 +577,12 @@ def _iter_get_mapped_triples_inputs() -> Iterable[Tuple[Any, Mapping[str, Any]]]
     # multiple labeled triples as list
     yield labeled, dict(factory=factory)
     # multiple labeled triples as array
-    yield numpy.asarray(labeled), dict(factory=factory)
+    yield np.asarray(labeled), dict(factory=factory)
     # >>> keyword only
     yield None, dict(mapped_triples=factory.mapped_triples)
     yield None, dict(factory=factory)
     yield None, dict(triples=labeled, factory=factory)
-    yield None, dict(triples=numpy.asarray(labeled), factory=factory)
+    yield None, dict(triples=np.asarray(labeled), factory=factory)
 
 
 @pytest.mark.parametrize(["x", "inputs"], _iter_get_mapped_triples_inputs())


### PR DESCRIPTION
This PR re-uses the `torch_max_mem` package for automatic batch size selection for `predict_triples_df`.