### PR TITLE
☑️💸 Update Losses' HPO default range checks

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -200,7 +200,6 @@ __all__ = [
     "DoubleMarginLoss",
     "SoftMarginRankingLoss",
     "PairwiseLogisticLoss",
-    "MarginPairwiseLoss",
     # Utils
     "loss_resolver",
 ]
@@ -917,6 +916,14 @@ class DeltaPointwiseLoss(PointwiseLoss):
     Pointwise Logistic (softplus)  softplus    $\lambda = 0$           $g(s, l) = \log(1+\exp(-\hat{l}*s))$                      :class:`pykeen.losses.SoftplusLoss`
     =============================  ==========  ======================  ========================================================  =============================================
     """  # noqa:E501
+
+    hpo_default: ClassVar[Mapping[str, Any]] = dict(
+        margin=DEFAULT_MARGIN_HPO_STRATEGY,
+        margin_activation=dict(
+            type="categorical",
+            choices=margin_activation_resolver.options,
+        ),
+    )
 
     def __init__(
         self,

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -730,6 +730,10 @@ class DoubleMarginLoss(PointwiseLoss):
         :raises ValueError:
             In case of an invalid combination.
         """
+        # 0. default
+        if all(p is None for p in (positive_margin, negative_margin, offset)):
+            return 1.0, 0.0
+
         # 1. positive & negative margin
         if positive_margin is not None and negative_margin is not None and offset is None:
             if negative_margin > positive_margin:
