### PR TITLE
🚨🦺 Fix fast tests not running

### DIFF
--- a/src/pykeen/experiments/ermlp/ali2020_ermlp_fb15k237.yaml
+++ b/src/pykeen/experiments/ermlp/ali2020_ermlp_fb15k237.yaml
@@ -14,6 +14,7 @@ pipeline:
   model_kwargs:
     embedding_dim: 64
     hidden_dim: 64
+    activation: relu
   optimizer: adam
   optimizer_kwargs:
     lr: 0.005779875816374009

--- a/src/pykeen/experiments/ermlp/ali2020_ermlp_wn18rr.yaml
+++ b/src/pykeen/experiments/ermlp/ali2020_ermlp_wn18rr.yaml
@@ -14,6 +14,7 @@ pipeline:
   model_kwargs:
     embedding_dim: 64
     hidden_dim: 64
+    activation: relu
   negative_sampler: basic
   negative_sampler_kwargs:
     num_negs_per_pos: 11

--- a/src/pykeen/nn/text.py
+++ b/src/pykeen/nn/text.py
@@ -110,7 +110,7 @@ class TextEncoder(nn.Module):
         :returns: shape: (len(labels), dim)
             a tensor representing the encodings for all labels
         """
-        determine_maximum_batch_size(
+        batch_size = determine_maximum_batch_size(
             batch_size=batch_size, device=get_preferred_device(self), maximum_batch_size=len(labels)
         )
         return _encode_all_memory_utilization_optimized(encoder=self, labels=labels, batch_size=batch_size).detach()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,6 +28,7 @@ from pykeen.triples.triples_factory import CoreTriplesFactory
 from pykeen.utils import all_in_bounds, extend_batch
 from tests import cases
 from tests.constants import EPSILON
+from tests.test_batch_size_reduction import MockModel
 
 SKIP_MODULES = {
     Model,
@@ -38,6 +39,7 @@ SKIP_MODULES = {
     InductiveERModel,
     FixedModel,
     EvaluationOnlyModel,
+    MockModel,
 }
 SKIP_MODULES.update(LiteralModel.__subclasses__())
 SKIP_MODULES.update(EvaluationOnlyModel.__subclasses__())

--- a/tests/test_training/test_lr_scheduler.py
+++ b/tests/test_training/test_lr_scheduler.py
@@ -11,8 +11,7 @@ from pykeen.pipeline import pipeline
     "cls, kwargs",
     [
         (None, None),
-        ("CosineAnnealingWarmRestarts", None),
-        ("CosineAnnealingWarmRestarts", {"T_0": 10}),
+        ("CosineAnnealingWarmRestarts", {"T_0": 10})
     ],
 )
 def test_lr_scheduler(cls: HintOrType[lr_scheduler.LRScheduler], kwargs: OptionalKwargs) -> None:

--- a/tests/test_training/test_lr_scheduler.py
+++ b/tests/test_training/test_lr_scheduler.py
@@ -9,10 +9,7 @@ from pykeen.pipeline import pipeline
 
 @pytest.mark.parametrize(
     "cls, kwargs",
-    [
-        (None, None),
-        ("CosineAnnealingWarmRestarts", {"T_0": 10})
-    ],
+    [(None, None), ("CosineAnnealingWarmRestarts", {"T_0": 10})],
 )
 def test_lr_scheduler(cls: HintOrType[lr_scheduler.LRScheduler], kwargs: OptionalKwargs) -> None:
     """Smoke-test for training with learning rate schedule."""

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,12 @@ allowlist_externals =
     /usr/bin/git
     /usr/local/bin/git
 
+[testenv:py]
+commands = coverage run -p -m pytest --durations=20 {posargs:tests} -m 'not slow'
+extras =
+    mlflow
+    tests
+
 [testenv:integration]
 commands = coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
 extras =


### PR DESCRIPTION
On master, the fast tests are not run. This seems to be an issue with the underlying tox enviromment.

```
$ tox -e py
.pkg: _optional_hooks> python $CODE/pykeen/venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_sdist> python $CODE/pykeen/venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_editable> python $CODE/pykeen/venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: build_sdist> python $CODE/pykeen/venv/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
py: install_package> venv/bin/uv pip install --reinstall --no-deps pykeen@$CODE/pykeen/.tox/.tmp/package/17/pykeen-1.10.3.dev0.tar.gz
  py: OK (2.70 seconds)
  congratulations :) (2.77 seconds)
```

After [3f8cc8e](https://github.com/pykeen/pykeen/pull/1458/commits/3f8cc8e09af29bd60ca9014b3feeda7cb02f9bdd), I get the following failing test cases:
```
FAILED tests/test_experiment_integrity.py::TestExperimentIntegrity::test_integrity_ermlp_ali2020_ermlp_fb15k237 - AssertionError: Errors found in ermlp: $CODE/pykeen/.tox/py/lib/python3.12/site-packages/pykeen/experiments/ermlp/ali2020_ermlp_fb15k237.yaml:
FAILED tests/test_experiment_integrity.py::TestExperimentIntegrity::test_integrity_ermlp_ali2020_ermlp_wn18rr - AssertionError: Errors found in ermlp: $CODE/pykeen/.tox/py/lib/python3.12/site-packages/pykeen/experiments/ermlp/ali2020_ermlp_wn18rr.yaml:
FAILED tests/test_models.py::TestTesting::test_testing - AssertionError: Items in the second set but not the first:
FAILED tests/test_nn/test_modules.py::ConvETests::test_scores - TypeError: ConvETests._exp_score() missing 6 required positional arguments: 'embedding_height', 'embedding_width', 'hr1d', 'hr2d', 'input_channels', and 't_bias'
FAILED tests/test_nn/test_modules.py::ConvKBTests::test_scores - TypeError: ConvKBTests._exp_score() missing 4 required positional arguments: 'conv', 'activation', 'hidden_dropout', and 'linear'
FAILED tests/test_nn/test_modules.py::CrossETests::test_scores - AttributeError: 'CrossEInteraction' object has no attribute 'combination_bias'
FAILED tests/test_nn/test_modules.py::KG2ETests::test_scores - TypeError: KG2ETests._exp_score() got an unexpected keyword argument 'h'
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_1d_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_2d_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_all_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_dropout - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_from_dataset - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_instance - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_max_id - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_no_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::TextRepresentationTests::test_str - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_1d_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_2d_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_all_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_dropout - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_from_dataset - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_instance - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_max_id - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_no_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::CachedTextRepresentationTests::test_str - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::WikidataTextRepresentationTests::test_1d_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::WikidataTextRepresentationTests::test_2d_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::WikidataTextRepresentationTests::test_all_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::WikidataTextRepresentationTests::test_dropout - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::WikidataTextRepresentationTests::test_instance - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::WikidataTextRepresentationTests::test_max_id - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::WikidataTextRepresentationTests::test_no_indices - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_representation.py::WikidataTextRepresentationTests::test_str - ValueError: Neither value nor default value found
FAILED tests/test_nn/test_text.py::CharacterEmbeddingTextEncoderTestCase::test_encode - ValueError: Neither value nor default value found
FAILED tests/test_training/test_lr_scheduler.py::test_lr_scheduler[CosineAnnealingWarmRestarts-None] - TypeError: CosineAnnealingWarmRestarts.__init__() missing 1 required positional argument: 'T_0'
```