### PR TITLE
🚚🪞Make sure inductive representation is on same device

### DIFF
--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -22,7 +22,7 @@ class InductiveERModel(ERModel):
 
     #: a mapping from inductive mode to corresponding entity representations
     #: note: there may be duplicate values, if entity representations are shared between validation and testing
-    _mode_to_representations: Mapping[InductiveMode, Sequence[Representation]]
+    _mode_to_representations: Mapping[str, Sequence[Representation]]
 
     def __init__(
         self,

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -98,7 +98,7 @@ class InductiveERModel(ERModel):
                 f"{self.__class__.__name__} does not support the transductive setting (i.e., when mode is None)"
             )
         if mode in self._mode_to_representations:
-            return self._mode_to_representations[mode]
+            return self._mode_to_representations[mode].to(self.device)
         raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")
 
     # docstr-coverage: inherited

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -3,6 +3,7 @@ from collections import ChainMap
 from typing import Mapping, Optional, Sequence
 
 from class_resolver import OneOrManyHintOrType, OneOrManyOptionalKwargs
+from torch import nn
 
 from ..nbase import ERModel
 from ...nn import Representation
@@ -60,12 +61,12 @@ class InductiveERModel(ERModel):
         entity_representations_kwargs = entity_representations_kwargs or {}
         # entity_representations_kwargs.pop("triples_factory", None)
         # note: this is *not* a nn.ModuleDict; the modules have to be registered elsewhere
-        self._mode_to_representations = {TRAINING: self.entity_representations}
+        _mode_to_representations = {TRAINING: self.entity_representations}
         if "triples_factory" in entity_representations_kwargs:
             entity_representations_kwargs = ChainMap(
                 dict(triples_factory=validation_factory), entity_representations_kwargs
             )
-        self._mode_to_representations[VALIDATION] = validation_entity_representations = self._build_representations(
+        _mode_to_representations[VALIDATION] = validation_entity_representations = self._build_representations(
             triples_factory=validation_factory,
             representations=entity_representations,
             representations_kwargs=entity_representations_kwargs,
@@ -87,7 +88,8 @@ class InductiveERModel(ERModel):
                 representations_kwargs=entity_representations_kwargs,
                 label="entity",
             )
-        self._mode_to_representations[TESTING] = testing_entity_representations
+        _mode_to_representations[TESTING] = testing_entity_representations
+        self._mode_to_representations = nn.ModuleDict(_mode_to_representations)
 
     # docstr-coverage: inherited
     def _get_entity_representations_from_inductive_mode(
@@ -98,7 +100,7 @@ class InductiveERModel(ERModel):
                 f"{self.__class__.__name__} does not support the transductive setting (i.e., when mode is None)"
             )
         if mode in self._mode_to_representations:
-            return self._mode_to_representations[mode].to(self.device)
+            return self._mode_to_representations[mode]
         raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")
 
     # docstr-coverage: inherited

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -89,7 +89,8 @@ class InductiveERModel(ERModel):
                 label="entity",
             )
         _mode_to_representations[TESTING] = testing_entity_representations
-        self._mode_to_representations = nn.ModuleDict(_mode_to_representations)
+        # note: "training" is an attribute of nn.Module -> need to rename to avoid name collision
+        self._mode_to_representations = nn.ModuleDict({f"{k}_factory": v for k, v in _mode_to_representations.items()})
 
     # docstr-coverage: inherited
     def _get_entity_representations_from_inductive_mode(
@@ -99,8 +100,9 @@ class InductiveERModel(ERModel):
             raise ValueError(
                 f"{self.__class__.__name__} does not support the transductive setting (i.e., when mode is None)"
             )
-        if mode in self._mode_to_representations:
-            return self._mode_to_representations[mode]
+        key = f"{mode}_factory"
+        if key in self._mode_to_representations:
+            return self._mode_to_representations[key]
         raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")
 
     # docstr-coverage: inherited


### PR DESCRIPTION
## Contributing to bug fixes

 - Fill out the template below
 - The pull request should only fix existing bug reports
 - The pull request should comply with these points mentioned in [the contribution guidelines](https://github.com/pykeen/pykeen/blob/master/.github/CONTRIBUTING.md#pull-request)


### Link to the relevant Bug(s)
https://github.com/pykeen/pykeen/issues/1228


### Description of the Change

Before returning `entity_representation` for the right mode, sent them to the same device as model.


### Possible Drawbacks

None?


### Verification Process

I tested this on the code in the original issue and also on https://github.com/pykeen/ilpc2022 for the small dataset. Both previously failed, but now run through as expected.


### Release Notes

- Make sure inductive representation is on same device
