### PR TITLE
🚨🏭 Warn about evaluation factory with inverse triples

### DIFF
--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -2,6 +2,8 @@
 
 """Implementation of basic instance factory which creates just instances based on standard KG triples."""
 
+from __future__ import annotations
+
 import math
 from abc import ABC, abstractmethod
 from typing import Callable, Generic, Iterable, Iterator, List, NamedTuple, Optional, Tuple, TypeVar
@@ -134,12 +136,13 @@ class SLCWAInstances(Instances[SLCWASampleType, SLCWABatch]):
         positives, negatives, masks = zip(*samples)
         positives = torch.cat(positives, dim=0)
         negatives = torch.cat(negatives, dim=0)
+        mask_batch: torch.BoolTensor | None
         if masks[0] is None:
             assert all(m is None for m in masks)
-            masks = None
+            mask_batch = None
         else:
-            masks = torch.cat(masks, dim=0)
-        return SLCWABatch(positives, negatives, masks)
+            mask_batch = torch.cat(masks, dim=0)
+        return SLCWABatch(positives, negatives, mask_batch)
 
     # docstr-coverage: inherited
     def get_collator(self) -> Optional[Callable[[List[SLCWASampleType]], SLCWABatch]]:  # noqa: D102


### PR DESCRIPTION
Closes #1339

Example Code:
```python
from pykeen.datasets import get_dataset
from pykeen.pipeline import pipeline

dataset = get_dataset(dataset="nations", dataset_kwargs=dict(create_inverse_triples=True))
dataset.testing.create_inverse_triples = True
result = pipeline(dataset=dataset, model="DistMult", epochs=0)
```

Output (slightly post-edited to highlight new warning message):
```
No random seed is specified. Setting to 2141943524.
No cuda devices were available. The model runs on CPU
INFO:pykeen.triples.triples_factory:Creating inverse triples.
INFO:pykeen.triples.triples_factory:Creating inverse triples.
Training epochs on cpu: 0epoch [00:00, ?epoch/s]


WARNING:pykeen.pipeline.api:Found evaluation_factory.create_inverse_triples=True which is ignored for evaluation factories. The model itself determines whether inverse relations are used in head prediction. Here, the model was created with training.create_inverse_triples=True


WARNING:torch_max_mem.api:Encountered tensors on device_types={'cpu'} while only ['cuda'] are considered safe for automatic memory utilization maximization. This may lead to undocumented crashes (but can be safe, too).
Evaluating on cpu: 100%|███| 201/201 [00:00<00:00, 2.78ktriple/s]
INFO:pykeen.evaluation.evaluator:Evaluation took 0.09s seconds
```