### PR TITLE
Fix class inheritance diagram in docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,8 +8,10 @@ version: 2
 # Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-lts-latest
+  apt_packages:
+    - graphviz
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Closes #1406

- [x] bump Python version for building the documentation
- [x] ensure that `graphviz` is installed

This seems to have fixed the diagram, cf. https://pykeen--1426.org.readthedocs.build/en/1426/reference/negative_sampling.html