### PR TITLE
🧼🫧 Fix shape handling in Interaction

### DIFF
--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -361,7 +361,7 @@ class ERModel(
             representations=representations,
             representations_kwargs=representations_kwargs,
             max_id=triples_factory.num_entities if label == "entity" else triples_factory.num_relations,
-            shapes=self.interaction.full_entity_shapes() if label == "entity" else self.interaction.relation_shape,
+            shapes=self.interaction.entity_shape if label == "entity" else self.interaction.relation_shape,
             label=label,
             **kwargs,
         )
@@ -654,8 +654,8 @@ class ERModel(
     ) -> tuple[HeadRepresentation, RelationRepresentation, TailRepresentation]:
         """Get representations for head, relation and tails."""
         head_representations = tail_representations = self._get_entity_representations_from_inductive_mode(mode=mode)
-        head_representations = [head_representations[i] for i in self.interaction.head_indices()]
-        tail_representations = [tail_representations[i] for i in self.interaction.tail_indices()]
+        head_representations = [head_representations[i] for i in self.interaction.head_indices]
+        tail_representations = [tail_representations[i] for i in self.interaction.tail_indices]
         hr, rr, tr = (
             [representation(indices=indices) for representation in representations]
             for indices, representations in (

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -134,7 +134,7 @@ def make_model_cls(
 
     entity_representations_kwargs, relation_representations_kwargs = _normalize_representation_kwargs(
         dimensions=dimensions,
-        interaction=interaction_instance,
+        interaction=interaction_instance, # type: ignore
         entity_representations_kwargs=entity_representations_kwargs,
         relation_representations_kwargs=relation_representations_kwargs,
     )

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -134,7 +134,7 @@ def make_model_cls(
 
     entity_representations_kwargs, relation_representations_kwargs = _normalize_representation_kwargs(
         dimensions=dimensions,
-        interaction=interaction_instance.__class__,  # type: ignore
+        interaction=interaction_instance,
         entity_representations_kwargs=entity_representations_kwargs,
         relation_representations_kwargs=relation_representations_kwargs,
     )
@@ -161,7 +161,7 @@ def make_model_cls(
 
 def _normalize_representation_kwargs(
     dimensions: Union[int, Mapping[str, int]],
-    interaction: type[Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation]],
+    interaction: Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation],
     entity_representations_kwargs: OptionalKwargs,
     relation_representations_kwargs: OptionalKwargs,
 ) -> tuple[Sequence[OptionalKwargs], Sequence[OptionalKwargs]]:
@@ -169,8 +169,8 @@ def _normalize_representation_kwargs(
     if isinstance(dimensions, int):
         dimensions = {"d": dimensions}
     assert isinstance(dimensions, dict)
-    if set(dimensions) < interaction.get_dimensions():
-        raise DimensionError(set(dimensions), interaction.get_dimensions())
+    if set(dimensions) < interaction.dimensions:
+        raise DimensionError(set(dimensions), interaction.dimensions)
     if entity_representations_kwargs is None:
         entity_representations_kwargs = [
             dict(shape=tuple(dimensions[d] for d in shape)) for shape in interaction.entity_shape

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -134,7 +134,7 @@ def make_model_cls(
 
     entity_representations_kwargs, relation_representations_kwargs = _normalize_representation_kwargs(
         dimensions=dimensions,
-        interaction=interaction_instance, # type: ignore
+        interaction=interaction_instance,  # type: ignore
         entity_representations_kwargs=entity_representations_kwargs,
         relation_representations_kwargs=relation_representations_kwargs,
     )

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -172,9 +172,6 @@ def _normalize_representation_kwargs(
     if set(dimensions) < interaction.get_dimensions():
         raise DimensionError(set(dimensions), interaction.get_dimensions())
     if entity_representations_kwargs is None:
-        # TODO: Does not work for interactions with separate tail_entity_shape (i.e., ConvE)
-        if interaction._tail_entity_shape is not None:
-            raise NotImplementedError
         entity_representations_kwargs = [
             dict(shape=tuple(dimensions[d] for d in shape)) for shape in interaction.entity_shape
         ]

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -2707,7 +2707,7 @@ class CPInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTensor]
         github: facebookresearch/kbc
     """
 
-    entity_shape = ("kd",)
+    entity_shape = ("kd", "kd")
     relation_shape = ("kd",)
     _head_indices = (0,)
     _tail_indices = (1,)

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -177,14 +177,14 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
     is_complex: ClassVar[bool] = False
 
     @property
-    def head_entity_shape(self) -> Sequence[str]:
+    def head_shape(self) -> Sequence[str]:
         """Return the symbolic shape for head entity representations."""
         if self._head_indices is None:
             return self.entity_shape
         return [self.entity_shape[i] for i in self._head_indices]
 
     @property
-    def tail_entity_shape(self) -> Sequence[str]:
+    def tail_shape(self) -> Sequence[str]:
         """Return the symbolic shape for tail entity representations."""
         if self._tail_indices is None:
             return self.entity_shape
@@ -201,7 +201,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
     def tail_indices(self) -> Sequence[int]:
         """Return the entity representation indices used for the tail representations."""
         if self._tail_indices is None:
-            return range(len(self.tail_entity_shape))
+            return range(len(self.tail_shape))
         return self._tail_indices
 
     @property

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -15,7 +15,6 @@ from typing import (
     Callable,
     ClassVar,
     Generic,
-    cast,
 )
 
 import more_itertools
@@ -158,10 +157,6 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
     #: The symbolic shapes for entity representations
     entity_shape: Sequence[str] = ("d",)
 
-    #: The symbolic shapes for entity representations for tail entities, if different.
-    #: Otherwise, the entity_shape is used for head & tail entities
-    _tail_entity_shape: Sequence[str] | None = None
-
     #: The symbolic shapes for relation representations
     relation_shape: Sequence[str] = ("d",)
 
@@ -171,6 +166,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
     # if the interaction function's tail parameter should only receive a subset of entity representations
     _tail_indices: Sequence[int] | None = None
 
+    # TODO: does not seem to be used
     #: the interaction's value range (for unrestricted input)
     value_range: ClassVar[ValueRange] = ValueRange()
 
@@ -181,40 +177,36 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
     is_complex: ClassVar[bool] = False
 
     @property
+    def head_entity_shape(self) -> Sequence[str]:
+        """Return the symbolic shape for head entity representations."""
+        if self._head_indices is None:
+            return self.entity_shape
+        return [self.entity_shape[i] for i in self._head_indices]
+
+    @property
     def tail_entity_shape(self) -> Sequence[str]:
         """Return the symbolic shape for tail entity representations."""
-        if self._tail_entity_shape is None:
+        if self._tail_indices is None:
             return self.entity_shape
-        return self._tail_entity_shape
+        return [self.entity_shape[i] for i in self._tail_indices]
 
+    @property
     def head_indices(self) -> Sequence[int]:
         """Return the entity representation indices used for the head representations."""
         if self._head_indices is None:
-            return list(range(len(self.entity_shape)))
+            return range(len(self.entity_shape))
         return self._head_indices
 
+    @property
     def tail_indices(self) -> Sequence[int]:
         """Return the entity representation indices used for the tail representations."""
         if self._tail_indices is None:
-            return list(range(len(self.tail_entity_shape)))
+            return range(len(self.tail_entity_shape))
         return self._tail_indices
-
-    def full_entity_shapes(self) -> Sequence[str]:
-        """Return all entity shapes (head & tail)."""
-        shapes: list[str | None] = [None] * (max(itt.chain(self.head_indices(), self.tail_indices())) + 1)
-        for hi, hs in zip(self.head_indices(), self.entity_shape):
-            shapes[hi] = hs
-        for ti, ts in zip(self.tail_indices(), self.tail_entity_shape):
-            if shapes[ti] is not None and ts != shapes[ti]:
-                raise ValueError("Shape conflict.")
-            shapes[ti] = ts
-        if None in shapes:
-            raise AssertionError("Unused shape.")
-        return cast(list[str], shapes)
 
     @classmethod
     def get_dimensions(cls) -> set[str]:
-        """Get all of the relevant dimension keys.
+        """Get all the relevant dimension keys.
 
         This draws from :data:`Interaction.entity_shape`, :data:`Interaction.relation_shape`, and in the case of
         :class:`ConvEInteraction`, the :data:`Interaction.tail_entity_shape`.
@@ -222,7 +214,7 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
         :returns: a set of strings representting the dimension keys.
         """
         # TODO: cannot cover dynamic shapes, e.g., AutoSF
-        return set(itt.chain(cls.entity_shape, cls._tail_entity_shape or set(), cls.relation_shape))
+        return set(itt.chain(cls.entity_shape, cls.relation_shape))
 
     @abstractmethod
     def forward(
@@ -808,7 +800,9 @@ class ConvEInteraction(Interaction[FloatTensor, FloatTensor, tuple[FloatTensor, 
     """
 
     # vector & scalar offset
-    _tail_entity_shape = ("d", "")
+    entity_shape = ("d", "")
+    # the offset is only used for tails
+    _head_indices = (0,)
 
     #: The head-relation encoder operating on 2D "images"
     hr2d: nn.Module
@@ -2232,7 +2226,8 @@ class MonotonicAffineTransformationInteraction(
         # forward entity/relation shapes
         self.entity_shape = base.entity_shape
         self.relation_shape = base.relation_shape
-        self._tail_entity_shape = base._tail_entity_shape
+        self._head_indices = base._head_indices
+        self._tail_indices = base._tail_indices
 
         # The parameters of the affine transformation: bias
         self.bias = nn.Parameter(torch.empty(size=tuple()), requires_grad=trainable_bias)

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -204,17 +204,15 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
             return range(len(self.tail_entity_shape))
         return self._tail_indices
 
-    @classmethod
-    def get_dimensions(cls) -> set[str]:
+    @property
+    def dimensions(self) -> set[str]:
         """Get all the relevant dimension keys.
 
-        This draws from :data:`Interaction.entity_shape`, :data:`Interaction.relation_shape`, and in the case of
-        :class:`ConvEInteraction`, the :data:`Interaction.tail_entity_shape`.
+        This draws from :data:`Interaction.entity_shape`, and :data:`Interaction.relation_shape`.
 
-        :returns: a set of strings representting the dimension keys.
+        :returns: a set of strings representing the dimension keys.
         """
-        # TODO: cannot cover dynamic shapes, e.g., AutoSF
-        return set(itt.chain(cls.entity_shape, cls.relation_shape))
+        return set(itt.chain(self.entity_shape, self.relation_shape))
 
     @abstractmethod
     def forward(

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -487,8 +487,7 @@ class InteractionTestCase(
                 for weight_shape in weight_shapes
             )
             for prefix_shape, weight_shapes in zip(
-                shapes,
-                [self.instance.entity_shape, self.instance.relation_shape, self.instance.tail_entity_shape],
+                shapes, [self.instance.head_entity_shape, self.instance.relation_shape, self.instance.tail_entity_shape]
             )
         )
         return unpack_singletons(*result)

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -487,7 +487,7 @@ class InteractionTestCase(
                 for weight_shape in weight_shapes
             )
             for prefix_shape, weight_shapes in zip(
-                shapes, [self.instance.head_entity_shape, self.instance.relation_shape, self.instance.tail_entity_shape]
+                shapes, [self.instance.head_shape, self.instance.relation_shape, self.instance.tail_shape]
             )
         )
         return unpack_singletons(*result)


### PR DESCRIPTION
This MR cleans up inconsistencies in how we handle symbolic shapes in `Interaction`.

It now uses `entity_shape` as the shape information for *all* entity representations (head & tail). `head_indices` and `tail_indices` can be used to derive the shapes for a given role, exposed as properties `head_shape` and `tail_shape`.

It also lifts the restriction of only using interactions with shared head and entity shape via the `interaction` + `dimensions` API inside `pipeline`, and converts the class method `get_dimensions` to an instance-property `dimensions` which now also supports interaction with variable number of representations, e.g., AutoSF.

Follow up:
I think it makes sense to change the generic type of `ERModel[HeadRepresentation, RelationRepresentation, TailRepresentation]` to `ERModel[EntityRepresentation, RelationRepresentation]` and only distinguish in the interaction.