### PR TITLE
🏋️ 🔧 Kwargs fix for edge weighting in `CompGCNLayer`

### DIFF
--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -621,7 +621,7 @@ class CompGCNLayer(nn.Module):
 
         # edge weighting
         self.edge_weighting: EdgeWeighting = edge_weight_resolver.make(
-            edge_weighting, output_dim=output_dim, attn_drop=attention_dropout, num_heads=attention_heads
+            edge_weighting, message_dim=output_dim, dropout=attention_dropout, num_heads=attention_heads
         )
 
         # message passing weights


### PR DESCRIPTION
The current code for edge weight initializer has kwargs 

https://github.com/pykeen/pykeen/blob/b840fc4cd96f2860c018c33c635baa7256bf887b/src/pykeen/nn/representation.py#L623-L625

inconsistent with the `AttentionEdgeWeighting` kwargs in `weighting.py`:

https://github.com/pykeen/pykeen/blob/b840fc4cd96f2860c018c33c635baa7256bf887b/src/pykeen/nn/weighting.py#L172-L182

This PR fixes kwargs in the edge weight initializer
