### PR TITLE
🤔🙅‍♀️ Fix TransH HPO compatability

### DIFF
--- a/src/pykeen/experiments/transh/wang2014_transh_fb15k.yaml
+++ b/src/pykeen/experiments/transh/wang2014_transh_fb15k.yaml
@@ -8,8 +8,8 @@ pipeline:
     embedding_dim: 100
     scoring_fct_norm: 2
     entity_initializer: "xavier_uniform"
-    entity_regularizer: "NormLimit"
-    entity_regularizer_kwargs:
+    regularizer: "NormLimit"
+    regularizer_kwargs:
       weight: 1.0
       apply_only_once: true
       dim: -1

--- a/src/pykeen/experiments/transh/wang2014_transh_wn18.yaml
+++ b/src/pykeen/experiments/transh/wang2014_transh_wn18.yaml
@@ -8,8 +8,8 @@ pipeline:
     embedding_dim: 50
     scoring_fct_norm: 2
     entity_initializer: "xavier_uniform"
-    entity_regularizer: "NormLimit"
-    entity_regularizer_kwargs:
+    regularizer: "NormLimit"
+    regularizer_kwargs:
       weight: 0.25
       apply_only_once: true
       dim: -1

--- a/src/pykeen/models/unimodal/trans_h.py
+++ b/src/pykeen/models/unimodal/trans_h.py
@@ -80,6 +80,8 @@ class TransH(ERModel):
         embedding_dim: int = 50,
         scoring_fct_norm: int = 2,
         entity_initializer: Hint[Initializer] = init.xavier_normal_,
+        # note: this parameter is not named "entity_regularizer" for compatability with the
+        #       regularizer-specific HPO code
         regularizer: HintOrType[Regularizer] = None,
         regularizer_kwargs: OptionalKwargs = None,
         relation_initializer: Hint[Initializer] = init.xavier_normal_,

--- a/src/pykeen/models/unimodal/trans_h.py
+++ b/src/pykeen/models/unimodal/trans_h.py
@@ -80,8 +80,8 @@ class TransH(ERModel):
         embedding_dim: int = 50,
         scoring_fct_norm: int = 2,
         entity_initializer: Hint[Initializer] = init.xavier_normal_,
-        entity_regularizer: HintOrType[Regularizer] = None,
-        entity_regularizer_kwargs: OptionalKwargs = None,
+        regularizer: HintOrType[Regularizer] = None,
+        regularizer_kwargs: OptionalKwargs = None,
         relation_initializer: Hint[Initializer] = init.xavier_normal_,
         relation_regularizer: HintOrType[Regularizer] = None,
         relation_regularizer_kwargs: OptionalKwargs = None,
@@ -96,9 +96,9 @@ class TransH(ERModel):
 
         :param entity_initializer:
             the entity initializer function
-        :param entity_regularizer:
+        :param regularizer:
             the entity regularizer. Defaults to :attr:`pykeen.models.TransH.regularizer_default`
-        :param entity_regularizer_kwargs:
+        :param regularizer_kwargs:
             keyword-based parameters for the entity regularizer. If `entity_regularizer` is None,
             the default from :attr:`pykeen.models.TransH.regularizer_default_kwargs` will be used instead
 
@@ -143,8 +143,8 @@ class TransH(ERModel):
         # which only regularizes the weights used in a batch
         self.append_weight_regularizer(
             parameter=self.entity_representations[0].parameters(),
-            regularizer=entity_regularizer,
-            regularizer_kwargs=entity_regularizer_kwargs,
+            regularizer=regularizer,
+            regularizer_kwargs=regularizer_kwargs,
             # note: the following is already the default
             # default_regularizer=self.regularizer_default,
             # default_regularizer_kwargs=self.regularizer_default_kwargs,


### PR DESCRIPTION
This PR renames TransH's `entity_regularizer` to `regularizer` which is less expressive, but makes TransH work with the HPO code again.

Fix #1273 