### PR TITLE
⛳💌 Separately Expose Clearing of Intermediate Evaluator Results

### DIFF
--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -108,7 +108,6 @@ class ClassificationEvaluator(Evaluator):
         # Because the order of the values of an dictionary is not guaranteed,
         # we need to retrieve scores and masks using the exact same key order.
         all_keys = list(self.all_scores.keys())
-
         y_score = np.concatenate([self.all_scores[k] for k in all_keys], axis=0).flatten()
         y_true = np.concatenate([self.all_positives[k] for k in all_keys], axis=0).flatten()
 

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -43,7 +43,7 @@ class ClassificationMetricResults(MetricResults):
                 value = value.item()
             data[key] = value
         data["num_scores"] = y_score.size
-        return ClassificationMetricResults(data=data)
+        return cls(data=data)
 
     # docstr-coverage: inherited
     def get_metric(self, name: str) -> float:  # noqa: D102
@@ -106,13 +106,12 @@ class ClassificationEvaluator(Evaluator):
         # Because the order of the values of an dictionary is not guaranteed,
         # we need to retrieve scores and masks using the exact same key order.
         all_keys = list(self.all_scores.keys())
-        # special case if no keys; this should only happen during size probing
-        if all_keys:
-            y_score = np.concatenate([self.all_scores[k] for k in all_keys], axis=0).flatten()
-            y_true = np.concatenate([self.all_positives[k] for k in all_keys], axis=0).flatten()
-        else:
-            logger.debug("Empty scores. This should only happen during size probing.")
+        if not all_keys:
+            logger.debug("Empty scores. This special case should only happen during size probing.")
             return ClassificationMetricResults(data=dict())
+
+        y_score = np.concatenate([self.all_scores[k] for k in all_keys], axis=0).flatten()
+        y_true = np.concatenate([self.all_positives[k] for k in all_keys], axis=0).flatten()
 
         # Clear buffers
         self.all_positives.clear()

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -40,6 +40,8 @@ class ClassificationMetricResults(MetricResults):
 
     # docstr-coverage: inherited
     def get_metric(self, name: str) -> float:  # noqa: D102
+        if name not in self.data:
+            raise KeyError(f"Unknown metric: '{name}'. Possible options are: {sorted(self.data.keys())}")
         return self.data[name]
 
 

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -2,7 +2,6 @@
 
 """Implementation of wrapper around sklearn metrics."""
 
-import logging
 from typing import Mapping, MutableMapping, Optional, Tuple, Type, cast
 
 import numpy as np
