### PR TITLE
🧪💨 Remove tests that never run

### DIFF
--- a/tests/cases.py
+++ b/tests/cases.py
@@ -64,7 +64,6 @@ from pykeen.metrics.ranking import (
 )
 from pykeen.models import RESCAL, ERModel, Model, TransE
 from pykeen.models.cli import build_cli_from_cls
-from pykeen.models.meta.filtered import CooccurrenceFilteredModel
 from pykeen.models.mocks import FixedModel
 from pykeen.nn.modules import DistMultInteraction, FunctionalInteraction, Interaction
 from pykeen.nn.representation import Representation


### PR DESCRIPTION
The `_test_score_equality` only ever gets skipped. I checked this by putting a raise in the middle of the function body, and re-running the whole testing suite. That exception never got caught anywhere, meaning that these tests always skip. They existed, as the docstring says, to help with migration to ERModel. Now that everything is an ERModel, this isn't required.