### PR TITLE
🔓📊 Relax type hint of RankBasedEvaluator's metrics/metrics_kwargs parameter pair to match `make_many`

### DIFF
--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -32,7 +32,7 @@ import numpy as np
 import numpy.random
 import pandas as pd
 import torch
-from class_resolver import HintOrType, OptionalKwargs
+from class_resolver import OneOrManyHintOrType, OneOrManyOptionalKwargs
 
 from .evaluator import Evaluator, MetricResults, prepare_filter_triples
 from .ranks import Ranks
@@ -301,8 +301,8 @@ class RankBasedEvaluator(Evaluator[RankBasedMetricKey]):
     def __init__(
         self,
         filtered: bool = True,
-        metrics: Optional[Sequence[HintOrType[RankBasedMetric]]] = None,
-        metrics_kwargs: OptionalKwargs = None,
+        metrics: OneOrManyHintOrType = None,
+        metrics_kwargs: OneOrManyOptionalKwargs = None,
         add_defaults: bool = True,
         clear_on_finalize: bool = True,
         **kwargs,


### PR DESCRIPTION
This is a small PR to relax the type hint the `metric`/`metric_kwargs` parameter-pair of `RankBasedEvaluator.__init__` to the one of `ClassResolver.make_many`.

In particular this indicates that you can also pass a single hint such as
```python
evaluator = RankBasedEvaluator(
  metrics="hits_at_k",
  metric_kwargs=dict(k=50),
)
```

or use "broadcasting" such as
```python
evaluator = RankBasedEvaluator(
  metrics="hits_at_k",
  metric_kwargs=[dict(k=k) for k in (32, 64, 128)],
)
```