### PR TITLE
Relax protobuf requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,6 @@ install_requires =
     pyyaml
     torch_max_mem>=0.1.1
     torch-ppr>=0.0.7
-    protobuf<4.0.0
     typing_extensions
 
 zip_safe = false


### PR DESCRIPTION
References #1331 by removing the protobuf tag. We don't actually import this ourselves anywhere in PyKEEN