### PR TITLE
🧹🧑‍⚖️ add gc_after_trial parameter for optuna

### DIFF
--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -563,6 +563,7 @@ def hpo_pipeline(
     # Optuna Optimization Settings
     n_trials: Optional[int] = None,
     timeout: Optional[int] = None,
+    gc_after_trial: Optional[bool] = None,
     n_jobs: Optional[int] = None,
     save_model_directory: Optional[str] = None,
 ) -> HpoPipelineResult:
@@ -709,6 +710,8 @@ def hpo_pipeline(
         the number of trials, cf. :meth:`optuna.study.Study.optimize`.
     :param timeout:
         the timeout, cf. :meth:`optuna.study.Study.optimize`.
+    :param gc_after_trial:
+        the garbage collection after trial, cf. :meth:`optuna.study.Study.optimize`.
     :param n_jobs:
         the number of jobs, cf. :meth:`optuna.study.Study.optimize`. Defaults to 1.
 
@@ -866,6 +869,7 @@ def hpo_pipeline(
         cast(Callable[[Trial], float], objective),
         n_trials=n_trials,
         timeout=timeout,
+        gc_after_trial=gc_after_trial,
         n_jobs=n_jobs or 1,
         catch=(MemoryError, RuntimeError),
     )


### PR DESCRIPTION
### Link to the relevant feature request
None, but found this useful, as I need it for my own code.

### Description of the Change

According to [this FAQ about Optuna](https://optuna.readthedocs.io/en/stable/faq.html#how-do-i-avoid-running-out-of-memory-oom-when-optimizing-studies), it can help to run the garbage collection when getting frequent OOMs. I propose making this parameter settable in pykeen for convenience.


### Possible Drawbacks

According to the Optuna FAQ, ChainerMNStudy does currently not provide gc_after_trial nor callbacks for optimize(). When using this class, you will have to call the garbage collector inside the objective function. However, this does not seem to be used in pykeen.


### Verification Process
It is an official parameter given in the Optuna docs and should not lead to any bugs.


### Release Notes
- introduced the gc_after_trial parameter for optuna.study.optimize() for garbage collection
