### PR TITLE
🩹🧑‍🏫 Fix scikit-learn dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     scipy>=1.7.0
     click
     click_default_group
-    sklearn
+    scikit-learn
     torch>=1.10; platform_system != "Windows"
     tqdm
     requests


### PR DESCRIPTION
The Scikit-learn dependency is wrongfully declared as "sklearn"

### Link to the relevant Bug(s)

https://github.com/pykeen/pykeen/issues/1121


### Description of the Change

Change the scikit-learn dependency to be correct


### Possible Drawbacks

Hopefully nothing?


### Verification Process

I successfully build the package


### Release Notes

Fixed wrong scikit-learn dependency
