### PR TITLE
🔥🧮 Torch tensor typing

### DIFF
--- a/src/pykeen/contrib/lightning.py
+++ b/src/pykeen/contrib/lightning.py
@@ -43,7 +43,7 @@ from pykeen.optimizers import optimizer_resolver
 from pykeen.sampling import NegativeSampler
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop
 from pykeen.triples.triples_factory import CoreTriplesFactory
-from pykeen.typing import InductiveMode, OneOrSequence
+from pykeen.typing import FloatTensor, InductiveMode, LongTensor, OneOrSequence
 
 __all__ = [
     "LitModule",
@@ -116,7 +116,7 @@ class LitModule(pytorch_lightning.LightningModule):
         self.mode = mode
         self.label_smoothing = label_smoothing
 
-    def forward(self, hr_batch: torch.LongTensor) -> torch.FloatTensor:
+    def forward(self, hr_batch: LongTensor) -> FloatTensor:
         """
         Perform the prediction or inference step by wrapping :meth:`pykeen.models.ERModel.predict_t`.
 

--- a/src/pykeen/datasets/ea/combination.py
+++ b/src/pykeen/datasets/ea/combination.py
@@ -82,7 +82,7 @@ def cat_shift_triples(*triples: Union[CoreTriplesFactory, MappedTriples]) -> tup
 
 def merge_label_to_id_mapping(
     *pairs: tuple[str, Mapping[str, int]],
-    offsets: LongTensor | None = None,
+    offsets: Optional[LongTensor] = None,
     mappings: Optional[Sequence[Mapping[int, int]]] = None,
     extra: Optional[Mapping[str, int]] = None,
 ) -> dict[str, int]:

--- a/src/pykeen/datasets/ea/combination.py
+++ b/src/pykeen/datasets/ea/combination.py
@@ -19,7 +19,16 @@ from class_resolver import ClassResolver
 from pandas.api.types import is_numeric_dtype, is_string_dtype
 
 from ...triples import CoreTriplesFactory, TriplesFactory
-from ...typing import COLUMN_HEAD, COLUMN_TAIL, EA_SIDE_LEFT, EA_SIDE_RIGHT, EA_SIDES, MappedTriples, TargetColumn
+from ...typing import (
+    COLUMN_HEAD,
+    COLUMN_TAIL,
+    EA_SIDE_LEFT,
+    EA_SIDE_RIGHT,
+    EA_SIDES,
+    LongTensor,
+    MappedTriples,
+    TargetColumn,
+)
 from ...utils import format_relative_comparison, get_connected_components
 
 __all__ = [
@@ -37,7 +46,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def cat_shift_triples(*triples: Union[CoreTriplesFactory, MappedTriples]) -> tuple[MappedTriples, torch.LongTensor]:
+def cat_shift_triples(*triples: Union[CoreTriplesFactory, MappedTriples]) -> tuple[MappedTriples, LongTensor]:
     """
     Concatenate (shifted) triples.
 
@@ -73,7 +82,7 @@ def cat_shift_triples(*triples: Union[CoreTriplesFactory, MappedTriples]) -> tup
 
 def merge_label_to_id_mapping(
     *pairs: tuple[str, Mapping[str, int]],
-    offsets: torch.LongTensor = None,
+    offsets: LongTensor | None = None,
     mappings: Optional[Sequence[Mapping[int, int]]] = None,
     extra: Optional[Mapping[str, int]] = None,
 ) -> dict[str, int]:
@@ -127,9 +136,9 @@ def merge_label_to_id_mapping(
 def merge_label_to_id_mappings(
     left: TriplesFactory,
     right: TriplesFactory,
-    relation_offsets: torch.LongTensor,
+    relation_offsets: LongTensor,
     # optional
-    entity_offsets: Optional[torch.LongTensor] = None,
+    entity_offsets: Optional[LongTensor] = None,
     entity_mappings: Optional[Sequence[Mapping[int, int]]] = None,
     extra_relations: Optional[Mapping[str, int]] = None,
 ) -> tuple[Mapping[str, int], Mapping[str, int]]:
@@ -173,8 +182,8 @@ def filter_map_alignment(
     alignment: pandas.DataFrame,
     left: CoreTriplesFactory,
     right: CoreTriplesFactory,
-    entity_offsets: torch.LongTensor,
-) -> torch.LongTensor:
+    entity_offsets: LongTensor,
+) -> LongTensor:
     """
     Convert dataframe with label or ID-based alignment.
 
@@ -220,7 +229,7 @@ def filter_map_alignment(
 
 def swap_index_triples(
     mapped_triples: MappedTriples,
-    dense_map: torch.LongTensor,
+    dense_map: LongTensor,
     index: TargetColumn,
 ) -> MappedTriples:
     """
@@ -254,7 +263,7 @@ class ProcessedTuple(NamedTuple):
     mapped_triples: MappedTriples
 
     #: the updated alignment, shape: (2, m)
-    alignment: torch.LongTensor
+    alignment: LongTensor
 
     #: additional keyword-based parameters for adjusting label-to-id mappings
     translation_kwargs: Mapping[str, Any]
@@ -269,7 +278,7 @@ class GraphPairCombinator(ABC):
         right: TriplesFactory,
         alignment: pandas.DataFrame,
         **kwargs,
-    ) -> tuple[TriplesFactory, torch.LongTensor]:
+    ) -> tuple[TriplesFactory, LongTensor]:
         """
         Combine two graphs using the alignment information.
 
@@ -307,6 +316,7 @@ class GraphPairCombinator(ABC):
                 **kwargs,
             )
         else:
+            # TODO: unreachable code
             max_ids = mapped_triples.max(axis=0).values
             triples_factory = CoreTriplesFactory(
                 mapped_triples=mapped_triples,
@@ -321,8 +331,8 @@ class GraphPairCombinator(ABC):
     def process(
         self,
         mapped_triples: MappedTriples,
-        alignment: torch.LongTensor,
-        offsets: torch.LongTensor,
+        alignment: LongTensor,
+        offsets: LongTensor,
     ) -> ProcessedTuple:
         """
         Process the combined mapped triples.
@@ -347,8 +357,8 @@ class DisjointGraphPairCombinator(GraphPairCombinator):
     def process(
         self,
         mapped_triples: MappedTriples,
-        alignment: torch.LongTensor,
-        offsets: torch.LongTensor,
+        alignment: LongTensor,
+        offsets: LongTensor,
     ) -> ProcessedTuple:  # noqa: D102
         return ProcessedTuple(
             mapped_triples,
@@ -364,8 +374,8 @@ class SwapGraphPairCombinator(GraphPairCombinator):
     def process(
         self,
         mapped_triples: MappedTriples,
-        alignment: torch.LongTensor,
-        offsets: torch.LongTensor,
+        alignment: LongTensor,
+        offsets: LongTensor,
     ) -> ProcessedTuple:  # noqa: D102
         # add swap triples
         # e1 ~ e2 => (e1, r, t) ~> (e2, r, t), or (h, r, e1) ~> (h, r, e2)
@@ -402,8 +412,8 @@ class ExtraRelationGraphPairCombinator(GraphPairCombinator):
     def process(
         self,
         mapped_triples: MappedTriples,
-        alignment: torch.LongTensor,
-        offsets: torch.LongTensor,
+        alignment: LongTensor,
+        offsets: LongTensor,
     ) -> ProcessedTuple:  # noqa: D102
         # add alignment triples with extra relation
         left_id, right_id = alignment
@@ -434,7 +444,7 @@ class ExtraRelationGraphPairCombinator(GraphPairCombinator):
 
 
 def iter_entity_mappings(
-    *old_new_ids_pairs: tuple[torch.LongTensor, torch.LongTensor], offsets: torch.LongTensor
+    *old_new_ids_pairs: tuple[LongTensor, LongTensor], offsets: LongTensor
 ) -> Iterable[Mapping[int, int]]:
     """
     Create explicit Id mappings.
@@ -462,8 +472,8 @@ class CollapseGraphPairCombinator(GraphPairCombinator):
     def process(
         self,
         mapped_triples: MappedTriples,
-        alignment: torch.LongTensor,
-        offsets: torch.LongTensor,
+        alignment: LongTensor,
+        offsets: LongTensor,
     ) -> ProcessedTuple:  # noqa: D102
         # determine connected components regarding the same-as relation (i.e., applies transitivity)
         entity_id_mapping = torch.arange(mapped_triples[:, 0::2].max().item() + 1)

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -9,12 +9,11 @@ from typing import NamedTuple, cast
 
 import numpy
 import numpy as np
-import torch
 
 from .evaluator import Evaluator, MetricResults
 from ..constants import TARGET_TO_INDEX
 from ..metrics.classification import ClassificationMetric, classification_metric_resolver
-from ..typing import SIDE_BOTH, ExtendedTarget, MappedTriples, Target, normalize_target
+from ..typing import SIDE_BOTH, ExtendedTarget, FloatTensor, MappedTriples, Target, normalize_target
 
 __all__ = [
     "ClassificationEvaluator",
@@ -123,16 +122,16 @@ class ClassificationEvaluator(Evaluator[ClassificationMetricKey]):
         self,
         hrt_batch: MappedTriples,
         target: Target,
-        scores: torch.FloatTensor,
-        true_scores: torch.FloatTensor | None = None,
-        dense_positive_mask: torch.FloatTensor | None = None,
+        scores: FloatTensor,
+        true_scores: FloatTensor | None = None,
+        dense_positive_mask: FloatTensor | None = None,
     ) -> None:  # noqa: D102
         if dense_positive_mask is None:
             raise KeyError("Sklearn evaluators need the positive mask!")
 
         # Transfer to cpu and convert to numpy
-        scores = scores.detach().cpu().numpy()
-        dense_positive_mask = dense_positive_mask.detach().cpu().numpy()
+        scores_np = scores.detach().cpu().numpy()
+        dense_positive_mask_np = dense_positive_mask.detach().cpu().numpy()
         remaining = [i for i in range(hrt_batch.shape[1]) if i != TARGET_TO_INDEX[target]]
         keys = hrt_batch[:, remaining].detach().cpu().numpy()
 
@@ -141,8 +140,8 @@ class ClassificationEvaluator(Evaluator[ClassificationMetricKey]):
             key = tuple(map(int, keys[i]))
             assert len(key) == 2
             key = cast(tuple[int, int], key)
-            self.all_scores[target][key] = scores[i]
-            self.all_positives[target][key] = dense_positive_mask[i]
+            self.all_scores[target][key] = scores_np[i]
+            self.all_positives[target][key] = dense_positive_mask_np[i]
 
     # docstr-coverage: inherited
     def clear(self) -> None:  # noqa: D102

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -27,7 +27,7 @@ from ..metrics.utils import Metric
 from ..models import Model
 from ..triples.triples_factory import restrict_triples
 from ..triples.utils import get_entities, get_relations
-from ..typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, InductiveMode, MappedTriples, Target
+from ..typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, BoolTensor, InductiveMode, MappedTriples, Target
 from ..utils import (
     FloatTensor,
     LongTensor,

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -29,6 +29,8 @@ from ..triples.triples_factory import restrict_triples
 from ..triples.utils import get_entities, get_relations
 from ..typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, InductiveMode, MappedTriples, Target
 from ..utils import (
+    FloatTensor,
+    LongTensor,
     determine_maximum_batch_size,
     flatten_dictionary,
     format_relative_comparison,
@@ -114,6 +116,7 @@ class MetricResults(Generic[MetricKeyType]):
         """Output the metrics as a pandas dataframe."""
         one_key = next(iter(self.data.keys()))
         # assert isinstance(one_key, NamedTuple)
+        # TODO: should we enforce this?
         one_key_nt = cast(NamedTuple, one_key)
         columns = [field.capitalize() for field in one_key_nt._fields] + ["Value"]
         return pandas.DataFrame([(*key, value) for key, value in self.data.items()], columns=columns)
@@ -162,9 +165,9 @@ class Evaluator(ABC, Generic[MetricKeyType]):
         self,
         hrt_batch: MappedTriples,
         target: Target,
-        scores: torch.FloatTensor,
-        true_scores: torch.FloatTensor | None = None,
-        dense_positive_mask: torch.FloatTensor | None = None,
+        scores: FloatTensor,
+        true_scores: FloatTensor | None = None,
+        dense_positive_mask: FloatTensor | None = None,
     ) -> None:
         """Process a batch of triples with their computed scores for all entities.
 
@@ -523,10 +526,10 @@ def evaluate(
 
 def create_sparse_positive_filter_(
     hrt_batch: MappedTriples,
-    all_pos_triples: torch.LongTensor,
-    relation_filter: torch.BoolTensor | None = None,
+    all_pos_triples: LongTensor,
+    relation_filter: BoolTensor | None = None,
     filter_col: int = 0,
-) -> tuple[torch.LongTensor, torch.BoolTensor]:
+) -> tuple[LongTensor, BoolTensor]:
     """Compute indices of all positives.
 
     For simplicity, only the head-side is described, i.e. filter_col=0. The tail-side is processed alike.
@@ -575,9 +578,9 @@ def create_sparse_positive_filter_(
 
 
 def create_dense_positive_mask_(
-    zero_tensor: torch.FloatTensor,
-    filter_batch: torch.LongTensor,
-) -> torch.FloatTensor:
+    zero_tensor: FloatTensor,
+    filter_batch: LongTensor,
+) -> FloatTensor:
     """Construct dense positive mask.
 
     :param zero_tensor: shape: (batch_size, num_entities)
@@ -593,9 +596,9 @@ def create_dense_positive_mask_(
 
 
 def filter_scores_(
-    scores: torch.FloatTensor,
-    filter_batch: torch.LongTensor,
-) -> torch.FloatTensor:
+    scores: FloatTensor,
+    filter_batch: LongTensor,
+) -> FloatTensor:
     """Filter scores by setting true scores to NaN.
 
     :param scores: shape: (batch_size, num_entities)
@@ -629,11 +632,11 @@ def _evaluate_batch(
     evaluator: Evaluator,
     slice_size: int | None,
     all_pos_triples: MappedTriples | None,
-    relation_filter: torch.BoolTensor | None,
-    restrict_entities_to: torch.LongTensor | None,
+    relation_filter: BoolTensor | None,
+    restrict_entities_to: LongTensor | None,
     *,
     mode: InductiveMode | None,
-) -> torch.BoolTensor:
+) -> BoolTensor:
     """
     Evaluate ranking for batch.
 

--- a/src/pykeen/evaluation/ogb_evaluator.py
+++ b/src/pykeen/evaluation/ogb_evaluator.py
@@ -15,7 +15,16 @@ from .rank_based_evaluator import RankBasedMetricKey, RankBasedMetricResults, Sa
 from ..metrics import RankBasedMetric
 from ..metrics.ranking import HitsAtK, InverseHarmonicMeanRank
 from ..models import Model
-from ..typing import LABEL_HEAD, LABEL_TAIL, RANK_REALISTIC, SIDE_BOTH, ExtendedTarget, MappedTriples, Target
+from ..typing import (
+    LABEL_HEAD,
+    LABEL_TAIL,
+    RANK_REALISTIC,
+    SIDE_BOTH,
+    ExtendedTarget,
+    LongTensor,
+    MappedTriples,
+    Target,
+)
 
 __all__ = [
     "OGBEvaluator",
@@ -226,7 +235,7 @@ def _evaluate_ogb(
     slice_size: int,
     mapped_triples: MappedTriples,
     model: Model,
-    negatives: torch.LongTensor,
+    negatives: LongTensor,
     target: Target,
     progress_bar: tqdm,
 ) -> tuple[torch.Tensor, torch.Tensor]:

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -38,6 +38,8 @@ from ..typing import (
     SIDE_BOTH,
     SIDES,
     ExtendedTarget,
+    FloatTensor,
+    LongTensor,
     MappedTriples,
     RankType,
     Target,
@@ -344,9 +346,9 @@ class RankBasedEvaluator(Evaluator[RankBasedMetricKey]):
         self,
         hrt_batch: MappedTriples,
         target: Target,
-        scores: torch.FloatTensor,
-        true_scores: torch.FloatTensor | None = None,
-        dense_positive_mask: torch.FloatTensor | None = None,
+        scores: FloatTensor,
+        true_scores: FloatTensor | None = None,
+        dense_positive_mask: FloatTensor | None = None,
     ) -> None:  # noqa: D102
         if true_scores is None:
             raise ValueError(f"{self.__class__.__name__} needs the true scores!")
@@ -494,7 +496,7 @@ def sample_negatives(
     additional_filter_triples: None | MappedTriples | list[MappedTriples] = None,
     num_samples: int = 50,
     num_entities: int | None = None,
-) -> Mapping[Target, torch.FloatTensor]:
+) -> Mapping[Target, FloatTensor]:
     """
     Sample true negatives for sampled evaluation.
 
@@ -522,7 +524,7 @@ def sample_negatives(
     all_ids = set(range(num_entities))
     negatives = {}
     for side in [LABEL_HEAD, LABEL_TAIL]:
-        this_negatives = cast(torch.FloatTensor, torch.empty(size=(num_triples, num_samples), dtype=torch.long))
+        this_negatives = torch.empty(size=(num_triples, num_samples), dtype=torch.long)
         other = TARGET_TO_KEY_LABELS[side]
         for _, group in pd.merge(id_df, all_df, on=other, suffixes=["_eval", "_all"]).groupby(
             by=other,
@@ -552,7 +554,7 @@ class SampledRankBasedEvaluator(RankBasedEvaluator):
     cf. https://arxiv.org/abs/2106.06935.
     """
 
-    negative_samples: Mapping[Target, torch.LongTensor]
+    negative_samples: Mapping[Target, LongTensor]
 
     def __init__(
         self,
@@ -560,8 +562,8 @@ class SampledRankBasedEvaluator(RankBasedEvaluator):
         *,
         additional_filter_triples: None | MappedTriples | list[MappedTriples] = None,
         num_negatives: int | None = None,
-        head_negatives: torch.LongTensor | None = None,
-        tail_negatives: torch.LongTensor | None = None,
+        head_negatives: LongTensor | None = None,
+        tail_negatives: LongTensor | None = None,
         **kwargs,
     ):
         """
@@ -625,9 +627,9 @@ class SampledRankBasedEvaluator(RankBasedEvaluator):
         self,
         hrt_batch: MappedTriples,
         target: Target,
-        scores: torch.FloatTensor,
-        true_scores: torch.FloatTensor | None = None,
-        dense_positive_mask: torch.FloatTensor | None = None,
+        scores: FloatTensor,
+        true_scores: FloatTensor | None = None,
+        dense_positive_mask: FloatTensor | None = None,
     ) -> None:  # noqa: D102
         if true_scores is None:
             raise ValueError(f"{self.__class__.__name__} needs the true scores!")
@@ -694,9 +696,9 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         self,
         hrt_batch: MappedTriples,
         target: Target,
-        scores: torch.FloatTensor,
-        true_scores: torch.FloatTensor | None = None,
-        dense_positive_mask: torch.FloatTensor | None = None,
+        scores: FloatTensor,
+        true_scores: FloatTensor | None = None,
+        dense_positive_mask: FloatTensor | None = None,
     ) -> None:  # noqa: D102
         super().process_scores_(
             hrt_batch=hrt_batch,

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -14,7 +14,6 @@ from typing import (
     Callable,
     NamedTuple,
     TypeVar,
-    cast,
 )
 
 import numpy as np

--- a/src/pykeen/evaluation/ranks.py
+++ b/src/pykeen/evaluation/ranks.py
@@ -6,7 +6,7 @@ from typing import Union
 
 import torch
 
-from ..typing import RANK_OPTIMISTIC, RANK_PESSIMISTIC, RANK_REALISTIC, RankType
+from ..typing import RANK_OPTIMISTIC, RANK_PESSIMISTIC, RANK_REALISTIC, FloatTensor, LongTensor, RankType
 
 __all__ = [
     "Ranks",
@@ -21,28 +21,28 @@ class Ranks:
     #: The optimistic rank is the rank when assuming all options with an equal score are placed
     #: behind the current test triple.
     #: shape: (batch_size,)
-    optimistic: torch.FloatTensor
+    optimistic: FloatTensor
 
     #: The realistic rank is the average of the optimistic and pessimistic rank, and hence the expected rank
     #: over all permutations of the elements with the same score as the currently considered option.
     #: shape: (batch_size,)
-    realistic: torch.FloatTensor
+    realistic: FloatTensor
 
     #: The pessimistic rank is the rank when assuming all options with an equal score are placed
     #: in front of current test triple.
     #: shape: (batch_size,)
-    pessimistic: torch.FloatTensor
+    pessimistic: FloatTensor
 
     #: The number of options is the number of items considered in the ranking. It may change for
     #: filtered evaluation
     #: shape: (batch_size,)
-    number_of_options: torch.LongTensor
+    number_of_options: LongTensor
 
-    def items(self) -> Iterable[tuple[RankType, torch.FloatTensor]]:
+    def items(self) -> Iterable[tuple[RankType, FloatTensor]]:
         """Iterate over pairs of rank types and their associated tensors."""
         yield from self.to_type_dict().items()
 
-    def to_type_dict(self) -> Mapping[RankType, torch.FloatTensor]:
+    def to_type_dict(self) -> Mapping[RankType, FloatTensor]:
         """Return mapping from rank-type to rank value tensor."""
         return {
             RANK_OPTIMISTIC: self.optimistic,
@@ -53,8 +53,8 @@ class Ranks:
     @classmethod
     def from_scores(
         cls,
-        true_score: torch.FloatTensor,
-        all_scores: torch.FloatTensor,
+        true_score: FloatTensor,
+        all_scores: FloatTensor,
     ) -> "Ranks":
         """Compute ranks given scores.
 
@@ -131,6 +131,8 @@ class RankBuilder:
     "sub-batch" / "slice" basis rather than batch level.
     """
 
+    # TODO: unused?
+
     #: the scores of the true choice, shape: (*bs), dtype: float
     y_true: torch.Tensor
 
@@ -143,7 +145,7 @@ class RankBuilder:
     #: the total number of compared scores, shape: (*bs), dtype: long
     total: Union[torch.Tensor, int] = 0
 
-    def update(self, y_pred: torch.FloatTensor) -> "RankBuilder":
+    def update(self, y_pred: FloatTensor) -> "RankBuilder":
         """Update the rank builder with a batch of scores.
 
         :param y_pred: shape: (*bs, partial_num_choices)
@@ -159,7 +161,7 @@ class RankBuilder:
             total=self.total + torch.isfinite(y_pred).sum(dim=-1),
         )
 
