### PR TITLE
fix issue of 'Full Inductive LP Example'

### DIFF
--- a/docs/source/tutorial/inductive_lp.rst
+++ b/docs/source/tutorial/inductive_lp.rst
@@ -204,7 +204,7 @@ in the sLCWA mode with 32 negative samples per positive, with NSSALoss, and Samp
     from pykeen.training import SLCWATrainingLoop
     from pykeen.evaluation.rank_based_evaluator import SampledRankBasedEvaluator
     from pykeen.stoppers import EarlyStopper
-
+    from pykeen.losses import NSSALoss
     from torch.optim import Adam
 
     dataset = InductiveFB15k237(version="v1", create_inverse_triples=True)
@@ -225,7 +225,7 @@ in the sLCWA mode with 32 negative samples per positive, with NSSALoss, and Samp
         triples_factory=dataset.transductive_training,  # training triples
         model=model,
         optimizer=optimizer,
-        negative_sampler_kwargs=dict(num_negs_per_pos=32)
+        negative_sampler_kwargs=dict(num_negs_per_pos=32),
         mode="training",   # necessary to specify for the inductive mode - training has its own set of nodes
     )
 


### PR DESCRIPTION
### Describe the bug

In the documentation of "[inductive link prediction](https://github.com/pykeen/pykeen/blob/master/docs/source/tutorial/inductive_lp.rst)", the last example titled "Full Inductive LP Example" (the last example) has two issues. 
Firstly, "`NSSALoss`" used in the model definition has not been imported. Second, after defining "`negative_sampler_kwargs`" in the definition of "`training_loop`", a comma ("`,`") has been missed. 

### How to reproduce

run the example

### Environment

Python 3.8.19
pykeen 1.10.2

### Additional information
_No response_