### PR TITLE
🦷 🔄 Extract inversion utilities

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,6 +20,7 @@ ignore =
     B018  # bugbear doesn't allow multi-line comments as of https://github.com/PyCQA/flake8-bugbear/issues/195
     # bugbear seems to emit false positives, cf. https://github.com/PyCQA/flake8-bugbear/issues/278
     B024
+    B028
 exclude =
     .tox,
     .git,

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -2,7 +2,7 @@
 
 """Relation inversion logic."""
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import TypeVar
 
 import torch
@@ -17,7 +17,7 @@ __all__ = [
 RelationID = TypeVar("RelationID", int, torch.LongTensor)
 
 
-class RelationInverter:
+class RelationInverter(ABC):
     """An interface for inverse-relation ID mapping."""
 
     # TODO: method is_inverse?
@@ -26,19 +26,17 @@ class RelationInverter:
     def get_inverse_id(self, relation_id: RelationID) -> RelationID:
         """Get the inverse ID for a given relation."""
         # TODO: inverse of inverse?
-        raise NotImplementedError
 
     @abstractmethod
     def _map(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:
-        raise NotImplementedError
+        """Map relations in a batch."""
 
     @abstractmethod
     def invert_(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:
         """Invert relations in a batch (in-place)."""
-        raise NotImplementedError
 
     def map(self, batch: torch.LongTensor, index: int = 1, invert: bool = False) -> torch.LongTensor:
-        """Map relations of batch, optionally also inverting them."""
+        """Map relations in a batch, optionally also inverting them."""
         batch = self._map(batch=batch, index=index)
         return self.invert_(batch=batch, index=index) if invert else batch
 

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+"""Relation inversion logic."""
+
+from abc import abstractmethod
+from typing import TypeVar
+
+import torch
+from class_resolver import Resolver
+
+__all__ = [
+    "RelationInverter",
+    "DefaultRelationInverter",
+    "relation_inverter_resolver",
+]
+
+RelationID = TypeVar("RelationID", int, torch.LongTensor)
+
+
+class RelationInverter:
+    """An interface for inverse-relation ID mapping."""
+
+    # TODO: method is_inverse?
+
+    @abstractmethod
+    def get_inverse_id(self, relation_id: RelationID) -> RelationID:
+        """Get the inverse ID for a given relation."""
+        # TODO: inverse of inverse?
+        raise NotImplementedError
+
+    @abstractmethod
+    def _map(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:
+        raise NotImplementedError
+
+    @abstractmethod
+    def invert_(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:
+        """Invert relations in a batch (in-place)."""
+        raise NotImplementedError
+
+    def map(self, batch: torch.LongTensor, index: int = 1, invert: bool = False) -> torch.LongTensor:
+        """Map relations of batch, optionally also inverting them."""
+        batch = self._map(batch=batch, index=index)
+        return self.invert_(batch=batch, index=index) if invert else batch
+
+
+class DefaultRelationInverter(RelationInverter):
+    """Maps normal relations to even IDs, and the corresponding inverse to the next odd ID."""
+
+    # docstr-coverage: inherited
+    def get_inverse_id(self, relation_id: RelationID) -> RelationID:  # noqa: D102
+        return relation_id + 1
+
+    # docstr-coverage: inherited
+    def _map(self, batch: torch.LongTensor, index: int = 1, invert: bool = False) -> torch.LongTensor:  # noqa: D102
+        batch = batch.clone()
+        batch[:, index] *= 2
+        return batch
+
+    # docstr-coverage: inherited
+    def invert_(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:  # noqa: D102
+        # The number of relations stored in the triples factory includes the number of inverse relations
+        # Id of inverse relation: relation + 1
+        batch[:, index] += 1
+        return batch
+
+
+relation_inverter_resolver: Resolver[RelationInverter] = Resolver.from_subclasses(
+    RelationInverter,
+    default=DefaultRelationInverter,
+)

--- a/src/pykeen/triples/__init__.py
+++ b/src/pykeen/triples/__init__.py
@@ -3,15 +3,7 @@
 """Classes for creating and storing training data from triples."""
 
 from .instances import Instances, LCWAInstances, SLCWAInstances
-from .triples_factory import (
-    AnyTriples,
-    CoreTriplesFactory,
-    KGInfo,
-    RelationInverter,
-    TriplesFactory,
-    get_mapped_triples,
-    relation_inverter,
-)
+from .triples_factory import AnyTriples, CoreTriplesFactory, KGInfo, TriplesFactory, get_mapped_triples
 from .triples_numeric_literals_factory import TriplesNumericLiteralsFactory
 
 __all__ = [
@@ -20,8 +12,6 @@ __all__ = [
     "SLCWAInstances",
     "KGInfo",
     "CoreTriplesFactory",
-    "RelationInverter",
-    "relation_inverter",
     "TriplesFactory",
     "TriplesNumericLiteralsFactory",
     "get_mapped_triples",


### PR DESCRIPTION
This serves a stopgap to reduce the diff in #752. This PR does the following:

1. Extracts the `RelationInverter` class from the triples.py module
2. Puts relation_inverter instances inside the Model and Labelling classes
3. Updates docs in `RelationInverter`  and makes inherit from a proper ABC superclass

no updates in functionalities, these are effectively private utilities so it shouldn't bother anyone