### PR TITLE
🐈👩 Increase maximum sphinx version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,8 +128,8 @@ tests = [
     "pytest",
 ]
 docs = [
-    "sphinx",
-    "sphinx-rtd-theme",
+    "sphinx>=8.0",
+    "sphinx-rtd-theme>=3.0",
     "sphinx-click",
     "sphinx_automodapi",
     "texext",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,8 +128,7 @@ tests = [
     "pytest",
 ]
 docs = [
-    # Sphinx >= 8.0 not supported by rtd theme, cf. https://github.com/readthedocs/sphinx_rtd_theme/issues/1582
-    "sphinx<8",
+    "sphinx",
     "sphinx-rtd-theme",
     "sphinx-click",
     "sphinx_automodapi",


### PR DESCRIPTION
Remove Sphinx<8 requirement (since https://github.com/readthedocs/sphinx_rtd_theme/issues/1582 was merged)