### PR TITLE
⚡🧪 Bring back lightning tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ install_requires =
     docdata
     class_resolver>=0.3.10
     pyyaml
-    rexmex
+    rexmex>=0.1.3
     torch_max_mem>=0.0.4
     torch-ppr>=0.0.7
     protobuf<4.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,8 @@ tensorboard =
 transformers =
     transformers
 lightning =
-    pytorch_lightning
+    # cf. https://github.com/Lightning-AI/lightning/pull/14117
+    pytorch_lightning>=1.7.2
 tests =
     unittest-templates>=0.0.5
     coverage

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -66,7 +66,6 @@ TEST_CONFIGURATIONS = (
 
 # test combinations of models with training loops
 @needs_packages("pytorch_lightning")
-@pytest.mark.skipif(True, reason="instability related to https://github.com/Lightning-AI/lightning/pull/14117")
 @pytest.mark.parametrize(("model", "model_kwargs", "training_loop"), TEST_CONFIGURATIONS)
 def test_lit_training(model, model_kwargs, training_loop):
     """Test training models with PyTorch Lightning."""


### PR DESCRIPTION
As https://github.com/Lightning-AI/lightning/pull/14117 has been fixed, and https://github.com/Lightning-AI/ecosystem-ci/pull/50 is regaining momentum, this PR brings back automatic PyTorch Lightning tests.