### PR TITLE
🧹⚙️ Update GHA

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,6 +21,8 @@ ignore =
     # bugbear seems to emit false positives, cf. https://github.com/PyCQA/flake8-bugbear/issues/278
     B024
     B028
+    # pydoclint: good point, but tbd in a separate commit
+    DOC301
 exclude =
     .tox,
     .git,

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Install dependencies
         run: pip install tox
       
-      - name: Check README.rst
-        run: tox -e readme
-      
       # - name: Check RST format
       #   run: tox -e doclint
+
+      - name: Check README.rst
+        run: tox -e readme
 
       - name: Check documentation build with Sphinx
         run: |

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: pip install tox
       
+      - name: Check README.rst
+        run: tox -e readme
+      
       # - name: Check RST format
       #   run: tox -e doclint
 

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # no need to check documentation wit multiple python versions
+        # no need to check documentation with multiple python versions
         python-version: [ "3.11" ]
     steps:
       - uses: actions/checkout@v4
@@ -29,15 +29,9 @@ jobs:
       
       - name: Install dependencies
         run: pip install tox
-
-      - name: Check RST conformity with doc8
-        run: tox -e doc8
       
       # - name: Check RST format
       #   run: tox -e doclint
-
-      - name: Check README.rst
-        run: tox -e readme
 
       - name: Check documentation build with Sphinx
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,20 +27,47 @@ jobs:
       - name: Install dependencies
         run: pip install tox
 
-      - name: Check package metadata with Pyroma
-        run: tox -e pyroma
-      
-      - name: Check docstring coverage
-        run: tox -e docstr-coverage
-
       - name: Check static typing with MyPy
         run: tox -e mypy
 
-      - name: Check manifest
-        run: tox -e manifest
-
       - name: Check code quality with flake8
         run: tox -e flake8
+  
+  lint-single-version:
+    name: Lint Single Version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.11" ]
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+        cache: 'pip'
+        cache-dependency-path: './setup.cfg'
+    
+    - name: Install dependencies
+      run: pip install tox
+
+    - name: Check package metadata with Pyroma
+      run: tox -e pyroma
+    
+    - name: Check docstring coverage
+      run: tox -e docstr-coverage
+
+    - name: Check manifest
+      run: tox -e manifest
+
+    - name: Check RST conformity with doc8
+      run: tox -e doc8
+    
+    - name: Check README.rst
+      run: tox -e readme
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,9 +64,6 @@ jobs:
 
     - name: Check RST conformity with doc8
       run: tox -e doc8
-    
-    - name: Check README.rst
-      run: tox -e readme
 
 
 concurrency:

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     click
     click_default_group
     scikit-learn
-    torch>=2.0
+    torch>=2.0,<2.4
     tqdm
     requests
     optuna>=2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -108,17 +108,18 @@ description = Run documentation linters.
 skip_install = true
 deps =
     black
-    darglint
     flake8<5.0.0
     # flake8-bandit
     flake8-black
     flake8-bugbear
     flake8-colors
+    # for support of "# docstr-coverage: inherited"
+    # note: pydocstyle is deprecated in favour of ruff
     flake8-docstrings<1.6
     flake8-isort==5.0.0
     flake8-print
     pep8-naming
-    pydocstyle
+    pydoclint[flake8]
 commands =
     flake8 src/pykeen/ tests/
 description = Run the flake8 tool with several plugins (bandit, docstrings, import order, pep8 naming).


### PR DESCRIPTION
- [x] check documentation in default job
- [x] only run `mypy` & `flake8` on different Python versions
- [ ] `pydocstyle` has been deprecated in favour of `ruff`, cf. https://github.com/PyCQA/pydocstyle/commit/8d0cdfc93e86e096bb5753f07dc5c7c373e63837
- [x] temporarily add a `torch<2.4` version constraint to fix issues on Windows, cf. https://github.com/pytorch/pytorch/issues/132400