### PR TITLE
🚫🔥 Block doc8=1.1.2 due to false positives

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -159,7 +159,7 @@ description = Make sure readme has been updated properly
 skip_install = true
 deps =
     sphinx
-    doc8
+    doc8!=1.1.2 # 1.1.2 emits false positives for some references
 commands =
     doc8 docs/source/ CHANGELOG.rst
 description = Run the doc8 tool to check the style of the RST files in the project docs.


### PR DESCRIPTION
This is a hotfix for the recent `master' pipeline failures due to an "unknown target name":
```
docs/source/tutorial/inductive_lp.rst:24: D000 Unknown target name: "ali2021".
docs/source/tutorial/inductive_lp.rst:51: D000 Unknown target name: "teru2020".
docs/source/tutorial/inductive_lp.rst:145: D000 Unknown target name: "teru2020".
docs/source/tutorial/inductive_lp.rst:158: D000 Unknown target name: "teru2020".
docs/source/tutorial/understanding_evaluation.rst:161: D000 Unknown target name: "bordes2013".
docs/source/tutorial/understanding_evaluation.rst:169: D000 Unknown target name: "bordes2013".
```
These are false positives and only seem to occur in the latest [`doc8==1.1.2` release](https://github.com/PyCQA/doc8/releases/tag/v1.1.2) from 2024-09-02.