-    def compute(self) -> torch.Tensor:
+    def compute(self) -> Ranks:
         """Calculate the ranks for the aggregated counts.
 
         :return:

--- a/src/pykeen/experiments/validate.py
+++ b/src/pykeen/experiments/validate.py
@@ -5,7 +5,6 @@ import pathlib
 from collections.abc import Iterable
 from typing import Callable, Optional, Union
 
-import torch
 from class_resolver import Hint
 from torch import nn
 
@@ -19,6 +18,7 @@ from ..optimizers import optimizer_resolver
 from ..regularizers import regularizer_resolver
 from ..sampling import negative_sampler_resolver
 from ..training import training_loop_resolver
+from ..typing import FloatTensor
 from ..utils import CONFIGURATION_FILE_FORMATS, load_configuration, normalize_string
 
 _SKIP_NAMES = {
@@ -45,7 +45,7 @@ _SKIP_ANNOTATIONS = {
     Optional[Model],
     type[Model],
     Optional[type[Model]],
-    Union[str, Callable[[torch.FloatTensor], torch.FloatTensor]],
+    Union[str, Callable[[FloatTensor], FloatTensor]],
     Hint[nn.Module],
 }
 _SKIP_EXTRANEOUS = {

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -3,8 +3,9 @@
 from abc import ABC, abstractmethod
 from typing import TypeVar
 
-import torch
 from class_resolver import Resolver
+
+from .typing import BoolTensor, LongTensor
 
 __all__ = [
     "RelationInverter",
@@ -12,7 +13,7 @@ __all__ = [
     "relation_inverter_resolver",
 ]
 
-RelationID = TypeVar("RelationID", int, torch.LongTensor)
+RelationID = TypeVar("RelationID", int, LongTensor)
 
 
 class RelationInverter(ABC):
@@ -26,20 +27,20 @@ class RelationInverter(ABC):
         # TODO: inverse of inverse?
 
     @abstractmethod
-    def _map(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:
+    def _map(self, batch: LongTensor, index: int = 1) -> LongTensor:
         """Map relations in a batch."""
 
     @abstractmethod
-    def invert_(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:
+    def invert_(self, batch: LongTensor, index: int = 1) -> LongTensor:
         """Invert relations in a batch (in-place)."""
 
-    def map(self, batch: torch.LongTensor, index: int = 1, invert: bool = False) -> torch.LongTensor:
+    def map(self, batch: LongTensor, index: int = 1, invert: bool = False) -> LongTensor:
         """Map relations in a batch, optionally also inverting them."""
         batch = self._map(batch=batch, index=index)
         return self.invert_(batch=batch, index=index) if invert else batch
 
     @abstractmethod
-    def is_inverse(self, ids: torch.LongTensor) -> torch.BoolTensor:
+    def is_inverse(self, ids: LongTensor) -> BoolTensor:
         """Return a mask whether the relation IDs correspond to inverse relations."""
 
 
@@ -51,20 +52,20 @@ class DefaultRelationInverter(RelationInverter):
         return relation_id + 1
 
     # docstr-coverage: inherited
-    def _map(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:  # noqa: D102
+    def _map(self, batch: LongTensor, index: int = 1) -> LongTensor:  # noqa: D102
         batch = batch.clone()
         batch[:, index] *= 2
         return batch
 
     # docstr-coverage: inherited
-    def invert_(self, batch: torch.LongTensor, index: int = 1) -> torch.LongTensor:  # noqa: D102
+    def invert_(self, batch: LongTensor, index: int = 1) -> LongTensor:  # noqa: D102
         # The number of relations stored in the triples factory includes the number of inverse relations
         # Id of inverse relation: relation + 1
         batch[:, index] += 1
         return batch
 
     # docstr-coverage: inherited
-    def is_inverse(self, ids: torch.LongTensor) -> torch.BoolTensor:  # noqa: D102
+    def is_inverse(self, ids: LongTensor) -> BoolTensor:  # noqa: D102
         return ids % 2 == 1
 
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -174,6 +174,8 @@ from torch import nn
 from torch.nn import functional
 from torch.nn.modules.loss import _Loss
 
+from .typing import BoolTensor, FloatTensor, LongTensor
+
 __all__ = [
     # Base Classes
     "Loss",
@@ -209,10 +211,10 @@ DEFAULT_MARGIN_HPO_STRATEGY = dict(type=float, low=0, high=3)
 
 
 def apply_label_smoothing(
-    labels: torch.FloatTensor,
+    labels: FloatTensor,
     epsilon: Optional[float] = None,
     num_classes: Optional[int] = None,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Apply label smoothing to a target tensor.
 
     Redistributes epsilon probability mass from the true target uniformly to the remaining classes by replacing
@@ -282,12 +284,12 @@ class Loss(_Loss):
 
     def process_slcwa_scores(
         self,
-        positive_scores: torch.FloatTensor,
-        negative_scores: torch.FloatTensor,
+        positive_scores: FloatTensor,
+        negative_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
-        batch_filter: Optional[torch.BoolTensor] = None,
+        batch_filter: Optional[BoolTensor] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """
         Process scores from sLCWA training loop.
 
