### PR TITLE
🔪💨 Remove slicability annotations

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -72,10 +72,6 @@ class Model(nn.Module, ABC):
     #: after training, but has no effect on the training.
     predict_with_sigmoid: bool
 
-    can_slice_h: ClassVar[bool]
-    can_slice_r: ClassVar[bool]
-    can_slice_t: ClassVar[bool]
-
     def __init__(
         self,
         *,

--- a/src/pykeen/models/baseline/models.py
+++ b/src/pykeen/models/baseline/models.py
@@ -20,10 +20,6 @@ __all__ = [
 class EvaluationOnlyModel(Model):
     """A model which only implements the methods used for evaluation."""
 
-    can_slice_h = False
-    can_slice_r = False
-    can_slice_t = False
-
     def __init__(self, triples_factory: CoreTriplesFactory):
         """Non-parametric models take a minimal set of arguments.
 

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -66,10 +66,6 @@ class _NewAbstractModel(Model, ABC):
     #: The default parameters for the default regularizer class
     regularizer_default_kwargs: ClassVar[Mapping[str, Any] | None] = None
 
-    can_slice_h = True
-    can_slice_r = True
-    can_slice_t = True
-
     def _reset_parameters_(self):  # noqa: D401
         """Reset all parameters of the model in-place."""
         # cf. https://github.com/mberr/ea-sota-comparison/blob/6debd076f93a329753d819ff4d01567a23053720/src/kgm/utils/torch_utils.py#L317-L372   # noqa:E501

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -208,11 +208,11 @@ class LCWATrainingLoop(TrainingLoop[LCWASampleType, LCWABatchType]):
         return slice_size
 
     def _check_slicing_availability(self, supports_sub_batching: bool):
-        if self.target == 0 and self.model.can_slice_h:
+        if self.target == 0:
             return
-        if self.target == 1 and self.model.can_slice_r:
+        if self.target == 1:
             return
-        if self.target == 2 and self.model.can_slice_t:
+        if self.target == 2:
             return
         elif supports_sub_batching:
             report = (


### PR DESCRIPTION
There are no trainable models that don't support slicing now, so I suggest we move this effectively unused variable. The only place where it wasn't true was for a model that can't be trained, and the only place it's read is during training, so it's not relevant anymore.