### PR TITLE
🌑⛱️ Inductive ERModel base class

### DIFF
--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -51,7 +51,7 @@ from class_resolver import ClassResolver, get_subclasses
 
 from .base import Model
 from .baseline import EvaluationOnlyModel, MarginalDistributionBaseline, SoftInverseTripleBaseline
-from .inductive import InductiveNodePiece, InductiveNodePieceGNN
+from .inductive import InductiveERModel, InductiveNodePiece, InductiveNodePieceGNN
 from .meta import CooccurrenceFilteredModel
 from .mocks import FixedModel
 from .multimodal import ComplExLiteral, DistMultLiteral, DistMultLiteralGated, LiteralModel
@@ -97,6 +97,7 @@ __all__ = [
     # Base Models
     "Model",
     "ERModel",
+    "InductiveERModel",
     "LiteralModel",
     "EvaluationOnlyModel",
     # Concrete Models
@@ -158,6 +159,7 @@ model_resolver: ClassResolver[Model] = ClassResolver.from_subclasses(
         _NewAbstractModel,
         # We might be able to relax this later
         ERModel,
+        InductiveERModel,
         LiteralModel,
         # baseline models behave differently
         EvaluationOnlyModel,

--- a/src/pykeen/models/inductive/__init__.py
+++ b/src/pykeen/models/inductive/__init__.py
@@ -2,10 +2,12 @@
 
 """Inductive models in PyKEEN."""
 
+from .base import InductiveERModel
 from .inductive_nodepiece import InductiveNodePiece
 from .inductive_nodepiece_gnn import InductiveNodePieceGNN
 
 __all__ = [
+    "InductiveERModel",
     "InductiveNodePiece",
     "InductiveNodePieceGNN",
 ]

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -1,6 +1,6 @@
 """Base classes for inductive models."""
 from collections import ChainMap
-from typing import Optional, Sequence
+from typing import Mapping, Optional, Sequence
 
 from class_resolver import OneOrManyHintOrType, OneOrManyOptionalKwargs
 
@@ -18,6 +18,10 @@ class InductiveERModel(ERModel):
     separate inference factory used during validation. During testing time, either the validation factory is re-used
     or another separate testing factory may be provided.
     """
+
+    #: a mapping from inductive mode to corresponding entity representations
+    #: note: there may be duplicate values, if entity representations are shared between validation and testing
+    _mode_to_representations: Mapping[InductiveMode, Sequence[Representation]]
 
     def __init__(
         self,
@@ -90,11 +94,9 @@ class InductiveERModel(ERModel):
         self, *, mode: Optional[InductiveMode]
     ) -> Sequence[Representation]:  # noqa: D102
         if mode in self._mode_to_representations:
+            assert mode is not None  # for mypy
             return self._mode_to_representations[mode]
-        elif mode is None:
-            raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
-        else:
-            raise ValueError(f"Invalid mode: {mode}")
+        raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")
 
     # docstr-coverage: inherited
     def _get_entity_len(self, *, mode: Optional[InductiveMode]) -> Optional[int]:  # noqa: D102

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -31,9 +31,7 @@ class InductiveERModel(ERModel):
         )
         # note: this is *not* a nn.ModuleDict; the modules have to be registered elsewhere
         self._mode_to_representations = {TRAINING: self.entity_representations}
-        self._mode_to_representations[
-            VALIDATION
-        ] = self.validation_entity_representations = self._build_representations(
+        self._mode_to_representations[VALIDATION] = validation_entity_representations = self._build_representations(
             triples_factory=validation_factory,
             entity_representations=entity_representations,
             entity_representations_kwargs=entity_representations_kwargs,
@@ -41,15 +39,15 @@ class InductiveERModel(ERModel):
 
         # shared
         if testing_factory is None:
-            self.testing_entity_representations = self.validation_entity_representations
+            testing_entity_representations = validation_entity_representations
         else:
             # non-shared
-            self.testing_entity_representations = self._build_representations(
+            testing_entity_representations = self._build_representations(
                 triples_factory=testing_factory,
                 entity_representations=entity_representations,
                 entity_representations_kwargs=entity_representations_kwargs,
             )
-        self._mode_to_representations[TESTING] = self.testing_entity_representations
+        self._mode_to_representations[TESTING] = testing_entity_representations
 
     # docstr-coverage: inherited
     def _get_entity_representations_from_inductive_mode(

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -1,0 +1,65 @@
+"""Base classes for inductive models."""
+from typing import Optional, Sequence
+
+from class_resolver import OneOrManyHintOrType, OneOrManyOptionalKwargs
+
+from ..nbase import ERModel
+from ...nn import Representation
+from ...triples import CoreTriplesFactory
+from ...typing import TESTING, TRAINING, VALIDATION, InductiveMode
+
+
+class InductiveERModel(ERModel):
+    """A base class for inductive models."""
+
+    def __init__(
+        self,
+        *,
+        triples_factory: CoreTriplesFactory,
+        entity_representations: OneOrManyHintOrType[Representation] = None,
+        entity_representations_kwargs: OneOrManyOptionalKwargs = None,
+        # inductive factories
+        validation_factory: CoreTriplesFactory,
+        testing_factory: Optional[CoreTriplesFactory] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            triples_factory=triples_factory,
+            entity_representations=entity_representations,
+            entity_representations_kwargs=entity_representations_kwargs,
+            **kwargs,
+        )
+        # note: this is *not* a nn.ModuleDict; the modules have to be registered elsewhere
+        self._mode_to_representation = {TRAINING: self.entity_representations}
+        self._mode_to_representation[VALIDATION] = self.validation_entity_representations = self._build_representations(
+            triples_factory=validation_factory,
+            entity_representations=entity_representations,
+            entity_representations_kwargs=entity_representations_kwargs,
+        )
+
+        # shared
+        if testing_factory is None:
+            self.testing_entity_representations = self.validation_entity_representations
+        else:
+            # non-shared
+            self.testing_entity_representations = self._build_representations(
+                triples_factory=testing_factory,
+                entity_representations=entity_representations,
+                entity_representations_kwargs=entity_representations_kwargs,
+            )
+        self._mode_to_representation[TESTING] = self.testing_entity_representations
+
+    # docstr-coverage: inherited
+    def _get_entity_representations_from_inductive_mode(
+        self, *, mode: Optional[InductiveMode]
+    ) -> Sequence[Representation]:  # noqa: D102
+        if mode in self._mode_to_representation:
+            return self._mode_to_representation[mode]
+        elif mode is None:
+            raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
+
+    # docstr-coverage: inherited
+    def _get_entity_len(self, *, mode: Optional[InductiveMode]) -> Optional[int]:  # noqa: D102
+        return self._get_entity_representations_from_inductive_mode(mode=mode)[0].max_id

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -93,8 +93,9 @@ class InductiveERModel(ERModel):
     def _get_entity_representations_from_inductive_mode(
         self, *, mode: Optional[InductiveMode]
     ) -> Sequence[Representation]:  # noqa: D102
+        if mode is None:
+            raise ValueError(f"{self.__class__.__name__} does not support the transductive setting (i.e., when mode is None)")
         if mode in self._mode_to_representations:
-            assert mode is not None  # for mypy
             return self._mode_to_representations[mode]
         raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")
 

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -23,6 +23,22 @@ class InductiveERModel(ERModel):
         testing_factory: Optional[CoreTriplesFactory] = None,
         **kwargs,
     ) -> None:
+        """Initialize the inductive model.
+
+        :param triples_factory:
+            the (training) factory
+        :param entity_representations:
+            the training entity representations
+        :param entity_representations_kwargs:
+            additional keyword-based parameters for the training entity representations
+        :param validation_factory:
+            the validation factory
+        :param testing_factory:
+            the testing factory. If None, the validation factory is re-used, i.e., validation and test entities come
+            from the same (unseen) set of entities.
+        :param kwargs:
+            additional keyword-based parameters passed to :meth:`ERModel.__init__`
+        """
         super().__init__(
             triples_factory=triples_factory,
             entity_representations=entity_representations,

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -94,7 +94,9 @@ class InductiveERModel(ERModel):
         self, *, mode: Optional[InductiveMode]
     ) -> Sequence[Representation]:  # noqa: D102
         if mode is None:
-            raise ValueError(f"{self.__class__.__name__} does not support the transductive setting (i.e., when mode is None)")
+            raise ValueError(
+                f"{self.__class__.__name__} does not support the transductive setting (i.e., when mode is None)"
+            )
         if mode in self._mode_to_representations:
             return self._mode_to_representations[mode]
         raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -30,8 +30,10 @@ class InductiveERModel(ERModel):
             **kwargs,
         )
         # note: this is *not* a nn.ModuleDict; the modules have to be registered elsewhere
-        self._mode_to_representation = {TRAINING: self.entity_representations}
-        self._mode_to_representation[VALIDATION] = self.validation_entity_representations = self._build_representations(
+        self._mode_to_representations = {TRAINING: self.entity_representations}
+        self._mode_to_representations[
+            VALIDATION
+        ] = self.validation_entity_representations = self._build_representations(
             triples_factory=validation_factory,
             entity_representations=entity_representations,
             entity_representations_kwargs=entity_representations_kwargs,
@@ -47,14 +49,14 @@ class InductiveERModel(ERModel):
                 entity_representations=entity_representations,
                 entity_representations_kwargs=entity_representations_kwargs,
             )
-        self._mode_to_representation[TESTING] = self.testing_entity_representations
+        self._mode_to_representations[TESTING] = self.testing_entity_representations
 
     # docstr-coverage: inherited
     def _get_entity_representations_from_inductive_mode(
         self, *, mode: Optional[InductiveMode]
     ) -> Sequence[Representation]:  # noqa: D102
-        if mode in self._mode_to_representation:
-            return self._mode_to_representation[mode]
+        if mode in self._mode_to_representations:
+            return self._mode_to_representations[mode]
         elif mode is None:
             raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
         else:

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -11,7 +11,13 @@ from ...typing import TESTING, TRAINING, VALIDATION, InductiveMode
 
 
 class InductiveERModel(ERModel):
-    """A base class for inductive models."""
+    """
+    A base class for inductive models.
+
+    This model assumes a shared set of relations between all triple sets (e.g., training and validation), and a
+    separate inference factory used during validation. During testing time, either the validation factory is re-used
+    or another separate testing factory may be provided.
+    """
 
     def __init__(
         self,

--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -3,24 +3,23 @@
 """A wrapper which combines an interaction function with NodePiece entity representations."""
 
 import logging
-from typing import Any, Callable, ClassVar, Mapping, Optional, Sequence
+from typing import Any, Callable, ClassVar, Mapping, Optional
 
 import torch
 from class_resolver import Hint, HintOrType, OptionalKwargs
 
-from ..nbase import ERModel, _prepare_representation_module_list
+from .base import InductiveERModel
+
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...nn import (
     DistMultInteraction,
     Interaction,
     NodePieceRepresentation,
-    Representation,
     SubsetRepresentation,
     representation_resolver,
 )
 from ...nn.node_piece import RelationTokenizer
 from ...triples.triples_factory import CoreTriplesFactory
-from ...typing import TESTING, TRAINING, VALIDATION, InductiveMode
 
 __all__ = [
     "InductiveNodePiece",
@@ -29,7 +28,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-class InductiveNodePiece(ERModel):
+class InductiveNodePiece(InductiveERModel):
     """A wrapper which combines an interaction function with NodePiece entity representations from [galkin2021]_.
 
     This model uses the :class:`pykeen.nn.NodePieceRepresentation` instead of a typical
@@ -115,6 +114,8 @@ class InductiveNodePiece(ERModel):
             max_id=2 * triples_factory.real_num_relations + 1,
             shape=embedding_dim,
         )
+        if validation_factory is None:
+            validation_factory = inference_factory
 
         super().__init__(
             triples_factory=triples_factory,
@@ -131,51 +132,8 @@ class InductiveNodePiece(ERModel):
                 max_id=triples_factory.num_relations,
                 base=relation_representations,
             ),
+            validation_factory=validation_factory,
+            testing_factory=test_factory,
             **kwargs,
         )
