### PR TITLE
🔵🟦 Approximate other representation with Low-Rank

### DIFF
--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -477,6 +477,12 @@ class LowRankRepresentation(Representation):
         """
         Construct a low-rank approximation of another representation.
 
+        .. note ::
+
+            While this method tries to find a good approximation of the base representation, you may lose all (useful)
+            inductive biases you had with the original one, e.g., from shared tokens in
+            :class:`pykeen.representation.NodePieceRepresentation`.
+
         :param other:
             the other representation
         :param kwargs:

--- a/tests/test_nn/test_representation.py
+++ b/tests/test_nn/test_representation.py
@@ -44,6 +44,11 @@ class LowRankEmbeddingRepresentationTests(cases.RepresentationTestCase):
         shape=(3, 7),
     )
 
+    def test_approximate(self):
+        """Test approximation of other representations."""
+        approx = self.cls.approximate(other=pykeen.nn.representation.Embedding(**self.instance_kwargs))
+        assert isinstance(approx, self.cls)
+
 
 class TensorEmbeddingTests(cases.RepresentationTestCase):
     """Tests for Embedding with 2-dimensional shape."""


### PR DESCRIPTION
This PR adds a small factory method to create a `LowRankRepresentation` which approximates any other representation. The approximation is determined using truncated SVD (in particular, [`torch.svd_lowrank`](https://pytorch.org/docs/stable/generated/torch.svd_lowrank.html?highlight=svd#torch.svd_lowrank)).