@@ -771,8 +775,8 @@ class DoubleMarginLoss(PointwiseLoss):
     def __init__(
         self,
         *,
-        positive_margin: Optional[float] = 1.0,
-        negative_margin: Optional[float] = 0.0,
+        positive_margin: Optional[float] = None,
+        negative_margin: Optional[float] = None,
         offset: Optional[float] = None,
         positive_negative_balance: float = 0.5,
         margin_activation: Hint[nn.Module] = "relu",

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -200,6 +200,7 @@ __all__ = [
     "DoubleMarginLoss",
     "SoftMarginRankingLoss",
     "PairwiseLogisticLoss",
+    "MarginPairwiseLoss",
     # Utils
     "loss_resolver",
 ]
@@ -455,10 +456,18 @@ class MarginPairwiseLoss(PairwiseLoss):
     function like the ReLU or softmax, and $\lambda$ is the margin.
     """
 
+    hpo_default: ClassVar[Mapping[str, Any]] = dict(
+        margin=DEFAULT_MARGIN_HPO_STRATEGY,
+        margin_activation=dict(
+            type="categorical",
+            choices=margin_activation_resolver.options,
+        ),
+    )
+
     def __init__(
         self,
-        margin: float,
-        margin_activation: Hint[nn.Module],
+        margin: float = 1.0,
+        margin_activation: Hint[nn.Module] = None,
         reduction: str = "mean",
     ):
         r"""Initialize the margin loss instance.

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -242,7 +242,7 @@ class CachedDatasetCase(DatasetTestCase):
         self.directory.cleanup()
 
 
-def iter_from_space(key: str, space: Mapping[str, Any]) -> Iterable[dict[str, Any]]:
+def iter_from_space(key: str, space: Mapping[str, Any]) -> Iterable[MutableMapping[str, Any]]:
     """Iterate over some configurations for a single hyperparameter."""
     typ = space["type"]
     if typ == "categorical":

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -383,6 +383,7 @@ class LossTestCase(GenericTestCase[Loss]):
             parameter_name
             for parameter_name, parameter in signature.parameters.items()
             if parameter.default == inspect.Parameter.empty
+            and parameter.kind not in {inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL}
         }.difference({"self"})
         missing_required = required_parameters.difference(self.cls.hpo_default.keys())
         assert not missing_required

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -250,6 +250,7 @@ def iter_from_space(key: str, space: Mapping[str, Any]) -> Iterable[MutableMappi
             yield {key: choice}
     elif typ in (float, int):
         yield {key: space["low"]}
+        yield {key: space["high"]}
     else:
         raise NotImplementedError(typ)
 

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2,6 +2,7 @@
 
 """Test cases for PyKEEN."""
 import inspect
+import itertools
 import logging
 import os
 import pathlib
@@ -61,7 +62,7 @@ from pykeen.datasets.kinships import KINSHIPS_TRAIN_PATH
 from pykeen.datasets.mocks import create_inductive_dataset
 from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH
 from pykeen.evaluation import Evaluator, MetricResults, evaluator_resolver
-from pykeen.losses import Loss, PairwiseLoss, PointwiseLoss, SetwiseLoss, UnsupportedLabelSmoothingError
+from pykeen.losses import Loss, PairwiseLoss, PointwiseLoss, SetwiseLoss, UnsupportedLabelSmoothingError, loss_resolver
 from pykeen.metrics import rank_based_metric_resolver
 from pykeen.metrics.ranking import (
     DerivedRankBasedMetric,
@@ -241,6 +242,26 @@ class CachedDatasetCase(DatasetTestCase):
         self.directory.cleanup()
 
 
+def iter_from_space(key: str, space: Mapping[str, Any]) -> Iterable[dict[str, Any]]:
+    """Iterate over some configurations for a single hyperparameter."""
+    typ = space["type"]
+    if typ == "categorical":
+        for choice in space["choices"]:
+            yield {key: choice}
+    elif typ in (float, int):
+        yield {key: space["low"]}
+    else:
+        raise NotImplementedError(typ)
+
+
+def iter_hpo_configs(hpo_default: Mapping[str, Mapping[str, Any]]) -> Iterable[Mapping[str, Any]]:
+    """Iterate over some representative configurations from the HPO default."""
+    for combination in itertools.product(
+        *(iter_from_space(key=key, space=space) for key, space in hpo_default.items())
+    ):
+        yield ChainMap(*combination)
+
+
 class LossTestCase(GenericTestCase[Loss]):
     """Base unittest for loss functions."""
 
@@ -365,6 +386,9 @@ class LossTestCase(GenericTestCase[Loss]):
         }.difference({"self"})
         missing_required = required_parameters.difference(self.cls.hpo_default.keys())
         assert not missing_required
+        # try to instantiate loss for some configurations in the HPO search space
+        for config in iter_hpo_configs(self.cls.hpo_default):
+            assert loss_resolver.make(query=self.cls, pos_kwargs=config)
 
 
 class PointwiseLossTestCase(LossTestCase):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -354,8 +354,17 @@ class LossTestCase(GenericTestCase[Loss]):
     def test_hpo_defaults(self):
         """Test hpo defaults."""
         signature = inspect.signature(self.cls.__init__)
+        # check for invalid keys
         invalid_keys = set(self.cls.hpo_default.keys()).difference(signature.parameters)
         assert not invalid_keys
+        # check that each parameter without a default occurs
+        required_parameters = {
+            parameter_name
+            for parameter_name, parameter in signature.parameters.items()
+            if parameter.default == inspect.Parameter.empty
+        }.difference({"self"})
+        missing_required = required_parameters.difference(self.cls.hpo_default.keys())
+        assert not missing_required
 
 
 class PointwiseLossTestCase(LossTestCase):

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -155,6 +155,12 @@ class MarginPairwiseLossTestCase(cases.GMRLTestCase):
     cls = pykeen.losses.MarginPairwiseLoss
 
 
+class DeltaPointwiseLossTestCase(cases.PointwiseLossTestCase):
+    """Tests for general delta point-wise loss."""
+
+    cls = pykeen.losses.DeltaPointwiseLoss
+
+
 class PairwiseLogisticLossTestCase(cases.GMRLTestCase):
     """Tests for the pairwise logistic loss."""
 
@@ -177,7 +183,6 @@ class TestLosses(unittest_templates.MetaTestCase[Loss]):
         pykeen.losses.PairwiseLoss,
         pykeen.losses.PointwiseLoss,
         pykeen.losses.SetwiseLoss,
-        pykeen.losses.DeltaPointwiseLoss,
         pykeen.losses.AdversarialLoss,
     }
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -149,6 +149,12 @@ class SoftMarginrankingLossTestCase(cases.GMRLTestCase):
     cls = pykeen.losses.SoftMarginRankingLoss
 
 
+class MarginPairwiseLossTestCase(cases.GMRLTestCase):
+    """Tests for general margin pairwise loss."""
+
+    cls = pykeen.losses.MarginPairwiseLoss
+
+
 class PairwiseLogisticLossTestCase(cases.GMRLTestCase):
     """Tests for the pairwise logistic loss."""
 
@@ -172,7 +178,6 @@ class TestLosses(unittest_templates.MetaTestCase[Loss]):
         pykeen.losses.PointwiseLoss,
         pykeen.losses.SetwiseLoss,
         pykeen.losses.DeltaPointwiseLoss,
-        pykeen.losses.MarginPairwiseLoss,
         pykeen.losses.AdversarialLoss,
     }
 


### PR DESCRIPTION
* [x] check instantiation of losses for a few configurations derived from the `hpo_default`
* [x] fix an issue with the default values of `DoubleMarginLoss` ([bb88719](https://github.com/pykeen/pykeen/pull/1337/commits/bb8871922eddfdff02d85a423111c8b3d699341b))
* [x] add suitable `hpo_default`s to the general
  - `MarginPairwiseLoss`
  - `DeltaPointwiseLoss`

Fix #1334