@@ -21,7 +20,6 @@ __all__ = [
 CLASSIFICATION_METRICS: Mapping[str, Type[ClassificationMetric]] = {
     cls().key: cls for cls in classification_metric_resolver
 }
-logger = logging.getLogger(__name__)
 
 
 class ClassificationMetricResults(MetricResults):

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -35,7 +35,7 @@ class ClassificationMetricResults(MetricResults):
         data = dict()
         for key, metric in CLASSIFICATION_METRICS.items():
             if y_true.size == 0:
-                logger.warning("Empty y_true?!")
+                logger.warning("Empty y_true for %s?!", key)
                 continue
             value = metric.score(y_true, y_score)
             if isinstance(value, np.number):

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -101,6 +101,11 @@ class ClassificationEvaluator(Evaluator):
             self.all_positives[key] = dense_positive_mask[i]
 
     # docstr-coverage: inherited
+    def clear(self) -> None:  # noqa: D102
+        self.all_positives.clear()
+        self.all_scores.clear()
+    
+    # docstr-coverage: inherited
     def finalize(self) -> ClassificationMetricResults:  # noqa: D102
         # Because the order of the values of an dictionary is not guaranteed,
         # we need to retrieve scores and masks using the exact same key order.
@@ -113,7 +118,6 @@ class ClassificationEvaluator(Evaluator):
         y_true = np.concatenate([self.all_positives[k] for k in all_keys], axis=0).flatten()
 
         # Clear buffers
-        self.all_positives.clear()
-        self.all_scores.clear()
+        self.clear()
 
         return ClassificationMetricResults.from_scores(y_true, y_score)

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -10,8 +10,7 @@ import torch
 
 from .evaluator import Evaluator, MetricResults
 from ..constants import TARGET_TO_INDEX
-from ..metrics.classification import classification_metric_resolver
-from ..metrics.utils import Metric
+from ..metrics.classification import ClassificationMetric, classification_metric_resolver
 from ..typing import MappedTriples, Target
 
 __all__ = [
@@ -19,7 +18,9 @@ __all__ = [
     "ClassificationMetricResults",
 ]
 
-CLASSIFICATION_METRICS: Mapping[str, Type[Metric]] = {cls().key: cls for cls in classification_metric_resolver}
+CLASSIFICATION_METRICS: Mapping[str, Type[ClassificationMetric]] = {
+    cls().key: cls for cls in classification_metric_resolver
+}
 logger = logging.getLogger(__name__)
 
 

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -110,9 +110,6 @@ class ClassificationEvaluator(Evaluator):
         # Because the order of the values of an dictionary is not guaranteed,
         # we need to retrieve scores and masks using the exact same key order.
         all_keys = list(self.all_scores.keys())
-        if not all_keys:
-            logger.debug("Empty scores. This special case should only happen during size probing.")
-            return ClassificationMetricResults(data=dict())
 
         y_score = np.concatenate([self.all_scores[k] for k in all_keys], axis=0).flatten()
         y_true = np.concatenate([self.all_positives[k] for k in all_keys], axis=0).flatten()

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -32,11 +32,10 @@ class ClassificationMetricResults(MetricResults):
     @classmethod
     def from_scores(cls, y_true: np.ndarray, y_score: np.ndarray):
         """Return an instance of these metrics from a given set of true and scores."""
+        if y_true.size == 0:
+            raise ValueError(f"Cannot calculate scores from empty array (y_true.shape={y_true.shape}).")
         data = dict()
         for key, metric in CLASSIFICATION_METRICS.items():
-            if y_true.size == 0:
-                logger.warning("Empty y_true for %s?!", key)
-                continue
             value = metric.score(y_true, y_score)
             if isinstance(value, np.number):
                 # TODO: fix this upstream / make metric.score comply to signature

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -104,7 +104,7 @@ class ClassificationEvaluator(Evaluator):
     def clear(self) -> None:  # noqa: D102
         self.all_positives.clear()
         self.all_scores.clear()
-    
+
     # docstr-coverage: inherited
     def finalize(self) -> ClassificationMetricResults:  # noqa: D102
         # Because the order of the values of an dictionary is not guaranteed,

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -145,6 +145,11 @@ class Evaluator(ABC):
             An optional binary (0/1) tensor indicating other true entities.
         """
         raise NotImplementedError
+    
+    @abstractmethod
+    def clear(self) -> None:
+        """Clear buffers and intermediate results."""
+        raise NotImplementedError
 
     @abstractmethod
     def finalize(self) -> MetricResults:
@@ -203,7 +208,7 @@ class Evaluator(ABC):
                 self.slice_size = slice_size
 
                 # Clear the ranks from the current evaluator
-                self.finalize()
+                self.clear()
 
         rv = evaluate(
             model=model,

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -145,7 +145,7 @@ class Evaluator(ABC):
             An optional binary (0/1) tensor indicating other true entities.
         """
         raise NotImplementedError
-    
+
     @abstractmethod
     def clear(self) -> None:
         """Clear buffers and intermediate results."""

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -344,6 +344,11 @@ class RankBasedEvaluator(Evaluator):
         self.num_candidates[target].append(batch_ranks.number_of_options.detach().cpu().numpy())
 
     # docstr-coverage: inherited
+    def clear(self) -> None:  # noqa: D102
+        self.ranks.clear()
+        self.num_candidates.clear()
+    
+    # docstr-coverage: inherited
     def finalize(self) -> RankBasedMetricResults:  # noqa: D102
         if self.num_entities is None:
             raise ValueError
@@ -351,13 +356,8 @@ class RankBasedEvaluator(Evaluator):
             metrics=self.metrics,
             rank_and_candidates=_iter_ranks(ranks=self.ranks, num_candidates=self.num_candidates),
         )
-        if not self.clear_on_finalize:
-            return result
-
-        # Clear buffers
-        self.ranks.clear()
-        self.num_candidates.clear()
-
+        if self.clear_on_finalize:
+            self.clear()
         return result
 
     def finalize_multi(self, n_boot: int = 1_000, seed: int = 42) -> Mapping[str, Sequence[float]]:

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -100,11 +100,6 @@ def _iter_ranks(
     num_candidates: Mapping[Target, Sequence[np.ndarray]],
     weights: Optional[Mapping[Target, Sequence[np.ndarray]]] = None,
 ) -> Iterable[RankPack]:
-    # terminate early if there are no ranks
-    if not ranks:
-        logger.debug("Empty ranks. This should only happen during size probing.")
-        return
-
     sides = sorted(num_candidates.keys())
     # flatten dictionaries
     ranks_flat = _flatten(ranks)
@@ -726,6 +721,11 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         self.keys[target].append(hrt_batch[:, TARGET_TO_KEYS[target]].detach().cpu().numpy())
 
     # docstr-coverage: inherited
+    def clear(self) -> None:  # noqa: D102
+        super().clear()
+        self.keys.clear()
+    
+    # docstr-coverage: inherited
     def finalize(self) -> RankBasedMetricResults:  # noqa: D102
         if self.num_entities is None:
             raise ValueError
@@ -738,8 +738,6 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
             rank_and_candidates=_iter_ranks(ranks=self.ranks, num_candidates=self.num_candidates, weights=weights),
         )
         # Clear buffers
