### PR TITLE
Remove unnecessary unsqueezing in MRL

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -841,7 +841,7 @@ class DoubleMarginLoss(PointwiseLoss):
                 )
         else:
             num_neg_per_pos = batch_filter.shape[1]
-            positive_scores = positive_scores.unsqueeze(dim=1).repeat(1, num_neg_per_pos, 1)[batch_filter]
+            positive_scores = positive_scores.repeat(1, num_neg_per_pos)[batch_filter]
             # shape: (nnz,)
             positive_loss = self._reduction_method(self.margin_activation(self.positive_margin - positive_scores))
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -490,9 +490,6 @@ class MarginPairwiseLoss(PairwiseLoss):
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
 
-        # prepare for broadcasting, shape: (batch_size, 1, 3)
-        positive_scores = positive_scores.unsqueeze(dim=1)
-
         if batch_filter is not None:
             # negative_scores have already been filtered in the sampler!
             num_neg_per_pos = batch_filter.shape[1]

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -493,7 +493,7 @@ class MarginPairwiseLoss(PairwiseLoss):
         if batch_filter is not None:
             # negative_scores have already been filtered in the sampler!
             num_neg_per_pos = batch_filter.shape[1]
-            positive_scores = positive_scores.repeat(1, num_neg_per_pos, 1)[batch_filter]
+            positive_scores = positive_scores.repeat(1, num_neg_per_pos)[batch_filter]
             # shape: (nnz,)
 
         return self(pos_scores=positive_scores, neg_scores=negative_scores)


### PR DESCRIPTION
As a side note, I wonder if improving the annotation of tensor dimensions in PyKEEN would be something good to do. Perhaps something like [torchtyping](https://github.com/patrick-kidger/torchtyping) or even just named tensors from pytorch itself. 

### Link to the relevant Bug(s)

Closes #1127

### Description of the Change

Removed unnecessary unsqueezing of positive scores in the `MarginRankingLoss`


### Possible Drawbacks

NA


### Verification Process

Ran a few instances of different models and datasets with MRL. Anecdotally I noticed a very modest speed boost with this fix. 


### Release Notes

- Remove unnecessary unsqueezing in MRL

