### PR TITLE
🐈👩 Increase maximum sphinx version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,8 @@ tests = [
     "pytest",
 ]
 docs = [
-    "sphinx<7",
+    # Sphinx >= 8.0 not supported by rtd theme, cf. https://github.com/readthedocs/sphinx_rtd_theme/issues/1582
+    "sphinx<8",
     "sphinx-rtd-theme",
     "sphinx-click",
     "sphinx_automodapi",


### PR DESCRIPTION
This PR bumps the sphinx version. >=8 is blocked by https://github.com/readthedocs/sphinx_rtd_theme/issues/1582 (which looks like it might be released soon).