-        self.keys.clear()
-        self.ranks.clear()
-        self.num_candidates.clear()
+        self.clear()        
 
         return result

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -342,7 +342,7 @@ class RankBasedEvaluator(Evaluator):
     def clear(self) -> None:  # noqa: D102
         self.ranks.clear()
         self.num_candidates.clear()
-    
+
     # docstr-coverage: inherited
     def finalize(self) -> RankBasedMetricResults:  # noqa: D102
         if self.num_entities is None:
@@ -724,7 +724,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
     def clear(self) -> None:  # noqa: D102
         super().clear()
         self.keys.clear()
-    
+
     # docstr-coverage: inherited
     def finalize(self) -> RankBasedMetricResults:  # noqa: D102
         if self.num_entities is None:
@@ -738,6 +738,6 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
             rank_and_candidates=_iter_ranks(ranks=self.ranks, num_candidates=self.num_candidates, weights=weights),
         )
         # Clear buffers
-        self.clear()        
+        self.clear()
 
         return result

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -58,6 +58,9 @@ class MockEvaluator(Evaluator):
     ) -> None:  # noqa: D102
         pass
 
+    def clear(self):  # noqa: D102
+        pass
+
     def finalize(self) -> MetricResults:  # noqa: D102
         result = RankBasedMetricResults.create_random(self.random_state)
         assert self.values_iter is not None

--- a/tests/test_evaluation/test_evaluators.py
+++ b/tests/test_evaluation/test_evaluators.py
@@ -405,6 +405,9 @@ class DummyEvaluator(Evaluator):
         elif target == LABEL_HEAD:
             self.counter -= 1
 
+    def clear(self):  # noqa: D102
+        pass
+
     def finalize(self) -> MetricResults:  # noqa: D102
         return RankBasedMetricResults(
             dict(


### PR DESCRIPTION
This PR introduces a new `clear` method to `Evaluator` which separates out the clearing of intermediate results and buffers used in `finalize`. Thereby, we can use `clear` during batch size probing, and avoid running into errors with empty ranks / scores arrays.

In reverts some previous changes which allowed empty arrays in rank-based evaluation and only emitted a warning, to raising an error again.

Fix #1194