### PR TITLE
🔧🥇 Fix BestKeeper and add tests for checkpoint schedules

### DIFF
--- a/src/pykeen/checkpoints/utils.py
+++ b/src/pykeen/checkpoints/utils.py
@@ -42,6 +42,8 @@ class ResultListenerAdapter(ResultTracker):
 
     def __post_init__(self):
         self.best = float("-inf") if self.metric_selection.maximize else float("+inf")
+        self.base_log_metrics = self.base.log_metrics
+        self.base.log_metrics = self.log_metrics
 
     # docstr-coverage: inherited
     def log_metrics(
@@ -50,6 +52,7 @@ class ResultListenerAdapter(ResultTracker):
         step: int | None = None,
         prefix: str | None = None,
     ) -> None:
+        self.base_log_metrics(metrics=metrics, step=step, prefix=prefix)
         self.last_step = step
 
         # prefix filter

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2734,7 +2734,7 @@ class ScoreConsumerTests(unittest_templates.GenericTestCase[pykeen.predict.Score
         pass
 
 
-class CheckpointKeeperBase(GenericTestCase[CheckpointKeeper]):
+class CheckpointKeeperTests(GenericTestCase[CheckpointKeeper]):
     """Generic tests for checkpoint keepers."""
 
     def test_call(self) -> None:

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -37,7 +37,6 @@ from torch import optim
 from torch.nn import functional
 from torch.optim import SGD, Adagrad
 
-from pykeen.checkpoints.keeper import CheckpointKeeper
 import pykeen.evaluation.evaluation_loop
 import pykeen.models
 import pykeen.nn.combination
@@ -47,6 +46,7 @@ import pykeen.nn.representation
 import pykeen.nn.text
 import pykeen.nn.weighting
 import pykeen.predict
+from pykeen.checkpoints import CheckpointKeeper, CheckpointSchedule
 from pykeen.datasets import Nations
 from pykeen.datasets.base import LazyDataset
 from pykeen.datasets.ea.combination import GraphPairCombinator
@@ -2732,6 +2732,19 @@ class ScoreConsumerTests(unittest_templates.GenericTestCase[pykeen.predict.Score
     def check(self):
         """Perform additional verification."""
         pass
+
+
+class CheckpointScheduleTests(GenericTestCase[CheckpointSchedule]):
+    """Generic tests for checkpoint schedules."""
+
+    def test_call(self) -> None:
+        """Smoke-test for calling."""
+        for step in self.iter_steps():
+            _result = self.instance(step=step)
+
+    def iter_steps(self) -> Iterator[int]:
+        """Iterate over steps."""
+        yield from range(20)
 
 
 class CheckpointKeeperTests(GenericTestCase[CheckpointKeeper]):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -11,7 +11,7 @@ import traceback
 import unittest
 from abc import ABC, abstractmethod
 from collections import ChainMap, Counter
-from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Collection, Iterable, Iterator, Mapping, MutableMapping, Sequence
 from typing import (
     Any,
     Callable,
@@ -37,6 +37,7 @@ from torch import optim
 from torch.nn import functional
 from torch.optim import SGD, Adagrad
 
+from pykeen.checkpoints.keeper import CheckpointKeeper
 import pykeen.evaluation.evaluation_loop
 import pykeen.models
 import pykeen.nn.combination
@@ -2731,3 +2732,27 @@ class ScoreConsumerTests(unittest_templates.GenericTestCase[pykeen.predict.Score
     def check(self):
         """Perform additional verification."""
         pass
+
+
+class CheckpointKeeperBase(GenericTestCase[CheckpointKeeper]):
+    """Generic tests for checkpoint keepers."""
+
+    def test_call(self) -> None:
+        """Test calling."""
+        for steps in self.iter_steps():
+            steps_copy = [s for s in steps]
+            kept = list(self.instance(steps=steps))
+            # check for unique values
+            assert len(kept) == len(set(kept))
+            # check for subset property
+            assert set(kept).issubset(steps_copy)
+            # maybe additional checks
+            self.check_result(steps=steps_copy, kept=kept)
+
+    def check_result(self, steps: list[int], kept: list[int]) -> None:
+        """Check result."""
+
+    def iter_steps(self) -> Iterator[list[int]]:
+        """Iterate over steps."""
+        yield list(range(10))
+        yield list(range(20))

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,0 +1,15 @@
+"""Tests for checkpointing."""
+
+from typing import ClassVar
+
+from unittest_templates import MetaTestCase
+
+from pykeen.checkpoints.keeper import CheckpointKeeper
+from tests.cases import CheckpointKeeperBase
+
+
+class CheckpointKeeperMetaTestCase(MetaTestCase[CheckpointKeeper]):
+    """Meta test case for checkpoint keepers."""
+
+    base_cls: ClassVar = CheckpointKeeper
+    base_test: ClassVar = CheckpointKeeperBase

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -6,10 +6,17 @@ from typing import Any, ClassVar
 import torch
 import unittest_templates
 
-from pykeen.checkpoints import keeper
+from pykeen.checkpoints import keeper, schedule
 from pykeen.checkpoints.utils import MetricSelection
 from pykeen.trackers.base import PythonResultTracker
-from tests.cases import CheckpointKeeperTests
+from tests.cases import CheckpointKeeperTests, CheckpointScheduleTests
+
+
+class CheckpointScheduleMetaTestCase(unittest_templates.MetaTestCase[schedule.CheckpointSchedule]):
+    """Meta test case for checkpoint schedules."""
+
+    base_cls: ClassVar = schedule.CheckpointSchedule
+    base_test: ClassVar = CheckpointScheduleTests
 
 
 class CheckpointKeeperMetaTestCase(unittest_templates.MetaTestCase[keeper.CheckpointKeeper]):

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,15 +1,70 @@
 """Tests for checkpointing."""
 
-from typing import ClassVar
+from collections.abc import Iterator, MutableMapping
+from typing import Any, ClassVar
 
-from unittest_templates import MetaTestCase
+import torch
+import unittest_templates
 
-from pykeen.checkpoints.keeper import CheckpointKeeper
-from tests.cases import CheckpointKeeperBase
+from pykeen.checkpoints import keeper
+from pykeen.checkpoints.utils import MetricSelection
+from pykeen.trackers.base import PythonResultTracker
+from tests.cases import CheckpointKeeperTests
 
 
-class CheckpointKeeperMetaTestCase(MetaTestCase[CheckpointKeeper]):
+class CheckpointKeeperMetaTestCase(unittest_templates.MetaTestCase[keeper.CheckpointKeeper]):
     """Meta test case for checkpoint keepers."""
 
-    base_cls: ClassVar = CheckpointKeeper
-    base_test: ClassVar = CheckpointKeeperBase
+    base_cls: ClassVar = keeper.CheckpointKeeper
+    base_test: ClassVar = CheckpointKeeperTests
+
+
+class ExplicitCheckpointKeeperTests(CheckpointKeeperTests):
+    """Tests for explicit."""
+
+    cls = keeper.ExplicitCheckpointKeeper
+    kwargs = dict(keep=(3, 6))
+
+
+class LastCheckpointKeeperTests(CheckpointKeeperTests):
+    """Tests for last."""
+
+    cls = keeper.LastCheckpointKeeper
+
+
+class BestCheckpointKeeperTests(CheckpointKeeperTests):
+    """Tests for best."""
+
+    cls = keeper.BestCheckpointKeeper
+    kwargs = dict(metric_selection=MetricSelection(metric="loss", prefix="validation"))
+
+    def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+        kwargs = super()._pre_instantiation_hook(kwargs)
+        kwargs["result_tracker"] = self.result_tracker = PythonResultTracker()
+        return kwargs
+
+    def iter_steps(self) -> Iterator[list[int]]:
+        for steps in super().iter_steps():
+            losses = torch.rand(len(steps), generator=self.generator)
+            for step, loss in zip(steps, losses.tolist()):
+                self.result_tracker.log_metrics(metrics=dict(loss=loss), step=step, prefix="validation")
+            yield steps
+
+
+class ModuloCheckpointKeeperTests(CheckpointKeeperTests):
+    """Tests for modulo."""
+
+    cls = keeper.ModuloCheckpointKeeper
+
+
+class UnionCheckpointKeeperTests(CheckpointKeeperTests):
+    """Tests for union."""
+
+    cls = keeper.UnionCheckpointKeeper
+    kwargs = dict(
+        bases=["last", "explicit"],
+        bases_kwargs=[
+            dict(keep=1),
+            dict(keep=(3, 7)),
+        ],
+    )


### PR DESCRIPTION
This PR fixes the `ResultListenerAdapter` not intercepting the actual `ResultTracker`, and adds simple tests for the checkpoint scheduler components.