### PR TITLE
🛗🧹 Remove functional interaction abstraction

### DIFF
--- a/src/pykeen/models/baseline/models.py
+++ b/src/pykeen/models/baseline/models.py
@@ -181,14 +181,14 @@ class SoftInverseTripleBaseline(EvaluationOnlyModel):
 
     # docstr-coverage: inherited
     def score_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
-        r = hr_batch[:, 1]
+        r = hr_batch[:, 1].cpu().numpy()
         scores = self.sim[r, :] @ self.rel_to_tail + self.sim_inv[r, :] @ self.rel_to_head
         scores = numpy.asarray(scores.todense())
         return torch.from_numpy(scores)
 
     # docstr-coverage: inherited
     def score_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
-        r = rt_batch[:, 0]
+        r = rt_batch[:, 0].cpu().numpy()
         scores = self.sim[r, :] @ self.rel_to_head + self.sim_inv[r, :] @ self.rel_to_tail
         scores = numpy.asarray(scores.todense())
         return torch.from_numpy(scores)

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -441,10 +441,6 @@ class NormBasedInteraction(Interaction, Generic[HeadRepresentation, RelationRepr
         self.p = p
         self.power_norm = power_norm
 
-    # docstr-coverage: inherited
-    def _prepare_state_for_functional(self) -> MutableMapping[str, Any]:  # noqa: D102
-        raise AssertionError("This is a relic.")
-
 
 @parse_docdata
 class TransEInteraction(NormBasedInteraction[FloatTensor, FloatTensor, FloatTensor]):
@@ -1482,7 +1478,7 @@ class RotatEInteraction(NormBasedInteraction[FloatTensor, FloatTensor, FloatTens
 
     is_complex: ClassVar[bool] = True
 
-    def __init__(self, p=2, power_norm=False):
+    def __init__(self, p: int = 2, power_norm: bool = False):
         """
         Initialize the interaction module.
 

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
 from operator import itemgetter
-from typing import Any, Callable, ClassVar, Generic, Optional, Union, cast, overload
+from typing import Any, ClassVar, Generic, Optional, Union, cast, overload
 
 import more_itertools
 import numpy
@@ -69,7 +69,6 @@ __all__ = [
     "interaction_resolver",
     # Base Classes
     "Interaction",
-    "FunctionalInteraction",
     "NormBasedInteraction",
     # Adapter classes
     "MonotonicAffineTransformationInteraction",
@@ -426,63 +425,6 @@ class Interaction(nn.Module, Generic[HeadRepresentation, RelationRepresentation,
                 mod.reset_parameters()
 
 
-class FunctionalInteraction(Interaction, Generic[HeadRepresentation, RelationRepresentation, TailRepresentation]):
-    """Base class for interaction functions."""
-
-    #: The functional interaction form
-    func: Callable[..., FloatTensor]
-
-    def forward(
-        self,
-        h: HeadRepresentation,
-        r: RelationRepresentation,
-        t: TailRepresentation,
-    ) -> FloatTensor:
-        """Compute broadcasted triple scores given broadcasted representations for head, relation and tails.
-
-        :param h: shape: (`*batch_dims`, `*dims`)
-            The head representations.
-        :param r: shape: (`*batch_dims`, `*dims`)
-            The relation representations.
-        :param t: shape: (`*batch_dims`, `*dims`)
-            The tail representations.
-
-        :return: shape: batch_dims
-            The scores.
-        """
-        return self.__class__.func(**self._prepare_for_functional(h=h, r=r, t=t))
-
-    def _prepare_for_functional(
-        self,
-        h: HeadRepresentation,
-        r: RelationRepresentation,
-        t: TailRepresentation,
-    ) -> Mapping[str, FloatTensor]:
-        """Conversion utility to prepare the arguments for the functional form."""
-        kwargs = self._prepare_hrt_for_functional(h=h, r=r, t=t)
-        kwargs.update(self._prepare_state_for_functional())
-        return kwargs
-
-    # docstr-coverage: inherited
-    @classmethod
-    def _prepare_hrt_for_functional(
-        cls,
-        h: HeadRepresentation,
-        r: RelationRepresentation,
-        t: TailRepresentation,
-    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
-        """Conversion utility to prepare the h/r/t representations for the functional form."""
-        # TODO: we only allow single-tensor representations here, but could easily generalize
-        assert all(torch.is_tensor(x) for x in (h, r, t))
-        if cls.is_complex:
-            h, r, t = ensure_complex(h, r, t)
-        return dict(h=h, r=r, t=t)
-
-    def _prepare_state_for_functional(self) -> MutableMapping[str, Any]:
-        """Conversion utility to prepare the state to be passed to the functional form."""
-        return dict()
-
-
 class NormBasedInteraction(Interaction, Generic[HeadRepresentation, RelationRepresentation, TailRepresentation], ABC):
     """Norm-based interactions use a (powered) $p$-norm in their scoring function."""
 
@@ -617,7 +559,7 @@ class TransFInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
 
 
 @parse_docdata
-class ComplExInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTensor]):
+class ComplExInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
     r"""The ComplEx interaction proposed by [trouillon2016]_.
 
     ComplEx operates on complex-valued entity and relation representations, i.e.,
@@ -662,19 +604,21 @@ class ComplExInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTe
 
     # TODO: update class docstring
 
-    # TODO: give this a better name?
-    @staticmethod
-    def func(h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
-        r"""Evaluate the interaction function.
+    def forward(self, h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
+        """Evaluate the interaction function.
 
-        :param h: shape: (`*batch_dims`, dim)
-            The complex head representations.
-        :param r: shape: (`*batch_dims`, dim)
-            The complex relation representations.
-        :param t: shape: (`*batch_dims`, dim)
-            The complex tail representations.
+        .. seealso::
+            :meth:`Interaction.forward <pykeen.nn.modules.Interaction.forward>` for a detailed description about
+            the generic batched form of the interaction function.
 
-        :return: shape: batch_dims
+        :param h: shape: ``(*batch_dims, d)``
+            The head representations.
+        :param r: shape: ``(*batch_dims, d)``
+            The relation representations.
+        :param t: shape: ``(*batch_dims, d)``
+            The tail representations.
+
+        :return: shape: ``batch_dims``
             The scores.
         """
         return torch.real(einsum("...d, ...d, ...d -> ...", h, r, torch.conj(t)))
@@ -1164,7 +1108,7 @@ class ConvKBInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
 
 
 @parse_docdata
-class DistMultInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTensor]):
+class DistMultInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
     r"""The stateless DistMult interaction function.
 
     This interaction is given by
@@ -1192,8 +1136,7 @@ class DistMultInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatT
         arxiv: 1412.6575
     """
 
-    @staticmethod
-    def func(h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
+    def forward(self, h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
         """Evaluate the interaction function.
 
         .. seealso::
@@ -1214,7 +1157,7 @@ class DistMultInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatT
 
 
 @parse_docdata
-class DistMAInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTensor]):
+class DistMAInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
     r"""The stateless DistMA interaction function from [shi2019]_.
 
     For head entity, relation, and tail representations $\mathbf{h}, \mathbf{r}, \mathbf{t} \in \mathbb{R}^d$,
@@ -1236,8 +1179,7 @@ class DistMAInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
         link: https://www.aclweb.org/anthology/D19-1075.pdf
     """
 
-    @staticmethod
-    def func(h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
+    def forward(self, h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
         """Evaluate the interaction function.
 
         .. seealso::
@@ -1516,7 +1458,7 @@ class TransRInteraction(NormBasedInteraction[FloatTensor, tuple[FloatTensor, Flo
 
 
 @parse_docdata
-class RotatEInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTensor]):
+class RotatEInteraction(NormBasedInteraction[FloatTensor, FloatTensor, FloatTensor]):
     r"""The RotatE interaction function proposed by [sun2019]_.
 
     RotatE operates on complex-valued entity and relation representations, i.e.,
@@ -1540,25 +1482,40 @@ class RotatEInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
 
     is_complex: ClassVar[bool] = True
 
-    # TODO: give this a better name?
-    @staticmethod
-    def func(h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
+    def __init__(self, p=2, power_norm=False):
+        """
+        Initialize the interaction module.
+
+        .. seealso::
+            The parameter ``p`` and ``power_norm`` are directly passed to
+            :class:`~pykeen.nn.modules.NormBasedInteraction`.
+
+        :param p:
+            The norm used with :func:`torch.linalg.vector_norm`. Typically is 1 or 2.
+        :param power_norm:
+            Whether to use the p-th power of the $L_p$ norm. It has the advantage of being differentiable around 0,
+            and numerically more stable.
+        """
+        super().__init__(p=p, power_norm=power_norm)
+
+    def forward(self, h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
         """Evaluate the interaction function.
 
-        .. note::
-            this method expects all tensors to be of complex datatype, i.e., `torch.is_complex(x)` to evaluate to
-            `True`.
+        .. seealso::
+            :meth:`Interaction.forward <pykeen.nn.modules.Interaction.forward>` for a detailed description about
+            the generic batched form of the interaction function.
 
-        :param h: shape: (`*batch_dims`, dim)
+        :param h: shape: ``(*batch_dims, d)``
             The head representations.
-        :param r: shape: (`*batch_dims`, dim)
+        :param r: shape: ``(*batch_dims, d)``
             The relation representations.
-        :param t: shape: (`*batch_dims`, dim)
+        :param t: shape: ``(*batch_dims, d)``
             The tail representations.
 
-        :return: shape: batch_dims
+        :return: shape: ``batch_dims``
             The scores.
         """
+        h, r, t = ensure_complex(h, r, t)
         if estimate_cost_of_sequence(h.shape, r.shape) < estimate_cost_of_sequence(r.shape, t.shape):
             # r expresses a rotation in complex plane.
             # rotate head by relation (=Hadamard product in complex space)
@@ -1575,7 +1532,7 @@ class RotatEInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTen
 
 
 @parse_docdata
-class HolEInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTensor]):
+class HolEInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
     r"""The stateless HolE interaction function.
 
     Holographic embeddings (HolE) make use of the circular correlation operator to compute interactions between
@@ -1605,12 +1562,7 @@ class HolEInteraction(FunctionalInteraction[FloatTensor, FloatTensor, FloatTenso
         arxiv: 1510.04935
     """
 
-    @staticmethod
-    def func(
-        h: torch.FloatTensor,
-        r: torch.FloatTensor,
-        t: torch.FloatTensor,
-    ) -> torch.FloatTensor:
+    def forward(self, h: FloatTensor, r: FloatTensor, t: FloatTensor) -> FloatTensor:
         """Evaluate the interaction function.
 
         .. seealso::
@@ -3655,7 +3607,7 @@ AutoSFBlock = tuple[int, int, int, Sign]
 
 
 @parse_docdata
-class AutoSFInteraction(FunctionalInteraction[HeadRepresentation, RelationRepresentation, TailRepresentation]):
+class AutoSFInteraction(Interaction[HeadRepresentation, RelationRepresentation, TailRepresentation]):
     r"""
     The AutoSF interaction as described by [zhang2020]_.
 
@@ -3825,40 +3777,25 @@ class AutoSFInteraction(FunctionalInteraction[HeadRepresentation, RelationRepres
             **kwargs,
         )
 
-    @staticmethod
-    def func(
-        h: HeadRepresentation,
-        r: RelationRepresentation,
-        t: TailRepresentation,
-        coefficients: Collection[AutoSFBlock],
-    ) -> FloatTensor:
-        r"""Evaluate an AutoSF-style interaction function as described by [zhang2020]_.
+    def forward(self, h: HeadRepresentation, r: RelationRepresentation, t: TailRepresentation) -> FloatTensor:
+        """Evaluate the interaction function.
 
-        :param h: each shape: (`*batch_dims`, dim)
-            The list of head representations.
-        :param r: each shape: (`*batch_dims`, dim)
-            The list of relation representations.
-        :param t: each shape: (`*batch_dims`, dim)
-            The list of tail representations.
-        :param coefficients:
-            the coefficients, cf. :class:`pykeen.nn.AutoSFInteraction`
+        .. seealso::
+            :meth:`Interaction.forward <pykeen.nn.modules.Interaction.forward>` for a detailed description about
+            the generic batched form of the interaction function.
 
-        :return: shape: `batch_dims`
-            The scores
+        :param h: shape: ``(*batch_dims, d)``
+            The head representations.
+        :param r: shape: ``(*batch_dims, d)``
+            The relation representations.
+        :param t: shape: ``(*batch_dims, d)``
+            The tail representations.
+
+        :return: shape: ``batch_dims``
+            The scores.
         """
-        return sum(sign * tensor_product(h[hi], r[ri], t[ti]).sum(dim=-1) for hi, ri, ti, sign in coefficients)
-
-    def _prepare_state_for_functional(self) -> MutableMapping[str, Any]:
-        return dict(coefficients=self.coefficients)
-
-    # docstr-coverage: inherited
-    @staticmethod
-    def _prepare_hrt_for_functional(
-        h: HeadRepresentation,
-        r: RelationRepresentation,
-        t: TailRepresentation,
-    ) -> MutableMapping[str, FloatTensor]:  # noqa: D102
-        return dict(zip("hrt", ensure_tuple(h, r, t)))
+        hl, rl, tl = ensure_tuple(h, r, t)
+        return sum(sign * tensor_product(hl[hi], rl[ri], tl[ti]).sum(dim=-1) for hi, ri, ti, sign in self.coefficients)
 
     def extend(self, *new_coefficients: tuple[int, int, int, Sign]) -> AutoSFInteraction:
         """Extend AutoSF function, as described in the greedy search algorithm in the paper."""
@@ -3941,7 +3878,6 @@ interaction_resolver: ClassResolver[Interaction] = ClassResolver.from_subclasses
     Interaction,
     skip={
         NormBasedInteraction,
-        FunctionalInteraction,
         MonotonicAffineTransformationInteraction,
         ClampedInteraction,
         DirectionAverageInteraction,

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -8,7 +8,7 @@ import logging
 import math
 from abc import ABC, abstractmethod
 from collections import Counter
-from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from operator import itemgetter
 from typing import Any, ClassVar, Generic, Optional, Union, cast, overload
 

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -600,7 +600,6 @@ class InteractionTestsTestCase(unittest_templates.MetaTestCase[pykeen.nn.modules
     base_test = cases.InteractionTestCase
     skip_cls = {
         pykeen.nn.modules.Interaction,
-        pykeen.nn.modules.FunctionalInteraction,
         pykeen.nn.modules.NormBasedInteraction,
         pykeen.nn.modules.ClampedInteraction,
         pykeen.nn.modules.DirectionAverageInteraction,

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -461,9 +461,8 @@ class SimplEInteractionTests(cases.InteractionTestCase):
         h_fwd, h_bwd = h
         r_fwd, r_bwd = r
         t_fwd, t_bwd = t
-        return 0.5 * pykeen.nn.modules.DistMultInteraction.func(
-            h_fwd, r_fwd, t_fwd
-        ) + 0.5 * pykeen.nn.modules.DistMultInteraction.func(t_bwd, r_bwd, h_bwd)
+        dist_mult = pykeen.nn.modules.DistMultInteraction()
+        return 0.5 * dist_mult(h_fwd, r_fwd, t_fwd) + 0.5 * dist_mult(t_bwd, r_bwd, h_bwd)
 
 
 class MuRETests(cases.TranslationalInteractionTests):
@@ -708,14 +707,12 @@ class AutoSFTests(cases.InteractionTestCase):
     )
 
     def _exp_score(
-        self,
-        h: Sequence[torch.FloatTensor],
-        r: Sequence[torch.FloatTensor],
-        t: Sequence[torch.FloatTensor],
-        coefficients: Sequence[tuple[int, int, int, Sign]],
+        self, h: Sequence[torch.FloatTensor], r: Sequence[torch.FloatTensor], t: Sequence[torch.FloatTensor]
     ) -> torch.FloatTensor:  # noqa: D102
         h, r, t = ensure_tuple(h, r, t)
-        return sum(s * (h[i] * r[j] * t[k]).sum(dim=-1) for i, j, k, s in coefficients)
+        instance = self.instance
+        assert isinstance(instance, pykeen.nn.modules.AutoSFInteraction)
+        return sum(s * (h[i] * r[j] * t[k]).sum(dim=-1) for i, j, k, s in instance.coefficients)
 
 
 class LineaRETests(cases.TranslationalInteractionTests):

--- a/tests/test_nn/test_modules.py
+++ b/tests/test_nn/test_modules.py
@@ -15,7 +15,7 @@ import pykeen.nn.modules
 import pykeen.nn.sim
 import pykeen.utils
 from pykeen.nn import quaternion
-from pykeen.typing import Representation, Sign
+from pykeen.typing import Representation
 from pykeen.utils import (
     clamp_norm,
     complex_normalize,


### PR DESCRIPTION
This is a cherry-pick from https://github.com/pykeen/pykeen/pull/1484 isolating the changes related to removing the `FunctionalInteraction` abstraction.

The motivation comprises
- its inconsistent use
- less useful rendered documentation (compared to moving the implementation to `forward`)

See also
- https://github.com/pykeen/pykeen/pull/1484