@@ -324,11 +326,11 @@ class Loss(_Loss):
 
     def process_lcwa_scores(
         self,
-        predictions: torch.FloatTensor,
-        labels: torch.FloatTensor,
+        predictions: FloatTensor,
+        labels: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """
         Process scores from LCWA training loop.
 
@@ -357,7 +359,7 @@ class PointwiseLoss(Loss):
     """Pointwise loss functions compute an independent loss term for each triple-label pair."""
 
     @staticmethod
-    def validate_labels(labels: torch.FloatTensor) -> bool:
+    def validate_labels(labels: FloatTensor) -> bool:
         """Check whether labels are in [0, 1]."""
         return labels.min() >= 0 and labels.max() <= 1
 
@@ -413,9 +415,9 @@ class BCEWithLogitsLoss(PointwiseLoss):
     # docstr-coverage: inherited
     def forward(
         self,
-        scores: torch.FloatTensor,
-        labels: torch.FloatTensor,
-    ) -> torch.FloatTensor:  # noqa: D102
+        scores: FloatTensor,
+        labels: FloatTensor,
+    ) -> FloatTensor:  # noqa: D102
         return functional.binary_cross_entropy_with_logits(scores, labels, reduction=self.reduction)
 
 
@@ -436,9 +438,9 @@ class MSELoss(PointwiseLoss):
     # docstr-coverage: inherited
     def forward(
         self,
-        scores: torch.FloatTensor,
-        labels: torch.FloatTensor,
-    ) -> torch.FloatTensor:  # noqa: D102
+        scores: FloatTensor,
+        labels: FloatTensor,
+    ) -> FloatTensor:  # noqa: D102
         assert self.validate_labels(labels=labels)
         return functional.mse_loss(scores, labels, reduction=self.reduction)
 
@@ -487,12 +489,12 @@ class MarginPairwiseLoss(PairwiseLoss):
     # docstr-coverage: inherited
     def process_slcwa_scores(
         self,
-        positive_scores: torch.FloatTensor,
-        negative_scores: torch.FloatTensor,
+        positive_scores: FloatTensor,
+        negative_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
-        batch_filter: Optional[torch.BoolTensor] = None,
+        batch_filter: Optional[BoolTensor] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -508,11 +510,11 @@ class MarginPairwiseLoss(PairwiseLoss):
     # docstr-coverage: inherited
     def process_lcwa_scores(
         self,
-        predictions: torch.FloatTensor,
-        labels: torch.FloatTensor,
+        predictions: FloatTensor,
+        labels: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -538,9 +540,9 @@ class MarginPairwiseLoss(PairwiseLoss):
 
     def forward(
         self,
-        pos_scores: torch.FloatTensor,
-        neg_scores: torch.FloatTensor,
-    ) -> torch.FloatTensor:
+        pos_scores: FloatTensor,
+        neg_scores: FloatTensor,
+    ) -> FloatTensor:
         """
         Compute the margin loss.
 
@@ -829,12 +831,12 @@ class DoubleMarginLoss(PointwiseLoss):
     # docstr-coverage: inherited
     def process_slcwa_scores(
         self,
-        positive_scores: torch.FloatTensor,
-        negative_scores: torch.FloatTensor,
+        positive_scores: FloatTensor,
+        negative_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
-        batch_filter: Optional[torch.BoolTensor] = None,
+        batch_filter: Optional[BoolTensor] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -864,11 +866,11 @@ class DoubleMarginLoss(PointwiseLoss):
     # docstr-coverage: inherited
     def process_lcwa_scores(
         self,
-        predictions: torch.FloatTensor,
-        labels: torch.FloatTensor,
+        predictions: FloatTensor,
+        labels: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             labels = apply_label_smoothing(
@@ -881,9 +883,9 @@ class DoubleMarginLoss(PointwiseLoss):
 
     def forward(
         self,
-        predictions: torch.FloatTensor,
-        labels: torch.FloatTensor,
-    ) -> torch.FloatTensor:
+        predictions: FloatTensor,
+        labels: FloatTensor,
+    ) -> FloatTensor:
         """
         Compute the double margin loss.
 
@@ -946,9 +948,9 @@ class DeltaPointwiseLoss(PointwiseLoss):
 
     def forward(
         self,
-        logits: torch.FloatTensor,
-        labels: torch.FloatTensor,
-    ) -> torch.FloatTensor:
+        logits: FloatTensor,
+        labels: FloatTensor,
+    ) -> FloatTensor:
         """Calculate the loss for the given scores and labels."""
         assert 0.0 <= labels.min() and labels.max() <= 1.0
         # scale labels from [0, 1] to [-1, 1]
@@ -1065,18 +1067,18 @@ class BCEAfterSigmoidLoss(PointwiseLoss):
     # docstr-coverage: inherited
     def forward(
         self,
-        logits: torch.FloatTensor,
-        labels: torch.FloatTensor,
+        logits: FloatTensor,
+        labels: FloatTensor,
         **kwargs,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         return functional.binary_cross_entropy(logits.sigmoid(), labels, **kwargs)
 
 
 def prepare_negative_scores_for_softmax(
-    batch_filter: Optional[torch.LongTensor],
-    negative_scores: torch.FloatTensor,
+    batch_filter: Optional[LongTensor],
+    negative_scores: FloatTensor,
     no_inf_rows: bool,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """
     Prepare negative scores for softmax.
 
@@ -1127,12 +1129,12 @@ class CrossEntropyLoss(SetwiseLoss):
     # docstr-coverage: inherited
     def process_slcwa_scores(
         self,
-        positive_scores: torch.FloatTensor,
-        negative_scores: torch.FloatTensor,
+        positive_scores: FloatTensor,
+        negative_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
-        batch_filter: Optional[torch.BoolTensor] = None,
+        batch_filter: Optional[BoolTensor] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # we need dense negative scores => unfilter if necessary
         negative_scores = prepare_negative_scores_for_softmax(
             batch_filter=batch_filter,
@@ -1161,11 +1163,11 @@ class CrossEntropyLoss(SetwiseLoss):
     # docstr-coverage: inherited
     def process_lcwa_scores(
         self,
-        predictions: torch.FloatTensor,
-        labels: torch.FloatTensor,
+        predictions: FloatTensor,
+        labels: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # make sure labels form a proper probability distribution
         labels = functional.normalize(labels, p=1, dim=-1)
         # calculate cross entropy loss
@@ -1245,11 +1247,11 @@ class InfoNCELoss(CrossEntropyLoss):
     # docstr-coverage: inherited
     def process_lcwa_scores(
         self,
-        predictions: torch.FloatTensor,
-        labels: torch.FloatTensor,
+        predictions: FloatTensor,
+        labels: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # determine positive; do not check with == since the labels are floats
         pos_mask = labels > 0.5
         # subtract margin from positive scores
@@ -1266,12 +1268,12 @@ class InfoNCELoss(CrossEntropyLoss):
     # docstr-coverage: inherited
     def process_slcwa_scores(
         self,
-        positive_scores: torch.FloatTensor,
-        negative_scores: torch.FloatTensor,
+        positive_scores: FloatTensor,
+        negative_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
-        batch_filter: Optional[torch.BoolTensor] = None,
+        batch_filter: Optional[BoolTensor] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # subtract margin from positive scores
         positive_scores = positive_scores - self.margin
         # normalize positive score shape
@@ -1307,11 +1309,11 @@ class AdversarialLoss(SetwiseLoss):
     # docstr-coverage: inherited
     def process_lcwa_scores(
         self,
-        predictions: torch.FloatTensor,
-        labels: torch.FloatTensor,
+        predictions: FloatTensor,
+        labels: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # determine positive; do not check with == since the labels are floats
         pos_mask = labels > 0.5
 
@@ -1337,12 +1339,12 @@ class AdversarialLoss(SetwiseLoss):
     # docstr-coverage: inherited
     def process_slcwa_scores(
         self,
-        positive_scores: torch.FloatTensor,
-        negative_scores: torch.FloatTensor,
+        positive_scores: FloatTensor,
+        negative_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
-        batch_filter: Optional[torch.BoolTensor] = None,
+        batch_filter: Optional[BoolTensor] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -1372,10 +1374,10 @@ class AdversarialLoss(SetwiseLoss):
     @abstractmethod
     def positive_loss_term(
         self,
-        pos_scores: torch.FloatTensor,
+        pos_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """
         Calculate the loss for the positive scores.
 
@@ -1394,10 +1396,10 @@ class AdversarialLoss(SetwiseLoss):
     @abstractmethod
     def negative_loss_term_unreduced(
         self,
-        neg_scores: torch.FloatTensor,
+        neg_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """
         Calculate the loss for the negative scores *without* reduction.
 
@@ -1415,12 +1417,12 @@ class AdversarialLoss(SetwiseLoss):
 
     def forward(
         self,
-        pos_scores: torch.FloatTensor,
-        neg_scores: torch.FloatTensor,
-        neg_weights: torch.FloatTensor,
+        pos_scores: FloatTensor,
+        neg_scores: FloatTensor,
+        neg_weights: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Calculate the loss for the given scores.
 
         :param pos_scores: shape: s_p
@@ -1490,10 +1492,10 @@ class NSSALoss(AdversarialLoss):
     # docstr-coverage: inherited
     def positive_loss_term(
         self,
-        pos_scores: torch.FloatTensor,
+        pos_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -1502,10 +1504,10 @@ class NSSALoss(AdversarialLoss):
     # docstr-coverage: inherited
     def negative_loss_term_unreduced(
         self,
-        neg_scores: torch.FloatTensor,
+        neg_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -1531,10 +1533,10 @@ class AdversarialBCEWithLogitsLoss(AdversarialLoss):
     # docstr-coverage: inherited
     def positive_loss_term(
         self,
-        pos_scores: torch.FloatTensor,
+        pos_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         return functional.binary_cross_entropy_with_logits(
             pos_scores,
             # TODO: maybe we can make this more efficient?
@@ -1545,10 +1547,10 @@ class AdversarialBCEWithLogitsLoss(AdversarialLoss):
     # docstr-coverage: inherited
     def negative_loss_term_unreduced(
         self,
-        neg_scores: torch.FloatTensor,
+        neg_scores: FloatTensor,
         label_smoothing: Optional[float] = None,
         num_entities: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         return functional.binary_cross_entropy_with_logits(
             neg_scores,
             # TODO: maybe we can make this more efficient?
@@ -1617,9 +1619,9 @@ class FocalLoss(PointwiseLoss):
     # docstr-coverage: inherited
     def forward(
         self,
-        prediction: torch.FloatTensor,
-        labels: torch.FloatTensor,
-    ) -> torch.FloatTensor:  # noqa: D102
+        prediction: FloatTensor,
+        labels: FloatTensor,
+    ) -> FloatTensor:  # noqa: D102
         p = prediction.sigmoid()
         ce_loss = functional.binary_cross_entropy_with_logits(prediction, labels, reduction="none")
         p_t = p * labels + (1 - p) * (1 - labels)

--- a/src/pykeen/lr_schedulers/__init__.py
+++ b/src/pykeen/lr_schedulers/__init__.py
@@ -21,20 +21,11 @@ __all__ = [
     "LRScheduler",
     "lr_schedulers_hpo_defaults",
     "lr_scheduler_resolver",
-    # Imported from PyTorch
-    "CosineAnnealingLR",
-    "CosineAnnealingWarmRestarts",
-    "CyclicLR",
-    "ExponentialLR",
-    "LambdaLR",
-    "MultiplicativeLR",
-    "MultiStepLR",
-    "OneCycleLR",
-    "StepLR",
 ]
 
 
-#: The default strategy for optimizing the lr_schedulers' hyper-parameters
+#: The default strategy for optimizing the lr_schedulers' hyper-parameters,
+#: based on :class:`torch.optim.lr_scheduler.LRScheduler`
 lr_schedulers_hpo_defaults: Mapping[type[LRScheduler], Mapping[str, Any]] = {
     CosineAnnealingLR: dict(
         T_max=dict(type=int, low=10, high=1000, step=50),

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -18,7 +18,16 @@ from torch import nn
 from ..inverse import RelationInverter, relation_inverter_resolver
 from ..losses import Loss, MarginRankingLoss, loss_resolver
 from ..triples import KGInfo
-from ..typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, InductiveMode, MappedTriples, Target
+from ..typing import (
+    LABEL_HEAD,
+    LABEL_RELATION,
+    LABEL_TAIL,
+    FloatTensor,
+    InductiveMode,
+    LongTensor,
+    MappedTriples,
+    Target,
+)
 from ..utils import NoRandomSeedNecessary, get_preferred_device, set_random_seed
 
 __all__ = [
@@ -172,7 +181,7 @@ class Model(nn.Module, ABC):
     """Abstract methods - Scoring"""
 
     @abstractmethod
-    def score_hrt(self, hrt_batch: torch.LongTensor, *, mode: InductiveMode | None = None) -> torch.FloatTensor:
+    def score_hrt(self, hrt_batch: LongTensor, *, mode: InductiveMode | None = None) -> FloatTensor:
         """Forward pass.
 
         This method takes head, relation and tail of each triple and calculates the corresponding score.
@@ -189,12 +198,12 @@ class Model(nn.Module, ABC):
     @abstractmethod
     def score_t(
         self,
-        hr_batch: torch.LongTensor,
+        hr_batch: LongTensor,
         *,
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
-        tails: torch.LongTensor | None = None,
-    ) -> torch.FloatTensor:
+        tails: LongTensor | None = None,
+    ) -> FloatTensor:
         """Forward pass using right side (tail) prediction.
 
         This method calculates the score for all possible tails for each (head, relation) pair.
@@ -216,12 +225,12 @@ class Model(nn.Module, ABC):
     @abstractmethod
     def score_r(
         self,
-        ht_batch: torch.LongTensor,
+        ht_batch: LongTensor,
         *,
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
-        relations: torch.LongTensor | None = None,
-    ) -> torch.FloatTensor:
+        relations: LongTensor | None = None,
+    ) -> FloatTensor:
         """Forward pass using middle (relation) prediction.
 
         This method calculates the score for all possible relations for each (head, tail) pair.
@@ -245,12 +254,12 @@ class Model(nn.Module, ABC):
     @abstractmethod
     def score_h(
         self,
-        rt_batch: torch.LongTensor,
+        rt_batch: LongTensor,
         *,
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
-        heads: torch.LongTensor | None = None,
-    ) -> torch.FloatTensor:
+        heads: LongTensor | None = None,
+    ) -> FloatTensor:
         """Forward pass using left side (head) prediction.
 
         This method calculates the score for all possible heads for each (relation, tail) pair.
@@ -270,7 +279,7 @@ class Model(nn.Module, ABC):
         """
 
     @abstractmethod
-    def collect_regularization_term(self) -> torch.FloatTensor:
+    def collect_regularization_term(self) -> FloatTensor:
         """Get the regularization term for the loss function."""
 
     """Concrete methods"""
@@ -308,7 +317,7 @@ class Model(nn.Module, ABC):
 
     """Prediction methods"""
 
-    def _prepare_batch(self, batch: torch.LongTensor, index_relation: int) -> torch.LongTensor:
+    def _prepare_batch(self, batch: LongTensor, index_relation: int) -> LongTensor:
         # send to device
         batch = batch.to(self.device)
 
@@ -319,7 +328,7 @@ class Model(nn.Module, ABC):
         # when trained on inverse relations, the internal relation ID is twice the original relation ID
         return self.relation_inverter.map(batch=batch, index=index_relation, invert=False)
 
-    def predict_hrt(self, hrt_batch: torch.LongTensor, *, mode: InductiveMode | None = None) -> torch.FloatTensor:
+    def predict_hrt(self, hrt_batch: LongTensor, *, mode: InductiveMode | None = None) -> FloatTensor:
         """Calculate the scores for triples.
 
         This method takes head, relation and tail of each triple and calculates the corresponding score.
@@ -342,9 +351,9 @@ class Model(nn.Module, ABC):
 
     def predict_h(
         self,
-        rt_batch: torch.LongTensor,
+        rt_batch: LongTensor,
         **kwargs,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Forward pass using left side (head) prediction for obtaining scores of all possible heads.
 
         This method calculates the score for all possible heads for each (relation, tail) pair.
@@ -377,9 +386,9 @@ class Model(nn.Module, ABC):
 
     def predict_t(
         self,
-        hr_batch: torch.LongTensor,
+        hr_batch: LongTensor,
         **kwargs,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Forward pass using right side (tail) prediction for obtaining scores of all possible tails.
 
         This method calculates the score for all possible tails for each (head, relation) pair.
@@ -412,9 +421,9 @@ class Model(nn.Module, ABC):
 
     def predict_r(
         self,
-        ht_batch: torch.LongTensor,
+        ht_batch: LongTensor,
         **kwargs,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Forward pass using middle (relation) prediction for obtaining scores of all possible relations.
 
         This method calculates the score for all possible relations for each (head, tail) pair.
@@ -441,9 +450,9 @@ class Model(nn.Module, ABC):
         hrt_batch: MappedTriples,
         target: Target,
         full_batch: bool = True,
-        ids: torch.LongTensor | None = None,
+        ids: LongTensor | None = None,
         **kwargs,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """
         Predict scores for the given target.
 
@@ -483,7 +492,7 @@ class Model(nn.Module, ABC):
 
     """Inverse scoring"""
 
-    def _prepare_inverse_batch(self, batch: torch.LongTensor, index_relation: int) -> torch.LongTensor:
+    def _prepare_inverse_batch(self, batch: LongTensor, index_relation: int) -> LongTensor:
         if not self.use_inverse_triples:
             raise ValueError(
                 "Your model is not configured to predict with inverse relations."
@@ -494,10 +503,10 @@ class Model(nn.Module, ABC):
 
     def score_hrt_inverse(
         self,
-        hrt_batch: torch.LongTensor,
+        hrt_batch: LongTensor,
         *,
         mode: InductiveMode | None = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         r"""
         Score triples based on inverse triples, i.e., compute $f(h,r,t)$ based on $f(t,r_{inv},h)$.
 
@@ -516,12 +525,12 @@ class Model(nn.Module, ABC):
         t_r_inv_h = self._prepare_inverse_batch(batch=hrt_batch, index_relation=1)
         return self.score_hrt(hrt_batch=t_r_inv_h, mode=mode)
 
-    def score_t_inverse(self, hr_batch: torch.LongTensor, *, tails: torch.LongTensor | None = None, **kwargs):
+    def score_t_inverse(self, hr_batch: LongTensor, *, tails: LongTensor | None = None, **kwargs):
         """Score all tails for a batch of (h,r)-pairs using the head predictions for the inverses $(*,r_{inv},h)$."""
         r_inv_h = self._prepare_inverse_batch(batch=hr_batch, index_relation=1)
         return self.score_h(rt_batch=r_inv_h, heads=tails, **kwargs)
 
-    def score_h_inverse(self, rt_batch: torch.LongTensor, *, heads: torch.LongTensor | None = None, **kwargs):
+    def score_h_inverse(self, rt_batch: LongTensor, *, heads: LongTensor | None = None, **kwargs):
         """Score all heads for a batch of (r,t)-pairs using the tail predictions for the inverses $(t,r_{inv},*)$."""
         t_r_inv = self._prepare_inverse_batch(batch=rt_batch, index_relation=0)
         return self.score_t(hr_batch=t_r_inv, tails=heads, **kwargs)

--- a/src/pykeen/models/baseline/models.py
+++ b/src/pykeen/models/baseline/models.py
@@ -8,7 +8,7 @@ import torch
 from .utils import get_csr_matrix, get_relation_similarity, marginal_score
 from ..base import Model
 from ...triples import CoreTriplesFactory
-from ...typing import InductiveMode
+from ...typing import FloatTensor, InductiveMode, LongTensor
 
 __all__ = [
     "EvaluationOnlyModel",
@@ -48,11 +48,11 @@ class EvaluationOnlyModel(Model):
         """Non-parametric models do not implement :meth:`Model.collect_regularization_term`."""
         raise RuntimeError
 
-    def score_hrt(self, hrt_batch: torch.LongTensor, **kwargs):  # noqa: D102
+    def score_hrt(self, hrt_batch: LongTensor, **kwargs):  # noqa: D102
         """Non-parametric models do not implement :meth:`Model.score_hrt`."""
         raise RuntimeError
 
-    def score_r(self, ht_batch: torch.LongTensor, **kwargs):  # noqa: D102
+    def score_r(self, ht_batch: LongTensor, **kwargs):  # noqa: D102
         """Non-parametric models do not implement :meth:`Model.score_r`."""
         raise RuntimeError
 
@@ -126,7 +126,7 @@ class MarginalDistributionBaseline(EvaluationOnlyModel):
             self.head_per_tail = self.tail_per_head = None
 
     # docstr-coverage: inherited
-    def score_t(self, hr_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return marginal_score(
             entity_relation_batch=hr_batch,
             per_entity=self.tail_per_head,
@@ -135,7 +135,7 @@ class MarginalDistributionBaseline(EvaluationOnlyModel):
         )
 
     # docstr-coverage: inherited
-    def score_h(self, rt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return marginal_score(
             entity_relation_batch=rt_batch.flip(1),
             per_entity=self.head_per_tail,
@@ -184,14 +184,14 @@ class SoftInverseTripleBaseline(EvaluationOnlyModel):
         )
 
     # docstr-coverage: inherited
-    def score_t(self, hr_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         r = hr_batch[:, 1]
         scores = self.sim[r, :] @ self.rel_to_tail + self.sim_inv[r, :] @ self.rel_to_head
         scores = numpy.asarray(scores.todense())
         return torch.from_numpy(scores)
 
     # docstr-coverage: inherited
-    def score_h(self, rt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         r = rt_batch[:, 0]
         scores = self.sim[r, :] @ self.rel_to_head + self.sim_inv[r, :] @ self.rel_to_tail
         scores = numpy.asarray(scores.todense())

--- a/src/pykeen/models/baseline/utils.py
+++ b/src/pykeen/models/baseline/utils.py
@@ -9,6 +9,7 @@ from sklearn.preprocessing import normalize as sklearn_normalize
 
 from ...triples import CoreTriplesFactory
 from ...triples.leakage import jaccard_similarity_scipy, triples_factory_to_sparse_matrices
+from ...typing import FloatTensor, LongTensor
 
 __all__ = [
     "get_csr_matrix",
@@ -53,11 +54,11 @@ def get_csr_matrix(
 
 
 def marginal_score(
-    entity_relation_batch: torch.LongTensor,
+    entity_relation_batch: LongTensor,
     per_entity: Optional[scipy.sparse.csr_matrix],
     per_relation: Optional[scipy.sparse.csr_matrix],
     num_entities: int,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Shared code for computing entity scores from marginals."""
     batch_size = entity_relation_batch.shape[0]
 

--- a/src/pykeen/models/inductive/inductive_nodepiece_gnn.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece_gnn.py
@@ -9,7 +9,13 @@ from torch import nn
 
 from .inductive_nodepiece import InductiveNodePiece
 from ...nn.representation import CompGCNLayer
-from ...typing import HeadRepresentation, InductiveMode, RelationRepresentation, TailRepresentation
+from ...typing import (
+    HeadRepresentation,
+    InductiveMode,
+    LongTensor,
+    RelationRepresentation,
+    TailRepresentation,
+)
 from ...utils import get_edge_index
 
 __all__ = [
@@ -102,9 +108,9 @@ class InductiveNodePieceGNN(InductiveNodePiece):
 
     def _get_representations(
         self,
-        h: Optional[torch.LongTensor],
-        r: Optional[torch.LongTensor],
-        t: Optional[torch.LongTensor],
+        h: Optional[LongTensor],
+        r: Optional[LongTensor],
+        t: Optional[LongTensor],
         mode: Optional[InductiveMode] = None,
     ) -> tuple[HeadRepresentation, RelationRepresentation, TailRepresentation]:
         """Get representations for head, relation and tails, in canonical shape with a GNN encoder."""

--- a/src/pykeen/models/meta/filtered.py
+++ b/src/pykeen/models/meta/filtered.py
@@ -12,7 +12,16 @@ from ..base import Model
 from ..baseline.utils import get_csr_matrix
 from ...constants import TARGET_TO_INDEX
 from ...triples.triples_factory import CoreTriplesFactory
-from ...typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, InductiveMode, MappedTriples, Target
+from ...typing import (
+    LABEL_HEAD,
+    LABEL_RELATION,
+    LABEL_TAIL,
+    FloatTensor,
+    InductiveMode,
+    LongTensor,
+    MappedTriples,
+    Target,
+)
 from ...utils import prepare_filter_triples
 
 __all__ = [
@@ -120,11 +129,11 @@ class CooccurrenceFilteredModel(Model):
 
     def _mask(
         self,
-        scores: torch.FloatTensor,
-        batch: torch.LongTensor,
+        scores: FloatTensor,
+        batch: LongTensor,
         target: Target,
         in_training: bool,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         if in_training and not self.apply_in_training:
             return scores
         fill_value = self.training_fill_value if in_training else self.inference_fill_value
@@ -154,17 +163,17 @@ class CooccurrenceFilteredModel(Model):
         return self.base._reset_parameters_()
 
     # docstr-coverage: inherited
-    def collect_regularization_term(self) -> torch.FloatTensor:  # noqa: D102
+    def collect_regularization_term(self) -> FloatTensor:  # noqa: D102
         return self.base.collect_regularization_term()
 
     # docstr-coverage: inherited
-    def score_hrt(self, hrt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_hrt(self, hrt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         if self.apply_in_training:
             raise NotImplementedError
         return self.base.score_hrt(hrt_batch=hrt_batch, **kwargs)
 
     # docstr-coverage: inherited
-    def score_h(self, rt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=self.base.score_h(rt_batch=rt_batch, **kwargs),
             batch=rt_batch,
@@ -173,7 +182,7 @@ class CooccurrenceFilteredModel(Model):
         )
 
     # docstr-coverage: inherited
-    def score_r(self, ht_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_r(self, ht_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=self.base.score_r(ht_batch=ht_batch, **kwargs),
             batch=ht_batch,
@@ -182,7 +191,7 @@ class CooccurrenceFilteredModel(Model):
         )
 
     # docstr-coverage: inherited
-    def score_t(self, hr_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=self.base.score_t(hr_batch=hr_batch, **kwargs),
             batch=hr_batch,
@@ -191,7 +200,7 @@ class CooccurrenceFilteredModel(Model):
         )
 
     # docstr-coverage: inherited
-    def predict_h(self, rt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def predict_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=super().predict_h(rt_batch, **kwargs),
             batch=rt_batch,
@@ -200,7 +209,7 @@ class CooccurrenceFilteredModel(Model):
         )
 
     # docstr-coverage: inherited
-    def predict_t(self, hr_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def predict_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=super().predict_t(hr_batch, **kwargs),
             batch=hr_batch,
@@ -209,7 +218,7 @@ class CooccurrenceFilteredModel(Model):
         )
 
     # docstr-coverage: inherited
-    def predict_r(self, ht_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def predict_r(self, ht_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=super().predict_r(ht_batch, **kwargs),
             batch=ht_batch,

--- a/src/pykeen/models/mocks.py
+++ b/src/pykeen/models/mocks.py
@@ -10,7 +10,7 @@ import torch
 
 from .base import Model
 from ..triples.triples_factory import KGInfo
-from ..typing import InductiveMode
+from ..typing import FloatTensor, InductiveMode, LongTensor
 
 __all__ = [
     "FixedModel",
@@ -69,37 +69,31 @@ class FixedModel(Model):
 
     def _generate_fake_scores(
         self,
-        h: torch.FloatTensor,
-        r: torch.FloatTensor,
-        t: torch.FloatTensor,
-    ) -> torch.FloatTensor:
+        h: FloatTensor,
+        r: FloatTensor,
+        t: FloatTensor,
+    ) -> FloatTensor:
         """Generate fake scores."""
         return (h * (self.num_entities * self.num_relations) + r * self.num_entities + t).float().requires_grad_(True)
 
     # docstr-coverage: inherited
-    def score_hrt(self, hrt_batch: torch.LongTensor, **kwargs) -> torch.FloatTensor:  # noqa: D102
+    def score_hrt(self, hrt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._generate_fake_scores(*hrt_batch.t()).unsqueeze(dim=-1)
 
     # docstr-coverage: inherited
-    def score_t(
-        self, hr_batch: torch.LongTensor, tails: Optional[torch.LongTensor] = None, **kwargs
-    ) -> torch.FloatTensor:  # noqa: D102
+    def score_t(self, hr_batch: LongTensor, tails: Optional[LongTensor] = None, **kwargs) -> FloatTensor:  # noqa: D102
         if tails is None:
             tails = torch.arange(self.num_entities, device=hr_batch.device).unsqueeze(dim=0)
         return self._generate_fake_scores(h=hr_batch[:, 0:1], r=hr_batch[:, 1:2], t=tails)
 
     # docstr-coverage: inherited
-    def score_r(
-        self, ht_batch: torch.LongTensor, relations: Optional[torch.LongTensor] = None, **kwargs
-    ) -> torch.FloatTensor:  # noqa: D102
+    def score_r(self, ht_batch: LongTensor, relations: Optional[LongTensor] = None, **kwargs) -> FloatTensor:  # noqa: D102
         if relations is None:
             relations = torch.arange(self.num_relations, device=ht_batch.device).unsqueeze(dim=0)
         return self._generate_fake_scores(h=ht_batch[:, 0:1], r=relations, t=ht_batch[:, 1:2])
 
     # docstr-coverage: inherited
-    def score_h(
-        self, rt_batch: torch.LongTensor, heads: Optional[torch.LongTensor] = None, **kwargs
-    ) -> torch.FloatTensor:  # noqa: D102
+    def score_h(self, rt_batch: LongTensor, heads: Optional[LongTensor] = None, **kwargs) -> FloatTensor:  # noqa: D102
         if heads is None:
             heads = torch.arange(self.num_entities, device=rt_batch.device).unsqueeze(dim=0)
         return self._generate_fake_scores(h=heads, r=rt_batch[:, 0:1], t=rt_batch[:, 1:2])

--- a/src/pykeen/models/multimodal/base.py
+++ b/src/pykeen/models/multimodal/base.py
@@ -2,7 +2,6 @@
 
 from typing import ClassVar
 
-import torch
 from class_resolver import HintOrType, OneOrManyHintOrType, OneOrManyOptionalKwargs, OptionalKwargs
 
 from ..nbase import ERModel
@@ -11,6 +10,7 @@ from ...nn.init import PretrainedInitializer
 from ...nn.modules import Interaction
 from ...nn.representation import CombinedRepresentation, Embedding, Representation
 from ...triples import TriplesNumericLiteralsFactory
+from ...typing import FloatTensor
 from ...utils import upgrade_to_sequence
 
 __all__ = [
@@ -19,9 +19,7 @@ __all__ = [
 
 
 class LiteralModel(
-    ERModel[
-        tuple[torch.FloatTensor, torch.FloatTensor], torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor]
-    ],
+    ERModel[tuple[FloatTensor, FloatTensor], FloatTensor, tuple[FloatTensor, FloatTensor]],
     autoreset=False,
 ):
     """Base class for models with entity literals that uses combinations from :class:`pykeen.nn.combinations`."""
@@ -32,7 +30,7 @@ class LiteralModel(
     def __init__(
         self,
         triples_factory: TriplesNumericLiteralsFactory,
-        interaction: HintOrType[Interaction[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]],
+        interaction: HintOrType[Interaction[FloatTensor, FloatTensor, FloatTensor]],
         entity_representations: OneOrManyHintOrType[Representation] = None,
         entity_representations_kwargs: OneOrManyOptionalKwargs = None,
         combination: HintOrType[Combination] = None,

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -26,7 +26,14 @@ from ..nn.modules import Interaction, interaction_resolver, parallel_unsqueeze
 from ..nn.representation import Representation
 from ..regularizers import Regularizer, regularizer_resolver
 from ..triples import KGInfo
-from ..typing import HeadRepresentation, InductiveMode, RelationRepresentation, TailRepresentation
+from ..typing import (
+    FloatTensor,
+    HeadRepresentation,
+    InductiveMode,
+    LongTensor,
+    RelationRepresentation,
+    TailRepresentation,
+)
 from ..utils import check_shapes, get_batchnorm_modules
 
 __all__ = [
@@ -222,10 +229,10 @@ def _prepare_representation_module_list(
 
 
 def repeat_if_necessary(
-    scores: torch.FloatTensor,
+    scores: FloatTensor,
     representations: Sequence[Representation],
     num: int | None,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """
     Repeat score tensor if necessary.
 
@@ -408,14 +415,14 @@ class ERModel(
 
     def forward(
         self,
-        h_indices: torch.LongTensor,
-        r_indices: torch.LongTensor,
-        t_indices: torch.LongTensor,
+        h_indices: LongTensor,
+        r_indices: LongTensor,
+        t_indices: LongTensor,
         slice_size: int | None = None,
         slice_dim: int = 0,
         *,
         mode: InductiveMode | None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Forward pass.
 
         This method takes head, relation and tail indices and calculates the corresponding scores.
@@ -446,7 +453,7 @@ class ERModel(
         h, r, t = self._get_representations(h=h_indices, r=r_indices, t=t_indices, mode=mode)
         return self.interaction.score(h=h, r=r, t=t, slice_size=slice_size, slice_dim=slice_dim)
 
-    def score_hrt(self, hrt_batch: torch.LongTensor, *, mode: InductiveMode | None = None) -> torch.FloatTensor:
+    def score_hrt(self, hrt_batch: LongTensor, *, mode: InductiveMode | None = None) -> FloatTensor:
         """Forward pass.
 
         This method takes head, relation and tail of each triple and calculates the corresponding score.
@@ -479,12 +486,12 @@ class ERModel(
     # docstr-coverage: inherited
     def score_t(
         self,
-        hr_batch: torch.LongTensor,
+        hr_batch: LongTensor,
         *,
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
-        tails: torch.LongTensor | None = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+        tails: LongTensor | None = None,
+    ) -> FloatTensor:  # noqa: D102
         # normalize before checking
         if slice_size and slice_size >= self.num_entities:
             slice_size = None
@@ -520,12 +527,12 @@ class ERModel(
     # docstr-coverage: inherited
     def score_h(
         self,
-        rt_batch: torch.LongTensor,
+        rt_batch: LongTensor,
         *,
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
-        heads: torch.LongTensor | None = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+        heads: LongTensor | None = None,
+    ) -> FloatTensor:  # noqa: D102
         # normalize before checking
         if slice_size and slice_size >= self.num_entities:
             slice_size = None
@@ -561,12 +568,12 @@ class ERModel(
     # docstr-coverage: inherited
     def score_r(
         self,
-        ht_batch: torch.LongTensor,
+        ht_batch: LongTensor,
         *,
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
-        relations: torch.LongTensor | None = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+        relations: LongTensor | None = None,
+    ) -> FloatTensor:  # noqa: D102
         # normalize before checking
         if slice_size and slice_size >= self.num_relations:
             slice_size = None
@@ -639,9 +646,9 @@ class ERModel(
 
     def _get_representations(
         self,
-        h: torch.LongTensor | None,
-        r: torch.LongTensor | None,
-        t: torch.LongTensor | None,
+        h: LongTensor | None,
+        r: LongTensor | None,
+        t: LongTensor | None,
         *,
         mode: InductiveMode | None,
     ) -> tuple[HeadRepresentation, RelationRepresentation, TailRepresentation]:

--- a/src/pykeen/models/uncertainty.py
+++ b/src/pykeen/models/uncertainty.py
@@ -62,7 +62,7 @@ from typing import Callable, NamedTuple, Optional
 import torch
 
 from .base import Model
-from ..typing import InductiveMode
+from ..typing import FloatTensor, InductiveMode, LongTensor
 from ..utils import get_dropout_modules
 
 __all__ = [
@@ -89,10 +89,10 @@ class UncertainPrediction(NamedTuple):
     """
 
     #: The scores
-    score: torch.FloatTensor
+    score: FloatTensor
 
     #: The uncertainty, in the same shape as scores
-    uncertainty: torch.FloatTensor
+    uncertainty: FloatTensor
 
     @classmethod
     def from_scores(cls, scores: torch.Tensor):
@@ -103,8 +103,8 @@ class UncertainPrediction(NamedTuple):
 @torch.inference_mode()
 def predict_uncertain_helper(
     model: Model,
-    batch: torch.LongTensor,
-    score_method: Callable[..., torch.FloatTensor],
+    batch: LongTensor,
+    score_method: Callable[..., FloatTensor],
     num_samples: int,
     slice_size: Optional[int] = None,
     *,
@@ -169,7 +169,7 @@ def predict_uncertain_helper(
 
 def predict_hrt_uncertain(
     model: Model,
-    hrt_batch: torch.LongTensor,
+    hrt_batch: LongTensor,
     num_samples: int = 5,
     *,
     mode: Optional[InductiveMode] = None,
@@ -220,7 +220,7 @@ def predict_hrt_uncertain(
 
 def predict_h_uncertain(
     model: Model,
-    rt_batch: torch.LongTensor,
+    rt_batch: LongTensor,
     num_samples: int = 5,
     slice_size: Optional[int] = None,
     *,
@@ -272,7 +272,7 @@ def predict_h_uncertain(
 
 def predict_r_uncertain(
     model: Model,
-    ht_batch: torch.LongTensor,
+    ht_batch: LongTensor,
     num_samples: int = 5,
     slice_size: Optional[int] = None,
     *,
@@ -317,7 +317,7 @@ def predict_r_uncertain(
 
 def predict_t_uncertain(
     model: Model,
-    hr_batch: torch.LongTensor,
+    hr_batch: LongTensor,
     num_samples: int = 5,
     slice_size: Optional[int] = None,
     *,

--- a/src/pykeen/models/unimodal/compgcn.py
+++ b/src/pykeen/models/unimodal/compgcn.py
@@ -9,7 +9,7 @@ from ..nbase import ERModel
 from ...nn.modules import DistMultInteraction, Interaction
 from ...nn.representation import CombinedCompGCNRepresentations
 from ...triples import CoreTriplesFactory
-from ...typing import RelationRepresentation, FloatTensor
+from ...typing import FloatTensor, RelationRepresentation
 
 __all__ = [
     "CompGCN",

--- a/src/pykeen/models/unimodal/compgcn.py
+++ b/src/pykeen/models/unimodal/compgcn.py
@@ -3,21 +3,20 @@
 from collections.abc import Mapping
 from typing import Any, Optional
 
-import torch
 from class_resolver import Hint
 
 from ..nbase import ERModel
 from ...nn.modules import DistMultInteraction, Interaction
 from ...nn.representation import CombinedCompGCNRepresentations
 from ...triples import CoreTriplesFactory
-from ...typing import RelationRepresentation
+from ...typing import RelationRepresentation, FloatTensor
 
 __all__ = [
     "CompGCN",
 ]
 
 
-class CompGCN(ERModel[torch.FloatTensor, RelationRepresentation, torch.FloatTensor]):
+class CompGCN(ERModel[FloatTensor, RelationRepresentation, FloatTensor]):
     """An implementation of CompGCN from [vashishth2020]_.
 
     This model uses graph convolutions, and composition functions.
@@ -41,7 +40,7 @@ class CompGCN(ERModel[torch.FloatTensor, RelationRepresentation, torch.FloatTens
         triples_factory: CoreTriplesFactory,
         embedding_dim: int = 64,
         encoder_kwargs: Optional[Mapping[str, Any]] = None,
-        interaction: Hint[Interaction[torch.FloatTensor, RelationRepresentation, torch.FloatTensor]] = None,
+        interaction: Hint[Interaction[FloatTensor, RelationRepresentation, FloatTensor]] = None,
         interaction_kwargs: Optional[Mapping[str, Any]] = None,
         **kwargs,
     ):

--- a/src/pykeen/models/unimodal/quate.py
+++ b/src/pykeen/models/unimodal/quate.py
@@ -12,7 +12,7 @@ from ...losses import BCEWithLogitsLoss, Loss
 from ...nn.init import init_quaternions
 from ...nn.modules import QuatEInteraction
 from ...regularizers import LpRegularizer, Regularizer
-from ...typing import Constrainer, Hint, Initializer
+from ...typing import Constrainer, FloatTensor, Hint, Initializer
 from ...utils import get_expected_norm
 
 __all__ = [
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-def quaternion_normalizer(x: torch.FloatTensor) -> torch.FloatTensor:
+def quaternion_normalizer(x: FloatTensor) -> FloatTensor:
     r"""
     Normalize the length of relation vectors, if the forward constraint has not been applied yet.
 

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -3,7 +3,6 @@
 from collections.abc import Mapping
 from typing import Any, Optional
 
-import torch
 from class_resolver import Hint, HintOrType
 from torch import nn
 
@@ -15,7 +14,7 @@ from ...nn.representation import Representation
 from ...nn.weighting import EdgeWeighting
 from ...regularizers import Regularizer
 from ...triples import CoreTriplesFactory
-from ...typing import Initializer, RelationRepresentation
+from ...typing import Initializer, RelationRepresentation, FloatTensor
 
 __all__ = [
     "RGCN",
@@ -23,7 +22,7 @@ __all__ = [
 
 
 class RGCN(
-    ERModel[torch.FloatTensor, RelationRepresentation, torch.FloatTensor],
+    ERModel[FloatTensor, RelationRepresentation, FloatTensor],
 ):
     r"""An implementation of R-GCN from [schlichtkrull2018]_.
 
@@ -90,7 +89,7 @@ class RGCN(
         relation_representations: HintOrType[Representation] = None,
         relation_initializer: Hint[Initializer] = nn.init.xavier_uniform_,
         relation_initializer_kwargs: Optional[Mapping[str, Any]] = None,
-        interaction: HintOrType[Interaction[torch.FloatTensor, RelationRepresentation, torch.FloatTensor]] = "DistMult",
+        interaction: HintOrType[Interaction[FloatTensor, RelationRepresentation, FloatTensor]] = "DistMult",
         interaction_kwargs: Optional[Mapping[str, Any]] = None,
         use_bias: bool = True,
         activation: Hint[nn.Module] = None,

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -14,7 +14,7 @@ from ...nn.representation import Representation
 from ...nn.weighting import EdgeWeighting
 from ...regularizers import Regularizer
 from ...triples import CoreTriplesFactory
-from ...typing import Initializer, RelationRepresentation, FloatTensor
+from ...typing import FloatTensor, Initializer, RelationRepresentation
 
 __all__ = [
     "RGCN",

--- a/src/pykeen/nn/combination.py
+++ b/src/pykeen/nn/combination.py
@@ -10,8 +10,8 @@ from class_resolver import ClassResolver, Hint, HintOrType, OptionalKwargs
 from class_resolver.contrib.torch import activation_resolver, aggregation_resolver
 from torch import nn
 
-from ..utils import ExtraReprMixin, combine_complex, split_complex
 from ..typing import FloatTensor
+from ..utils import ExtraReprMixin, combine_complex, split_complex
 
 __all__ = [
     "Combination",

--- a/src/pykeen/nn/combination.py
+++ b/src/pykeen/nn/combination.py
@@ -11,6 +11,7 @@ from class_resolver.contrib.torch import activation_resolver, aggregation_resolv
 from torch import nn
 
 from ..utils import ExtraReprMixin, combine_complex, split_complex
+from ..typing import FloatTensor
 
 __all__ = [
     "Combination",
@@ -29,7 +30,7 @@ class Combination(nn.Module, ExtraReprMixin, ABC):
     """Base class for combinations."""
 
     @abstractmethod
-    def forward(self, xs: Sequence[torch.FloatTensor]) -> torch.FloatTensor:
+    def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:
         """
         Combine a sequence of individual representations.
 
@@ -72,7 +73,7 @@ class ConcatCombination(Combination):
         self.dim = dim
 
     # docstr-coverage: inherited
-    def forward(self, xs: Sequence[torch.FloatTensor]) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         return torch.cat(xs, dim=self.dim)
 
     # docstr-coverage: inherited
@@ -123,7 +124,7 @@ class ConcatProjectionCombination(ConcatCombination):
         )
 
     # docstr-coverage: inherited
-    def forward(self, xs: Sequence[torch.FloatTensor]) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         return self.projection(super().forward(xs))
 
 
@@ -132,7 +133,7 @@ class ConcatAggregationCombination(ConcatCombination):
 
     def __init__(
         self,
-        aggregation: Hint[Callable[[torch.FloatTensor], torch.FloatTensor]] = None,
+        aggregation: Hint[Callable[[FloatTensor], FloatTensor]] = None,
         dim: int = -1,
     ) -> None:
         """
@@ -148,7 +149,7 @@ class ConcatAggregationCombination(ConcatCombination):
         self.aggregation = aggregation_resolver.make(aggregation)
 
     # docstr-coverage: inherited
-    def forward(self, xs: Sequence[torch.FloatTensor]) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         return self.aggregation(super().forward(xs=xs), dim=self.dim)
 
     # docstr-coverage: inherited
@@ -191,7 +192,7 @@ class ComplexSeparatedCombination(Combination):
         self.imag_combination = combination_resolver.make(imag_combination, imag_combination_kwargs)
 
     # docstr-coverage: inherited
-    def forward(self, xs: Sequence[torch.FloatTensor]) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         if not any(x.is_complex() for x in xs):
             raise ValueError(
                 f"{self.__class__} is a combination for complex representations, but none of the inputs was of "
@@ -302,7 +303,7 @@ class GatedCombination(Combination):
         )
 
     # docstr-coverage: inherited
-    def forward(self, xs: Sequence[torch.FloatTensor]) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         assert len(xs) == 2
         z = self.gate(xs)
         h = self.combination(xs)

--- a/src/pykeen/nn/compositions.py
+++ b/src/pykeen/nn/compositions.py
@@ -8,6 +8,7 @@ from class_resolver import ClassResolver
 from torch import nn
 
 from .functional import circular_correlation
+from ..typing import FloatTensor
 
 __all__ = [
     # Base
@@ -22,14 +23,14 @@ __all__ = [
 ]
 
 
-Composition = Callable[[torch.FloatTensor, torch.FloatTensor], torch.FloatTensor]
+Composition = Callable[[FloatTensor, FloatTensor], FloatTensor]
 
 
 class CompositionModule(nn.Module, ABC):
     """An (element-wise) composition function for vectors."""
 
     @abstractmethod
-    def forward(self, a: torch.FloatTensor, b: torch.FloatTensor) -> torch.FloatTensor:
+    def forward(self, a: FloatTensor, b: FloatTensor) -> FloatTensor:
         """Compose two batches of vectors.
 
         The tensors have to be broadcastable.
@@ -49,7 +50,7 @@ class FunctionalCompositionModule(CompositionModule):
     func: ClassVar[Composition]
 
     # docstr-coverage: inherited
-    def forward(self, a: torch.FloatTensor, b: torch.FloatTensor) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, a: FloatTensor, b: FloatTensor) -> FloatTensor:  # noqa: D102
         return self.__class__.func(a, b)
 
 

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -1,7 +1,7 @@
 """Compute kernels for common sub-tasks."""
 
-from ..utils import einsum
 from ..typing import FloatTensor
+from ..utils import einsum
 
 __all__ = [
     "batched_dot",

--- a/src/pykeen/nn/compute_kernel.py
+++ b/src/pykeen/nn/compute_kernel.py
@@ -1,8 +1,7 @@
 """Compute kernels for common sub-tasks."""
 
-import torch
-
 from ..utils import einsum
+from ..typing import FloatTensor
 
 __all__ = [
     "batched_dot",
@@ -10,31 +9,31 @@ __all__ = [
 
 
 def _batched_dot_manual(
-    a: torch.FloatTensor,
-    b: torch.FloatTensor,
-) -> torch.FloatTensor:
+    a: FloatTensor,
+    b: FloatTensor,
+) -> FloatTensor:
     return (a * b).sum(dim=-1)
 
 
 # TODO benchmark
 def _batched_dot_matmul(
-    a: torch.FloatTensor,
-    b: torch.FloatTensor,
-) -> torch.FloatTensor:
+    a: FloatTensor,
+    b: FloatTensor,
+) -> FloatTensor:
     return (a.unsqueeze(dim=-2) @ b.unsqueeze(dim=-1)).view(a.shape[:-1])
 
 
 # TODO benchmark
 def _batched_dot_einsum(
-    a: torch.FloatTensor,
-    b: torch.FloatTensor,
-) -> torch.FloatTensor:
+    a: FloatTensor,
+    b: FloatTensor,
+) -> FloatTensor:
     return einsum("...i,...i->...", a, b)
 
 
 def batched_dot(
-    a: torch.FloatTensor,
-    b: torch.FloatTensor,
-) -> torch.FloatTensor:
+    a: FloatTensor,
+    b: FloatTensor,
+) -> FloatTensor:
     """Compute "element-wise" dot-product between batched vectors."""
     return _batched_dot_manual(a, b)

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -14,7 +14,7 @@ from torch import broadcast_tensors, nn
 
 from .compute_kernel import batched_dot
 from .sim import KG2E_SIMILARITIES
-from ..typing import GaussianDistribution
+from ..typing import FloatTensor, GaussianDistribution
 from ..utils import (
     clamp_norm,
     einsum,
@@ -26,7 +26,6 @@ from ..utils import (
     tensor_product,
     tensor_sum,
 )
-from ...typing import FloatTensor
 
 __all__ = [
     "conve_interaction",

--- a/src/pykeen/nn/functional.py
+++ b/src/pykeen/nn/functional.py
@@ -26,6 +26,7 @@ from ..utils import (
     tensor_product,
     tensor_sum,
 )
+from ...typing import FloatTensor
 
 __all__ = [
     "conve_interaction",
@@ -60,10 +61,10 @@ __all__ = [
 
 
 def _apply_optional_bn_to_tensor(
-    x: torch.FloatTensor,
+    x: FloatTensor,
     output_dropout: nn.Dropout,
     batch_norm: nn.BatchNorm1d | None = None,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Apply optional batch normalization and dropout layer. Supports multiple batch dimensions."""
     if batch_norm is not None:
         shape = x.shape
@@ -94,16 +95,16 @@ def _add_cuda_warning(func):
 
 @_add_cuda_warning
 def conve_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    t_bias: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+    t_bias: FloatTensor,
     input_channels: int,
     embedding_height: int,
     embedding_width: int,
     hr2d: nn.Module,
     hr1d: nn.Module,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the ConvE interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -159,14 +160,14 @@ def conve_interaction(
 
 
 def convkb_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
     conv: nn.Conv2d,
     activation: nn.Module,
     hidden_dropout: nn.Dropout,
     linear: nn.Linear,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the ConvKB interaction function.
 
     .. math::
@@ -207,10 +208,10 @@ def convkb_interaction(
 
 
 def distmult_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-) -> torch.FloatTensor:
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+) -> FloatTensor:
     """Evaluate the DistMult interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -227,10 +228,10 @@ def distmult_interaction(
 
 
 def dist_ma_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-) -> torch.FloatTensor:
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+) -> FloatTensor:
     r"""Evaluate the DistMA interaction function from [shi2019]_.
 
     .. math ::
@@ -250,13 +251,13 @@ def dist_ma_interaction(
 
 
 def ermlp_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
     hidden: nn.Linear,
     activation: nn.Module,
     final: nn.Linear,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the ER-MLP interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -292,11 +293,11 @@ def ermlp_interaction(
 
 
 def ermlpe_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
     mlp: nn.Module,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the ER-MLPE interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -323,10 +324,10 @@ def ermlpe_interaction(
 
 
 def hole_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-) -> torch.FloatTensor:
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+) -> FloatTensor:
     """Evaluate the HolE interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -347,9 +348,9 @@ def hole_interaction(
 
 
 def circular_correlation(
-    a: torch.FloatTensor,
-    b: torch.FloatTensor,
-) -> torch.FloatTensor:
+    a: FloatTensor,
+    b: FloatTensor,
+) -> FloatTensor:
     """
     Compute the circular correlation between to vectors.
 
@@ -376,15 +377,15 @@ def circular_correlation(
 
 
 def kg2e_interaction(
-    h_mean: torch.FloatTensor,
-    h_var: torch.FloatTensor,
-    r_mean: torch.FloatTensor,
-    r_var: torch.FloatTensor,
-    t_mean: torch.FloatTensor,
-    t_var: torch.FloatTensor,
+    h_mean: FloatTensor,
+    h_var: FloatTensor,
+    r_mean: FloatTensor,
+    r_var: FloatTensor,
+    t_mean: FloatTensor,
+    t_var: FloatTensor,
     similarity: str = "KL",
     exact: bool = True,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the KG2E interaction function.
 
     :param h_mean: shape: (`*batch_dims`, d)
@@ -416,15 +417,15 @@ def kg2e_interaction(
 
 
 def ntn_interaction(
-    h: torch.FloatTensor,
-    t: torch.FloatTensor,
-    w: torch.FloatTensor,
-    vh: torch.FloatTensor,
-    vt: torch.FloatTensor,
-    b: torch.FloatTensor,
-    u: torch.FloatTensor,
+    h: FloatTensor,
+    t: FloatTensor,
+    w: FloatTensor,
+    vh: FloatTensor,
+    vt: FloatTensor,
+    b: FloatTensor,
+    u: FloatTensor,
     activation: nn.Module,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the NTN interaction function.
 
     .. math::
@@ -465,15 +466,15 @@ def ntn_interaction(
 
 
 def proje_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    d_e: torch.FloatTensor,
-    d_r: torch.FloatTensor,
-    b_c: torch.FloatTensor,
-    b_p: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+    d_e: FloatTensor,
+    d_r: FloatTensor,
+    b_c: FloatTensor,
+    b_p: FloatTensor,
     activation: nn.Module,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the ProjE interaction function.
 
     .. math::
@@ -512,10 +513,10 @@ def proje_interaction(
 
 
 def rescal_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-) -> torch.FloatTensor:
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+) -> FloatTensor:
     """Evaluate the RESCAL interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -532,14 +533,14 @@ def rescal_interaction(
 
 
 def simple_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    h_inv: torch.FloatTensor,
-    r_inv: torch.FloatTensor,
-    t_inv: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+    h_inv: FloatTensor,
+    r_inv: FloatTensor,
+    t_inv: FloatTensor,
     clamp: tuple[float, float] | None = None,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the SimplE interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -570,13 +571,13 @@ def simple_interaction(
 
 
 def se_interaction(
-    h: torch.FloatTensor,
-    r_h: torch.FloatTensor,
-    r_t: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    r_h: FloatTensor,
+    r_t: FloatTensor,
+    t: FloatTensor,
     p: int,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the Structured Embedding interaction function.
 
     .. math ::
@@ -606,12 +607,12 @@ def se_interaction(
 
 
 def toruse_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
     p: int | str = 2,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the TorusE interaction function from [ebisu2018].
 
     .. note ::
@@ -638,15 +639,15 @@ def toruse_interaction(
 
 
 def transd_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    h_p: torch.FloatTensor,
-    r_p: torch.FloatTensor,
-    t_p: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+    h_p: FloatTensor,
+    r_p: FloatTensor,
+    t_p: FloatTensor,
     p: int,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the TransD interaction function.
 
     :param h: shape: (`*batch_dims`, d_e)
@@ -684,12 +685,12 @@ def transd_interaction(
 
 
 def transe_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
     p: int | str = 2,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the TransE interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -710,10 +711,10 @@ def transe_interaction(
 
 
 def transf_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-) -> torch.FloatTensor:
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+) -> FloatTensor:
     """Evaluate the TransF interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -730,13 +731,13 @@ def transf_interaction(
 
 
 def transh_interaction(
-    h: torch.FloatTensor,
-    w_r: torch.FloatTensor,
-    d_r: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    w_r: FloatTensor,
+    d_r: FloatTensor,
+    t: FloatTensor,
     p: int,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the DistMult interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -770,13 +771,13 @@ def transh_interaction(
 
 
 def transr_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    m_r: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+    m_r: FloatTensor,
     p: int,
     power_norm: bool = True,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the TransR interaction function.
 
     :param h: shape: (`*batch_dims`, d_e)
@@ -805,16 +806,16 @@ def transr_interaction(
 
 
 def tucker_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    core_tensor: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+    core_tensor: FloatTensor,
     do_h: nn.Dropout,
     do_r: nn.Dropout,
     do_hr: nn.Dropout,
     bn_h: nn.BatchNorm1d | None,
     bn_hr: nn.BatchNorm1d | None,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the TuckEr interaction function.
 
     Compute scoring function W x_1 h x_2 r x_3 t as in the official implementation, i.e. as
@@ -875,15 +876,15 @@ def tucker_interaction(
 
 
 def mure_interaction(
-    h: torch.FloatTensor,
-    b_h: torch.FloatTensor,
-    r_vec: torch.FloatTensor,
-    r_mat: torch.FloatTensor,
-    t: torch.FloatTensor,
-    b_t: torch.FloatTensor,
+    h: FloatTensor,
+    b_h: FloatTensor,
+    r_vec: FloatTensor,
+    r_mat: FloatTensor,
+    t: FloatTensor,
+    b_t: FloatTensor,
     p: int | float | str = 2,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the MuRE interaction function from [balazevic2019b]_.
 
     .. math ::
@@ -923,11 +924,11 @@ def mure_interaction(
 
 
 def um_interaction(
-    h: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    t: FloatTensor,
     p: int,
     power_norm: bool = True,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the SimplE interaction function.
 
     :param h: shape: (`*batch_dims`, dim)
@@ -946,13 +947,13 @@ def um_interaction(
 
 
 def pair_re_interaction(
-    h: torch.FloatTensor,
-    t: torch.FloatTensor,
-    r_h: torch.FloatTensor,
-    r_t: torch.FloatTensor,
+    h: FloatTensor,
+    t: FloatTensor,
+    r_h: FloatTensor,
+    r_t: FloatTensor,
     p: int | str = 2,
     power_norm: bool = True,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the PairRE interaction function.
 
     .. math ::
@@ -983,10 +984,10 @@ def pair_re_interaction(
 
 
 def quat_e_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    table: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+    table: FloatTensor,
 ):
     """Evaluate the interaction function of QuatE for given embeddings.
 
@@ -1009,14 +1010,14 @@ def quat_e_interaction(
 
 
 def cross_e_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    c_r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    bias: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    c_r: FloatTensor,
+    t: FloatTensor,
+    bias: FloatTensor,
     activation: nn.Module,
     dropout: nn.Dropout | None = None,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""
     Evaluate the interaction function of CrossE for the given representations from [zhang2019b]_.
 
@@ -1069,10 +1070,10 @@ def cross_e_interaction(
 
 
 def cp_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-) -> torch.FloatTensor:
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+) -> FloatTensor:
     """Evaluate the Canonical Tensor Decomposition interaction function.
 
     :param h: shape: (`*batch_dims`, rank, dim)
@@ -1090,19 +1091,19 @@ def cp_interaction(
 
 def triple_re_interaction(
     # head
-    h: torch.FloatTensor,
+    h: FloatTensor,
     # relation
-    r_head: torch.FloatTensor,
-    r_mid: torch.FloatTensor,
-    r_tail: torch.FloatTensor,
+    r_head: FloatTensor,
+    r_mid: FloatTensor,
+    r_tail: FloatTensor,
     # tail
-    t: torch.FloatTensor,
+    t: FloatTensor,
     # version 2: relation factor offset
     u: float | None = None,
     # extension: negative (power) norm
     p: int = 2,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the TripleRE interaction function.
 
     .. seealso ::
@@ -1147,13 +1148,13 @@ def triple_re_interaction(
 
 
 def transformer_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
     transformer: nn.TransformerEncoder,
-    position_embeddings: torch.FloatTensor,
+    position_embeddings: FloatTensor,
     final: nn.Module,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Evaluate the Transformer interaction function, as described in [galkin2020]_..
 
     .. math ::
@@ -1204,11 +1205,11 @@ def transformer_interaction(
 
 
 def multilinear_tucker_interaction(
-    h: torch.FloatTensor,
-    r: torch.FloatTensor,
-    t: torch.FloatTensor,
-    core_tensor: torch.FloatTensor,
-) -> torch.FloatTensor:
+    h: FloatTensor,
+    r: FloatTensor,
+    t: FloatTensor,
+    core_tensor: FloatTensor,
+) -> FloatTensor:
     r"""Evaluate the (original) multi-linear TuckEr interaction function.
 
     .. math ::
@@ -1232,17 +1233,17 @@ def multilinear_tucker_interaction(
 
 def linea_re_interaction(
     # head
-    h: torch.FloatTensor,
+    h: FloatTensor,
     # relation
-    r_head: torch.FloatTensor,
-    r_mid: torch.FloatTensor,
-    r_tail: torch.FloatTensor,
+    r_head: FloatTensor,
+    r_mid: FloatTensor,
+    r_tail: FloatTensor,
     # tail
-    t: torch.FloatTensor,
+    t: FloatTensor,
     # extension: negative (power) norm
     p: int = 2,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate the LineaRE interaction function.
 
     .. note ::

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -18,7 +18,7 @@ from torch.nn import functional
 from .text import TextEncoder, text_encoder_resolver
 from .utils import iter_matrix_power, safe_diagonal
 from ..triples import CoreTriplesFactory, TriplesFactory
-from ..typing import Initializer, MappedTriples, OneOrSequence
+from ..typing import FloatTensor, Initializer, LongTensor, MappedTriples, OneOrSequence
 from ..utils import compose, get_edge_index, iter_weisfeiler_lehman, upgrade_to_sequence
 
 __all__ = [
@@ -168,8 +168,8 @@ uniform_norm_p1_: Initializer = cast(
 
 
 def init_quaternions(
-    x: torch.FloatTensor,
-) -> torch.FloatTensor:
+    x: FloatTensor,
+) -> FloatTensor:
     """
     Initialize quaternion.
 
@@ -227,7 +227,7 @@ class PretrainedInitializer:
         )
     """
 
-    def __init__(self, tensor: torch.FloatTensor) -> None:
+    def __init__(self, tensor: FloatTensor) -> None:
         """
         Initialize the initializer.
 
@@ -356,9 +356,9 @@ class WeisfeilerLehmanInitializer(PretrainedInitializer):
         color_initializer_kwargs: OptionalKwargs = None,
         shape: OneOrSequence[int] = 32,
         # variants for the edge index
-        edge_index: Optional[torch.LongTensor] = None,
+        edge_index: Optional[LongTensor] = None,
         num_entities: Optional[int] = None,
-        mapped_triples: Optional[torch.LongTensor] = None,
+        mapped_triples: Optional[LongTensor] = None,
         triples_factory: Optional[CoreTriplesFactory] = None,
         # additional parameters for iter_weisfeiler_lehman
         **kwargs,

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -17,8 +17,8 @@ from .representation import LowRankRepresentation, Representation
 from .utils import ShapeError, adjacency_tensor_to_stacked_matrix, use_horizontal_stacking
 from .weighting import EdgeWeighting, edge_weight_resolver
 from ..triples import CoreTriplesFactory
-from ..utils import ExtraReprMixin, einsum
 from ..typing import FloatTensor, LongTensor
+from ..utils import ExtraReprMixin, einsum
 
 __all__ = [
     "RGCNRepresentation",

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -18,6 +18,7 @@ from .utils import ShapeError, adjacency_tensor_to_stacked_matrix, use_horizonta
 from .weighting import EdgeWeighting, edge_weight_resolver
 from ..triples import CoreTriplesFactory
 from ..utils import ExtraReprMixin, einsum
+from ..typing import FloatTensor, LongTensor
 
 __all__ = [
     "RGCNRepresentation",
@@ -86,13 +87,13 @@ class Decomposition(nn.Module, ExtraReprMixin, ABC):
 
     def forward(
         self,
-        x: torch.FloatTensor,
-        source: torch.LongTensor,
-        target: torch.LongTensor,
-        edge_type: torch.LongTensor,
-        edge_weights: Optional[torch.FloatTensor] = None,
-        accumulator: Optional[torch.FloatTensor] = None,
-    ) -> torch.FloatTensor:
+        x: FloatTensor,
+        source: LongTensor,
+        target: LongTensor,
+        edge_type: LongTensor,
+        edge_weights: Optional[FloatTensor] = None,
+        accumulator: Optional[FloatTensor] = None,
+    ) -> FloatTensor:
         """Relation-specific message passing from source to target.
 
         :param x: shape: (num_nodes, input_dim)
@@ -456,12 +457,12 @@ class RGCNLayer(nn.Module):
 
     def forward(
         self,
-        x: torch.FloatTensor,
-        source: torch.LongTensor,
-        target: torch.LongTensor,
-        edge_type: torch.LongTensor,
-        edge_weights: Optional[torch.FloatTensor] = None,
-    ) -> torch.FloatTensor:
+        x: FloatTensor,
+        source: LongTensor,
+        target: LongTensor,
+        edge_type: LongTensor,
+        edge_weights: Optional[FloatTensor] = None,
+    ) -> FloatTensor:
         """
         Calculate enriched entity representations.
 
@@ -669,7 +670,7 @@ class RGCNRepresentation(Representation):
             elif any(p.requires_grad for p in m.parameters()):
                 logger.warning("Layers %s has parameters, but no reset_parameters.", m)
 
-    def _real_forward_all(self) -> torch.FloatTensor:
+    def _real_forward_all(self) -> FloatTensor:
         if self.enriched_embeddings is not None:
             return self.enriched_embeddings
 
@@ -717,8 +718,8 @@ class RGCNRepresentation(Representation):
 
     def _plain_forward(
         self,
-        indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:
+        indices: Optional[LongTensor] = None,
+    ) -> FloatTensor:
         """Enrich the entity embeddings of the decoder using R-GCN message propagation."""
         x = self._real_forward_all()
         if indices is not None:

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -23,7 +23,7 @@ import torch
 from class_resolver import ClassResolver, Hint, OptionalKwargs
 from class_resolver.contrib.torch import activation_resolver
 from docdata import parse_docdata
-from torch import FloatTensor, nn
+from torch import nn
 from torch.nn.init import xavier_normal_
 
 from . import functional as pkf

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -31,6 +31,7 @@ from .algebra import quaterion_multiplication_table
 from .init import initializer_resolver
 from ..metrics.utils import ValueRange
 from ..typing import (
+    FloatTensor,
     HeadRepresentation,
     HintOrType,
     Initializer,
@@ -118,12 +119,12 @@ def parallel_slice_batches(
     :yields: batches of sliced representations
     """
     # normalize input
-    rs: Sequence[Sequence[torch.FloatTensor]] = ensure_tuple(*representations)
+    rs: Sequence[Sequence[FloatTensor]] = ensure_tuple(*representations)
     # get number of head/relation/tail representations
     length = list(map(len, rs))
     splits = numpy.cumsum([0] + length)
     # flatten list
-    rsl: Sequence[torch.FloatTensor] = sum(map(list, rs), [])
+    rsl: Sequence[FloatTensor] = sum(map(list, rs), [])
     # split tensors
     parts = [r.split(split_size, dim=dim) for r in rsl]
     # broadcasting
@@ -137,7 +138,7 @@ def parallel_slice_batches(
 
 def parallel_unsqueeze(x: Representation, dim: int) -> Representation:
     """Unsqueeze all representations along the given dimension."""
-    xs: Sequence[torch.FloatTensor] = upgrade_to_sequence(x)
+    xs: Sequence[FloatTensor] = upgrade_to_sequence(x)
     xs = [xx.unsqueeze(dim=dim) for xx in xs]
     return xs[0] if len(xs) == 1 else xs
 
@@ -220,7 +221,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
 
         :param h: shape: (`*batch_dims`, `*dims`)
@@ -241,7 +242,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
         t: TailRepresentation,
         slice_size: int | None = None,
         slice_dim: int = 1,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Compute broadcasted triple scores with optional slicing.
 
         .. note ::
@@ -279,7 +280,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Score a batch of triples.
 
         :param h: shape: (batch_size, d_e)
@@ -300,7 +301,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
         slice_size: int | None = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Score all head entities.
 
         :param all_entities: shape: (num_entities, d_e)
@@ -328,7 +329,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
         all_relations: RelationRepresentation,
         t: TailRepresentation,
         slice_size: int | None = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Score all relations.
 
         :param h: shape: (batch_size, d_e)
@@ -356,7 +357,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
         r: RelationRepresentation,
         all_entities: TailRepresentation,
         slice_size: int | None = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Score all tail entities.
 
         :param h: shape: (batch_size, d_e)
@@ -391,14 +392,14 @@ class FunctionalInteraction(Interaction, Generic[HeadRepresentation, RelationRep
     """Base class for interaction functions."""
 
     #: The functional interaction form
-    func: Callable[..., torch.FloatTensor]
+    func: Callable[..., FloatTensor]
 
     def forward(
         self,
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
 
         :param h: shape: (`*batch_dims`, `*dims`)
@@ -418,7 +419,7 @@ class FunctionalInteraction(Interaction, Generic[HeadRepresentation, RelationRep
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> Mapping[str, torch.FloatTensor]:
+    ) -> Mapping[str, FloatTensor]:
         """Conversion utility to prepare the arguments for the functional form."""
         kwargs = self._prepare_hrt_for_functional(h=h, r=r, t=t)
         kwargs.update(self._prepare_state_for_functional())
@@ -431,7 +432,7 @@ class FunctionalInteraction(Interaction, Generic[HeadRepresentation, RelationRep
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         """Conversion utility to prepare the h/r/t representations for the functional form."""
         # TODO: we only allow single-tensor representations here, but could easily generalize
         assert all(torch.is_tensor(x) for x in (h, r, t))
@@ -623,7 +624,7 @@ def _calculate_missing_shape_information(
 
 @parse_docdata
 class ConvEInteraction(
-    FunctionalInteraction[torch.FloatTensor, torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor]],
+    FunctionalInteraction[FloatTensor, FloatTensor, tuple[FloatTensor, FloatTensor]],
 ):
     """A stateful module for the ConvE interaction function.
 
@@ -754,7 +755,7 @@ class ConvEInteraction(
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(h=h, r=r, t=t[0], t_bias=t[1])
 
     # docstr-coverage: inherited
@@ -1000,9 +1001,9 @@ class ERMLPEInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
 @parse_docdata
 class TransRInteraction(
     NormBasedInteraction[
-        torch.FloatTensor,
-        tuple[torch.FloatTensor, torch.FloatTensor],
-        torch.FloatTensor,
+        FloatTensor,
+        tuple[FloatTensor, FloatTensor],
+        FloatTensor,
     ],
 ):
     """A stateful module for the TransR interaction function.
@@ -1036,7 +1037,7 @@ class TransRInteraction(
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(h=h, r=r[0], t=t, m_r=r[1])
 
 
@@ -1195,9 +1196,9 @@ class RESCALInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
 @parse_docdata
 class SEInteraction(
     NormBasedInteraction[
-        torch.FloatTensor,
-        tuple[torch.FloatTensor, torch.FloatTensor],
-        torch.FloatTensor,
+        FloatTensor,
+        tuple[FloatTensor, FloatTensor],
+        FloatTensor,
     ],
 ):
     """A stateful module for the Structured Embedding (SE) interaction function.
@@ -1221,7 +1222,7 @@ class SEInteraction(
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(h=h, t=t, r_h=r[0], r_t=r[1])
 
 
@@ -1331,7 +1332,7 @@ class TuckerInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
 
 @parse_docdata
 class UMInteraction(
-    NormBasedInteraction[torch.FloatTensor, None, torch.FloatTensor],
+    NormBasedInteraction[FloatTensor, None, FloatTensor],
 ):
     """A stateful module for the UnstructuredModel interaction function.
 
@@ -1367,12 +1368,12 @@ class UMInteraction(
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(h=h, t=t)
 
 
 @parse_docdata
-class TorusEInteraction(NormBasedInteraction[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]):
+class TorusEInteraction(NormBasedInteraction[FloatTensor, FloatTensor, FloatTensor]):
     """A stateful module for the TorusE interaction function.
 
     .. seealso:: :func:`pykeen.nn.functional.toruse_interaction`
@@ -1403,9 +1404,9 @@ class TorusEInteraction(NormBasedInteraction[torch.FloatTensor, torch.FloatTenso
 @parse_docdata
 class TransDInteraction(
     NormBasedInteraction[
-        tuple[torch.FloatTensor, torch.FloatTensor],
-        tuple[torch.FloatTensor, torch.FloatTensor],
-        tuple[torch.FloatTensor, torch.FloatTensor],
+        tuple[FloatTensor, FloatTensor],
+        tuple[FloatTensor, FloatTensor],
+        tuple[FloatTensor, FloatTensor],
     ],
 ):
     """A stateful module for the TransD interaction function.
@@ -1437,10 +1438,10 @@ class TransDInteraction(
     # docstr-coverage: inherited
     @staticmethod
     def _prepare_hrt_for_functional(
-        h: tuple[torch.FloatTensor, torch.FloatTensor],
-        r: tuple[torch.FloatTensor, torch.FloatTensor],
-        t: tuple[torch.FloatTensor, torch.FloatTensor],
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+        h: tuple[FloatTensor, FloatTensor],
+        r: tuple[FloatTensor, FloatTensor],
+        t: tuple[FloatTensor, FloatTensor],
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         h, h_p = h
         r, r_p = r
         t, t_p = t
@@ -1450,9 +1451,9 @@ class TransDInteraction(
 @parse_docdata
 class NTNInteraction(
     FunctionalInteraction[
-        torch.FloatTensor,
-        tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor],
-        torch.FloatTensor,
+        FloatTensor,
+        tuple[FloatTensor, FloatTensor, FloatTensor, FloatTensor, FloatTensor],
+        FloatTensor,
     ],
 ):
     """A stateful module for the NTN interaction function.
@@ -1491,10 +1492,10 @@ class NTNInteraction(
     # docstr-coverage: inherited
     @staticmethod
     def _prepare_hrt_for_functional(
-        h: torch.FloatTensor,
-        r: tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor],
-        t: torch.FloatTensor,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+        h: FloatTensor,
+        r: tuple[FloatTensor, FloatTensor, FloatTensor, FloatTensor, FloatTensor],
+        t: FloatTensor,
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         w, vh, vt, b, u = r
         return dict(h=h, t=t, w=w, b=b, u=u, vh=vh, vt=vt)
 
@@ -1506,9 +1507,9 @@ class NTNInteraction(
 @parse_docdata
 class KG2EInteraction(
     FunctionalInteraction[
-        tuple[torch.FloatTensor, torch.FloatTensor],
-        tuple[torch.FloatTensor, torch.FloatTensor],
-        tuple[torch.FloatTensor, torch.FloatTensor],
+        tuple[FloatTensor, FloatTensor],
+        tuple[FloatTensor, FloatTensor],
+        tuple[FloatTensor, FloatTensor],
     ],
 ):
     """A stateful module for the KG2E interaction function.
@@ -1546,10 +1547,10 @@ class KG2EInteraction(
     # docstr-coverage: inherited
     @staticmethod
     def _prepare_hrt_for_functional(
-        h: tuple[torch.FloatTensor, torch.FloatTensor],
-        r: tuple[torch.FloatTensor, torch.FloatTensor],
-        t: tuple[torch.FloatTensor, torch.FloatTensor],
-    ) -> MutableMapping[str, torch.FloatTensor]:
+        h: tuple[FloatTensor, FloatTensor],
+        r: tuple[FloatTensor, FloatTensor],
+        t: tuple[FloatTensor, FloatTensor],
+    ) -> MutableMapping[str, FloatTensor]:
         h_mean, h_var = h
         r_mean, r_var = r
         t_mean, t_var = t
@@ -1591,7 +1592,7 @@ class TransHInteraction(NormBasedInteraction[FloatTensor, tuple[FloatTensor, Flo
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(h=h, w_r=r[1], d_r=r[0], t=t)
 
 
@@ -1626,7 +1627,7 @@ class MuREInteraction(
         h: tuple[FloatTensor, FloatTensor, FloatTensor],
         r: tuple[FloatTensor, FloatTensor],
         t: tuple[FloatTensor, FloatTensor, FloatTensor],
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         h, b_h, _ = h
         t, _, b_t = t
         r_vec, r_mat = r
@@ -1636,9 +1637,9 @@ class MuREInteraction(
 @parse_docdata
 class SimplEInteraction(
     FunctionalInteraction[
-        tuple[torch.FloatTensor, torch.FloatTensor],
-        tuple[torch.FloatTensor, torch.FloatTensor],
-        tuple[torch.FloatTensor, torch.FloatTensor],
+        tuple[FloatTensor, FloatTensor],
+        tuple[FloatTensor, FloatTensor],
+        tuple[FloatTensor, FloatTensor],
     ],
 ):
     """A module wrapper for the SimplE interaction function.
@@ -1679,7 +1680,7 @@ class SimplEInteraction(
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(h=h[0], h_inv=h[1], r=r[0], r_inv=r[1], t=t[0], t_inv=t[1])
 
 
@@ -1707,16 +1708,16 @@ class PairREInteraction(NormBasedInteraction[FloatTensor, tuple[FloatTensor, Flo
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(h=h, r_h=r[0], r_t=r[1], t=t)
 
 
 @parse_docdata
 class QuatEInteraction(
     FunctionalInteraction[
-        torch.FloatTensor,
-        torch.FloatTensor,
-        torch.FloatTensor,
+        FloatTensor,
+        FloatTensor,
+        FloatTensor,
     ],
 ):
     """A module wrapper for the QuatE interaction function.
@@ -1830,7 +1831,7 @@ class MonotonicAffineTransformationInteraction(
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         return self.log_scale.exp() * self.base(h=h, r=r, t=t) + self.bias
 
 
@@ -1893,7 +1894,7 @@ class CrossEInteraction(FunctionalInteraction[FloatTensor, tuple[FloatTensor, Fl
         h: FloatTensor,
         r: tuple[FloatTensor, FloatTensor],
         t: FloatTensor,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         r, c_r = r
         return dict(h=h, r=r, c_r=c_r, t=t)
 
@@ -1956,7 +1957,7 @@ class BoxEInteraction(
         h: tuple[FloatTensor, FloatTensor],
         r: tuple[FloatTensor, FloatTensor, FloatTensor, FloatTensor, FloatTensor, FloatTensor],
         t: tuple[FloatTensor, FloatTensor],
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         rh_base, rh_delta, rh_size, rt_base, rt_delta, rt_size = r
         h_pos, h_bump = h
         t_pos, t_bump = t
@@ -1984,7 +1985,7 @@ class BoxEInteraction(
         return state
 
     @staticmethod
-    def product_normalize(x: torch.FloatTensor, dim: int = -1) -> torch.FloatTensor:
+    def product_normalize(x: FloatTensor, dim: int = -1) -> FloatTensor:
         r"""Normalize a tensor along a given dimension so that the geometric mean is 1.0.
 
         :param x: shape: s
@@ -1999,10 +2000,10 @@ class BoxEInteraction(
 
     @staticmethod
     def point_to_box_distance(
-        points: torch.FloatTensor,
-        box_lows: torch.FloatTensor,
-        box_highs: torch.FloatTensor,
-    ) -> torch.FloatTensor:
+        points: FloatTensor,
+        box_lows: FloatTensor,
+        box_highs: FloatTensor,
+    ) -> FloatTensor:
         r"""Compute the point to box distance function proposed by [abboud2020]_ in an element-wise fashion.
 
         :param points: shape: ``(*, d)``
@@ -2052,13 +2053,13 @@ class BoxEInteraction(
     @classmethod
     def boxe_kg_arity_position_score(
         cls,
-        entity_pos: torch.FloatTensor,
-        other_entity_bump: torch.FloatTensor,
-        relation_box: tuple[torch.FloatTensor, torch.FloatTensor],
+        entity_pos: FloatTensor,
+        other_entity_bump: FloatTensor,
+        relation_box: tuple[FloatTensor, FloatTensor],
         tanh_map: bool,
         p: int,
         power_norm: bool,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         r"""Perform the BoxE computation at a single arity position.
 
         .. note::
@@ -2111,10 +2112,10 @@ class BoxEInteraction(
     @classmethod
     def compute_box(
         cls,
-        base: torch.FloatTensor,
-        delta: torch.FloatTensor,
-        size: torch.FloatTensor,
-    ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
+        base: FloatTensor,
+        delta: FloatTensor,
+        size: FloatTensor,
+    ) -> tuple[FloatTensor, FloatTensor]:
         r"""Compute the lower and upper corners of a resulting box.
 
         :param base: shape: ``(*, d)``
@@ -2151,19 +2152,19 @@ class BoxEInteraction(
     @staticmethod
     def func(
         # head
-        h_pos: torch.FloatTensor,
-        h_bump: torch.FloatTensor,
+        h_pos: FloatTensor,
+        h_bump: FloatTensor,
         # relation box: head
-        rh_base: torch.FloatTensor,
-        rh_delta: torch.FloatTensor,
-        rh_size: torch.FloatTensor,
+        rh_base: FloatTensor,
+        rh_delta: FloatTensor,
+        rh_size: FloatTensor,
         # relation box: tail
-        rt_base: torch.FloatTensor,
-        rt_delta: torch.FloatTensor,
-        rt_size: torch.FloatTensor,
+        rt_base: FloatTensor,
+        rt_delta: FloatTensor,
+        rt_size: FloatTensor,
         # tail
-        t_pos: torch.FloatTensor,
-        t_bump: torch.FloatTensor,
+        t_pos: FloatTensor,
+        t_bump: FloatTensor,
         # power norm
         tanh_map: bool = True,
         p: int = 2,
@@ -2317,7 +2318,7 @@ class MultiLinearTuckerInteraction(
         h: tuple[FloatTensor, FloatTensor],
         r: FloatTensor,
         t: tuple[FloatTensor, FloatTensor],
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(h=h[0], r=r, t=t[1])
 
     def _prepare_state_for_functional(self) -> MutableMapping[str, Any]:
@@ -2325,7 +2326,7 @@ class MultiLinearTuckerInteraction(
 
 
 @parse_docdata
-class TransformerInteraction(FunctionalInteraction[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]):
+class TransformerInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTensor]):
     """Transformer-based interaction, as described in [galkin2020]_.
 
     ---
@@ -2670,7 +2671,7 @@ class AutoSFInteraction(FunctionalInteraction[HeadRepresentation, RelationRepres
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> MutableMapping[str, torch.FloatTensor]:  # noqa: D102
+    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
         return dict(zip("hrt", ensure_tuple(h, r, t)))
 
     def extend(self, *new_coefficients: tuple[int, int, int, Sign]) -> AutoSFInteraction:

--- a/src/pykeen/nn/node_piece/representation.py
+++ b/src/pykeen/nn/node_piece/representation.py
@@ -15,7 +15,7 @@ from ..perceptron import ConcatMLP
 from ..representation import CombinedRepresentation, Representation
 from ..utils import ShapeError
 from ...triples import CoreTriplesFactory
-from ...typing import MappedTriples, OneOrSequence
+from ...typing import FloatTensor, LongTensor, MappedTriples, OneOrSequence
 from ...utils import broadcast_upgrade_to_sequences
 
 __all__ = [
@@ -47,11 +47,11 @@ class TokenizationRepresentation(Representation):
     vocabulary: Representation
 
     #: the assigned tokens for each entity
-    assignment: torch.LongTensor
+    assignment: LongTensor
 
     def __init__(
         self,
-        assignment: torch.LongTensor,
+        assignment: LongTensor,
         token_representation: HintOrType[Representation] = None,
         token_representation_kwargs: OptionalKwargs = None,
         shape: Optional[OneOrSequence[int]] = None,
@@ -173,8 +173,8 @@ class TokenizationRepresentation(Representation):
     # docstr-coverage: inherited
     def _plain_forward(
         self,
-        indices: Optional[torch.LongTensor] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+        indices: Optional[LongTensor] = None,
+    ) -> FloatTensor:  # noqa: D102
         # get token IDs, shape: (*, num_chosen_tokens)
         token_ids = self.assignment
         if indices is not None:
@@ -244,7 +244,7 @@ class NodePieceRepresentation(CombinedRepresentation):
         tokenizers: OneOrManyHintOrType[Tokenizer] = None,
         tokenizers_kwargs: OneOrManyOptionalKwargs = None,
         num_tokens: OneOrSequence[int] = 2,
-        aggregation: Union[None, str, Callable[[torch.FloatTensor, int], torch.FloatTensor]] = None,
+        aggregation: Union[None, str, Callable[[FloatTensor, int], FloatTensor]] = None,
         max_id: Optional[int] = None,
         **kwargs,
     ):

--- a/src/pykeen/nn/node_piece/tokenization.py
+++ b/src/pykeen/nn/node_piece/tokenization.py
@@ -17,7 +17,7 @@ from .anchor_selection import AnchorSelection, anchor_selection_resolver
 from .loader import PrecomputedTokenizerLoader, precomputed_tokenizer_loader_resolver
 from .utils import prepare_edges_for_metis, random_sample_no_replacement
 from ...constants import PYKEEN_MODULE
-from ...typing import DeviceHint, MappedTriples
+from ...typing import DeviceHint, LongTensor, MappedTriples
 from ...utils import format_relative_comparison, get_edge_index, resolve_device
 
 __all__ = [
@@ -45,7 +45,7 @@ class Tokenizer:
         num_tokens: int,
         num_entities: int,
         num_relations: int,
-    ) -> tuple[int, torch.LongTensor]:
+    ) -> tuple[int, LongTensor]:
         """
         Tokenize the entities contained given the triples.
 
@@ -74,7 +74,7 @@ class RelationTokenizer(Tokenizer):
         num_tokens: int,
         num_entities: int,
         num_relations: int,
-    ) -> tuple[int, torch.LongTensor]:  # noqa: D102
+    ) -> tuple[int, LongTensor]:  # noqa: D102
         # tokenize: represent entities by bag of relations
         h, r, t = mapped_triples.t()
 
@@ -134,10 +134,10 @@ class AnchorTokenizer(Tokenizer):
 
     def _call(
         self,
-        edge_index: torch.LongTensor,
+        edge_index: LongTensor,
         num_tokens: int,
         num_entities: int,
-    ) -> tuple[int, torch.LongTensor]:
+    ) -> tuple[int, LongTensor]:
         edge_index = edge_index.numpy()
         # select anchors
         logger.info(f"Selecting anchors according to {self.anchor_selection}")
@@ -162,7 +162,7 @@ class AnchorTokenizer(Tokenizer):
         num_tokens: int,
         num_entities: int,
         num_relations: int,
-    ) -> tuple[int, torch.LongTensor]:  # noqa: D102
+    ) -> tuple[int, LongTensor]:  # noqa: D102
         return self._call(
             edge_index=get_edge_index(mapped_triples=mapped_triples),
             num_tokens=num_tokens,
@@ -200,7 +200,7 @@ class MetisAnchorTokenizer(AnchorTokenizer):
         num_tokens: int,
         num_entities: int,
         num_relations: int,
-    ) -> tuple[int, torch.LongTensor]:  # noqa: D102
+    ) -> tuple[int, LongTensor]:  # noqa: D102
         try:
             import torch_sparse
         except ImportError as err:
@@ -329,7 +329,7 @@ class PrecomputedPoolTokenizer(Tokenizer):
     # docstr-coverage: inherited
     def __call__(
         self, mapped_triples: MappedTriples, num_tokens: int, num_entities: int, num_relations: int
-    ) -> tuple[int, torch.LongTensor]:  # noqa: D102
+    ) -> tuple[int, LongTensor]:  # noqa: D102
         if num_entities != len(self.pool):
             raise ValueError(f"Invalid number of entities ({num_entities}); expected {len(self.pool)}")
         if self.randomize_selection:

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -8,6 +8,8 @@ import numpy
 import torch
 from tqdm.auto import tqdm
 
+from ...typing import LongTensor
+
 __all__ = [
     "random_sample_no_replacement",
     "ensure_num_entities",
@@ -21,7 +23,7 @@ def random_sample_no_replacement(
     pool: Mapping[int, Collection[int]],
     num_tokens: int,
     num_entities: Optional[int] = None,
-) -> torch.LongTensor:
+) -> LongTensor:
     """Sample randomly without replacement num_tokens relations for each entity.
 
     If a graph has disconnected nodes, then num_entities > number of rows in the pool.
@@ -59,7 +61,7 @@ def ensure_num_entities(edge_index: numpy.ndarray, num_entities: Optional[int] =
     return edge_index.max().item() + 1
 
 
-def prepare_edges_for_metis(edge_index: torch.Tensor) -> torch.LongTensor:
+def prepare_edges_for_metis(edge_index: torch.Tensor) -> LongTensor:
     """Prepare the edge index for METIS partitioning to prevent segfaults."""
     # remove self-loops
     mask = edge_index[0] != edge_index[1]

--- a/src/pykeen/nn/perceptron.py
+++ b/src/pykeen/nn/perceptron.py
@@ -2,8 +2,8 @@
 
 from typing import Optional, Union
 
-import torch
 from torch import nn
+from ..typing import FloatTensor
 
 __all__ = [
     "ConcatMLP",
@@ -50,7 +50,7 @@ class ConcatMLP(nn.Sequential):
         )
         self.flatten_dims = flatten_dims
 
-    def forward(self, xs: torch.FloatTensor, dim: int) -> torch.FloatTensor:
+    def forward(self, xs: FloatTensor, dim: int) -> FloatTensor:
         """Forward the MLP on the given dimension.
 
         :param xs: The tensor to forward

--- a/src/pykeen/nn/perceptron.py
+++ b/src/pykeen/nn/perceptron.py
@@ -3,6 +3,7 @@
 from typing import Optional, Union
 
 from torch import nn
+
 from ..typing import FloatTensor
 
 __all__ = [

--- a/src/pykeen/nn/sim.py
+++ b/src/pykeen/nn/sim.py
@@ -8,6 +8,7 @@ import torch
 from .compute_kernel import batched_dot
 from ..typing import GaussianDistribution
 from ..utils import at_least_eps, calculate_broadcasted_elementwise_result_shape, tensor_sum
+from ...typing import FloatTensor
 
 __all__ = [
     "expected_likelihood",
@@ -22,7 +23,7 @@ def expected_likelihood(
     r: GaussianDistribution,
     t: GaussianDistribution,
     exact: bool = True,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Compute the similarity based on expected likelihood.
 
     .. math::
@@ -74,7 +75,7 @@ def kullback_leibler_similarity(
     r: GaussianDistribution,
     t: GaussianDistribution,
     exact: bool = True,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Compute the negative KL divergence.
 
     This is done between two Gaussian distributions given by mean `mu_*` and diagonal covariance matrix `sigma_*`.
@@ -122,7 +123,7 @@ def _vectorized_kl_divergence(
     r: GaussianDistribution,
     t: GaussianDistribution,
     exact: bool = True,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     r"""Vectorized implementation of KL-divergence.
 
     Computes the divergence between :math:`\mathcal{N}(\mu_e, \Sigma_e)` and :math:`\mathcal{N}(\mu_r, \Sigma_r)`
@@ -207,7 +208,7 @@ def _torch_kl_similarity(
     h: GaussianDistribution,
     r: GaussianDistribution,
     t: GaussianDistribution,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Compute KL similarity using torch.distributions.
 
     :param h: shape: (batch_size, num_heads, 1, 1, d)

--- a/src/pykeen/nn/sim.py
+++ b/src/pykeen/nn/sim.py
@@ -6,9 +6,8 @@ import math
 import torch
 
 from .compute_kernel import batched_dot
-from ..typing import GaussianDistribution
+from ..typing import FloatTensor, GaussianDistribution
 from ..utils import at_least_eps, calculate_broadcasted_elementwise_result_shape, tensor_sum
-from ...typing import FloatTensor
 
 __all__ = [
     "expected_likelihood",

--- a/src/pykeen/nn/text.py
+++ b/src/pykeen/nn/text.py
@@ -14,6 +14,7 @@ from torch import nn
 from torch_max_mem import maximize_memory_utilization
 from tqdm.auto import tqdm
 
+from ..typing import FloatTensor
 from ..utils import determine_maximum_batch_size, get_preferred_device, resolve_device, upgrade_to_sequence
 
 if TYPE_CHECKING:
@@ -61,7 +62,7 @@ def _encode_all_memory_utilization_optimized(
 class TextEncoder(nn.Module):
     """An encoder for text."""
 
-    def forward(self, labels: Union[str, Sequence[str]]) -> torch.FloatTensor:
+    def forward(self, labels: Union[str, Sequence[str]]) -> FloatTensor:
         """
         Encode a batch of text.
 
@@ -76,7 +77,7 @@ class TextEncoder(nn.Module):
         return self.forward_normalized(texts=labels)
 
     @abstractmethod
-    def forward_normalized(self, texts: Sequence[str]) -> torch.FloatTensor:
+    def forward_normalized(self, texts: Sequence[str]) -> FloatTensor:
         """
         Encode a batch of text.
 
@@ -93,7 +94,7 @@ class TextEncoder(nn.Module):
         self,
         labels: Sequence[str],
         batch_size: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Encode all labels (inference mode & batched).
 
         :param labels:
@@ -139,7 +140,7 @@ class CharacterEmbeddingTextEncoder(TextEncoder):
         dim: int = 32,
         character_representation: HintOrType["Representation"] = None,
         vocabulary: str = string.printable,
-        aggregation: Hint[Callable[..., torch.FloatTensor]] = None,
+        aggregation: Hint[Callable[..., FloatTensor]] = None,
     ) -> None:
         """Initialize the encoder.
 
@@ -162,7 +163,7 @@ class CharacterEmbeddingTextEncoder(TextEncoder):
         )
 
     # docstr-coverage: inherited
-    def forward_normalized(self, texts: Sequence[str]) -> torch.FloatTensor:  # noqa: D102
+    def forward_normalized(self, texts: Sequence[str]) -> FloatTensor:  # noqa: D102
         # tokenize
         token_ids = [[self.token_to_id.get(c, self.unknown_idx) for c in text] for text in texts]
         # pad
@@ -218,7 +219,7 @@ class TransformerTextEncoder(TextEncoder):
         self.max_length = max_length or 512
 
     # docstr-coverage: inherited
-    def forward_normalized(self, texts: Sequence[str]) -> torch.FloatTensor:  # noqa: D102
+    def forward_normalized(self, texts: Sequence[str]) -> FloatTensor:  # noqa: D102
         return self.model(
             **self.tokenizer(
                 texts,

--- a/src/pykeen/nn/utils.py
+++ b/src/pykeen/nn/utils.py
@@ -19,7 +19,7 @@ import torch
 from tqdm.auto import tqdm
 
 from ..constants import PYKEEN_MODULE
-from ..typing import OneOrSequence
+from ..typing import FloatTensor, LongTensor, OneOrSequence
 from ..utils import nested_get, rate_limited, upgrade_to_sequence
 from ..version import get_version
 
@@ -124,10 +124,10 @@ def use_horizontal_stacking(
 def adjacency_tensor_to_stacked_matrix(
     num_relations: int,
     num_entities: int,
-    source: torch.LongTensor,
-    target: torch.LongTensor,
-    edge_type: torch.LongTensor,
-    edge_weights: torch.FloatTensor | None = None,
+    source: LongTensor,
+    target: LongTensor,
+    edge_type: LongTensor,
+    edge_weights: FloatTensor | None = None,
     horizontal: bool = True,
 ) -> torch.Tensor:
     """

--- a/src/pykeen/nn/vision.py
+++ b/src/pykeen/nn/vision.py
@@ -19,7 +19,7 @@ from .representation import BackfillRepresentation, Representation
 from .utils import ShapeError, WikidataCache
 from ..datasets import Dataset
 from ..triples import TriplesFactory
-from ..typing import OneOrSequence
+from ..typing import FloatTensor, LongTensor, OneOrSequence
 
 try:
     from PIL import Image
@@ -180,8 +180,8 @@ class VisualRepresentation(Representation):
 
     @staticmethod
     def _encode(
-        images: torch.FloatTensor, encoder: torch.nn.Module, pool: Callable[[torch.FloatTensor], torch.FloatTensor]
-    ) -> torch.FloatTensor:
+        images: FloatTensor, encoder: torch.nn.Module, pool: Callable[[FloatTensor], FloatTensor]
+    ) -> FloatTensor:
         """
         Encode images with the given encoder and pooling methods.
 
@@ -197,7 +197,7 @@ class VisualRepresentation(Representation):
         return pool(encoder(images)["feature"])
 
     # docstr-coverage: inherited
-    def _plain_forward(self, indices: Optional[torch.LongTensor] = None) -> torch.FloatTensor:  # noqa: D102
+    def _plain_forward(self, indices: Optional[LongTensor] = None) -> FloatTensor:  # noqa: D102
         dataset = self.images
         if indices is not None:
             dataset = torch.utils.data.Subset(dataset=dataset, indices=indices)

--- a/src/pykeen/nn/weighting.py
+++ b/src/pykeen/nn/weighting.py
@@ -7,6 +7,7 @@ import torch
 from class_resolver import ClassResolver
 from torch import nn
 
+from ..typing import FloatTensor, LongTensor
 from ..utils import einsum
 
 try:
@@ -26,7 +27,7 @@ __all__ = [
 
 def softmax(
     src: torch.Tensor,
-    index: torch.LongTensor,
+    index: LongTensor,
     num_nodes: Union[None, int, torch.Tensor] = None,
     dim: int = 0,
 ) -> torch.Tensor:
@@ -83,11 +84,11 @@ class EdgeWeighting(nn.Module):
     @abstractmethod
     def forward(
         self,
-        source: torch.LongTensor,
-        target: torch.LongTensor,
-        message: Optional[torch.FloatTensor] = None,
-        x_e: Optional[torch.FloatTensor] = None,
-    ) -> torch.FloatTensor:
+        source: LongTensor,
+        target: LongTensor,
+        message: Optional[FloatTensor] = None,
+        x_e: Optional[FloatTensor] = None,
+    ) -> FloatTensor:
         """Compute edge weights.
 
         :param source: shape: (num_edges,)
@@ -105,7 +106,7 @@ class EdgeWeighting(nn.Module):
         raise NotImplementedError
 
 
-def _inverse_frequency_weighting(idx: torch.LongTensor) -> torch.FloatTensor:
+def _inverse_frequency_weighting(idx: LongTensor) -> FloatTensor:
     """Calculate inverse relative frequency weighting."""
     # Calculate in-degree, i.e. number of incoming edges
     inv, cnt = torch.unique(idx, return_counts=True, return_inverse=True)[1:]
@@ -118,11 +119,11 @@ class InverseInDegreeEdgeWeighting(EdgeWeighting):
     # docstr-coverage: inherited
     def forward(
         self,
-        source: torch.LongTensor,
-        target: torch.LongTensor,
-        message: Optional[torch.FloatTensor] = None,
-        x_e: Optional[torch.FloatTensor] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+        source: LongTensor,
+        target: LongTensor,
+        message: Optional[FloatTensor] = None,
+        x_e: Optional[FloatTensor] = None,
+    ) -> FloatTensor:  # noqa: D102
         weight = _inverse_frequency_weighting(idx=target)
         if message is not None:
             return message * weight.unsqueeze(dim=-1)
@@ -136,11 +137,11 @@ class InverseOutDegreeEdgeWeighting(EdgeWeighting):
     # docstr-coverage: inherited
     def forward(
         self,
-        source: torch.LongTensor,
-        target: torch.LongTensor,
-        message: Optional[torch.FloatTensor] = None,
-        x_e: Optional[torch.FloatTensor] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+        source: LongTensor,
+        target: LongTensor,
+        message: Optional[FloatTensor] = None,
+        x_e: Optional[FloatTensor] = None,
+    ) -> FloatTensor:  # noqa: D102
         weight = _inverse_frequency_weighting(idx=source)
         if message is not None:
             return message * weight.unsqueeze(dim=-1)
@@ -154,11 +155,11 @@ class SymmetricEdgeWeighting(EdgeWeighting):
     # docstr-coverage: inherited
     def forward(
         self,
-        source: torch.LongTensor,
-        target: torch.LongTensor,
-        message: Optional[torch.FloatTensor] = None,
-        x_e: Optional[torch.FloatTensor] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+        source: LongTensor,
+        target: LongTensor,
+        message: Optional[FloatTensor] = None,
+        x_e: Optional[FloatTensor] = None,
+    ) -> FloatTensor:  # noqa: D102
         weight = (_inverse_frequency_weighting(idx=source) * _inverse_frequency_weighting(idx=target)).sqrt()
         if message is not None:
             return message * weight.unsqueeze(dim=-1)
@@ -202,11 +203,11 @@ class AttentionEdgeWeighting(EdgeWeighting):
     # docstr-coverage: inherited
     def forward(
         self,
-        source: torch.LongTensor,
-        target: torch.LongTensor,
-        message: Optional[torch.FloatTensor] = None,
-        x_e: Optional[torch.FloatTensor] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+        source: LongTensor,
+        target: LongTensor,
+        message: Optional[FloatTensor] = None,
+        x_e: Optional[FloatTensor] = None,
+    ) -> FloatTensor:  # noqa: D102
         if message is None or x_e is None:
             raise ValueError(f"{self.__class__.__name__} requires message and x_e.")
 

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -270,7 +270,7 @@ import math
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from operator import itemgetter
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
 import numpy
 import pandas
@@ -580,7 +580,7 @@ def _get_input_batch(
             f"Exactly one of {{head, relation, tail}} must be None, but got {head}, {relation}, {tail}",
         )
 
-    batch = cast(LongTensor, torch.as_tensor([batch_ids], dtype=torch.long))
+    batch = torch.as_tensor([batch_ids], dtype=torch.long)
     return target, batch, (batch_ids[0], batch_ids[1])
 
 

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -289,8 +289,10 @@ from .typing import (
     LABEL_RELATION,
     LABEL_TAIL,
     DeviceHint,
+    FloatTensor,
     InductiveMode,
     LabeledTriples,
+    LongTensor,
     MappedTriples,
     Target,
 )
@@ -444,10 +446,10 @@ class ScorePack:
     """A pair of result triples and scores."""
 
     #: the ID-based triples, shape: (n, 3)
-    result: torch.LongTensor
+    result: LongTensor
 
     #: the scores
-    scores: torch.FloatTensor
+    scores: FloatTensor
 
     def process(self, factory: Optional[CoreTriplesFactory] = None, **kwargs) -> "TriplePredictions":
         """Start post-processing scores."""
@@ -528,7 +530,7 @@ def _get_input_batch(
     head: Union[None, int, str] = None,
     relation: Union[None, int, str] = None,
     tail: Union[None, int, str] = None,
-) -> tuple[Target, torch.LongTensor, tuple[int, int]]:
+) -> tuple[Target, LongTensor, tuple[int, int]]:
     """Prepare input batch for prediction.
 
     :param factory:
@@ -578,21 +580,21 @@ def _get_input_batch(
             f"Exactly one of {{head, relation, tail}} must be None, but got {head}, {relation}, {tail}",
         )
 
-    batch = cast(torch.LongTensor, torch.as_tensor([batch_ids], dtype=torch.long))
+    batch = cast(LongTensor, torch.as_tensor([batch_ids], dtype=torch.long))
     return target, batch, (batch_ids[0], batch_ids[1])
 
 
 # note type alias annotation required,
 # cf. https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 # batch, TODO: ids?
-PredictionBatch: TypeAlias = torch.LongTensor
+PredictionBatch: TypeAlias = LongTensor
 
 
 class ScoreConsumer:
     """A consumer of scores for visitor pattern."""
 
-    result: torch.LongTensor
-    scores: torch.FloatTensor
+    result: LongTensor
+    scores: FloatTensor
     flatten: bool
 
     @abstractmethod
@@ -600,7 +602,7 @@ class ScoreConsumer:
         self,
         batch: PredictionBatch,
         target: Target,
-        scores: torch.FloatTensor,
+        scores: FloatTensor,
     ) -> None:
         """Consume scores for the given hr_batch."""
         raise NotImplementedError
@@ -624,7 +626,7 @@ class CountScoreConsumer(ScoreConsumer):
         self,
         batch: PredictionBatch,
         target: Target,
-        scores: torch.FloatTensor,
+        scores: FloatTensor,
     ) -> None:  # noqa: D102
         self.batch_count += batch.shape[0]
         self.score_count += scores.numel()
@@ -655,7 +657,7 @@ class TopKScoreConsumer(ScoreConsumer):
         self,
         batch: PredictionBatch,
         target: Target,
-        scores: torch.FloatTensor,
+        scores: FloatTensor,
     ) -> None:  # noqa: D102
         batch_size, num_scores = scores.shape
         assert batch.shape == (batch_size, 2)
@@ -733,10 +735,10 @@ class AllScoreConsumer(ScoreConsumer):
         self,
         batch: PredictionBatch,
         target: Target,
-        scores: torch.FloatTensor,
+        scores: FloatTensor,
     ) -> None:  # noqa: D102
         j = 0
-        selectors: list[Union[slice, torch.LongTensor]] = []
+        selectors: list[Union[slice, LongTensor]] = []
         for col in COLUMN_LABELS:
             if col == target:
                 selector = slice(None)
@@ -802,12 +804,12 @@ class AllPredictionDataset(PredictionDataset):
         return self.num_entities * self.num_relations
 
     # docstr-coverage: inherited
-    def __getitem__(self, item: int) -> torch.LongTensor:  # noqa: D105
+    def __getitem__(self, item: int) -> LongTensor:  # noqa: D105
         quotient, remainder = divmod(item, self.divisor)
         return torch.as_tensor([quotient, remainder])
 
 
-Restriction = Union[torch.LongTensor, Collection[int], int]
+Restriction = Union[LongTensor, Collection[int], int]
 
 
 class PartiallyRestrictedPredictionDataset(PredictionDataset):
@@ -848,7 +850,7 @@ class PartiallyRestrictedPredictionDataset(PredictionDataset):
     """
 
     #: the choices for the first and second component of the input batch
-    parts: tuple[torch.LongTensor, torch.LongTensor]
+    parts: tuple[LongTensor, LongTensor]
 
     def __init__(
         self,
@@ -874,7 +876,7 @@ class PartiallyRestrictedPredictionDataset(PredictionDataset):
             if the target position is restricted, or any non-target position is not restricted
         """
         super().__init__(target=target)
-        parts: list[torch.LongTensor] = []
+        parts: list[LongTensor] = []
         for restriction, on in zip((heads, relations, tails), COLUMN_LABELS):
             if on == target:
                 if restriction is not None:
@@ -950,7 +952,7 @@ def consume_scores(
             consumer(batch, target=dataset.target, scores=scores)
 
 
-def _build_pack(result: torch.LongTensor, scores: torch.FloatTensor, flatten: bool = False) -> ScorePack:
+def _build_pack(result: LongTensor, scores: FloatTensor, flatten: bool = False) -> ScorePack:
     """Sort final result and package in a score pack."""
     scores, indices = torch.sort(scores.flatten() if flatten else scores, descending=True)
     result = result[indices]
@@ -964,7 +966,7 @@ def _predict_triples_batched(
     batch_size: int,
     *,
     mode: Optional[InductiveMode],
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Predict scores for triples in batches."""
     return torch.cat(
         [
@@ -1042,7 +1044,7 @@ def predict_target(
     tail: Union[None, int, str] = None,
     #
     triples_factory: Optional[TriplesFactory] = None,
-    targets: Union[None, torch.LongTensor, Sequence[Union[int, str]]] = None,
+    targets: Union[None, LongTensor, Sequence[Union[int, str]]] = None,
     mode: Optional[InductiveMode] = None,
 ) -> Predictions:
     """Get predictions for the head, relation, and/or tail combination.

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -12,6 +12,7 @@ from class_resolver import ClassResolver, normalize_string
 from torch import nn
 from torch.nn import functional
 
+from .typing import FloatTensor
 from .utils import lp_norm, powersum_norm
 
 __all__ = [
@@ -38,10 +39,10 @@ class Regularizer(nn.Module, ABC):
     """A base class for all regularizers."""
 
     #: The overall regularization weight
-    weight: torch.FloatTensor
+    weight: FloatTensor
 
     #: The current regularization term (a scalar)
-    regularization_term: torch.FloatTensor
+    regularization_term: FloatTensor
 
     #: Should the regularization only be applied once? This was used for ConvKB and defaults to False.
     apply_only_once: bool
@@ -88,11 +89,11 @@ class Regularizer(nn.Module, ABC):
         self.updated = False
 
     @abstractmethod
-    def forward(self, x: torch.FloatTensor) -> torch.FloatTensor:
+    def forward(self, x: FloatTensor) -> FloatTensor:
         """Compute the regularization term for one tensor."""
         raise NotImplementedError
 
-    def update(self, *tensors: torch.FloatTensor) -> None:
+    def update(self, *tensors: FloatTensor) -> None:
         """Update the regularization term based on passed tensors."""
         if not self.training or not torch.is_grad_enabled() or (self.apply_only_once and self.updated):
             return
@@ -100,11 +101,11 @@ class Regularizer(nn.Module, ABC):
         self.updated = True
 
     @property
-    def term(self) -> torch.FloatTensor:
+    def term(self) -> FloatTensor:
         """Return the weighted regularization term."""
         return self.regularization_term * self.weight
 
-    def pop_regularization_term(self) -> torch.FloatTensor:
+    def pop_regularization_term(self) -> FloatTensor:
         """Return the weighted regularization term, and reset the regularize afterwards."""
         # If there are tracked parameters, update based on them
         if self.tracked_parameters:
@@ -137,12 +138,12 @@ class NoRegularizer(Regularizer):
     hpo_default: ClassVar[Mapping[str, Any]] = {}
 
     # docstr-coverage: inherited
-    def update(self, *tensors: torch.FloatTensor) -> None:  # noqa: D102
+    def update(self, *tensors: FloatTensor) -> None:  # noqa: D102
         # no need to compute anything
         pass
 
     # docstr-coverage: inherited
-    def forward(self, x: torch.FloatTensor) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         # always return zero
         return torch.zeros(1, dtype=x.dtype, device=x.device)
 
@@ -191,7 +192,7 @@ class LpRegularizer(Regularizer):
         self.p = p
 
     # docstr-coverage: inherited
-    def forward(self, x: torch.FloatTensor) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         return lp_norm(x=x, p=self.p, dim=self.dim, normalize=self.normalize).mean()
 
 
@@ -235,7 +236,7 @@ class PowerSumRegularizer(Regularizer):
         self.p = p
 
     # docstr-coverage: inherited
-    def forward(self, x: torch.FloatTensor) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         return powersum_norm(x, p=self.p, dim=self.dim, normalize=self.normalize).mean()
 
 
@@ -281,7 +282,7 @@ class NormLimitRegularizer(Regularizer):
         self.power_norm = power_norm
 
     # docstr-coverage: inherited
-    def forward(self, x: torch.FloatTensor) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         if self.power_norm:
             norm = powersum_norm(x, p=self.p, dim=self.dim, normalize=False)
         else:
@@ -318,11 +319,11 @@ class OrthogonalityRegularizer(Regularizer):
         self.epsilon = epsilon
 
     # docstr-coverage: inherited
-    def forward(self, x: torch.FloatTensor) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         raise NotImplementedError(f"{self.__class__.__name__} regularizer is order-sensitive!")
 
     # docstr-coverage: inherited
-    def update(self, *tensors: torch.FloatTensor) -> None:  # noqa: D102
+    def update(self, *tensors: FloatTensor) -> None:  # noqa: D102
         if len(tensors) != 2:
             raise ValueError("Expects exactly two tensors")
         if self.apply_only_once and self.updated:
@@ -338,7 +339,7 @@ class CombinedRegularizer(Regularizer):
     """A convex combination of regularizers."""
 
     # The normalization factor to balance individual regularizers' contribution.
-    normalization_factor: torch.FloatTensor
+    normalization_factor: FloatTensor
 
     hpo_default = dict(total_weight=dict(type=float, low=0.01, high=1.0, scale="log"), regularizers=tuple())
 
@@ -378,7 +379,7 @@ class CombinedRegularizer(Regularizer):
         return any(r.normalize for r in self.regularizers)
 
     # docstr-coverage: inherited
-    def forward(self, x: torch.FloatTensor) -> torch.FloatTensor:  # noqa: D102
+    def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         return self.normalization_factor * sum(r.weight * r.forward(x) for r in self.regularizers)
 
 

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -8,7 +8,7 @@ import torch
 
 from .negative_sampler import NegativeSampler
 from ..constants import LABEL_HEAD, LABEL_TAIL, TARGET_TO_INDEX
-from ..typing import Target
+from ..typing import LongTensor, Target
 
 __all__ = [
     "BasicNegativeSampler",
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 
-def random_replacement_(batch: torch.LongTensor, index: int, selection: slice, size: int, max_index: int) -> None:
+def random_replacement_(batch: LongTensor, index: int, selection: slice, size: int, max_index: int) -> None:
     """
     Replace a column of a batch of indices by random indices.
 
@@ -83,7 +83,7 @@ class BasicNegativeSampler(NegativeSampler):
         self._corruption_indices = [TARGET_TO_INDEX[side] for side in self.corruption_scheme]
 
     # docstr-coverage: inherited
-    def corrupt_batch(self, positive_batch: torch.LongTensor) -> torch.LongTensor:  # noqa: D102
+    def corrupt_batch(self, positive_batch: LongTensor) -> LongTensor:  # noqa: D102
         batch_shape = positive_batch.shape[:-1]
 
         # clone positive batch for corruption (.repeat_interleave creates a copy)

--- a/src/pykeen/sampling/bernoulli_negative_sampler.py
+++ b/src/pykeen/sampling/bernoulli_negative_sampler.py
@@ -4,7 +4,7 @@ import torch
 
 from .basic_negative_sampler import random_replacement_
 from .negative_sampler import NegativeSampler
-from ..typing import COLUMN_HEAD, COLUMN_TAIL, MappedTriples
+from ..typing import COLUMN_HEAD, COLUMN_TAIL, LongTensor, MappedTriples
 
 __all__ = [
     "BernoulliNegativeSampler",
@@ -69,7 +69,7 @@ class BernoulliNegativeSampler(NegativeSampler):
             self.corrupt_head_probability[r] = tph / (tph + hpt)
 
     # docstr-coverage: inherited
-    def corrupt_batch(self, positive_batch: torch.LongTensor) -> torch.LongTensor:  # noqa: D102
+    def corrupt_batch(self, positive_batch: LongTensor) -> LongTensor:  # noqa: D102
         batch_shape = positive_batch.shape[:-1]
 
         # Decide whether to corrupt head or tail

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -129,7 +129,7 @@ import torch
 from class_resolver import ClassResolver
 from torch import nn
 
-from ..typing import MappedTriples
+from ..typing import BoolTensor, LongTensor, MappedTriples
 from ..utils import triple_tensor_to_set
 
 __all__ = [
@@ -146,7 +146,7 @@ class Filterer(nn.Module):
     def forward(
         self,
         negative_batch: MappedTriples,
-    ) -> torch.BoolTensor:
+    ) -> BoolTensor:
         """Filter all proposed negative samples that are positive in the training dataset.
 
         Normally there is a low probability that proposed negative samples are positive in the training datasets and
@@ -169,7 +169,7 @@ class Filterer(nn.Module):
         return ~self.contains(batch=negative_batch)
 
     @abstractmethod
-    def contains(self, batch: MappedTriples) -> torch.BoolTensor:
+    def contains(self, batch: MappedTriples) -> BoolTensor:
         """
         Check whether a triple is contained.
 
@@ -202,7 +202,7 @@ class PythonSetFilterer(Filterer):
         self.triples = triple_tensor_to_set(mapped_triples)
 
     # docstr-coverage: inherited
-    def contains(self, batch: MappedTriples) -> torch.BoolTensor:  # noqa: D102
+    def contains(self, batch: MappedTriples) -> BoolTensor:  # noqa: D102
         return torch.as_tensor(
             data=[tuple(triple) in self.triples for triple in batch.view(-1, 3).tolist()],
             dtype=torch.bool,
@@ -222,10 +222,10 @@ class BloomFilterer(Filterer):
     """
 
     #: some prime numbers for tuple hashing
-    mersenne: torch.LongTensor
+    mersenne: LongTensor
 
     #: The bit-array for the Bloom filter data structure
-    bit_array: torch.BoolTensor
+    bit_array: BoolTensor
 
     def __init__(self, mapped_triples: MappedTriples, error_rate: float = 0.001):
         """
@@ -307,7 +307,7 @@ class BloomFilterer(Filterer):
     def probe(
         self,
         batch: MappedTriples,
-    ) -> Iterable[torch.LongTensor]:
+    ) -> Iterable[LongTensor]:
         """
         Iterate over indices from the probes.
 
@@ -332,7 +332,7 @@ class BloomFilterer(Filterer):
         for i in self.probe(batch=triples):
             self.bit_array[i] = True
 
-    def contains(self, batch: MappedTriples) -> torch.BoolTensor:
+    def contains(self, batch: MappedTriples) -> BoolTensor:
         """
         Check whether a triple is contained.
 

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -4,12 +4,11 @@ from abc import abstractmethod
 from collections.abc import Mapping
 from typing import Any, ClassVar, Optional
 
-import torch
 from class_resolver import HintOrType, normalize_string
 from torch import nn
 
 from .filtering import Filterer, filterer_resolver
-from ..typing import MappedTriples
+from ..typing import BoolTensor, LongTensor, MappedTriples
 
 __all__ = [
     "NegativeSampler",
@@ -79,7 +78,7 @@ class NegativeSampler(nn.Module):
         """Get the normalized name of the negative sampler."""
         return normalize_string(cls.__name__, suffix=NegativeSampler.__name__)
 
-    def sample(self, positive_batch: torch.LongTensor) -> tuple[torch.LongTensor, Optional[torch.BoolTensor]]:
+    def sample(self, positive_batch: LongTensor) -> tuple[LongTensor, Optional[BoolTensor]]:
         """
         Generate negative samples from the positive batch.
 
@@ -105,7 +104,7 @@ class NegativeSampler(nn.Module):
         return negative_batch, self.filterer(negative_batch=negative_batch)
 
     @abstractmethod
-    def corrupt_batch(self, positive_batch: torch.LongTensor) -> torch.LongTensor:
+    def corrupt_batch(self, positive_batch: LongTensor) -> LongTensor:
         """
         Generate negative samples from the positive batch without application of any filter.
 

--- a/src/pykeen/sampling/pseudo_type.py
+++ b/src/pykeen/sampling/pseudo_type.py
@@ -6,7 +6,7 @@ import logging
 import torch
 
 from .negative_sampler import NegativeSampler
-from ..typing import MappedTriples
+from ..typing import LongTensor, MappedTriples
 from ..utils import create_relation_to_entity_set_mapping
 
 __all__ = [
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def create_index(
     mapped_triples: MappedTriples,
     num_relations: int,
-) -> tuple[torch.LongTensor, torch.LongTensor]:
+) -> tuple[LongTensor, LongTensor]:
     """
     Create an index for efficient vectorized pseudo-type negative sampling.
 
@@ -69,10 +69,10 @@ class PseudoTypedNegativeSampler(NegativeSampler):
     """
 
     #: The array of offsets within the data array, shape: (2 * num_relations + 1,)
-    offsets: torch.LongTensor
+    offsets: LongTensor
 
     #: The concatenated sorted sets of head/tail entities
-    data: torch.LongTensor
+    data: LongTensor
 
     def __init__(
         self,
@@ -92,7 +92,7 @@ class PseudoTypedNegativeSampler(NegativeSampler):
         self.data, self.offsets = create_index(mapped_triples=mapped_triples, num_relations=self.num_relations)
 
     # docstr-coverage: inherited
-    def corrupt_batch(self, positive_batch: torch.LongTensor):  # noqa: D102
+    def corrupt_batch(self, positive_batch: LongTensor):  # noqa: D102
         batch_size = positive_batch.shape[0]
 
         # shape: (batch_size, num_neg_per_pos, 3)

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -4,7 +4,6 @@ import logging
 from math import ceil
 from typing import Callable, ClassVar, Optional, Union
 
-import torch
 from torch.nn import functional
 from torch.utils.data import DataLoader, TensorDataset
 from torch_max_mem.api import is_oom_error
@@ -14,7 +13,7 @@ from ..losses import Loss
 from ..models import Model
 from ..triples import CoreTriplesFactory
 from ..triples.instances import LCWABatchType, LCWASampleType
-from ..typing import InductiveMode, MappedTriples
+from ..typing import FloatTensor, InductiveMode, MappedTriples
 
 __all__ = [
     "LCWATrainingLoop",
@@ -113,7 +112,7 @@ class LCWATrainingLoop(TrainingLoop[LCWASampleType, LCWABatchType]):
         stop: Optional[int],
         label_smoothing: float = 0.0,
         slice_size: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         # Split batch components
         batch_pairs, batch_labels_full = batch
 
@@ -141,7 +140,7 @@ class LCWATrainingLoop(TrainingLoop[LCWASampleType, LCWABatchType]):
         stop: int,
         label_smoothing: float = 0.0,
         slice_size: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         return self._process_batch_static(
             model=self.model,
             score_method=self.score_method,
@@ -264,7 +263,7 @@ class SymmetricLCWATrainingLoop(TrainingLoop[tuple[MappedTriples], tuple[MappedT
         stop: int,
         label_smoothing: float = 0,
         slice_size: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         # unpack
         hrt_batch = batch[0]
         # Send batch to device

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Optional
 
-import torch.utils.data
 from class_resolver import HintOrType, OptionalKwargs
 from torch.utils.data import DataLoader
 
@@ -13,7 +12,7 @@ from ..models.base import Model
 from ..sampling import NegativeSampler
 from ..triples import CoreTriplesFactory
 from ..triples.instances import SLCWABatch, SLCWASampleType
-from ..typing import InductiveMode
+from ..typing import FloatTensor, InductiveMode
 
 __all__ = [
     "SLCWATrainingLoop",
@@ -81,7 +80,7 @@ class SLCWATrainingLoop(TrainingLoop[SLCWASampleType, SLCWABatch]):
         stop: Optional[int],
         label_smoothing: float = 0.0,
         slice_size: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         # Slicing is not possible in sLCWA training loops
         if slice_size is not None:
             raise AttributeError("Slicing is not possible for sLCWA training loops.")
@@ -127,7 +126,7 @@ class SLCWATrainingLoop(TrainingLoop[SLCWASampleType, SLCWABatch]):
         stop: int,
         label_smoothing: float = 0.0,
         slice_size: Optional[int] = None,
-    ) -> torch.FloatTensor:  # noqa: D102
+    ) -> FloatTensor:  # noqa: D102
         return self._process_batch_static(
             model=self.model,
             loss=self.loss,

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -43,7 +43,7 @@ from ..models import RGCN, Model
 from ..stoppers import Stopper
 from ..trackers import ResultTracker, tracker_resolver
 from ..triples import CoreTriplesFactory, TriplesFactory
-from ..typing import InductiveMode
+from ..typing import FloatTensor, InductiveMode
 from ..utils import format_relative_comparison, get_batchnorm_modules, get_preferred_device, normalize_string
 
 __all__ = [
@@ -899,7 +899,7 @@ class TrainingLoop(Generic[SampleType, BatchType], ABC):
         stop: int,
         label_smoothing: float = 0.0,
         slice_size: Optional[int] = None,
-    ) -> torch.FloatTensor:
+    ) -> FloatTensor:
         """Process a single batch and returns the loss."""
         raise NotImplementedError
 

--- a/src/pykeen/triples/generation.py
+++ b/src/pykeen/triples/generation.py
@@ -4,7 +4,7 @@ import torch
 
 from .triples_factory import CoreTriplesFactory
 from .utils import get_entities, get_relations
-from ..typing import TorchRandomHint
+from ..typing import MappedTriples, TorchRandomHint
 from ..utils import ensure_torch_random_state
 
 __all__ = [
@@ -19,7 +19,7 @@ def generate_triples(
     num_triples: int = 101,
     compact: bool = True,
     random_state: TorchRandomHint = None,
-) -> torch.LongTensor:
+) -> MappedTriples:
     """Generate random triples in a torch tensor."""
     random_state = ensure_torch_random_state(random_state)
 

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -15,7 +15,7 @@ from torch.utils import data
 
 from .utils import compute_compressed_adjacency_list
 from ..sampling import NegativeSampler, negative_sampler_resolver
-from ..typing import MappedTriples
+from ..typing import BoolTensor, FloatTensor, LongTensor, MappedTriples
 
 __all__ = [
     "Instances",
@@ -26,22 +26,22 @@ __all__ = [
 # TODO: the same
 SampleType = TypeVar("SampleType")
 BatchType = TypeVar("BatchType")
-LCWASampleType = tuple[MappedTriples, torch.FloatTensor]
-LCWABatchType = tuple[MappedTriples, torch.FloatTensor]
-SLCWASampleType = tuple[MappedTriples, MappedTriples, Optional[torch.BoolTensor]]
+LCWASampleType = tuple[MappedTriples, FloatTensor]
+LCWABatchType = tuple[MappedTriples, FloatTensor]
+SLCWASampleType = tuple[MappedTriples, MappedTriples, Optional[BoolTensor]]
 
 
 class SLCWABatch(NamedTuple):
     """A batch for sLCWA training."""
 
     #: the positive triples, shape: (batch_size, 3)
-    positives: torch.LongTensor
+    positives: LongTensor
 
     #: the negative triples, shape: (batch_size, num_negatives_per_positive, 3)
-    negatives: torch.LongTensor
+    negatives: LongTensor
 
     #: filtering masks for negative triples, shape: (batch_size, num_negatives_per_positive)
-    masks: torch.BoolTensor | None
+    masks: BoolTensor | None
 
 
 class Instances(data.Dataset[BatchType], Generic[SampleType, BatchType], ABC):
@@ -132,11 +132,11 @@ class SLCWAInstances(Instances[SLCWASampleType, SLCWABatch]):
     def collate(samples: Iterable[SLCWASampleType]) -> SLCWABatch:
         """Collate samples."""
         # each shape: (1, 3), (1, k, 3), (1, k, 3)?
-        masks: torch.LongTensor | None
+        masks: LongTensor | None
         positives, negatives, masks = zip(*samples)
         positives = torch.cat(positives, dim=0)
         negatives = torch.cat(negatives, dim=0)
-        mask_batch: torch.BoolTensor | None
+        mask_batch: BoolTensor | None
         if masks[0] is None:
             assert all(m is None for m in masks)
             mask_batch = None

--- a/src/pykeen/triples/leakage.py
+++ b/src/pykeen/triples/leakage.py
@@ -18,7 +18,7 @@ import torch
 
 from pykeen.datasets.base import EagerDataset
 from pykeen.triples.triples_factory import CoreTriplesFactory, TriplesFactory, cat_triples
-from pykeen.typing import MappedTriples
+from pykeen.typing import LongTensor, MappedTriples
 from pykeen.utils import compact_mapping, get_connected_components
 
 __all__ = [
@@ -95,8 +95,8 @@ def triples_factory_to_sparse_matrices(
 
 
 def _to_one_hot(
-    rows: torch.LongTensor,
-    cols: torch.LongTensor,
+    rows: LongTensor,
+    cols: LongTensor,
     shape: tuple[int, int],
 ) -> scipy.sparse.spmatrix:
     """Create a one-hot matrix given indices of non-zero elements (potentially containing duplicates)."""
@@ -274,9 +274,9 @@ def unleak(
 
 
 def _generate_compact_vectorized_lookup(
-    ids: torch.LongTensor,
+    ids: LongTensor,
     label_to_id: Mapping[str, int],
-) -> tuple[Mapping[str, int], torch.LongTensor]:
+) -> tuple[Mapping[str, int], LongTensor]:
     """
     Given a tensor of IDs and a label to ID mapping, retain only occurring IDs, and compact the mapping.
 
@@ -307,8 +307,8 @@ def _generate_compact_vectorized_lookup(
 
 def _translate_triples(
     triples: MappedTriples,
-    entity_translation: torch.LongTensor,
-    relation_translation: torch.LongTensor,
+    entity_translation: LongTensor,
+    relation_translation: LongTensor,
 ) -> MappedTriples:
     """
     Translate triples given vectorized translations for entities and relations.

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -12,7 +12,7 @@ import torch
 from class_resolver.api import ClassResolver, HintOrType
 
 from ..constants import COLUMN_LABELS
-from ..typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, MappedTriples, Target, TorchRandomHint
+from ..typing import LABEL_HEAD, LABEL_RELATION, LABEL_TAIL, BoolTensor, MappedTriples, Target, TorchRandomHint
 from ..utils import ensure_torch_random_state
 
 logger = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ def _get_covered_entities(df: pandas.DataFrame, chosen: Collection[int]) -> set[
     return set(numpy.unique(df.loc[df["index"].isin(chosen), [LABEL_HEAD, LABEL_TAIL]]))
 
 
-def _get_cover_deterministic(triples: MappedTriples) -> torch.BoolTensor:
+def _get_cover_deterministic(triples: MappedTriples) -> BoolTensor:
     """
     Get a coverage mask for all entities and relations.
 
@@ -226,7 +226,7 @@ def _prepare_cleanup(
     training: MappedTriples,
     testing: MappedTriples,
     max_ids: Optional[tuple[int, int]] = None,
-) -> torch.BoolTensor:
+) -> BoolTensor:
     """
     Calculate a mask for the test triples with triples containing test-only entities or relations.
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -26,7 +26,15 @@ from .splitting import split
 from .utils import TRIPLES_DF_COLUMNS, load_triples, tensor_to_df
 from ..constants import COLUMN_LABELS
 from ..inverse import relation_inverter_resolver
-from ..typing import EntityMapping, LabeledTriples, MappedTriples, RelationMapping, TorchRandomHint
+from ..typing import (
+    BoolTensor,
+    EntityMapping,
+    LabeledTriples,
+    LongTensor,
+    MappedTriples,
+    RelationMapping,
+    TorchRandomHint,
+)
 from ..utils import (
     ExtraReprMixin,
     compact_mapping,
@@ -140,7 +148,7 @@ def _get_triple_mask(
     columns: Union[int, Collection[int]],
     invert: bool = False,
     max_id: Optional[int] = None,
-) -> torch.BoolTensor:
+) -> BoolTensor:
     # normalize input
     triples = triples[:, columns]
     if isinstance(columns, int):
@@ -188,7 +196,7 @@ class Labeling:
 
     def label(
         self,
-        ids: Union[int, Sequence[int], np.ndarray, torch.LongTensor],
+        ids: Union[int, Sequence[int], np.ndarray, LongTensor],
         unknown_label: str = "unknown",
     ) -> np.ndarray:
         """Convert IDs to labels."""
@@ -649,7 +657,7 @@ class CoreTriplesFactory(KGInfo):
         self,
         relations: Collection[int],
         invert: bool = False,
-    ) -> torch.BoolTensor:
+    ) -> BoolTensor:
         """Get a boolean mask for triples with the given relations."""
         return _get_triple_mask(
             ids=relations,
@@ -661,7 +669,7 @@ class CoreTriplesFactory(KGInfo):
 
     def tensor_to_df(
         self,
-        tensor: torch.LongTensor,
+        tensor: LongTensor,
         **kwargs: Union[torch.Tensor, np.ndarray, Sequence],
     ) -> pd.DataFrame:
         """Take a tensor of triples and make a pandas dataframe with labels.
@@ -1151,7 +1159,7 @@ class TriplesFactory(CoreTriplesFactory):
         self,
         relations: Union[Collection[int], Collection[str]],
         invert: bool = False,
-    ) -> torch.BoolTensor:
+    ) -> BoolTensor:
         """Get a boolean mask for triples with the given relations."""
         return super().get_mask_for_relations(relations=self.relations_to_ids(relations=relations), invert=invert)
 
@@ -1187,7 +1195,7 @@ class TriplesFactory(CoreTriplesFactory):
             top=top or 100,
         )
 
-    def _word_cloud(self, *, ids: torch.LongTensor, id_to_label: Mapping[int, str], top: int):
+    def _word_cloud(self, *, ids: LongTensor, id_to_label: Mapping[int, str], top: int):
         try:
             from wordcloud import WordCloud
         except ImportError:
@@ -1219,7 +1227,7 @@ class TriplesFactory(CoreTriplesFactory):
     # docstr-coverage: inherited
     def tensor_to_df(
         self,
-        tensor: torch.LongTensor,
+        tensor: LongTensor,
         **kwargs: Union[torch.Tensor, np.ndarray, Sequence],
     ) -> pd.DataFrame:  # noqa: D102
         data = super().tensor_to_df(tensor=tensor, **kwargs)

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -11,7 +11,7 @@ import torch
 
 from .triples_factory import TriplesFactory
 from .utils import load_triples
-from ..typing import EntityMapping, LabeledTriples, MappedTriples
+from ..typing import EntityMapping, FloatTensor, LabeledTriples, MappedTriples
 
 __all__ = [
     "TriplesNumericLiteralsFactory",
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_matrix_of_literals(
-    numeric_triples: np.array,
+    numeric_triples: np.ndarray,
     entity_to_id: EntityMapping,
 ) -> tuple[np.ndarray, dict[str, int]]:
     """Create matrix of literals where each row corresponds to an entity and each column to a literal."""
@@ -107,7 +107,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
             literals_to_id=literals_to_id,
         )
 
-    def get_numeric_literals_tensor(self) -> torch.FloatTensor:
+    def get_numeric_literals_tensor(self) -> FloatTensor:
         """Return the numeric literals as a tensor."""
         return torch.as_tensor(self.numeric_literals, dtype=torch.float32)
 

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -9,7 +9,7 @@ import pandas
 import torch
 from class_resolver import FunctionResolver
 
-from ..typing import LabeledTriples, MappedTriples
+from ..typing import LabeledTriples, LongTensor, MappedTriples
 
 __all__ = [
     "compute_compressed_adjacency_list",
@@ -87,18 +87,18 @@ def load_triples(
     return df.to_numpy()
 
 
-def get_entities(triples: torch.LongTensor) -> set[int]:
+def get_entities(triples: LongTensor) -> set[int]:
     """Get all entities from the triples."""
     return set(triples[:, [0, 2]].flatten().tolist())
 
 
-def get_relations(triples: torch.LongTensor) -> set[int]:
+def get_relations(triples: LongTensor) -> set[int]:
     """Get all relations from the triples."""
     return set(triples[:, 1].tolist())
 
 
 def tensor_to_df(
-    tensor: torch.LongTensor,
+    tensor: LongTensor,
     **kwargs: Union[torch.Tensor, np.ndarray, Sequence],
 ) -> pandas.DataFrame:
     """Take a tensor of triples and make a pandas dataframe with labels.
@@ -146,7 +146,7 @@ def tensor_to_df(
 def compute_compressed_adjacency_list(
     mapped_triples: MappedTriples,
     num_entities: Optional[int] = None,
-) -> tuple[torch.LongTensor, torch.LongTensor, torch.LongTensor]:
+) -> tuple[LongTensor, LongTensor, LongTensor]:
     """Compute compressed undirected adjacency list representation for efficient sampling.
 
     The compressed adjacency list format is inspired by CSR sparse matrix format.

--- a/src/pykeen/typing.py
+++ b/src/pykeen/typing.py
@@ -8,6 +8,7 @@ from typing import Callable, Literal, NamedTuple, TypeVar, Union, cast
 import numpy as np
 import torch
 from class_resolver import Hint, HintOrType, HintType
+from typing_extensions import TypeAlias  # Python <=3.10
 
 __all__ = [
     # General types
@@ -61,21 +62,28 @@ __all__ = [
 
 X = TypeVar("X")
 
+# some PyTorch functions to not properly propagate types (e.g., float() does not return FloatTensor but Tensor)
+# however it is still useful to distinguish float tensors from long ones
+# to make the switch easier once PyTorch improves typing, we use a global type alias inside PyKEEN.
+BoolTensor: TypeAlias = torch.Tensor  # replace by torch.BoolTensor
+FloatTensor: TypeAlias = torch.Tensor  # replace by torch.FloatTensor
+LongTensor: TypeAlias = torch.Tensor  # replace by torch.LongTensor
+
 #: A function that mutates the input and returns a new object of the same type as output
 Mutation = Callable[[X], X]
 OneOrSequence = Union[X, Sequence[X]]
 
 LabeledTriples = np.ndarray
-MappedTriples = torch.LongTensor
+MappedTriples = LongTensor
 EntityMapping = Mapping[str, int]
 RelationMapping = Mapping[str, int]
 
 #: A function that can be applied to a tensor to initialize it
-Initializer = Mutation[torch.FloatTensor]
+Initializer = Mutation[FloatTensor]
 #: A function that can be applied to a tensor to normalize it
-Normalizer = Mutation[torch.FloatTensor]
+Normalizer = Mutation[FloatTensor]
 #: A function that can be applied to a tensor to constrain it
-Constrainer = Mutation[torch.FloatTensor]
+Constrainer = Mutation[FloatTensor]
 
 
 def cast_constrainer(f) -> Constrainer:
@@ -88,23 +96,23 @@ DeviceHint = Hint[torch.device]
 #: A hint for a :class:`torch.Generator`
 TorchRandomHint = Union[None, int, torch.Generator]
 
-Representation = TypeVar("Representation", bound=OneOrSequence[torch.FloatTensor])
+Representation = TypeVar("Representation", bound=OneOrSequence[FloatTensor])
 #: A type variable for head representations used in :class:`pykeen.models.Model`,
 #: :class:`pykeen.nn.modules.Interaction`, etc.
-HeadRepresentation = TypeVar("HeadRepresentation", bound=OneOrSequence[torch.FloatTensor])
+HeadRepresentation = TypeVar("HeadRepresentation", bound=OneOrSequence[FloatTensor])
 #: A type variable for relation representations used in :class:`pykeen.models.Model`,
 #: :class:`pykeen.nn.modules.Interaction`, etc.
-RelationRepresentation = TypeVar("RelationRepresentation", bound=OneOrSequence[torch.FloatTensor])
+RelationRepresentation = TypeVar("RelationRepresentation", bound=OneOrSequence[FloatTensor])
 #: A type variable for tail representations used in :class:`pykeen.models.Model`,
 #: :class:`pykeen.nn.modules.Interaction`, etc.
-TailRepresentation = TypeVar("TailRepresentation", bound=OneOrSequence[torch.FloatTensor])
+TailRepresentation = TypeVar("TailRepresentation", bound=OneOrSequence[FloatTensor])
 
 
 class GaussianDistribution(NamedTuple):
     """A gaussian distribution with diagonal covariance matrix."""
 
-    mean: torch.FloatTensor
-    diagonal_covariance: torch.FloatTensor
+    mean: FloatTensor
+    diagonal_covariance: FloatTensor
 
 
 Sign = Literal[-1, 1]

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -41,7 +41,7 @@ from docdata import get_docdata
 from torch import nn
 
 from .constants import PYKEEN_BENCHMARKS
-from .typing import DeviceHint, MappedTriples, TorchRandomHint
+from .typing import BoolTensor, DeviceHint, FloatTensor, LongTensor, MappedTriples, TorchRandomHint
 from .version import get_git_hash
 
 __all__ = [
@@ -118,7 +118,7 @@ logger = logging.getLogger(__name__)
 _CUDNN_ERROR = "cuDNN error: CUDNN_STATUS_NOT_SUPPORTED. This error may appear if you passed in a non-contiguous input."
 
 
-def at_least_eps(x: torch.FloatTensor) -> torch.FloatTensor:
+def at_least_eps(x: FloatTensor) -> FloatTensor:
     """Make sure a tensor is greater than zero."""
     # get datatype specific epsilon
     eps = torch.finfo(x.dtype).eps
@@ -354,28 +354,28 @@ class Result(ABC):
 
 
 def split_complex(
-    x: torch.FloatTensor,
-) -> tuple[torch.FloatTensor, torch.FloatTensor]:
+    x: FloatTensor,
+) -> tuple[FloatTensor, FloatTensor]:
     """Split a complex tensor into real and imaginary part."""
     x = torch.view_as_real(x)
     return x[..., 0], x[..., 1]
 
 
-def view_complex(x: torch.FloatTensor) -> torch.Tensor:
+def view_complex(x: FloatTensor) -> torch.Tensor:
     """Convert a PyKEEN complex tensor representation into a torch one."""
     real, imag = split_complex(x=x)
     return torch.complex(real=real, imag=imag)
 
 
-def view_complex_native(x: torch.FloatTensor) -> torch.Tensor:
+def view_complex_native(x: FloatTensor) -> torch.Tensor:
     """Convert a PyKEEN complex tensor representation into a torch one using :func:`torch.view_as_complex`."""
     return torch.view_as_complex(x.view(*x.shape[:-1], -1, 2))
 
 
 def combine_complex(
-    x_re: torch.FloatTensor,
-    x_im: torch.FloatTensor,
-) -> torch.FloatTensor:
+    x_re: FloatTensor,
+    x_im: FloatTensor,
+) -> FloatTensor:
     """Combine a complex tensor from real and imaginary part."""
     return torch.view_as_complex(torch.stack([x_re, x_im], dim=-1))
 
@@ -560,8 +560,8 @@ def get_optimal_sequence(*shapes: tuple[int, ...]) -> tuple[int, tuple[int, ...]
 
 
 def _reorder(
-    tensors: tuple[torch.FloatTensor, ...],
-) -> tuple[torch.FloatTensor, ...]:
+    tensors: tuple[FloatTensor, ...],
+) -> tuple[FloatTensor, ...]:
     """Re-order tensors for broadcasted element-wise combination of tensors.
 
     The optimal execution plan gets cached so that the optimization is only performed once for a fixed set of shapes.
@@ -583,22 +583,22 @@ def _reorder(
     return tuple(tensors[i] for i in order)
 
 
-def tensor_sum(*tensors: torch.FloatTensor) -> torch.FloatTensor:
+def tensor_sum(*tensors: FloatTensor) -> FloatTensor:
     """Compute element-wise sum of tensors in broadcastable shape."""
     return sum(_reorder(tensors=tensors))
 
 
-def tensor_product(*tensors: torch.FloatTensor) -> torch.FloatTensor:
+def tensor_product(*tensors: FloatTensor) -> FloatTensor:
     """Compute element-wise product of tensors in broadcastable shape."""
     head, *rest = _reorder(tensors=tensors)
     return functools.reduce(operator.mul, rest, head)
 
 
 def negative_norm_of_sum(
-    *x: torch.FloatTensor,
+    *x: FloatTensor,
     p: str | int | float = 2,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate negative norm of a sum of vectors on already broadcasted representations.
 
     :param x: shape: (batch_size, num_heads, num_relations, num_tails, dim)
@@ -615,10 +615,10 @@ def negative_norm_of_sum(
 
 
 def negative_norm(
-    x: torch.FloatTensor,
+    x: FloatTensor,
     p: str | int | float = 2,
     power_norm: bool = False,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Evaluate negative norm of a vector.
 
     :param x: shape: (batch_size, num_heads, num_relations, num_tails, dim)
@@ -639,10 +639,10 @@ def negative_norm(
 
 
 def project_entity(
-    e: torch.FloatTensor,
-    e_p: torch.FloatTensor,
-    r_p: torch.FloatTensor,
-) -> torch.FloatTensor:
+    e: FloatTensor,
+    e_p: FloatTensor,
+    r_p: FloatTensor,
+) -> FloatTensor:
     r"""Project entity relation-specific.
 
     .. math::
@@ -696,12 +696,12 @@ def _normalize_dim(dim: int | str) -> int:
 
 # TODO delete? See note in test_sim.py on its only usage
 def convert_to_canonical_shape(
-    x: torch.FloatTensor,
+    x: FloatTensor,
     dim: int | str,
     num: int | None = None,
     batch_size: int = 1,
     suffix_shape: int | Sequence[int] = -1,
-) -> torch.FloatTensor:
+) -> FloatTensor:
     """Convert a tensor to canonical shape.
 
     :param x:
@@ -820,7 +820,7 @@ def extend_batch(
     batch: MappedTriples,
     max_id: int,
     dim: int,
-    ids: torch.LongTensor | None = None,
+    ids: LongTensor | None = None,
 ) -> MappedTriples:
     """Extend batch for 1-to-all scoring by explicit enumeration.
 
@@ -963,7 +963,7 @@ class Bias(nn.Module):
         """Reset the layer's parameters."""
         nn.init.zeros_(self.bias)
 
-    def forward(self, x: torch.FloatTensor) -> torch.FloatTensor:
+    def forward(self, x: FloatTensor) -> FloatTensor:
         """Add the learned bias to the input.
 
         :param x: shape: (n, d)
@@ -975,7 +975,7 @@ class Bias(nn.Module):
         return x + self.bias.unsqueeze(dim=0)
 
 
-def lp_norm(x: torch.FloatTensor, p: float, dim: int | None, normalize: bool) -> torch.FloatTensor:
+def lp_norm(x: FloatTensor, p: float, dim: int | None, normalize: bool) -> FloatTensor:
     """Return the $L_p$ norm."""
     value = x.norm(p=p, dim=dim)
     if not normalize:
@@ -983,7 +983,7 @@ def lp_norm(x: torch.FloatTensor, p: float, dim: int | None, normalize: bool) ->
     return value / get_expected_norm(p=p, d=x.shape[-1])
 
 
-def powersum_norm(x: torch.FloatTensor, p: float, dim: int | None, normalize: bool) -> torch.FloatTensor:
+def powersum_norm(x: FloatTensor, p: float, dim: int | None, normalize: bool) -> FloatTensor:
     """Return the power sum norm."""
     value = x.abs().pow(p).sum(dim=dim)
     if not normalize:
@@ -1058,12 +1058,12 @@ def getattr_or_docdata(cls, key: str) -> str:
     raise KeyError
 
 
-def triple_tensor_to_set(tensor: torch.LongTensor) -> set[tuple[int, ...]]:
+def triple_tensor_to_set(tensor: LongTensor) -> set[tuple[int, ...]]:
     """Convert a tensor of triples to a set of int-tuples."""
     return set(map(tuple, tensor.tolist()))
 
 
-def is_triple_tensor_subset(a: torch.LongTensor, b: torch.LongTensor) -> bool:
+def is_triple_tensor_subset(a: LongTensor, b: LongTensor) -> bool:
     """Check whether one tensor of triples is a subset of another one."""
     return triple_tensor_to_set(a).issubset(triple_tensor_to_set(b))
 
@@ -1246,7 +1246,7 @@ def ensure_complex(*xs: torch.Tensor) -> Iterable[torch.Tensor]:
 
 def _weisfeiler_lehman_iteration(
     adj: torch.Tensor,
-    colors: torch.LongTensor,
+    colors: LongTensor,
     dense_dtype: torch.dtype = torch.long,
 ) -> torch.Tensor:
     """
@@ -1283,7 +1283,7 @@ def _weisfeiler_lehman_iteration(
 
 def _weisfeiler_lehman_iteration_approx(
     adj: torch.Tensor,
-    colors: torch.LongTensor,
+    colors: LongTensor,
     dim: int = 32,
     decimals: int = 6,
 ) -> torch.Tensor:
@@ -1328,7 +1328,7 @@ def _weisfeiler_lehman_iteration_approx(
 
 
 def iter_weisfeiler_lehman(
-    edge_index: torch.LongTensor,
+    edge_index: LongTensor,
     max_iter: int = 2,
     num_nodes: int | None = None,
     approximate: bool = False,
@@ -1434,8 +1434,8 @@ def get_edge_index(
     # cannot use Optional[pykeen.triples.CoreTriplesFactory] due to cyclic imports
     triples_factory: Any | None = None,
     mapped_triples: MappedTriples | None = None,
-    edge_index: torch.LongTensor | None = None,
-) -> torch.LongTensor:
+    edge_index: LongTensor | None = None,
+) -> LongTensor:
     """
     Get the edge index from a number of different sources.
 
@@ -1589,7 +1589,7 @@ except ImportError:
     einsum = torch.einsum
 
 
-def isin_many_dim(elements: torch.Tensor, test_elements: torch.Tensor, dim: int = 0) -> torch.BoolTensor:
+def isin_many_dim(elements: torch.Tensor, test_elements: torch.Tensor, dim: int = 0) -> BoolTensor:
     """Return whether elements are contained in test elements."""
     inverse, counts = torch.cat([elements, test_elements], dim=dim).unique(
         return_counts=True, return_inverse=True, dim=dim


### PR DESCRIPTION
This PR extracts global type aliases for `torch.BoolTensor`, `torch.FloatTensor` and `torch.LongTensor`.

In PyTorch, almost all methods are typed to return a `torch.Tensor` instead of explicit base classes like `torch.FloatTensor`, even for operations like `Tensor.float()`. If we keep annotating with the more concrete data type related subclasses, we will either get some type warnings or have to explicitly `typing.cast` each time. On the other hand, if we replace everything with `torch.Tensor`, we may lose some semantics of the annotation, e.g. whether ids or embeddings are used.

The diff is quite large, but I think it's worth it.