### PR TITLE
🔧🔮 Fix predict_all for inductive inference

### DIFF
--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -1007,6 +1007,9 @@ def predict_all(
 
     :return:
         A score pack of parallel triples and scores
+
+    :raises ValueError:
+        if an inductive inference mode is selected, but the model does not support it
     """
     # note: the models' predict method takes care of setting the model to evaluation mode
     logger.warning(

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -1017,15 +1017,7 @@ def predict_all(
         f"score evaluations.",
     )
 
-    if mode is None:
-        num_entities = model.num_entities
-    elif not isinstance(model, InductiveERModel):
-        raise ValueError(f"{mode=} is invalid for a model that does not support inductive inference.")
-    else:
-        inf_num_entities = model._get_entity_len(mode=mode)
-        if inf_num_entities is None:
-            raise ValueError(f"Could not determine the number of entities for {mode=}")
-        num_entities = inf_num_entities
+    num_entities = model._get_entity_len(mode=mode)
 
     consumer: ScoreConsumer
     if k is None:

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -282,7 +282,7 @@ from tqdm.auto import tqdm
 from typing_extensions import TypeAlias  # Python <=3.9
 
 from .constants import COLUMN_LABELS, TARGET_TO_INDEX
-from .models import InductiveERModel, Model
+from .models import Model
 from .triples import AnyTriples, CoreTriplesFactory, TriplesFactory, get_mapped_triples
 from .triples.utils import tensor_to_df
 from .typing import (

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -1029,7 +1029,7 @@ def predict_all(
         logger.warning(
             "Not providing k to `predict_all` entails huge memory requirements for reasonably-sized knowledge graphs.",
         )
-        consumer = AllScoreConsumer(num_entities=num_entities, num_relations=model.num_relations)
+        consumer = AllScoreConsumer(num_entities=num_entities, num_relations=model.num_real_relations)
     else:
         consumer = TopKScoreConsumer(k=k, device=model.device)
     dataset = AllPredictionDataset(num_entities=num_entities, num_relations=model.num_real_relations, target=target)

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -1019,8 +1019,10 @@ def predict_all(
     elif not isinstance(model, InductiveERModel):
         raise ValueError(f"{mode=} is invalid for a model that does not support inductive inference.")
     else:
-        num_entities = model._get_entity_len(mode=mode)
-        assert num_entities is not None
+        inf_num_entities = model._get_entity_len(mode=mode)
+        if inf_num_entities is None:
+            raise ValueError(f"Could not determine the number of entities for {mode=}")
+        num_entities = inf_num_entities
 
     consumer: ScoreConsumer
     if k is None:

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -1018,6 +1018,8 @@ def predict_all(
     )
 
     num_entities = model._get_entity_len(mode=mode)
+    if num_entities is None:
+        raise ValueError(f"Could not determine num_entities for {mode=}")
 
     consumer: ScoreConsumer
     if k is None:

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -169,7 +169,7 @@ def test_predict_all(model: pykeen.models.Model, k: Optional[int], target: pykee
     """Test the predict method."""
     pack = pykeen.predict.predict_all(model=model, k=k, target=target, batch_size=batch_size)
     _check_score_pack(
-        pack=pack, model=model, num_triples=model.num_entities**2 * model.num_relations if k is None else k
+        pack=pack, model=model, num_triples=model.num_entities**2 * model.num_real_relations if k is None else k
     )
 
 


### PR DESCRIPTION
Fix #1319

- set `num_entities` according to prediction mode (in inductive inference, the number of entities in the inference graph may be different to the training graph)
- fix shape of all-score array for `create_inverse_triples=True` 