### PR TITLE
🥄🧩 Utility to create inductive NodePiece representations

### DIFF
--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -149,13 +149,19 @@ class InductiveNodePiece(InductiveERModel):
         self, triples_factory: CoreTriplesFactory
     ) -> NodePieceRepresentation:
         """
-        Utility method to create suitable NodePiece representations for a new triples factory.
+        Create NodePiece representations for a new triples factory.
+
+        The representations are initialized such that the same relation representations are used, and the aggregation
+        is shared.
 
         :param triples_factory:
             the triples factory used for relation tokenization; must share the same relation to ID mapping.
 
         :return:
             a new NodePiece entity representation with shared relation tokenization and aggregation.
+
+        :raises ValueError:
+            if the triples factory does not request inverse triples, or the number of relations differs.
         """
         if not triples_factory.create_inverse_triples:
             raise ValueError("Must create a triples factory with inverse triples")

--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -12,13 +12,13 @@ from class_resolver import Hint, HintOrType, OptionalKwargs
 from .base import InductiveERModel
 from ...constants import DEFAULT_EMBEDDING_HPO_EMBEDDING_DIM_RANGE
 from ...nn import (
+    ConcatAggregationCombination,
     DistMultInteraction,
     Interaction,
     NodePieceRepresentation,
     SubsetRepresentation,
-    representation_resolver,
-    ConcatAggregationCombination,
     TokenizationRepresentation,
+    representation_resolver,
 )
 from ...nn.node_piece import RelationTokenizer
 from ...triples.triples_factory import CoreTriplesFactory

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -272,6 +272,28 @@ class TestInductiveNodePiece(cases.InductiveModelTestCase):
     cls = pykeen.models.InductiveNodePiece
     create_inverse_triples = True
 
+    def test_create_entity_representation_for_new_triples(self):
+        """Test create_entity_representation_for_new_triples."""
+        assert isinstance(self.instance, pykeen.models.InductiveNodePiece)
+        # simulate creating a new triples factory with shared set of relations by shuffling
+        mapped_triples = self.factory.mapped_triples
+        mapped_triples = torch.stack(
+            [
+                mapped_triples[:, 0][torch.randperm(len(mapped_triples))],
+                mapped_triples[:, 1],
+                mapped_triples[:, 2][torch.randperm(len(mapped_triples))],
+            ],
+            dim=1,
+        )
+        factory = CoreTriplesFactory(
+            mapped_triples=mapped_triples,
+            num_entities=self.factory.num_entities,
+            num_relations=self.factory.real_num_relations,
+            create_inverse_triples=True,
+        )
+        new_instance = self.instance.create_entity_representation_for_new_triples(factory)
+        assert isinstance(new_instance, pykeen.nn.NodePieceRepresentation)
+
 
 class TestInductiveNodePieceGNN(cases.InductiveModelTestCase):
     """Test the InductiveNodePieceGNN model."""


### PR DESCRIPTION
This PR adds a utility to create inductive NodePiece entity representations for given triples factory.