### PR TITLE
Load pipeline results

### DIFF
--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -453,6 +453,23 @@ class PipelineResult(Result):
 
     @classmethod
     def load_from_directory(cls, directory: Union[str, pathlib.Path]) -> "PipelineResult":
+        """
+        Load the artifacts saved in the directory previously given to :func:`save_to_directory`.
+
+        It is mandatory to have at least the results file inside the directory.
+        Optional artifacts such as the model, the metadata and the training triples factory
+        will be reloaded if they are found inside the directory.
+
+        :param directory:
+            the directory path. It should coincide with the directory given to :func:`save_to_directory`
+        :return: The reloaded pipeline results.
+
+        .. note:: 
+            The returned :class:`PipelineResult` is different from the one that has been
+            saved, since it has `None` :attr:`random_state`, :attr:`training_loop` and :attr:`stopper`
+            and its :attr:`configuration`, :attr:`version` and :attr:`git_hash` will be reinitialized.
+            
+        """
         pipeline_kwargs = {}
         directory = normalize_path(path=directory)
 

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -394,11 +394,7 @@ class PipelineResult(Result):
         return results
 
     def _get_pipeline_info(self) -> Mapping[str, Any]:
-        pipeline_info = dict(
-            random_seed=self.random_seed,
-            version=self.version,
-            git_hash=self.git_hash
-        )
+        pipeline_info = dict(random_seed=self.random_seed, version=self.version, git_hash=self.git_hash)
         return pipeline_info
 
     def save_to_directory(
@@ -477,7 +473,7 @@ class PipelineResult(Result):
             the directory path. It should coincide with the directory given to :func:`save_to_directory`
         :return: The reloaded pipeline results.
 
-        .. note:: 
+        .. note::
             The returned :class:`PipelineResult` is different from the one that has been
             saved, since it has `None` :attr:`random_state`, :attr:`training_loop` and :attr:`stopper`
             and its :attr:`configuration`, :attr:`version` and :attr:`git_hash` will be reinitialized.
@@ -488,12 +484,12 @@ class PipelineResult(Result):
 
         if not directory.is_dir():
             raise FileNotFoundError(f"The results directory {directory} doesn't exist.")
-        
+
         # load results (mandatory)
         result_file_path = directory.joinpath(cls.RESULT_FILE_NAME)
         if not result_file_path.is_file():
             raise FileNotFoundError(f"The results file {result_file_path} doesn't exist.")
-        
+
         with result_file_path.open("r") as result_file:
             results = json.load(result_file)
             times = results["times"]
@@ -529,8 +525,12 @@ class PipelineResult(Result):
 
         # warn users about default attributes
         pipeline_res_fields = [field.name for field in fields(PipelineResult)]
-        pipeline_res_missing_fields = [f"`{field}`" for field in pipeline_res_fields if field not in pipeline_kwargs.keys()]
-        logging.warn(f"The restored `PipelineResult` will have default values for the attributes: {', '.join(pipeline_res_missing_fields)}.")
+        pipeline_res_missing_fields = [
+            f"`{field}`" for field in pipeline_res_fields if field not in pipeline_kwargs.keys()
+        ]
+        logging.warn(
+            f"The restored `PipelineResult` will have default values for the attributes: {', '.join(pipeline_res_missing_fields)}."
+        )
 
         return PipelineResult(**pipeline_kwargs)
 

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -502,7 +502,7 @@ class PipelineResult(Result):
 
         # load training triples
         training_triples_file_path = directory.joinpath(cls.TRAINING_TRIPLES_FILE_NAME)
-        if training_triples_file_path.exists():
+        if training_triples_file_path.is_dir():
             pipeline_kwargs["training"] = CoreTriplesFactory.from_path_binary(training_triples_file_path)
 
         return PipelineResult(**pipeline_kwargs)

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -491,13 +491,13 @@ class PipelineResult(Result):
 
         # load metadata
         metadata_file_path = directory.joinpath(cls.METADATA_FILE_NAME)
-        if metadata_file_path.exists():
+        if metadata_file_path.is_file():
             with metadata_file_path.open("r") as metadata_file:
                 pipeline_kwargs["metadata"] = json.load(metadata_file)
 
         # load model
         model_file_path = directory.joinpath(cls.MODEL_FILE_NAME)
-        if model_file_path.exists():
+        if model_file_path.is_file():
             pipeline_kwargs["model"] = torch.load(model_file_path)
 
         # load training triples

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -473,11 +473,16 @@ class PipelineResult(Result):
             the directory path. It should coincide with the directory given to :func:`save_to_directory`
         :return: The reloaded pipeline results.
 
+        :raises FileNotFoundError:
+            If the directory or the results file stored with :func:`save_to_directory` are not found.
+        :raises KeyError:
+            If one of the files stored in the directory have been damaged and don't contain the JSON keys
+            saved by :func:`save_to_directory`.
+
         .. note::
             The returned :class:`PipelineResult` is different from the one that has been
-            saved, since it has `None` :attr:`random_state`, :attr:`training_loop` and :attr:`stopper`
-            and its :attr:`configuration`, :attr:`version` and :attr:`git_hash` will be reinitialized.
-
+            saved, since it could have default values for some of the attributes that this function
+            has not been able to restore.
         """
         pipeline_kwargs = {}
         directory = normalize_path(path=directory)

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -478,7 +478,7 @@ class PipelineResult(Result):
         
         # load results (mandatory)
         result_file_path = directory.joinpath(cls.RESULT_FILE_NAME)
-        if not result_file_path.exists():
+        if not result_file_path.is_file():
             raise FileNotFoundError(f"The results file {result_file_path} doesn't exist.")
         
         with result_file_path.open("r") as result_file:

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -268,12 +268,6 @@ def triple_hash(*triples: MappedTriples) -> Mapping[str, str]:
 class PipelineResult(Result):
     """A dataclass containing the results of running :func:`pykeen.pipeline.pipeline`."""
 
-    #: The model trained by the pipeline
-    model: Model
-
-    #: The training triples
-    training: CoreTriplesFactory
-
     #: The losses during training
     losses: List[float]
 
@@ -285,6 +279,12 @@ class PipelineResult(Result):
 
     #: How long in seconds did evaluation take?
     evaluate_seconds: float
+
+    #: The model trained by the pipeline
+    model: Optional[Model] = None
+
+    #: The training triples
+    training: Optional[CoreTriplesFactory] = None
 
     #: The random seed used at the beginning of the pipeline
     random_seed: Optional[int] = None
@@ -468,7 +468,7 @@ class PipelineResult(Result):
             The returned :class:`PipelineResult` is different from the one that has been
             saved, since it has `None` :attr:`random_state`, :attr:`training_loop` and :attr:`stopper`
             and its :attr:`configuration`, :attr:`version` and :attr:`git_hash` will be reinitialized.
-            
+
         """
         pipeline_kwargs = {}
         directory = normalize_path(path=directory)


### PR DESCRIPTION
### Link to the relevant feature request
<!--

Link to the issue describing the feature request. The affected feature request should have the label 'help wanted' or
'accepted'.

-->

#1192 

### Description of the Change

<!--

We must be able to understand the design of your change from this description, so please walk us through the concepts.

-->

Add the classmethod `load_from_directory` to the class `pykeen.pipeline.PipelineResult`. The class method produces an instance of `PipelineResult` containing the information stored in the directory produced via `save_to_directory`.

Not all the instance attributes can be reloaded, since they're not saved to the directory. The attributes `training_loop`, `training`, `model` and `random_seed` have been made optional, with `None` default values. The `stopper` (if present) is not reloaded because of some missing information (it was already optional). Other attributes such as `configuration`, `version` and `git_hash` are not reloaded, but their default value has been kept.

### Alternatives

I considered subclassing `PipelineResult` with a new class `ReloadedResult` which contained default values for the parameters that could've not been restored. However, I think this solution adds too much complexity.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Users should be warned about the missing information. Making the `random_seed`, `training`, `model` and `training_loop` as optional should not create any problem.
### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you
performed and describe the results you observed.

-->

Performed tests with `tox -e py` and `tox -e docs-test` without any error. 
Tried to save and reload the results obtained via:
```
pipeline_result = pipeline(
    dataset='Nations',
    model='TransE'
)
pipeline_result.save_to_directory('nations_transe')
```
with different configurations for the boolean flags, with success. Still have to write some unit tests for the new function.