### PR TITLE
Fix bug that still shows tqdm when use_tqdm=False in Evaluator

### DIFF
--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -309,7 +309,7 @@ class Evaluator(ABC, Generic[MetricKeyType]):
         device = device or model.device
         tqdm_kwargs = dict(tqdm_kwargs or {})
         if not use_tqdm:
-            tqdm_kwargs.update(dict(disable=True))
+            tqdm_kwargs["disable"] = True
         try:
             result = self._evaluate_on_device(
                 model=model,

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -309,7 +309,7 @@ class Evaluator(ABC, Generic[MetricKeyType]):
         device = device or model.device
         tqdm_kwargs = dict(tqdm_kwargs or {})
         if not use_tqdm:
-            tqdm_kwargs.update(dict(disable=False))
+            tqdm_kwargs.update(dict(disable=True))
         try:
             result = self._evaluate_on_device(
                 model=model,


### PR DESCRIPTION
Sorry for not using the template for fixing bugs, but I think in this simple case it is not necessary. Fixes #1390.
The bug is caused due to a mistake in bools:

```python
if not use_tqdm:
    tqdm_kwargs.update(dict(disable=False))
```

should be

```python
if not use_tqdm: #condition is triggered if use_tqdm=False
    tqdm_kwargs.update(dict(disable=True)) # disable should be set to True not False
```