### PR TITLE
🩹🛁 Fix backfill representation

### DIFF
--- a/docs/source/examples/nn/representation/backfill.py
+++ b/docs/source/examples/nn/representation/backfill.py
@@ -6,10 +6,8 @@ from pykeen.datasets import get_dataset
 from pykeen.nn import BackfillRepresentation, Embedding, init
 from pykeen.pipeline import pipeline
 
-# %%
 dataset = get_dataset(dataset="nations")
 
-# %%
 # we start by creating the representation for those entities where we have pre-trained features
 # here we simulate this for a set of Asian countries
 embedding_dim = 32
@@ -18,23 +16,19 @@ pre_trained_embeddings = torch.rand(len(known_ids), embedding_dim)
 initializer = init.PretrainedInitializer(tensor=pre_trained_embeddings)
 base_repr = Embedding(max_id=len(known_ids), shape=(embedding_dim,), initializer=initializer, trainable=False)
 
-# %%
 # Next, we directly create representations for the remaining ones using the backfill representation.
 # To do this, we need to create an iterable (e.g., a set) of all of the entity IDs that are in the base
 # representation. Then, the assignments to the base representation and an auxillary representation are
 # automatically generated for the base class.
 entity_repr = BackfillRepresentation(base_ids=known_ids, max_id=dataset.num_entities, base=base_repr)
 
-# %%
 # We assume that we do not have any pre-trained information for relations here for simplicity and train
 # them from scratch.
 relation_repr = Embedding(max_id=dataset.num_relations, shape=(embedding_dim,))
 
-# %%
 # The combined representation can now be used as any other representation, e.g., to train a model with
-# :class:`pykeen.nn.modules.DistMultInteraction` interaction:
+# distmult interaction:
 result = pipeline(
-    # model=ERModel,
     dataset=dataset,
     interaction="distmult",
     dimensions=dict(d=embedding_dim),

--- a/docs/source/examples/nn/representation/backfill.py
+++ b/docs/source/examples/nn/representation/backfill.py
@@ -1,0 +1,45 @@
+"""Example for backfill representations."""
+
+import torch
+
+from pykeen.datasets import get_dataset
+from pykeen.nn import BackfillRepresentation, Embedding, init
+from pykeen.pipeline import pipeline
+
+# %%
+dataset = get_dataset(dataset="nations")
+
+# %%
+# we start by creating the representation for those entities where we have pre-trained features
+# here we simulate this for a set of Asian countries
+embedding_dim = 32
+known_ids = dataset.training.entities_to_ids(["burma", "china", "india", "indonesia"])
+pre_trained_embeddings = torch.rand(len(known_ids), embedding_dim)
+initializer = init.PretrainedInitializer(tensor=pre_trained_embeddings)
+base_repr = Embedding(max_id=len(known_ids), shape=(embedding_dim,), initializer=initializer, trainable=False)
+
+# %%
+# Next, we directly create representations for the remaining ones using the backfill representation.
+# To do this, we need to create an iterable (e.g., a set) of all of the entity IDs that are in the base
+# representation. Then, the assignments to the base representation and an auxillary representation are
+# automatically generated for the base class.
+entity_repr = BackfillRepresentation(base_ids=known_ids, max_id=dataset.num_entities, base=base_repr)
+
+# %%
+# We assume that we do not have any pre-trained information for relations here for simplicity and train
+# them from scratch.
+relation_repr = Embedding(max_id=dataset.num_relations, shape=(embedding_dim,))
+
+# %%
+# The combined representation can now be used as any other representation, e.g., to train a model with
+# :class:`pykeen.nn.modules.DistMultInteraction` interaction:
+result = pipeline(
+    # model=ERModel,
+    dataset=dataset,
+    interaction="distmult",
+    dimensions=dict(d=embedding_dim),
+    model_kwargs=dict(
+        entity_representations=entity_repr,
+        relation_representations=relation_repr,
+    ),
+)

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1476,7 +1476,7 @@ class PartitionRepresentation(Representation):
         super().__init__(max_id=assignment.shape[0], shape=shape, **kwargs)
 
         # assign modules / buffers *after* super init
-        self.bases = bases
+        self.bases = nn.ModuleList(bases)
         self.register_buffer(name="assignment", tensor=assignment)
 
     # docstr-coverage: inherited

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1512,45 +1512,7 @@ class PartitionRepresentation(Representation):
 class BackfillRepresentation(PartitionRepresentation):
     """A variant of a partition representation that is easily applicable to a single base representation.
 
-    Similarly to the :class:`PartitionRepresentation` representation example, we start by
-    creating the representation for those entities where we have labels:
-
-    >>> from pykeen.nn import Embedding, init
-    >>> num_entities = 5
-    >>> labels = {1: "a first description", 4: "a second description"}
-    >>> label_initializer = init.LabelBasedInitializer(labels=list(labels.values()))
-    >>> shape = label_initializer.tensor.shape[1:]
-    >>> label_repr = Embedding(max_id=len(labels), shape=shape, initializer=label_initializer, trainable=False)
-
-    Next, we directly create representations for the remaining ones using the backfill representation.
-    To do this, we need to create an iterable (e.g., a set) of all of the entity IDs that are in the base
-    representation. Then, the assignments to the base representation and an auxillary representation are
-    automatically generated for the base class
-
-    >>> from pykeen.nn import BackfillRepresentation
-    >>> entity_repr = BackfillRepresentation(base_ids=set(labels), max_id=num_entities, base=label_repr)
-
-    For brevity, we use here randomly generated triples factories instead of the actual data
-
-    >>> from pykeen.triples.generation import generate_triples_factory
-    >>> training = generate_triples_factory(num_entities=num_entities, num_relations=5, num_triples=31)
-    >>> testing = generate_triples_factory(num_entities=num_entities, num_relations=5, num_triples=17)
-
-    The combined representation can now be used as any other representation, e.g., to train a model with
-    :class:`pykeen.nn.modules.DistMultInteraction` interaction:
-
-    >>> from pykeen.pipeline import pipeline
-    >>> from pykeen.models import ERModel
-    >>> pipeline(
-    ...     model=ERModel,
-    ...     interaction="distmult",
-    ...     model_kwargs=dict(
-    ...         entity_representation=entity_repr,
-    ...         relation_representation_kwargs=dict(shape=shape),
-    ...     ),
-    ...     training=training,
-    ...     testing=testing,
-    ... )
+    .. literalinclude:: ../examples/nn/representation/backfill.py
 
     ---
     name: Backfill


### PR DESCRIPTION
- [x] wrap `bases` into `nn.ModuleList` before assigning attribute of `BackfillRepresentation` (this is important to ensure that PyTorch moves the sub-modules to the same device)
- [x] extract `BackfillRepresentation` into file and fix it