-        self.inference_representation = _prepare_representation_module_list(
-            representations=NodePieceRepresentation,
-            representation_kwargs=dict(
-                triples_factory=inference_factory,
-                tokenizers=RelationTokenizer,
-                token_representations=relation_representations,
-                aggregation=aggregation,
-                num_tokens=num_tokens,
-            ),
-            max_id=inference_factory.num_entities,
-            shapes=self.interaction.full_entity_shapes(),
-            label="entity",
-        )
-
-        self.num_train_entities = triples_factory.num_entities
-        self.num_inference_entities, self.num_valid_entities, self.num_test_entities = None, None, None
-        if inference_factory is not None:
-            self.num_inference_entities = inference_factory.num_entities
-            self.num_valid_entities = self.num_test_entities = self.num_inference_entities
-        else:
-            self.num_valid_entities = validation_factory.num_entities
-            self.num_test_entities = test_factory.num_entities
-
-    # docstr-coverage: inherited
-    def _get_entity_representations_from_inductive_mode(
-        self, *, mode: Optional[InductiveMode]
-    ) -> Sequence[Representation]:  # noqa: D102
-        if mode == TRAINING:
-            return self.entity_representations
-        elif mode == TESTING or mode == VALIDATION:
-            return self.inference_representation
-        elif mode is None:
-            raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
-        else:
-            raise ValueError(f"Invalid mode: {mode}")
-
-    # docstr-coverage: inherited
-    def _get_entity_len(self, *, mode: Optional[InductiveMode]) -> Optional[int]:  # noqa: D102
-        if mode == TRAINING:
-            return self.num_train_entities
-        elif mode == TESTING:
-            return self.num_test_entities
-        elif mode == VALIDATION:
-            return self.num_valid_entities
-        else:
-            raise ValueError
+        # TODO: re-apply fix from https://github.com/pykeen/pykeen/pull/1104

