### PR TITLE
Remove create_inverse_triples from init call to superclass

### DIFF
--- a/src/pykeen/datasets/inductive/ilpc2022.py
+++ b/src/pykeen/datasets/inductive/ilpc2022.py
@@ -46,7 +46,6 @@ class ILPC2022Small(UnpackedRemoteDisjointInductiveDataset):
             inductive_inference_url=SMALL_INFERENCE_URL,
             inductive_validation_url=SMALL_INFERENCE_VAL_URL,
             inductive_testing_url=SMALL_INFERENCE_TEST_URL,
-            create_inverse_triples=True,
             eager=True,
             **kwargs,
         )
@@ -75,7 +74,6 @@ class ILPC2022Large(UnpackedRemoteDisjointInductiveDataset):
             inductive_inference_url=LARGE_INFERENCE_URL,
             inductive_validation_url=LARGE_INFERENCE_VAL_URL,
             inductive_testing_url=LARGE_INFERENCE_TEST_URL,
-            create_inverse_triples=True,
             eager=True,
             **kwargs,
         )

--- a/src/pykeen/datasets/inductive/ilpc2022.py
+++ b/src/pykeen/datasets/inductive/ilpc2022.py
@@ -36,7 +36,7 @@ class ILPC2022Small(UnpackedRemoteDisjointInductiveDataset):
         github: https://github.com/pykeen/ilpc2022
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, create_inverse_triples: bool = True, **kwargs):
         """Initialize the inductive link prediction dataset.
 
         :param kwargs: keyword arguments to forward to the base dataset class, cf. DisjointInductivePathDataset
@@ -46,6 +46,7 @@ class ILPC2022Small(UnpackedRemoteDisjointInductiveDataset):
             inductive_inference_url=SMALL_INFERENCE_URL,
             inductive_validation_url=SMALL_INFERENCE_VAL_URL,
             inductive_testing_url=SMALL_INFERENCE_TEST_URL,
+            create_inverse_triples=create_inverse_triples,
             eager=True,
             **kwargs,
         )
@@ -64,7 +65,7 @@ class ILPC2022Large(UnpackedRemoteDisjointInductiveDataset):
         github: https://github.com/pykeen/ilpc2022
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, create_inverse_triples: bool = True, **kwargs):
         """Initialize the inductive link prediction dataset.
 
         :param kwargs: keyword arguments to forward to the base dataset class, cf. DisjointInductivePathDataset
@@ -74,6 +75,7 @@ class ILPC2022Large(UnpackedRemoteDisjointInductiveDataset):
             inductive_inference_url=LARGE_INFERENCE_URL,
             inductive_validation_url=LARGE_INFERENCE_VAL_URL,
             inductive_testing_url=LARGE_INFERENCE_TEST_URL,
+            create_inverse_triples=create_inverse_triples,
             eager=True,
             **kwargs,
         )

--- a/src/pykeen/datasets/inductive/ilpc2022.py
+++ b/src/pykeen/datasets/inductive/ilpc2022.py
@@ -39,6 +39,7 @@ class ILPC2022Small(UnpackedRemoteDisjointInductiveDataset):
     def __init__(self, create_inverse_triples: bool = True, **kwargs):
         """Initialize the inductive link prediction dataset.
 
+        :param create_inverse_triples: Should inverse triples be created?
         :param kwargs: keyword arguments to forward to the base dataset class, cf. DisjointInductivePathDataset
         """
         super().__init__(
@@ -68,6 +69,7 @@ class ILPC2022Large(UnpackedRemoteDisjointInductiveDataset):
     def __init__(self, create_inverse_triples: bool = True, **kwargs):
         """Initialize the inductive link prediction dataset.
 
+        :param create_inverse_triples: Should inverse triples be created?
         :param kwargs: keyword arguments to forward to the base dataset class, cf. DisjointInductivePathDataset
         """
         super().__init__(


### PR DESCRIPTION
### Link to the relevant Bug(s)

Fixes #1392 


### Description of the Change

Enable to pass `create_inverse_triples` in the constructor of ILPC2022Small and ILPC2022Large.


### Possible Drawbacks

-


### Verification Process

-


### Release Notes

- Fixed a bug that caused a crash when loading the inductive ILPC datasets