### PR TITLE
🔝📐 Bump PyTorch Geometric cpu-build version for CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ envlist =
 [testenv]
 commands =
     # custom installation for PyG, cf. https://github.com/rusty1s/pytorch_scatter/pull/268
-    pip install torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric --find-links https://data.pyg.org/whl/torch-2.0.0+cpu.html
+    pip install torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric --find-links https://data.pyg.org/whl/torch-2.1.0+cpu.html
     coverage run -p -m pytest --durations=20 {posargs:tests} -m "not slow"
 # ensure we use the CPU-only version of torch
 setenv =


### PR DESCRIPTION
PyTorch 2.1 has been released and is used in our CI pipeline by default. We need to update the package links for cpu builds of the PyTorch Geometric packages.