### PR TITLE
⁉️⭕ Raise error when encountering a checkpoint_name in the HPO configuration

### DIFF
--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -247,6 +247,14 @@ class Objective:
             kwargs_ranges=self.training_kwargs_ranges,
         )
 
+        # a fixed checkpoint_name leads avoid collision across trials
+        checkpoint_name = _training_kwargs.get("checkpoint_name", None)
+        if checkpoint_name:
+            raise ValueError(
+                f"Cannot set a fixed {checkpoint_name=} across all trials; if you want to save the final model per "
+                f"trial, use `save_model_directory` instead!",
+            )
+
         # create result tracker to allow to gracefully close failed trials
         result_tracker = tracker_resolver.make(query=self.result_tracker, pos_kwargs=self.result_tracker_kwargs)
 


### PR DESCRIPTION
When providing a `checkpoint_name` only the second trial will fail, since it finds an existing checkpoint and tries to continue training, but the model configuration has likely changed.

This PR checks the configuration and directly raises an error with a descriptive error message.

cf. https://github.com/pykeen/pykeen/issues/1300