### PR TITLE
Check for invalid max_id at top of backfill init

### DIFF
--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1570,6 +1570,11 @@ class BackfillRepresentation(PartitionRepresentation):
             If the backfill representation is initialized within this constructor,
             it will receive the base representation's shape.
         """
+
+        # If the maximum id is not greater than the maximum base id, the backfill representation creation will fail at a later stage.
+        if max_id <= max(base_ids):
+            raise ValueError(f"max_id={max_id}: Value must be greater than the largest base_id ({max(base_ids)})")
+
         # import here to avoid cyclic import
         from . import representation_resolver
 

--- a/tests/test_nn/test_representation.py
+++ b/tests/test_nn/test_representation.py
@@ -426,14 +426,22 @@ class BackfillRepresentationTests(cases.RepresentationTestCase):
         base_ids=[i for i in range(cases.RepresentationTestCase.max_id) if i % 2],
     )
 
-    def test_max_id_verification(self):
+    def test_max_id_verification_raises_value_error(self):
         """Test that an invalid max_id raises a ValueError."""
         with self.assertRaises(ValueError):
             pykeen.nn.representation.BackfillRepresentation(
                 base_ids=[0, 1, 2],
                 max_id=2,
-                base=pykeen.nn.representation.Embedding(num_embeddings=3, shape=(3,)),
+                base=pykeen.nn.representation.Embedding(max_id=3, shape=(3,)),
             )
+    
+    def test_max_id_verification(self):
+        """Test that a valid max_id does not raise a ValueError."""
+        pykeen.nn.representation.BackfillRepresentation(
+            base_ids=[0, 1, 2],
+            max_id=12,
+            base=pykeen.nn.representation.Embedding(max_id=3, shape=(3,)),
+        )
 
 
 class TransformedRepresentationTest(cases.RepresentationTestCase):

--- a/tests/test_nn/test_representation.py
+++ b/tests/test_nn/test_representation.py
@@ -426,6 +426,15 @@ class BackfillRepresentationTests(cases.RepresentationTestCase):
         base_ids=[i for i in range(cases.RepresentationTestCase.max_id) if i % 2],
     )
 
+    def test_max_id_verification(self):
+        """Test that an invalid max_id raises a ValueError."""
+        with self.assertRaises(ValueError):
+            pykeen.nn.representation.BackfillRepresentation(
+                base_ids=[0, 1, 2],
+                max_id=2,
+                base=pykeen.nn.representation.Embedding(num_embeddings=3, shape=(3,)),
+            )
+
 
 class TransformedRepresentationTest(cases.RepresentationTestCase):
     """Tests for transformed representations."""


### PR DESCRIPTION
**Description of the Change**
- max_id values lower than the highest id of the base_ids for backfill always result in an exception. Also, if the value is lower than the length of the base_ids array, then this results in an exception due to tensor of negative length. 
- This change introduces a very small check to provide actionable feedback if this condition is identified, so that the user can receive this actionable resolution tip, rather than cryptic errors from torch later on.

**Possible Drawbacks**
- If in the future this behavior needs to be allowed, this check will need to be removed

**Verification Process**
- reproduced conditions that previously threw errors during representation backfill, and confirmed that they produce the new explicit exception instead
- unit test added to validate throws & does not throw conditions. 

Release Notes
Bugfix: Raise ValueError on invalid max_id value passed to BackfillRepresentation constructor