--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -9,7 +9,6 @@ import torch
 from class_resolver import Hint, HintOrType, OptionalKwargs
 
 from .base import InductiveERModel
-
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...nn import (
     DistMultInteraction,

--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -139,7 +139,7 @@ class InductiveNodePiece(InductiveERModel):
         # note: we need to share the aggregation across representations, since the aggregation may have
         #   trainable parameters
         np: NodePieceRepresentation = self.entity_representations[0]
-        for representations in self._mode_to_representation.values():
+        for representations in self._mode_to_representations.values():
             assert len(representations) == 1
             np2 = representations[0]
             assert isinstance(np2, NodePieceRepresentation)

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -165,7 +165,7 @@ def _prepare_representation_module_list(
     shapes: Sequence[str],
     label: str,
     representations: OneOrManyHintOrType[Representation] = None,
-    representation_kwargs: OneOrManyOptionalKwargs = None,
+    representations_kwargs: OneOrManyOptionalKwargs = None,
     skip_checks: bool = False,
 ) -> Sequence[Representation]:
     """
@@ -176,7 +176,7 @@ def _prepare_representation_module_list(
 
     :param representations:
         the representations, or hints for them.
-    :param representation_kwargs:
+    :param representations_kwargs:
         additional keyword-based parameters for instantiating representations from hints.
     :param max_id:
         the maximum representation ID. Newly instantiated representations will contain that many representations, and
@@ -196,7 +196,7 @@ def _prepare_representation_module_list(
     """
     # TODO: allow max_id being present in representation_kwargs; if it matches max_id
     # TODO: we could infer some shapes from the given interaction shape information
-    rs = representation_resolver.make_many(representations, kwargs=representation_kwargs, max_id=max_id)
+    rs = representation_resolver.make_many(representations, kwargs=representations_kwargs, max_id=max_id)
 
     # check max-id
     for r in rs:
@@ -331,14 +331,14 @@ class ERModel(
         self.entity_representations = self._build_representations(
             triples_factory=triples_factory,
             representations=entity_representations,
-            representation_kwargs=entity_representations_kwargs,
+            representations_kwargs=entity_representations_kwargs,
             label="entity",
             skip_checks=skip_checks,
         )
         self.relation_representations = self._build_representations(
             triples_factory=triples_factory,
             representations=relation_representations,
-            representation_kwargs=relation_representations_kwargs,
+            representations_kwargs=relation_representations_kwargs,
             label="relation",
             skip_checks=skip_checks,
         )
@@ -359,7 +359,7 @@ class ERModel(
         """Build representations for the given factory."""
         return _prepare_representation_module_list(
             representations=representations,
-            representation_kwargs=representations_kwargs,
+            representations_kwargs=representations_kwargs,
             max_id=triples_factory.num_entities if label == "entity" else triples_factory.num_relations,
             shapes=self.interaction.full_entity_shapes() if label == "entity" else self.interaction.relation_shape,
             label=label,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,7 +12,15 @@ import unittest_templates
 
 import pykeen.experiments
 import pykeen.models
-from pykeen.models import ERModel, EvaluationOnlyModel, FixedModel, Model, _NewAbstractModel, model_resolver
+from pykeen.models import (
+    ERModel,
+    EvaluationOnlyModel,
+    FixedModel,
+    Model,
+    _NewAbstractModel,
+    model_resolver,
+    InductiveERModel,
+)
 from pykeen.models.multimodal.base import LiteralModel
 from pykeen.nn import Embedding, NodePieceRepresentation
 from pykeen.nn.combination import ConcatAggregationCombination
@@ -28,6 +36,7 @@ SKIP_MODULES = {
     # DummyModel,
     LiteralModel,
     ERModel,
+    InductiveERModel,
     FixedModel,
     EvaluationOnlyModel,
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,10 +16,10 @@ from pykeen.models import (
     ERModel,
     EvaluationOnlyModel,
     FixedModel,
+    InductiveERModel,
     Model,
     _NewAbstractModel,
     model_resolver,
-    InductiveERModel,
 )
 from pykeen.models.multimodal.base import LiteralModel
 from pykeen.nn import Embedding, NodePieceRepresentation


### PR DESCRIPTION
This PR extracts a base class for inductive models.

This should make it easier to build your own inductive models without NodePiece representations, e.g., using textual features as in [BLP](https://github.com/dfdazac/blp).