### PR TITLE
⚙️🔢 Fix InductiveNodePiece for parametric aggregations

### DIFF
--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -133,6 +133,7 @@ class InductiveNodePiece(ERModel):
             ),
             **kwargs,
         )
+        # create inference entity representations
         self.inference_representation = _prepare_representation_module_list(
             representations=NodePieceRepresentation,
             representation_kwargs=dict(
@@ -146,6 +147,11 @@ class InductiveNodePiece(ERModel):
             shapes=self.interaction.full_entity_shapes(),
             label="entity",
         )
+        # note: we need to share the aggregation across representations, since the aggregation may have
+        #   trainable parameters
+        np: NodePieceRepresentation = self.entity_representations[0]
+        np_inf: NodePieceRepresentation = self.inference_representation[0]
+        np_inf.combination = np.combination
 
         self.num_train_entities = triples_factory.num_entities
         self.num_inference_entities, self.num_valid_entities, self.num_test_entities = None, None, None


### PR DESCRIPTION
This PR fixes a bug in `InductiveNodePiece`, where the inference representation's combination was not shared with the (training) entity representations. In case of parametric combinations, such as the MLP option, this leads to using an un-trained aggregation.


#### Background
- detected by @gawainx in https://github.com/pykeen/ilpc2022/issues/7 - thanks!
- introduced in #964 (found via `git bisect` between [v1.8.2](https://github.com/pykeen/pykeen/tree/v1.8.2) and [v1.9.0](https://github.com/pykeen/pykeen/tree/v1.9.0), i.e., [v1.8.2...v1.9.0](https://github.com/pykeen/pykeen/compare/v1.8.2...v1.9.0))
- isolated by @migalkin by comparing the number of trainable parameters via
```python
{name: param.shape for name, param in mod.named_parameters()}
```