### PR TITLE
🫴🔋 fix to pass any negative sampler kwargs through if present

### DIFF
--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1068,6 +1068,11 @@ def _handle_training_loop(
 
     if negative_sampler is None:
         negative_sampler_cls = None
+        if negative_sampler_kwargs and issubclass(training_loop_cls, SLCWATrainingLoop):
+            training_loop_kwargs = dict(training_loop_kwargs)
+            training_loop_kwargs.update(
+                negative_sampler_kwargs=negative_sampler_kwargs,
+            )
     elif not issubclass(training_loop_cls, SLCWATrainingLoop):
         raise ValueError("Can not specify negative sampler with LCWA")
     else:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,7 +19,6 @@ from pykeen.nn.representation import Embedding
 from pykeen.pipeline import PipelineResult, pipeline
 from pykeen.pipeline.api import replicate_pipeline_from_config
 from pykeen.regularizers import NoRegularizer
-from pykeen.sampling.basic_negative_sampler import BasicNegativeSampler
 from pykeen.sampling.negative_sampler import NegativeSampler
 from pykeen.training import SLCWATrainingLoop
 from pykeen.triples.generation import generate_triples_factory


### PR DESCRIPTION
### Link to the relevant Bug(s)

Closes #1118 

### Description of the Change

There is now a check for `negative_sampler_kwargs` which sets them even if there is no `negative_sampler` value.

### Possible Drawbacks

Probably there is a cleaner way to do this.

### Verification Process

Running the pipeline with `negative_sampler_kwargs` set without a `negative_sampler` value now works as expected.

### Release Notes

- Fixed an issues where negative sampler kwags were ignored
