### PR TITLE
🐛🐔 Fixing bug with index-error for predict.consume_scores

### DIFF
--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -850,7 +850,7 @@ class PartiallyRestrictedPredictionDataset(PredictionDataset):
             the prediction target
 
         :raises NotImplementedError:
-            if the target position restricted, or any non-target position is not restricted
+            if the target position is restricted, or any non-target position is not restricted
         """
         super().__init__(target=target)
         parts: List[torch.LongTensor] = []

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -875,7 +875,7 @@ class PartiallyRestrictedPredictionDataset(PredictionDataset):
     # docstr-coverage: inherited
     def __getitem__(self, item: int) -> PredictionBatch:  # noqa: D105
         quotient, remainder = divmod(item, len(self.parts[0]))
-        return torch.as_tensor([self.parts[0][quotient], self.parts[1][remainder]])
+        return torch.as_tensor([self.parts[0][remainder], self.parts[1][quotient]])
 
 
 @torch.inference_mode()

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -874,8 +874,8 @@ class PartiallyRestrictedPredictionDataset(PredictionDataset):
 
     # docstr-coverage: inherited
     def __getitem__(self, item: int) -> PredictionBatch:  # noqa: D105
-        quotient, remainder = divmod(item, len(self.parts[0]))
-        return torch.as_tensor([self.parts[0][remainder], self.parts[1][quotient]])
+        remainder, quotient = divmod(item, len(self.parts[0]))
+        return torch.as_tensor([self.parts[0][quotient], self.parts[1][remainder]])
 
 
 @torch.inference_mode()

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -380,4 +380,4 @@ def test_partially_restricted_prediction_dataset(heads, relations, tails, target
     )
     # try accessing each element
     for i in range(len(ds)):
-        _item = ds[i]
+        _ = ds[i]

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -364,3 +364,20 @@ def test_predict_target(
     )
     assert isinstance(pred, pykeen.predict.TargetPredictions)
     assert pred.factory == factory
+
+
+@pytest.mark.parametrize(
+    ["heads", "relations", "tails", "target"],
+    [
+        # tail prediction
+        ([1, 2], [3], None, pykeen.typing.LABEL_TAIL),
+    ],
+)
+def test_partially_restricted_prediction_dataset(heads, relations, tails, target):
+    """Test for PartiallyRestrictedPredictionDataset."""
+    ds = pykeen.predict.PartiallyRestrictedPredictionDataset(
+        heads=heads, relations=relations, tails=tails, target=target
+    )
+    # try accessing each element
+    for i in range(len(ds)):
+        _item = ds[i]

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ envlist =
 [testenv]
 commands =
     # custom installation for PyG, cf. https://github.com/rusty1s/pytorch_scatter/pull/268
-    pip install torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
+    pip install torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
     coverage run -p -m pytest --durations=20 {posargs:tests} -m "not slow"
 # ensure we use the CPU-only version of torch
 setenv =


### PR DESCRIPTION
### Link to the relevant Bug(s)

fix https://github.com/pykeen/pykeen/issues/1156




### Description of the Change
Remainder is actually quotient, and quotient is actually remainder. The Change flips these.

Fixed `IndexError` where it had flipped the the remainder and quotient. (Error not visible on original code snippet as it had the same amount of entities and relation (making it a square). If say we had 1000 entities and 1 relation (1000 x 1) it would originally iterate (1 x 1000) getting an index error. This flips these indices.

My guess is this error occurred when the working example had same amount of entities and relations, so it would work regardless just iterating horizontally instead of vertically.


### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
- If any other methods utilizes `__getitem__` (line 876-878), it will also flip for them. 

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you
performed and describe the results you observed.

-->
* Tried AllPredictionDataset as well, and it appears unaffected.


### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that any user can understand.

Example:

- Fixed an issue where model parameters were not set correctly.
- Increased the performance of method X by avoiding redundant re-calculations of the loading vectors.

-->

- Fixed iteration index-error for prediction bug