### PR TITLE
Modernize extension loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ dependencies = [
     "torch_max_mem>=0.1.1",
     "torch-ppr>=0.0.7",
     "typing_extensions",
-    "setuptools", # for pkg_resources entrypoint loading, need to update
 ]
 
 [project.optional-dependencies]

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -52,7 +52,7 @@ from .sampling import negative_sampler_resolver
 from .stoppers import stopper_resolver
 from .trackers import tracker_resolver
 from .training import training_loop_resolver
-from .triples.utils import EXTENSION_IMPORTERS, PREFIX_IMPORTERS
+from .triples.utils import EXTENSION_IMPORTER_RESOLVER, PREFIX_IMPORTER_RESOLVER
 from .utils import get_until_first_blank, getattr_or_docdata
 from .version import env_table
 
@@ -220,9 +220,9 @@ def _help_representations(tablefmt: str = "github", *, link_fmt: Optional[str] =
 @ls.command()
 def importers():
     """List triple importers."""
-    for prefix, f in sorted(PREFIX_IMPORTERS.items()):
+    for prefix, f in sorted(PREFIX_IMPORTER_RESOLVER.lookup_dict.items()):
         click.secho(f"prefix: {prefix} from {inspect.getmodule(f).__name__}")
-    for suffix, f in sorted(EXTENSION_IMPORTERS.items()):
+    for suffix, f in sorted(EXTENSION_IMPORTER_RESOLVER.lookup_dict.items()):
         click.secho(f"suffix: {suffix} from {inspect.getmodule(f).__name__}")
 
 

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -3,8 +3,9 @@
 """Built-in datasets for PyKEEN.
 
 New datasets (inheriting from :class:`pykeen.datasets.Dataset`) can be registered with PyKEEN using the
-:mod:`pykeen.datasets` group in Python entrypoints in your own `setup.py` or `setup.cfg` package configuration.
-They are loaded automatically with :func:`pkg_resources.iter_entry_points`.
+:mod:`pykeen.datasets` group in Python entrypoints in your own `setup.py`, `setup.cfg`, `pyproject.toml`,
+or other package configuration. They are loaded automatically with :func:`importlib.metadata.entry_points`
+via :mod:`class_resolver`.
 """
 
 import logging

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -3,7 +3,7 @@
 """Instance creation utilities."""
 
 import pathlib
-from typing import Callable, List, Optional, Sequence, Set, TextIO, Tuple, TypeAlias, Union
+from typing import Callable, List, Optional, Sequence, Set, TextIO, Tuple, Union
 
 import numpy as np
 import pandas
@@ -22,7 +22,7 @@ __all__ = [
 
 TRIPLES_DF_COLUMNS = ("head_id", "head_label", "relation_id", "relation_label", "tail_id", "tail_label")
 
-Importer: TypeAlias = Callable[[str], LabeledTriples]
+Importer = Callable[[str], LabeledTriples]
 
 #: Functions for specifying exotic resources with a given prefix
 PREFIX_IMPORTER_RESOLVER: FunctionResolver[Importer] = FunctionResolver.from_entrypoint(

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -3,12 +3,12 @@
 """Instance creation utilities."""
 
 import pathlib
-from typing import Callable, List, Mapping, Optional, Sequence, Set, TextIO, Tuple, Union
+from typing import Callable, List, Optional, Sequence, Set, TextIO, Tuple, TypeAlias, Union
 
 import numpy as np
 import pandas
 import torch
-from pkg_resources import iter_entry_points
+from class_resolver import FunctionResolver
 
 from ..typing import LabeledTriples, MappedTriples
 
@@ -22,18 +22,17 @@ __all__ = [
 
 TRIPLES_DF_COLUMNS = ("head_id", "head_label", "relation_id", "relation_label", "tail_id", "tail_label")
 
-
-def _load_importers(group_subname: str) -> Mapping[str, Callable[[str], LabeledTriples]]:
-    return {
-        entry_point.name: entry_point.load()
-        for entry_point in iter_entry_points(group=f"pykeen.triples.{group_subname}")
-    }
-
+Importer: TypeAlias = Callable[[str], LabeledTriples]
 
 #: Functions for specifying exotic resources with a given prefix
-PREFIX_IMPORTERS: Mapping[str, Callable[[str], LabeledTriples]] = _load_importers("prefix_importer")
+PREFIX_IMPORTER_RESOLVER: FunctionResolver[Importer] = FunctionResolver.from_entrypoint(
+    "pykeen.triples.prefix_importer"
+)
+
 #: Functions for specifying exotic resources based on their file extension
-EXTENSION_IMPORTERS: Mapping[str, Callable[[str], LabeledTriples]] = _load_importers("extension_importer")
+EXTENSION_IMPORTER_RESOLVER: FunctionResolver[Importer] = FunctionResolver.from_entrypoint(
+    "pykeen.triples.extension_importer"
+)
 
 
 def load_triples(
@@ -53,7 +52,7 @@ def load_triples(
         For example, if the order is head-tail-relation, pass ``(0, 2, 1)``
     :returns: A numpy array representing "labeled" triples.
 
-    :raises ValueError: if a column remapping was passed but it was not a length 3 sequence
+    :raises ValueError: if a column remapping was passed, but it was not a length 3 sequence
 
     Besides TSV handling, PyKEEN does not come with any importers pre-installed. A few can be found at:
 
@@ -62,11 +61,11 @@ def load_triples(
     """
     if isinstance(path, (str, pathlib.Path)):
         path = str(path)
-        for extension, handler in EXTENSION_IMPORTERS.items():
+        for extension, handler in EXTENSION_IMPORTER_RESOLVER.lookup_dict.items():
             if path.endswith(f".{extension}"):
                 return handler(path)
 
-        for prefix, handler in PREFIX_IMPORTERS.items():
+        for prefix, handler in PREFIX_IMPORTER_RESOLVER.lookup_dict.items():
             if path.startswith(f"{prefix}:"):
                 return handler(path[len(f"{prefix}:") :])
 


### PR DESCRIPTION
This PR switches out the deprecated usage of setuptools to using `importlib.metadata` (via `class_resolver`)