### PR TITLE
📚 🧼 Format docstrings

### DIFF
--- a/docs/source/analysis/dataset_degree_distributions.rst
+++ b/docs/source/analysis/dataset_degree_distributions.rst
@@ -1,16 +1,14 @@
 Dataset Degree Distributions
 ============================
+
 .. image:: ../img/dataset_degree_distributions.svg
-  :alt: Dataset Degree Distribution
+    :alt: Dataset Degree Distribution
 
-This plot shows various statistics (mean, variance, skewness and kurtosis) of
-the degree distributions of all contained
-`datasets <../reference/datasets.html>`_. Since the triples contained
-in knowledge graphs are directed, the degree is further distinguished into
-out-degree (head) and in-degree (tail). Notice further that the plots are in
-log-log space, i.e., both axes are shown logarithmically scaled.
+This plot shows various statistics (mean, variance, skewness and kurtosis) of the degree distributions of all contained
+`datasets <../reference/datasets.html>`_. Since the triples contained in knowledge graphs are directed, the degree is
+further distinguished into out-degree (head) and in-degree (tail). Notice further that the plots are in log-log space,
+i.e., both axes are shown logarithmically scaled.
 
-In particular, we observe that the higher order moments skewness and kurtosis
-increase with increasing graph size, and are generally larger than one. This
-hints at a fat-tail degree distribution, i.e., the existence of hub entities,
-with a large degree while the majority of entities has only a few neighbors.
+In particular, we observe that the higher order moments skewness and kurtosis increase with increasing graph size, and
+are generally larger than one. This hints at a fat-tail degree distribution, i.e., the existence of hub entities, with a
+large degree while the majority of entities has only a few neighbors.

--- a/docs/source/analysis/index.rst
+++ b/docs/source/analysis/index.rst
@@ -1,7 +1,8 @@
 Analysis
 ========
-.. toctree::
-   :name: analysis
-   :caption: Analysis
 
-   dataset_degree_distributions
+.. toctree::
+    :name: analysis
+    :caption: Analysis
+
+    dataset_degree_distributions

--- a/docs/source/byo/interaction.rst
+++ b/docs/source/byo/interaction.rst
@@ -1,78 +1,82 @@
 Bring Your Own Interaction
 ==========================
-This is a tutorial about how to implement your own interaction modules
-(also known as scoring functions) as subclasses of
-:class:`pykeen.nn.modules.Interaction` for use in PyKEEN.
+
+This is a tutorial about how to implement your own interaction modules (also known as scoring functions) as subclasses
+of :class:`pykeen.nn.modules.Interaction` for use in PyKEEN.
 
 Implementing your first Interaction Module
 ------------------------------------------
-Imagine you've taken a time machine back to 2013 and you have just
-invented TransE, defined as:
+
+Imagine you've taken a time machine back to 2013 and you have just invented TransE, defined as:
 
 .. math::
 
     f(h, r, t) = -\| \mathbf{e}_h + \mathbf{r}_r - \mathbf{e}_t \|_2
 
-where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$,
-$\mathbf{r}_j$ is the $d$-dimensional representation for relation $j$, and
-$\|...\|_2$ is the $L_2$ norm.
+where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$, $\mathbf{r}_j$ is the $d$-dimensional
+representation for relation $j$, and $\|...\|_2$ is the $L_2$ norm.
 
-To implement TransE in PyKEEN, you need to subclass the
-:class:`pykeen.nn.modules.Interaction`. This class it itself
-a subclass of :class:`torch.nn.Module`, which means that you need to provide
-an implementation of :meth:`torch.nn.Module.forward`. However, the arguments
-are predefined as ``h``, ``r``, and ``t``, which correspond to the representations
-of the head, relation, and tail, respectively.
+To implement TransE in PyKEEN, you need to subclass the :class:`pykeen.nn.modules.Interaction`. This class it itself a
+subclass of :class:`torch.nn.Module`, which means that you need to provide an implementation of
+:meth:`torch.nn.Module.forward`. However, the arguments are predefined as ``h``, ``r``, and ``t``, which correspond to
+the representations of the head, relation, and tail, respectively.
 
 .. code-block:: python
 
     from pykeen.nn.modules import Interaction
+
 
     class TransEInteraction(Interaction):
         def forward(self, h, r, t):
             return -(h + r - t).norm(p=2, dim=-1)
 
-Note the ``dim=-1`` because this operation is actually defined over
-an entire batch of head, relation, and tail representations.
+Note the ``dim=-1`` because this operation is actually defined over an entire batch of head, relation, and tail
+representations.
 
-.. seealso:: A reference implementation is provided in :class:`pykeen.nn.modules.TransEInteraction`
+.. seealso::
 
-As a researcher who just invented TransE, you might wonder what would happen if you replaced
-the addition ``+`` with multiplication ``*``. You might then end up with a new interaction like this
-(which just happens to be DistMult, which was published just a year after TransE):
+    A reference implementation is provided in :class:`pykeen.nn.modules.TransEInteraction`
+
+As a researcher who just invented TransE, you might wonder what would happen if you replaced the addition ``+`` with
+multiplication ``*``. You might then end up with a new interaction like this (which just happens to be DistMult, which
+was published just a year after TransE):
 
 .. math::
 
     f(h, r, t) = \mathbf{e}_h^T diag(\mathbf{r}_r) \mathbf{e}_t
 
-where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$,
-$\mathbf{r}_j$ is the $d$-dimensional representation for relation $j$.
+where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$, $\mathbf{r}_j$ is the $d$-dimensional
+representation for relation $j$.
 
 .. code-block:: python
 
     from pykeen.nn.modules import Interaction
+
 
     class DistMultInteraction(Interaction):
         def forward(self, h, r, t):
             return (h * r * t).sum(dim=-1)
 
-.. seealso:: A reference implementation is provided in :class:`pykeen.nn.modules.DistMultInteraction`
+.. seealso::
+
+    A reference implementation is provided in :class:`pykeen.nn.modules.DistMultInteraction`
 
 Interactions with Hyper-Parameters
 ----------------------------------
-While we previously defined TransE with the $L_2$ norm, it could be calculated with
-a different value for $p$:
+
+While we previously defined TransE with the $L_2$ norm, it could be calculated with a different value for $p$:
 
 .. math::
 
     f(h, r, t) = -\| \mathbf{e}_h + \mathbf{r}_r - \mathbf{e}_t \|_p
 
-This could be incorporated into the interaction definition by using the ``__init__()``,
-storing the value for $p$ in the instance, then accessing it in ``forward()``.
+This could be incorporated into the interaction definition by using the ``__init__()``, storing the value for $p$ in the
+instance, then accessing it in ``forward()``.
 
 .. code-block:: python
 
     from pykeen.nn.modules import Interaction
+
 
     class TransEInteraction(Interaction):
         def __init__(self, p: int):
@@ -86,28 +90,30 @@ In general, you can put whatever you want in ``__init__()`` to support the calcu
 
 Interactions with Trainable Parameters
 --------------------------------------
-In ER-MLP, the multi-layer perceptron consists of an input layer with $3 \times d$ neurons, a hidden layer
-with $d$ neurons and output layer with one neuron. The input is represented by the concatenation embeddings
-of the heads, relations and tail embeddings. It is defined as:
 
-.. math ::
+In ER-MLP, the multi-layer perceptron consists of an input layer with $3 \times d$ neurons, a hidden layer with $d$
+neurons and output layer with one neuron. The input is represented by the concatenation embeddings of the heads,
+relations and tail embeddings. It is defined as:
+
+.. math::
 
     f(h, r, t) = W_2 ReLU(W_1 cat(h, r, t) + b_1) + b_2
 
-with hidden dimension $y$, $W_1 \in \mathcal{R}^{3d \times y}$, $W_2\ \in \mathcal{R}^y$, and
-biases $b_1 \in \mathcal{R}^y$ and $b_2 \in \mathcal{R}$.
+with hidden dimension $y$, $W_1 \in \mathcal{R}^{3d \times y}$, $W_2\in \mathcal{R}^y$, and biases $b_1 \in
+\mathcal{R}^y$ and $b_2 \in \mathcal{R}$.
 
-$W_1$, $W_1$, $b_1$, and $b_2$ are *global* parameters, meaning that they are trainable,
-but are neither attached to the entities nor relations. Unlike the $p$ in TransE, these global
-trainable parameters are not considered hyper-parameters. However, like hyper-parameters,
-they can also be defined in the `__init__` function of your :class:`pykeen.nn.modules.Interaction`
-class. They are trained jointly with the entity and relation embeddings during training.
+$W_1$, $W_1$, $b_1$, and $b_2$ are *global* parameters, meaning that they are trainable, but are neither attached to the
+entities nor relations. Unlike the $p$ in TransE, these global trainable parameters are not considered hyper-parameters.
+However, like hyper-parameters, they can also be defined in the `__init__` function of your
+:class:`pykeen.nn.modules.Interaction` class. They are trained jointly with the entity and relation embeddings during
+training.
 
 .. code-block:: python
 
     import torch.nn
     from pykeen.nn.modules import Interaction
     from pykeen.utils import broadcast_cat
+
 
     class ERMLPInteraction(Interaction):
         def __init__(self, embedding_dim: int, hidden_dim: int):
@@ -123,24 +129,25 @@ class. They are trained jointly with the entity and relation embeddings during t
             x = broadcast_cat([h, r, t], dim=-1)
             return self.mlp(x)
 
-Note that :func:`pykeen.utils.broadcast_cat` was used instead of the standard
-:func:`torch.cat` because of the standardization of shapes of head, relation, and tail vectors.
+Note that :func:`pykeen.utils.broadcast_cat` was used instead of the standard :func:`torch.cat` because of the
+standardization of shapes of head, relation, and tail vectors.
 
-.. seealso:: A reference implementation is provided in :class:`pykeen.nn.modules.ERMLPInteraction`
+.. seealso::
+
+    A reference implementation is provided in :class:`pykeen.nn.modules.ERMLPInteraction`
 
 Interactions with Different Shaped Vectors
 ------------------------------------------
-The Structured Embedding uses a 2-tensor for representing each relation,
-with an interaction defined as:
+
+The Structured Embedding uses a 2-tensor for representing each relation, with an interaction defined as:
 
 .. math::
 
     f(h, r, t) = - \|\textbf{M}_{r}^{head} \textbf{e}_h  - \textbf{M}_{r}^{tail} \textbf{e}_t\|_p
 
-where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$,
-$\mathbf{M}^{head}_j$ is the $d \times d$-dimensional representation for relation $j$ for head entities,
-$\mathbf{M}^{tail}_j$ is the $d \times d$-dimensional representation for relation $j$ for tail entities, and
-$\|...\|_2$ is the $L_p$ norm.
+where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$, $\mathbf{M}^{head}_j$ is the $d \times
+d$-dimensional representation for relation $j$ for head entities, $\mathbf{M}^{tail}_j$ is the $d \times d$-dimensional
+representation for relation $j$ for tail entities, and $\|...\|_2$ is the $L_p$ norm.
 
 For the purposes of this tutorial, we will propose a simplification to Strucuterd Embedding (also similar to TransR)
 where the same relation 2-tensor is used to project both the head and tail entities as in:
@@ -149,48 +156,48 @@ where the same relation 2-tensor is used to project both the head and tail entit
 
     f(h, r, t) = - \|\textbf{M}_{r} \textbf{e}_h  - \textbf{M}_{r} \textbf{e}_t\|_2
 
-where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$,
-$\mathbf{M}_j$ is the $d \times d$-dimensional representation for relation $j$, and
-$\|...\|_2$ is the $L_2$ norm.
+where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$, $\mathbf{M}_j$ is the $d \times
+d$-dimensional representation for relation $j$, and $\|...\|_2$ is the $L_2$ norm.
 
 .. code-block:: python
 
     from pykeen.nn.modules import Interaction
 
+
     class SimplifiedStructuredEmbeddingInteraction(Interaction):
-        relation_shape = ('dd',)
+        relation_shape = ("dd",)
 
         def forward(self, h, r, t):
             h_proj = r @ h.unsqueeze(dim=-1)
             t_proj = r @ t.unsqueeze(dim=-1)
             return -(h_proj - t_proj).squeeze(dim=-1).norm(p=2, dim=-1)
 
-Note the definition of the ``relation_shape``. By default, the ``entity_shape`` and
-``relation_shape`` are both equal to ``('d', )``, which uses eigen-notation to show
-that they both are 1-tensors with the same shape. In this simplified version of
-Structured Embedding, we need to denote that the shape of the relation is $d \times d$,
-so it's written as ``dd``.
+Note the definition of the ``relation_shape``. By default, the ``entity_shape`` and ``relation_shape`` are both equal to
+``('d', )``, which uses eigen-notation to show that they both are 1-tensors with the same shape. In this simplified
+version of Structured Embedding, we need to denote that the shape of the relation is $d \times d$, so it's written as
+``dd``.
 
 .. seealso::
 
-    Reference implementations are provided in :class:`pykeen.nn.modules.StructuredEmbeddingInteraction`
-    and in :class:`pykeen.nn.modules.TransRInteraction`.
+    Reference implementations are provided in :class:`pykeen.nn.modules.StructuredEmbeddingInteraction` and in
+    :class:`pykeen.nn.modules.TransRInteraction`.
 
 Interactions with Multiple Representations
 ------------------------------------------
-Sometimes, like in the canonical version of Structured Embedding, you need more than
-one representation for entities and/or relations. To specify this, you just need to
-extend the tuple for ``relation_shape`` with more entries, each corresponding to the
-sequence of representations.
+
+Sometimes, like in the canonical version of Structured Embedding, you need more than one representation for entities
+and/or relations. To specify this, you just need to extend the tuple for ``relation_shape`` with more entries, each
+corresponding to the sequence of representations.
 
 .. code-block:: python
 
     from pykeen.nn.modules import Interaction
 
+
     class StructuredEmbeddingInteraction(Interaction):
         relation_shape = (
-            'dd',  # Corresponds to $\mathbf{M}^{head}_j$
-            'dd',  # Corresponds to $\mathbf{M}^{tail}_j$
+            "dd",  # Corresponds to $\mathbf{M}^{head}_j$
+            "dd",  # Corresponds to $\mathbf{M}^{tail}_j$
         )
 
         def forward(self, h, r, t):
@@ -203,21 +210,21 @@ sequence of representations.
 
 Interactions with Different Dimension Vectors
 ---------------------------------------------
-TransD is an example of an interaction module that not only uses two different
-representations for each entity and two representations for each relation, but they are
-of different dimensions.
 
-It can be implemented by choosing a different letter for use in the ``entity_shape`` and/or
-``relation_shape`` dictionary. Ultimately, the letters used are arbitrary, but you need to
-remember what they are when using the :func:`pykeen.models.make_model`,
-:func:`pykeen.models.make_model_cls`, or :func:`pykeen.pipeline.interaction_pipeline` functions
-to instantiate a model, make a model class, or run the pipeline using your custom interaction
-module (respectively).
+TransD is an example of an interaction module that not only uses two different representations for each entity and two
+representations for each relation, but they are of different dimensions.
+
+It can be implemented by choosing a different letter for use in the ``entity_shape`` and/or ``relation_shape``
+dictionary. Ultimately, the letters used are arbitrary, but you need to remember what they are when using the
+:func:`pykeen.models.make_model`, :func:`pykeen.models.make_model_cls`, or :func:`pykeen.pipeline.interaction_pipeline`
+functions to instantiate a model, make a model class, or run the pipeline using your custom interaction module
+(respectively).
 
 .. code-block:: python
 
     from pykeen.nn.modules import Interaction
     from pykeen.utils import project_entity
+
 
     class TransDInteraction(Interaction):
         entity_shape = ("d", "d")
@@ -241,38 +248,42 @@ module (respectively).
 
 .. note::
 
-    The :func:`pykeen.utils.project_entity` function was used in this implementation to
-    reduce the complexity. So far, it's the case that all of the models using multiple different representation
-    dimensions are quite complicated and don't fall into the paradigm of presenting simple examples.
+    The :func:`pykeen.utils.project_entity` function was used in this implementation to reduce the complexity. So far,
+    it's the case that all of the models using multiple different representation dimensions are quite complicated and
+    don't fall into the paradigm of presenting simple examples.
 
-.. seealso:: A reference implementation is provided in :class:`pykeen.nn.modules.TransDInteraction`
+.. seealso::
+
+    A reference implementation is provided in :class:`pykeen.nn.modules.TransDInteraction`
 
 Differences between :class:`pykeen.nn.modules.Interaction` and :class:`pykeen.models.Model`
 -------------------------------------------------------------------------------------------
-The high-level :func:`pipeline` function allows you to pass pre-defined subclasses
-of :class:`pykeen.models.Model` such as :class:`pykeen.models.TransE` or
-:class:`pykeen.models.DistMult`. These classes are high-level wrappers around the interaction
-functions :class:`pykeen.nn.modules.TransEInteraction` and :class:`nn.modules.DistMultInteraction`
-that are more suited for running benchmarking experiments or practical applications of knowledge
-graph embeddings that include lots of information about default hyper-parameters, recommended
-hyper-parameter optimization strategies, and more complex applications of regularization schemas.
 
-As a researcher, the :class:`pykeen.nn.modules.Interaction` is a way to quickly translate
-ideas into new models that can be used without all of the overhead of defining a
-:class:`pykeen.models.Model`. These components are also completely reusable throughout PyKEEN
-(e.g., in self-rolled training loops) and can be used as standalone components outside of PyKEEN.
+The high-level :func:`pipeline` function allows you to pass pre-defined subclasses of :class:`pykeen.models.Model` such
+as :class:`pykeen.models.TransE` or :class:`pykeen.models.DistMult`. These classes are high-level wrappers around the
+interaction functions :class:`pykeen.nn.modules.TransEInteraction` and :class:`nn.modules.DistMultInteraction` that are
+more suited for running benchmarking experiments or practical applications of knowledge graph embeddings that include
+lots of information about default hyper-parameters, recommended hyper-parameter optimization strategies, and more
+complex applications of regularization schemas.
 
-If you are happy with your interaction module and would like to go the next step to
-making it generally reusable, check the "Extending the Models" tutorial.
+As a researcher, the :class:`pykeen.nn.modules.Interaction` is a way to quickly translate ideas into new models that can
+be used without all of the overhead of defining a :class:`pykeen.models.Model`. These components are also completely
+reusable throughout PyKEEN (e.g., in self-rolled training loops) and can be used as standalone components outside of
+PyKEEN.
+
+If you are happy with your interaction module and would like to go the next step to making it generally reusable, check
+the "Extending the Models" tutorial.
 
 *Ad hoc* Models from Interactions
 ---------------------------------
+
 .. automodule:: pykeen.models.resolve
 
 Interaction Pipeline
 --------------------
-The :func:`pykeen.pipeline.pipeline` also allows passing of an interaction such
-that the following code block can be compressed:
+
+The :func:`pykeen.pipeline.pipeline` also allows passing of an interaction such that the following code block can be
+compressed:
 
 .. code-block:: python
 
@@ -281,14 +292,10 @@ that the following code block can be compressed:
 
     model = make_model_cls(
         interaction=TransEInteraction,
-        interaction_kwargs={'p': 2},
-        dimensions={'d': 100},
+        interaction_kwargs={"p": 2},
+        dimensions={"d": 100},
     )
-    results = pipeline(
-        dataset='Nations',
-        model=model,
-        ...
-    )
+    results = pipeline(dataset="Nations", model=model, ...)
 
 into:
 
@@ -298,12 +305,8 @@ into:
     from pykeen.nn.modules import TransEInteraction
 
     results = pipeline(
-        dataset='Nations',
-        interaction=TransEInteraction,
-        interaction_kwargs={'p': 2},
-        dimensions={'d': 100},
-        ...
+        dataset="Nations", interaction=TransEInteraction, interaction_kwargs={"p": 2}, dimensions={"d": 100}, ...
     )
 
-This can be used with any subclass of the :class:`pykeen.nn.modules.Interaction`, not only
-ones that are implemented in the PyKEEN package.
+This can be used with any subclass of the :class:`pykeen.nn.modules.Interaction`, not only ones that are implemented in
+the PyKEEN package.

--- a/docs/source/contrib/lightning.rst
+++ b/docs/source/contrib/lightning.rst
@@ -1,5 +1,6 @@
 PyTorch Lightning Integration
 =============================
+
 .. automodapi:: pykeen.contrib.lightning
     :no-heading:
     :headings: --

--- a/docs/source/examples/nn/pyg/overall.py
+++ b/docs/source/examples/nn/pyg/overall.py
@@ -1,8 +1,7 @@
-"""
-Example for using PyTorch Geometric.
+"""Example for using PyTorch Geometric.
 
-Combine static label-based entity features with a trainable GCN encoder for entity representations,
-with learned embeddings for relation representations and a DistMult interaction function.
+Combine static label-based entity features with a trainable GCN encoder for entity representations, with learned
+embeddings for relation representations and a DistMult interaction function.
 """
 
 from pykeen.datasets import get_dataset

--- a/docs/source/extending/datasets.rst
+++ b/docs/source/extending/datasets.rst
@@ -1,28 +1,31 @@
 Extending the Datasets
 ======================
-While the core of PyKEEN uses the :class:`pykeen.triples.TriplesFactory` for handling sets of triples,
-the definition of a training, validation, and testing trichotomy for a given dataset is very useful
-for reproducible benchmarking. The internal :class:`pykeen.datasets.base.Dataset` class can be considered
-as a three-tuple of datasets (though it's implemented as a class such that it can be extended). There
-are several datasets included in PyKEEN already, each coming from sources that look different. This
-tutorial gives some insight into implementing your own Dataset class.
+
+While the core of PyKEEN uses the :class:`pykeen.triples.TriplesFactory` for handling sets of triples, the definition of
+a training, validation, and testing trichotomy for a given dataset is very useful for reproducible benchmarking. The
+internal :class:`pykeen.datasets.base.Dataset` class can be considered as a three-tuple of datasets (though it's
+implemented as a class such that it can be extended). There are several datasets included in PyKEEN already, each coming
+from sources that look different. This tutorial gives some insight into implementing your own Dataset class.
 
 Pre-split Datasets
 ------------------
+
 Unpacked Remote Dataset
 ~~~~~~~~~~~~~~~~~~~~~~~
-Use this tutorial if you have three separate URLs for the respective training, testing, and validation
-sets that are each 3 column TSV files. A good example can be found at
-https://github.com/ZhenfengLei/KGDatasets/tree/master/DBpedia50. There's a base class called
-:class:`pykeen.datasets.base.UnpackedRemoteDataset` that can be used to wrap it like the following:
+
+Use this tutorial if you have three separate URLs for the respective training, testing, and validation sets that are
+each 3 column TSV files. A good example can be found at https://github.com/ZhenfengLei/KGDatasets/tree/master/DBpedia50.
+There's a base class called :class:`pykeen.datasets.base.UnpackedRemoteDataset` that can be used to wrap it like the
+following:
 
 .. code-block:: python
 
     from pykeen.datasets.base import UnpackedRemoteDataset
 
-    TEST_URL =  'https://raw.githubusercontent.com/ZhenfengLei/KGDatasets/master/DBpedia50/test.txt'
-    TRAIN_URL = 'https://raw.githubusercontent.com/ZhenfengLei/KGDatasets/master/DBpedia50/train.txt'
-    VALID_URL = 'https://raw.githubusercontent.com/ZhenfengLei/KGDatasets/master/DBpedia50/valid.txt'
+    TEST_URL = "https://raw.githubusercontent.com/ZhenfengLei/KGDatasets/master/DBpedia50/test.txt"
+    TRAIN_URL = "https://raw.githubusercontent.com/ZhenfengLei/KGDatasets/master/DBpedia50/train.txt"
+    VALID_URL = "https://raw.githubusercontent.com/ZhenfengLei/KGDatasets/master/DBpedia50/valid.txt"
+
 
     class DBpedia50(UnpackedRemoteDataset):
         def __init__(self, **kwargs):
@@ -35,40 +38,38 @@ https://github.com/ZhenfengLei/KGDatasets/tree/master/DBpedia50. There's a base 
 
 Unsplit Datasets
 ----------------
-Use this tutorial if you have a single URL for a TSV dataset that needs to be automatically split into
-training, testing, and validation. A good example can be found at
-https://github.com/hetio/hetionet/raw/master/hetnet/tsv. There's a base class called
-:class:`pykeen.datasets.base.SingleTabbedDataset` that can be used to wrap it like the following:
+
+Use this tutorial if you have a single URL for a TSV dataset that needs to be automatically split into training,
+testing, and validation. A good example can be found at https://github.com/hetio/hetionet/raw/master/hetnet/tsv. There's
+a base class called :class:`pykeen.datasets.base.SingleTabbedDataset` that can be used to wrap it like the following:
 
 .. code-block:: python
 
-
     from pykeen.datasets.base import SingleTabbedDataset
 
-    URL = 'https://github.com/hetio/hetionet/raw/master/hetnet/tsv/hetionet-v1.0-edges.sif.gz'
+    URL = "https://github.com/hetio/hetionet/raw/master/hetnet/tsv/hetionet-v1.0-edges.sif.gz"
+
 
     class Hetionet(SingleTabbedDataset):
         def __init__(self, **kwargs):
             super().__init__(url=URL, **kwargs)
 
-
-The value for `URL` can be anything that can be read by :func:`pandas.read_csv`. Additional options
-can be passed through to the reading function, such as ``sep=','``, with the keyword argument
-``read_csv_kwargs=dict(sep=',')``. Note that the default separator for Pandas is a comma, but PyKEEN
-overrides it to be a tab, so you'll have to explicitly set it if you want a comma. Since there's a random
-aspect to this process, you can also set the seed used for splitting with the ``random_state`` keyword
-argument.
+The value for `URL` can be anything that can be read by :func:`pandas.read_csv`. Additional options can be passed
+through to the reading function, such as ``sep=','``, with the keyword argument ``read_csv_kwargs=dict(sep=',')``. Note
+that the default separator for Pandas is a comma, but PyKEEN overrides it to be a tab, so you'll have to explicitly set
+it if you want a comma. Since there's a random aspect to this process, you can also set the seed used for splitting with
+the ``random_state`` keyword argument.
 
 Updating the ``setup.cfg``
 --------------------------
-Whether you're making a pull request against PyKEEN or implementing a dataset in your own package,
-you can use Python entrypoints to register your dataset with PyKEEN. Below is an example of the
-entrypoints that register :class:`pykeen.datasets.Hetionet`, :class:`pykeen.datasets.DRKG`,
-and others that appear in the PyKEEN `setup.cfg <https://github.com/pykeen/pykeen/blob/master/setup.cfg>`_.
-Under the ``pykeen.datasets`` header, you can pick whatever name you want for the dataset as the key
-(appearing on the left side of the equals, e.g. ``hetionet``) and the path to the class (appearing on
-the right side of the equals, e.g., ``pykeen.datasets.hetionet:Hetionet``). The right side
-is constructed by the path to the module, the colon ``:``, then the name of the class.
+
+Whether you're making a pull request against PyKEEN or implementing a dataset in your own package, you can use Python
+entrypoints to register your dataset with PyKEEN. Below is an example of the entrypoints that register
+:class:`pykeen.datasets.Hetionet`, :class:`pykeen.datasets.DRKG`, and others that appear in the PyKEEN `setup.cfg
+<https://github.com/pykeen/pykeen/blob/master/setup.cfg>`_. Under the ``pykeen.datasets`` header, you can pick whatever
+name you want for the dataset as the key (appearing on the left side of the equals, e.g. ``hetionet``) and the path to
+the class (appearing on the right side of the equals, e.g., ``pykeen.datasets.hetionet:Hetionet``). The right side is
+constructed by the path to the module, the colon ``:``, then the name of the class.
 
 .. code-block:: ini
 
@@ -83,5 +84,5 @@ is constructed by the path to the module, the colon ``:``, then the name of the 
         drkg             = pykeen.datasets.drkg:DRKG
         ...
 
-If you're working on a development version of PyKEEN, you also need to run ``pykeen readme`` in the shell
-to update the README.md file.
+If you're working on a development version of PyKEEN, you also need to run ``pykeen readme`` in the shell to update the
+README.md file.

--- a/docs/source/extending/models.rst
+++ b/docs/source/extending/models.rst
@@ -1,14 +1,14 @@
 Extending the Models
 ====================
-You should first read the tutorial on bringing your own interaction module.
-This tutorial is about how to wrap a custom interaction module with a model
-module for general reuse and application.
+
+You should first read the tutorial on bringing your own interaction module. This tutorial is about how to wrap a custom
+interaction module with a model module for general reuse and application.
 
 Implementing a model by subclassing :class:`pykeen.models.ERModel`
 ------------------------------------------------------------------
-The following code block demonstrates how an interaction model can be used to define a full
-KGEM using the :class:`pykeen.models.ERModel` base class.
 
+The following code block demonstrates how an interaction model can be used to define a full KGEM using the
+:class:`pykeen.models.ERModel` base class.
 
 .. code-block:: python
 
@@ -58,15 +58,16 @@ KGEM using the :class:`pykeen.models.ERModel` base class.
                 **kwargs,
             )
 
-The actual implementation of DistMult can be found in :class:`pykeen.models.DistMult`. Note that
-it additionally contains configuration for the initializers, constrainers, and regularizers
-for each of the embeddings as well as class-level defaults for hyper-parameters and hyper-parameter
-optimization. Modifying these is covered in other tutorials.
+The actual implementation of DistMult can be found in :class:`pykeen.models.DistMult`. Note that it additionally
+contains configuration for the initializers, constrainers, and regularizers for each of the embeddings as well as
+class-level defaults for hyper-parameters and hyper-parameter optimization. Modifying these is covered in other
+tutorials.
 
 Specifying Defaults
-~~~~~~~~~~~~~~~~~~~~
-If you have a preferred loss function for your model, you can add the ``loss_default`` class variable
-where the value is the loss class.
+~~~~~~~~~~~~~~~~~~~
+
+If you have a preferred loss function for your model, you can add the ``loss_default`` class variable where the value is
+the loss class.
 
 .. code-block:: python
 
@@ -75,34 +76,30 @@ where the value is the loss class.
     from pykeen.models import ERModel
     from pykeen.losses import Loss, NSSALoss
 
+
     class DistMult(ERModel):
         loss_default: ClassVar[Type[Loss]] = NSSALoss
         ...
 
-Now, when using the pipeline, the :class:`pykeen.losses.NSSALoss`. loss is used by default
-if none is given. The same kind of modifications can be made to set a default regularizer
-with ``regularizer_default``.
+Now, when using the pipeline, the :class:`pykeen.losses.NSSALoss`. loss is used by default if none is given. The same
+kind of modifications can be made to set a default regularizer with ``regularizer_default``.
 
 Specifying Hyper-parameter Optimization Default Ranges
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-All subclasses of :class:`pykeen.models.Model` can specify the default
-ranges or values used during hyper-parameter optimization (HPO). PyKEEN
-implements a simple dictionary-based configuration that is interpreted
-by :func:`pykeen.hpo.hpo.suggest_kwargs` in the HPO pipeline.
 
-HPO default ranges can be applied to all keyword arguments appearing in the
-``__init__()`` function of your model by setting a class-level variable called
-``hpo_default``.
+All subclasses of :class:`pykeen.models.Model` can specify the default ranges or values used during hyper-parameter
+optimization (HPO). PyKEEN implements a simple dictionary-based configuration that is interpreted by
+:func:`pykeen.hpo.hpo.suggest_kwargs` in the HPO pipeline.
 
-For example, the ``embedding_dim`` can be specified as being on a range between
-100 and 150 with the following:
+HPO default ranges can be applied to all keyword arguments appearing in the ``__init__()`` function of your model by
+setting a class-level variable called ``hpo_default``.
+
+For example, the ``embedding_dim`` can be specified as being on a range between 100 and 150 with the following:
 
 .. code-block:: python
 
     class DistMult(ERModel):
-        hpo_default = {
-            'embedding_dim': dict(type=int, low=100, high=150)
-        }
+        hpo_default = {"embedding_dim": dict(type=int, low=100, high=150)}
         ...
 
 A step size can be imposed with ``q``:
@@ -115,55 +112,53 @@ A step size can be imposed with ``q``:
         }
         ...
 
-An alternative scale can be imposed with ``scale``. Right now, the
-default is linear, and ``scale`` can optionally be set to ``power_two``
-for integers as in:
+An alternative scale can be imposed with ``scale``. Right now, the default is linear, and ``scale`` can optionally be
+set to ``power_two`` for integers as in:
 
 .. code-block:: python
 
     class DistMult(ERModel):
         hpo_default = {
             # will uniformly give 16, 32, 64, 128 (left inclusive, right exclusive)
-            'hidden_dim': dict(type=int, low=4, high=8, scale='power_two')
+            "hidden_dim": dict(type=int, low=4, high=8, scale="power_two")
         }
         ...
 
-.. warning:: Alternative scales can not currently be used in combination with step size (``q``).
+.. warning::
 
-There are other possibilities for specifying the ``type`` as ``float``, ``categorical``,
-or as ``bool``.
+    Alternative scales can not currently be used in combination with step size (``q``).
 
-With ``float``, you can't use the ``q`` option nor set the scale to ``power_two``,
-but the scale can be set to ``log`` (see :class:`optuna.distributions.LogUniformDistribution`).
+There are other possibilities for specifying the ``type`` as ``float``, ``categorical``, or as ``bool``.
+
+With ``float``, you can't use the ``q`` option nor set the scale to ``power_two``, but the scale can be set to ``log``
+(see :class:`optuna.distributions.LogUniformDistribution`).
 
 .. code-block:: python
 
     hpo_default = {
         # will uniformly give floats on the range of [1.0, 2.0) (exclusive)
-        'alpha': dict(type='float', low=1.0, high=2.0),
-
+        "alpha": dict(type="float", low=1.0, high=2.0),
         # will uniformly give 1.0, 2.0, or 4.0 (exclusive)
-        'beta': dict(type='float', low=1.0, high=8.0, scale='log'),
+        "beta": dict(type="float", low=1.0, high=8.0, scale="log"),
     }
 
-With ``categorical``, you can form a dictionary like the following using ``type='categorical'``
-and giving a ``choices`` entry that contains a sequence of either integers, floats, or strings.
+With ``categorical``, you can form a dictionary like the following using ``type='categorical'`` and giving a ``choices``
+entry that contains a sequence of either integers, floats, or strings.
 
 .. code-block:: python
 
-    hpo_default = {
-        'similarity': dict(type='categorical', choices=[...])
-    }
+    hpo_default = {"similarity": dict(type="categorical", choices=[...])}
 
 With ``bool``, you can simply use ``dict(type=bool)`` or ``dict(type='bool')``.
 
 .. note::
 
-    The HPO rules are subject to change as they are tightly coupled to :mod:`optuna`,
-    which since version 2.0.0 has introduced several new possibilities.
+    The HPO rules are subject to change as they are tightly coupled to :mod:`optuna`, which since version 2.0.0 has
+    introduced several new possibilities.
 
 Implementing a model by instantiating :class:`pykeen.models.ERModel`
 --------------------------------------------------------------------
+
 Instead of creating a new class, you can also directly use the :class:`pykeen.models.ERModel`, e.g.
 
 .. code-block:: python
@@ -181,9 +176,9 @@ Instead of creating a new class, you can also directly use the :class:`pykeen.mo
 
 Using a Custom Model with the Pipeline
 --------------------------------------
-We can use this new model with all available losses, evaluators,
-training pipelines, inverse triple modeling, via the :func:`pykeen.pipeline.pipeline`,
-since in addition to the names of models (given as strings), it can also take model
+
+We can use this new model with all available losses, evaluators, training pipelines, inverse triple modeling, via the
+:func:`pykeen.pipeline.pipeline`, since in addition to the names of models (given as strings), it can also take model
 classes in the ``model`` argument.
 
 .. code-block:: python
@@ -192,6 +187,6 @@ classes in the ``model`` argument.
 
     pipeline(
         model=DistMult,
-        dataset='Nations',
-        loss='NSSA',
+        dataset="Nations",
+        loss="NSSA",
     )

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,86 +1,88 @@
 PyKEEN
 ======
+
 .. automodule:: pykeen
 
 .. toctree::
-   :caption: Getting Started
-   :name: quickstart
-   :maxdepth: 2
+    :caption: Getting Started
+    :name: quickstart
+    :maxdepth: 2
 
-   installation
-   tutorial/first_steps
-   tutorial/models
-   tutorial/representations
-   tutorial/interactions
-   tutorial/trackers/index
-   tutorial/checkpoints
-   tutorial/translational_toy_example
-   tutorial/understanding_evaluation
-   tutorial/running_hpo
-   tutorial/running_ablation
-   tutorial/performance
-   tutorial/node_piece
-   tutorial/inductive_lp
-   tutorial/splitting
-   contrib/lightning
-   tutorial/using_resolvers
-   tutorial/normalizer_constrainer_regularizer
-   tutorial/troubleshooting
-
-.. toctree::
-   :caption: Bring Your Own
-   :name: byo
-   :maxdepth: 2
-
-   byo/data
-   byo/interaction
+    installation
+    tutorial/first_steps
+    tutorial/models
+    tutorial/representations
+    tutorial/interactions
+    tutorial/trackers/index
+    tutorial/checkpoints
+    tutorial/translational_toy_example
+    tutorial/understanding_evaluation
+    tutorial/running_hpo
+    tutorial/running_ablation
+    tutorial/performance
+    tutorial/node_piece
+    tutorial/inductive_lp
+    tutorial/splitting
+    contrib/lightning
+    tutorial/using_resolvers
+    tutorial/normalizer_constrainer_regularizer
+    tutorial/troubleshooting
 
 .. toctree::
-   :caption: Extending PyKEEN
-   :name: extending
-   :maxdepth: 2
+    :caption: Bring Your Own
+    :name: byo
+    :maxdepth: 2
 
-   extending/datasets
-   extending/models
-
-.. toctree::
-   :caption: Reference
-   :name: reference
-   :maxdepth: 2
-
-   reference/pipeline
-   reference/models
-   reference/datasets
-   reference/triples
-   reference/training
-   reference/stoppers
-   reference/losses
-   reference/regularizers
-   reference/trackers
-   reference/negative_sampling
-   reference/optimizers
-   reference/evaluation
-   reference/metrics
-   reference/hpo
-   reference/ablation
-   reference/predict
-   reference/uncertainty
-   reference/sealant
-   reference/constants
-   reference/checkpoints
-   reference/nn/index
-   reference/utils
+    byo/data
+    byo/interaction
 
 .. toctree::
-   :caption: Appendix
-   :name: appendix
-   :maxdepth: 2
+    :caption: Extending PyKEEN
+    :name: extending
+    :maxdepth: 2
 
-   analysis/index
-   references
+    extending/datasets
+    extending/models
+
+.. toctree::
+    :caption: Reference
+    :name: reference
+    :maxdepth: 2
+
+    reference/pipeline
+    reference/models
+    reference/datasets
+    reference/triples
+    reference/training
+    reference/stoppers
+    reference/losses
+    reference/regularizers
+    reference/trackers
+    reference/negative_sampling
+    reference/optimizers
+    reference/evaluation
+    reference/metrics
+    reference/hpo
+    reference/ablation
+    reference/predict
+    reference/uncertainty
+    reference/sealant
+    reference/constants
+    reference/checkpoints
+    reference/nn/index
+    reference/utils
+
+.. toctree::
+    :caption: Appendix
+    :name: appendix
+    :maxdepth: 2
+
+    analysis/index
+    references
 
 Indices and Tables
 ------------------
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+
+- :ref:`genindex`
+- :ref:`modindex`
+- :ref:`search`

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,16 +1,17 @@
 Installation
 ============
+
 Linux and Mac Users
 -------------------
-The latest stable version of PyKEEN can be downloaded and installed from
-`PyPI <https://pypi.org/project/pykeen>`_ with:
+
+The latest stable version of PyKEEN can be downloaded and installed from `PyPI <https://pypi.org/project/pykeen>`_ with:
 
 .. code-block:: bash
 
     $ pip install pykeen
 
-The latest version of PyKEEN can be installed directly from the
-source on `GitHub <https://github.com/pykeen/pykeen>`_ with:
+The latest version of PyKEEN can be installed directly from the source on `GitHub <https://github.com/pykeen/pykeen>`_
+with:
 
 .. code-block:: bash
 
@@ -18,19 +19,20 @@ source on `GitHub <https://github.com/pykeen/pykeen>`_ with:
 
 Google Colab and Kaggle Users
 -----------------------------
-`Google Colab <https://colab.research.google.com>`_ and `Kaggle <https://www.kaggle.com>`_ both provide
-a hosted version of Google's custom Jupyter notebook environment that work similarly. After opening
-a new notebook on one of these service, start your notebook with the following two lines:
+
+`Google Colab <https://colab.research.google.com>`_ and `Kaggle <https://www.kaggle.com>`_ both provide a hosted version
+of Google's custom Jupyter notebook environment that work similarly. After opening a new notebook on one of these
+service, start your notebook with the following two lines:
 
 .. code-block::
 
     ! pip install git+https://github.com/pykeen/pykeen.git
     pykeen.env()
 
-This will install the latest code, then output relevant system and environment information with :func:`pykeen.env`.
-It works because Jupyter interprets any line beginning with a bang ``!`` that the remainder of the
-line should be interpreted as a bash command. If you want to make your notebook compatible on both
-hosted and local installations, change it slightly to check if PyKEEN is already installed:
+This will install the latest code, then output relevant system and environment information with :func:`pykeen.env`. It
+works because Jupyter interprets any line beginning with a bang ``!`` that the remainder of the line should be
+interpreted as a bash command. If you want to make your notebook compatible on both hosted and local installations,
+change it slightly to check if PyKEEN is already installed:
 
 .. code-block::
 
@@ -39,37 +41,36 @@ hosted and local installations, change it slightly to check if PyKEEN is already
 
 .. note::
 
-    Old versions of PyKEEN that used :mod:`class_resolve` version 0.3.4 and below loaded
-    datasets via entrypoints. This was unpredictable on Kaggle and Google Colab, so it was
-    removed in https://github.com/pykeen/pykeen/pull/832. More information can also be found
-    on `PyKEEN issue #373 <https://github.com/pykeen/pykeen/issues/373>`_.
+    Old versions of PyKEEN that used :mod:`class_resolve` version 0.3.4 and below loaded datasets via entrypoints. This
+    was unpredictable on Kaggle and Google Colab, so it was removed in https://github.com/pykeen/pykeen/pull/832. More
+    information can also be found on `PyKEEN issue #373 <https://github.com/pykeen/pykeen/issues/373>`_.
 
 To enable GPU usage, go to the Runtime -> Change runtime type menu to enable a GPU with your notebook.
 
 Windows Users
 -------------
-We've added experimental support for Windows as of `!95 <https://github.com/pykeen/pykeen/pull/95>`_.
-However, be warned, it's much less straightforward to install PyTorch and therefore PyKEEN on Windows.
 
-First, to install PyTorch, you must install `Anaconda <https://www.anaconda.com/>`_ and follow
-the instructions on the `PyTorch website <https://pytorch.org/get-started/locally/>`_.
-Then, assuming your `python` and `pip` command are linked to the same place where conda is installing,
-you can proceed with the normal installation (or the installation from GitHub as shown above):
+We've added experimental support for Windows as of `!95 <https://github.com/pykeen/pykeen/pull/95>`_. However, be
+warned, it's much less straightforward to install PyTorch and therefore PyKEEN on Windows.
+
+First, to install PyTorch, you must install `Anaconda <https://www.anaconda.com/>`_ and follow the instructions on the
+`PyTorch website <https://pytorch.org/get-started/locally/>`_. Then, assuming your `python` and `pip` command are linked
+to the same place where conda is installing, you can proceed with the normal installation (or the installation from
+GitHub as shown above):
 
 .. code-block:: bash
 
     $ pip install pykeen
 
-If you're having trouble with ``pip`` or ``sqlite``, you might also have to use
-``conda install pip setuptools wheel sqlite``. See our
-`GitHub Actions configuration <https://github.com/pykeen/pykeen/blob/master/.github/workflows/tests.yml>`_
-on GitHub for inspiration.
+If you're having trouble with ``pip`` or ``sqlite``, you might also have to use ``conda install pip setuptools wheel
+sqlite``. See our `GitHub Actions configuration
+<https://github.com/pykeen/pykeen/blob/master/.github/workflows/tests.yml>`_ on GitHub for inspiration.
 
-If you know better ways to install on Windows or would like to share some references,
-we'd really appreciate it.
+If you know better ways to install on Windows or would like to share some references, we'd really appreciate it.
 
 Development
 -----------
+
 The latest code can be installed in development mode with:
 
 .. code-block:: bash
@@ -78,11 +79,11 @@ The latest code can be installed in development mode with:
     $ cd pykeen
     $ pip install -e .
 
-If you're interested in making contributions, please see our
-`contributing guide <https://github.com/pykeen/pykeen/blob/master/CONTRIBUTING.md>`_.
+If you're interested in making contributions, please see our `contributing guide
+<https://github.com/pykeen/pykeen/blob/master/CONTRIBUTING.md>`_.
 
-To automatically ensure compliance to our style guide, please install pre-commit
-hooks using the following code block from in the same directory.
+To automatically ensure compliance to our style guide, please install pre-commit hooks using the following code block
+from in the same directory.
 
 .. code-block:: bash
 
@@ -91,23 +92,23 @@ hooks using the following code block from in the same directory.
 
 Extras
 ------
-PyKEEN has several extras for installation that are defined in the ``[options.extras_require]`` section
-of the ``setup.cfg``. They can be included with installation using the bracket notation like in
-``pip install pykeen[docs]`` or ``pip install -e .[docs]``. Several can be listed, comma-delimited like in
-``pip install pykeen[docs,plotting]``.
 
-================  =========================================================================================
-Name              Description
-================  =========================================================================================
-``templating``    Building of templated documentation, like the README
-``plotting``      Plotting with ``seaborn`` and generation of word clouds
-``mlflow``        Tracking of results with ``mlflow``
-``wandb``         Tracking of results with ``wandb``
-``neptune``       Tracking of results with ``neptune``
-``tensorboard``   Tracking of results with :mod:`tensorboard` via :mod:`torch.utils.tensorboard`
-``transformers``  Label-based initialization with ``transformers``.
-``tests``         Code needed to run tests. Typically handled with ``tox -e py``
-``docs``          Building of the documentation
-``opt_einsum``    Improve performance of :func:`torch.einsum` by replacing with :func:`opt_einsum.contract`
-``biomedicine``   Use of :mod:`pyobo` for lookup of biomedical entity labels
-================  =========================================================================================
+PyKEEN has several extras for installation that are defined in the ``[options.extras_require]`` section of the
+``setup.cfg``. They can be included with installation using the bracket notation like in ``pip install pykeen[docs]`` or
+``pip install -e .[docs]``. Several can be listed, comma-delimited like in ``pip install pykeen[docs,plotting]``.
+
+================ =========================================================================================
+Name             Description
+================ =========================================================================================
+``templating``   Building of templated documentation, like the README
+``plotting``     Plotting with ``seaborn`` and generation of word clouds
+``mlflow``       Tracking of results with ``mlflow``
+``wandb``        Tracking of results with ``wandb``
+``neptune``      Tracking of results with ``neptune``
+``tensorboard``  Tracking of results with :mod:`tensorboard` via :mod:`torch.utils.tensorboard`
+``transformers`` Label-based initialization with ``transformers``.
+``tests``        Code needed to run tests. Typically handled with ``tox -e py``
+``docs``         Building of the documentation
+``opt_einsum``   Improve performance of :func:`torch.einsum` by replacing with :func:`opt_einsum.contract`
+``biomedicine``  Use of :mod:`pyobo` for lookup of biomedical entity labels
+================ =========================================================================================

--- a/docs/source/reference/ablation.rst
+++ b/docs/source/reference/ablation.rst
@@ -1,5 +1,8 @@
 Ablation
 ========
+
 .. autofunction:: pykeen.ablation.ablation_pipeline
+
 .. autofunction:: pykeen.ablation.prepare_ablation_from_config
+
 .. autofunction:: pykeen.ablation.prepare_ablation

--- a/docs/source/reference/checkpoints.rst
+++ b/docs/source/reference/checkpoints.rst
@@ -1,4 +1,5 @@
 Flexible Weight Checkpoints
 ===========================
+
 .. automodapi:: pykeen.checkpoints
     :no-heading:

--- a/docs/source/reference/constants.rst
+++ b/docs/source/reference/constants.rst
@@ -1,5 +1,6 @@
 Constants
 =========
+
 .. automodule:: pykeen.constants
     :members:
 

--- a/docs/source/reference/datasets.rst
+++ b/docs/source/reference/datasets.rst
@@ -1,5 +1,6 @@
 Datasets
 ========
+
 .. automodapi:: pykeen.datasets
     :include-all-objects:
 
@@ -9,8 +10,10 @@ Datasets
 
 Inductive Datasets
 ==================
+
 .. automodapi:: pykeen.datasets.inductive
 
 Entity Alignment
 ================
+
 .. automodapi:: pykeen.datasets.ea.combination

--- a/docs/source/reference/evaluation.rst
+++ b/docs/source/reference/evaluation.rst
@@ -1,5 +1,6 @@
 Evaluation
 ==========
+
 .. automodapi:: pykeen.evaluation
     :no-heading:
     :headings: --

--- a/docs/source/reference/hpo.rst
+++ b/docs/source/reference/hpo.rst
@@ -1,5 +1,6 @@
 Hyper-parameter Optimization
 ============================
+
 .. autoclass:: pykeen.hpo.HpoPipelineResult
     :members:
 

--- a/docs/source/reference/losses.rst
+++ b/docs/source/reference/losses.rst
@@ -1,13 +1,14 @@
 Loss Functions
 ==============
+
 .. automodapi:: pykeen.losses
     :no-heading:
     :headings: --
     :skip: Loss
     :include-all-objects:
 
-
 Base Classes
 ------------
+
 .. autoclass:: pykeen.losses.Loss
     :members:

--- a/docs/source/reference/metrics.rst
+++ b/docs/source/reference/metrics.rst
@@ -1,5 +1,6 @@
 Metrics
 =======
+
 .. automodapi:: pykeen.metrics
     :no-heading:
     :inherited-members:

--- a/docs/source/reference/models.rst
+++ b/docs/source/reference/models.rst
@@ -1,5 +1,6 @@
 Models
 ======
+
 .. automodapi:: pykeen.models
     :no-heading:
     :headings: --

--- a/docs/source/reference/negative_sampling.rst
+++ b/docs/source/reference/negative_sampling.rst
@@ -1,5 +1,6 @@
 Negative Sampling
 =================
+
 .. automodapi:: pykeen.sampling
     :no-heading:
     :headings: --
@@ -7,6 +8,7 @@ Negative Sampling
 
 Filtering
 =========
+
 .. automodapi:: pykeen.sampling.filtering
     :no-heading:
     :headings: --

--- a/docs/source/reference/nn/combinations.rst
+++ b/docs/source/reference/nn/combinations.rst
@@ -1,5 +1,6 @@
 Combinations
 ============
+
 .. automodapi:: pykeen.nn.combination
     :no-heading:
     :include-all-objects:

--- a/docs/source/reference/nn/compositions.rst
+++ b/docs/source/reference/nn/compositions.rst
@@ -1,5 +1,6 @@
 Compositions
 ============
+
 .. automodapi:: pykeen.nn.compositions
     :no-heading:
     :include-all-objects:

--- a/docs/source/reference/nn/index.rst
+++ b/docs/source/reference/nn/index.rst
@@ -1,22 +1,23 @@
 :mod:`pykeen.nn`
 ================
+
 .. automodule:: pykeen.nn
 
 .. toctree::
-   :caption: nn
-   :name: nn
+    :caption: nn
+    :name: nn
 
-   modules
-   similarity
-   representation
-   init
-   message_passing
-   pyg_message_passing
-   weighting
-   combinations
-   compositions
-   perceptron
-   utils
-   node_piece
-   text
-   vision
+    modules
+    similarity
+    representation
+    init
+    message_passing
+    pyg_message_passing
+    weighting
+    combinations
+    compositions
+    perceptron
+    utils
+    node_piece
+    text
+    vision

--- a/docs/source/reference/nn/init.rst
+++ b/docs/source/reference/nn/init.rst
@@ -1,5 +1,6 @@
 Initialization
---------------
+==============
+
 .. automodapi:: pykeen.nn.init
     :no-heading:
     :include-all-objects:

--- a/docs/source/reference/nn/message_passing.rst
+++ b/docs/source/reference/nn/message_passing.rst
@@ -1,5 +1,6 @@
 Message Passing
 ===============
+
 .. automodapi:: pykeen.nn.message_passing
     :no-heading:
     :headings: --

--- a/docs/source/reference/nn/modules.rst
+++ b/docs/source/reference/nn/modules.rst
@@ -1,5 +1,6 @@
 Stateful Interaction Modules
 ============================
+
 .. automodapi:: pykeen.nn.modules
     :no-heading:
     :include-all-objects:

--- a/docs/source/reference/nn/node_piece.rst
+++ b/docs/source/reference/nn/node_piece.rst
@@ -1,4 +1,5 @@
 NodePiece
 =========
+
 .. automodapi:: pykeen.nn.node_piece
     :include-all-objects:

--- a/docs/source/reference/nn/perceptron.rst
+++ b/docs/source/reference/nn/perceptron.rst
@@ -1,4 +1,5 @@
 Perceptron
 ==========
+
 .. automodule:: pykeen.nn.perceptron
     :members:

--- a/docs/source/reference/nn/pyg_message_passing.rst
+++ b/docs/source/reference/nn/pyg_message_passing.rst
@@ -1,5 +1,6 @@
 PyG Message Passing
 ===================
+
 .. automodapi:: pykeen.nn.pyg
     :no-heading:
     :include-all-objects:

--- a/docs/source/reference/nn/representation.rst
+++ b/docs/source/reference/nn/representation.rst
@@ -1,5 +1,6 @@
 Representation
 ==============
+
 .. automodapi:: pykeen.nn.representation
     :no-heading:
     :include-all-objects:

--- a/docs/source/reference/nn/similarity.rst
+++ b/docs/source/reference/nn/similarity.rst
@@ -1,4 +1,5 @@
 Similarity
 ==========
+
 .. automodapi:: pykeen.nn.sim
     :include-all-objects:

--- a/docs/source/reference/nn/text.rst
+++ b/docs/source/reference/nn/text.rst
@@ -1,5 +1,6 @@
 Text Encoders
--------------
+=============
+
 .. automodapi:: pykeen.nn.text
     :no-heading:
     :include-all-objects:

--- a/docs/source/reference/nn/utils.rst
+++ b/docs/source/reference/nn/utils.rst
@@ -1,5 +1,6 @@
 Utilities
 =========
+
 .. automodule:: pykeen.nn.utils
     :members:
 

--- a/docs/source/reference/nn/vision.rst
+++ b/docs/source/reference/nn/vision.rst
@@ -1,5 +1,6 @@
 Vision Encoders
----------------
+===============
+
 .. automodapi:: pykeen.nn.vision
     :no-heading:
     :include-all-objects:

--- a/docs/source/reference/nn/weighting.rst
+++ b/docs/source/reference/nn/weighting.rst
@@ -1,5 +1,6 @@
 Weighting
 =========
+
 .. automodapi:: pykeen.nn.weighting
     :no-heading:
     :headings: --

--- a/docs/source/reference/optimizers.rst
+++ b/docs/source/reference/optimizers.rst
@@ -1,5 +1,6 @@
 Optimizers
 ==========
+
 .. automodapi:: pykeen.optimizers
     :include-all-objects:
     :skip: Optimizer

--- a/docs/source/reference/pipeline.rst
+++ b/docs/source/reference/pipeline.rst
@@ -1,5 +1,6 @@
 Pipeline
 ========
+
 .. automodapi:: pykeen.pipeline
     :no-heading:
     :no-inheritance-diagram:

--- a/docs/source/reference/predict.rst
+++ b/docs/source/reference/predict.rst
@@ -1,6 +1,7 @@
 .. _making_predictions:
 
 Prediction
-===========
+==========
+
 .. automodapi:: pykeen.predict
     :no-heading:

--- a/docs/source/reference/regularizers.rst
+++ b/docs/source/reference/regularizers.rst
@@ -1,5 +1,6 @@
 Regularizers
 ============
+
 .. automodapi:: pykeen.regularizers
     :no-heading:
     :headings: --
@@ -8,6 +9,7 @@ Regularizers
 
 Base Classes
 ------------
+
 .. autoclass:: pykeen.regularizers.Regularizer
     :members:
     :exclude-members: to

--- a/docs/source/reference/sealant.rst
+++ b/docs/source/reference/sealant.rst
@@ -1,3 +1,4 @@
 Sealant
 =======
+
 .. automodapi:: pykeen.triples.leakage

--- a/docs/source/reference/stoppers.rst
+++ b/docs/source/reference/stoppers.rst
@@ -1,5 +1,6 @@
 Stoppers
 ========
+
 .. automodapi:: pykeen.stoppers
     :no-heading:
     :headings: --

--- a/docs/source/reference/trackers.rst
+++ b/docs/source/reference/trackers.rst
@@ -1,5 +1,6 @@
 Result Trackers
 ===============
+
 .. automodapi:: pykeen.trackers
     :no-heading:
     :headings: --

--- a/docs/source/reference/training.rst
+++ b/docs/source/reference/training.rst
@@ -1,5 +1,6 @@
 Training
 ========
+
 .. automodapi:: pykeen.training
     :no-heading:
     :headings: --
@@ -8,6 +9,7 @@ Training
 
 Callbacks
 ---------
+
 .. automodapi:: pykeen.training.callbacks
     :no-heading:
     :headings: ~~
@@ -15,6 +17,7 @@ Callbacks
 
 Learning Rate Schedulers
 ------------------------
+
 .. automodapi:: pykeen.lr_schedulers
     :no-heading:
     :headings: ~~

--- a/docs/source/reference/triples.rst
+++ b/docs/source/reference/triples.rst
@@ -1,5 +1,6 @@
 Triples
 =======
+
 .. automodapi:: pykeen.triples
     :no-heading:
     :include-all-objects:
@@ -7,33 +8,39 @@ Triples
 
 Utilities
 ---------
+
 .. automodule:: pykeen.triples.utils
     :members:
 
-
 Triples Workflows
 =================
+
 Splitting
 ---------
+
 .. automodapi:: pykeen.triples.splitting
     :no-heading:
 
 Remixing
----------
+--------
+
 .. automodapi:: pykeen.triples.remix
     :no-heading:
 
 Deterioration
 -------------
+
 .. automodapi:: pykeen.triples.deteriorate
     :no-heading:
 
 Generation
 ----------
+
 .. automodapi:: pykeen.triples.generation
     :no-heading:
 
 Analysis
-----------
+--------
+
 .. automodule:: pykeen.triples.analysis
     :members:

--- a/docs/source/reference/uncertainty.rst
+++ b/docs/source/reference/uncertainty.rst
@@ -1,5 +1,6 @@
 Uncertainty
 ===========
+
 .. automodapi:: pykeen.models.uncertainty
     :no-heading:
     :headings: --

--- a/docs/source/reference/utils.rst
+++ b/docs/source/reference/utils.rst
@@ -1,10 +1,11 @@
 Utilities
 =========
+
 .. automodule:: pykeen.utils
-   :members:
+    :members:
 
 .. autofunction:: pykeen.env
 
 .. automodule:: pykeen.version
-   :members:
-   :exclude-members: env
+    :members:
+    :exclude-members: env

--- a/docs/source/tutorial/first_steps.rst
+++ b/docs/source/tutorial/first_steps.rst
@@ -2,16 +2,16 @@
 
 First Steps
 ===========
+
 .. automodule:: pykeen.pipeline.api
 
 Loading a pre-trained Model
 ---------------------------
+
 Many of the previous examples ended with saving the results using the
-:meth:`pykeen.pipeline.PipelineResult.save_to_directory`. One of the
-artifacts written to the given directory is the ``trained_model.pkl``
-file. Because all PyKEEN models inherit from :class:`torch.nn.Module`,
-we use the PyTorch mechanisms for saving and loading them. This means
-that you can use :func:`torch.load` to load a model like:
+:meth:`pykeen.pipeline.PipelineResult.save_to_directory`. One of the artifacts written to the given directory is the
+``trained_model.pkl`` file. Because all PyKEEN models inherit from :class:`torch.nn.Module`, we use the PyTorch
+mechanisms for saving and loading them. This means that you can use :func:`torch.load` to load a model like:
 
 .. literalinclude:: ../examples/first_steps/load_pretrained.py
     :lines: 3-5
@@ -21,74 +21,71 @@ https://pytorch.org/tutorials/beginner/saving_loading_models.html.
 
 Mapping Entity and Relation Identifiers to their Names
 ------------------------------------------------------
-While PyKEEN internally maps entities and relations to
-contiguous identifiers, it's still useful to be able to interact
-with datasets, triples factories, and models using the labels
-of the entities and relations.
 
-We can map a triples factory's entities to identifiers using
-:func:`TriplesFactory.entities_to_ids` like in the following
-example:
+While PyKEEN internally maps entities and relations to contiguous identifiers, it's still useful to be able to interact
+with datasets, triples factories, and models using the labels of the entities and relations.
+
+We can map a triples factory's entities to identifiers using :func:`TriplesFactory.entities_to_ids` like in the
+following example:
 
 .. literalinclude:: ../examples/first_steps/entity_and_relation_mapping.py
     :lines: 4-11,38-39
 
-Similarly, we can map a triples factory's relations to identifiers
-using :data:`TriplesFactory.relations_to_ids` like in the following
-example:
+Similarly, we can map a triples factory's relations to identifiers using :data:`TriplesFactory.relations_to_ids` like in
+the following example:
 
 .. literalinclude:: ../examples/first_steps/entity_and_relation_mapping.py
     :lines: 40
 
 .. warning::
 
-    It's important to notice that we should use a triples factory with the same mapping
-    that was used to train the model - otherwise we might end up with incorrect IDs.
+    It's important to notice that we should use a triples factory with the same mapping that was used to train the model
+    - otherwise we might end up with incorrect IDs.
 
 Using Learned Embeddings
 ------------------------
-The embeddings learned for entities and relations are not only useful for link
-prediction (see :ref:`making_predictions`), but also for other downstream machine
-learning tasks like clustering, regression, and classification.
 
-Knowledge graph embedding models can potentially have multiple entity representations and
-multiple relation representations, so they are respectively stored as sequences in the
-``entity_representations`` and ``relation_representations`` attributes of each model.
-While the exact contents of these sequences are model-dependent, the first element of
-each is usually the "primary" representation for either the entities or relations.
+The embeddings learned for entities and relations are not only useful for link prediction (see
+:ref:`making_predictions`), but also for other downstream machine learning tasks like clustering, regression, and
+classification.
 
-Typically, the values in these sequences are instances of the :class:`pykeen.nn.representation.Embedding`.
-This implements a similar, but more powerful, interface to the built-in :class:`torch.nn.Embedding`
-class. However, the values in these sequences can more generally be instances of any subclasses of
-:class:`pykeen.nn.representation.Representation`. This allows for more powerful encoders those in GNNs
-such as :class:`pykeen.models.RGCN` to be implemented and used.
+Knowledge graph embedding models can potentially have multiple entity representations and multiple relation
+representations, so they are respectively stored as sequences in the ``entity_representations`` and
+``relation_representations`` attributes of each model. While the exact contents of these sequences are model-dependent,
+the first element of each is usually the "primary" representation for either the entities or relations.
+
+Typically, the values in these sequences are instances of the :class:`pykeen.nn.representation.Embedding`. This
+implements a similar, but more powerful, interface to the built-in :class:`torch.nn.Embedding` class. However, the
+values in these sequences can more generally be instances of any subclasses of
+:class:`pykeen.nn.representation.Representation`. This allows for more powerful encoders those in GNNs such as
+:class:`pykeen.models.RGCN` to be implemented and used.
 
 The entity representations and relation representations can be accessed like this:
 
 .. literalinclude:: ../examples/first_steps/using_learned_embeddings.py
     :lines: 4-14
 
-Most models, like :class:`pykeen.models.TransE`, only have one representation for entities and one
-for relations. This means that the ``entity_representations`` and ``relation_representations``
-lists both have a length of 1. All of the entity embeddings can be accessed like:
+Most models, like :class:`pykeen.models.TransE`, only have one representation for entities and one for relations. This
+means that the ``entity_representations`` and ``relation_representations`` lists both have a length of 1. All of the
+entity embeddings can be accessed like:
 
 .. literalinclude:: ../examples/first_steps/using_learned_embeddings.py
     :lines: 17-24
 
-Since all representations are subclasses of :class:`torch.nn.Module`, you need to call them like functions
-to invoke the `forward()` and get the values.
+Since all representations are subclasses of :class:`torch.nn.Module`, you need to call them like functions to invoke the
+`forward()` and get the values.
 
 .. literalinclude:: ../examples/first_steps/using_learned_embeddings.py
     :lines: 28-29
 
-The `forward()` function of all :class:`pykeen.nn.representation.Representation` takes an ``indices`` parameter.
-By default, it is ``None`` and returns all values. More explicitly, this looks like:
+The `forward()` function of all :class:`pykeen.nn.representation.Representation` takes an ``indices`` parameter. By
+default, it is ``None`` and returns all values. More explicitly, this looks like:
 
 .. literalinclude:: ../examples/first_steps/using_learned_embeddings.py
     :lines: 33-34
 
-If you'd like to only look up certain embeddings, you can use the ``indices`` parameter
-and pass a :class:`torch.LongTensor` with their corresponding indices.
+If you'd like to only look up certain embeddings, you can use the ``indices`` parameter and pass a
+:class:`torch.LongTensor` with their corresponding indices.
 
 .. literalinclude:: ../examples/first_steps/using_learned_embeddings.py
     :lines: 37-39
@@ -100,52 +97,47 @@ You might want to detach them from the GPU and convert to a :class:`numpy.ndarra
 
 .. warning::
 
-    Some old-style models (e.g., ones inheriting from :class:`pykeen.models.EntityRelationEmbeddingModel`)
-    don't fully implement the ``entity_representations`` and ``relation_representations`` interface. This means
-    that they might have additional embeddings stored in attributes that aren't exposed through these sequences.
-    For example, :class:`pykeen.models.TransD` has a secondary entity embedding in
-    :data:`pykeen.models.TransD.entity_projections`.
+    Some old-style models (e.g., ones inheriting from :class:`pykeen.models.EntityRelationEmbeddingModel`) don't fully
+    implement the ``entity_representations`` and ``relation_representations`` interface. This means that they might have
+    additional embeddings stored in attributes that aren't exposed through these sequences. For example,
+    :class:`pykeen.models.TransD` has a secondary entity embedding in :data:`pykeen.models.TransD.entity_projections`.
     Eventually, all models will be upgraded to new-style models and this won't be a problem.
 
 Beyond the Pipeline
 -------------------
-While the pipeline provides a high-level interface, each aspect of the
-training process is encapsulated in classes that can be more finely
-tuned or subclassed. Below is an example of code that might have been
-executed with one of the previous examples.
+
+While the pipeline provides a high-level interface, each aspect of the training process is encapsulated in classes that
+can be more finely tuned or subclassed. Below is an example of code that might have been executed with one of the
+previous examples.
 
 .. literalinclude:: ../examples/first_steps/beyond_pipeline.py
     :lines: 3-
 
-
 Preview: Evaluation Loops
 -------------------------
-PyKEEN is currently in the transition to use torch's data-loaders for evaluation, too.
-While not being active for the high-level `pipeline`, you can already use it explicitly:
+
+PyKEEN is currently in the transition to use torch's data-loaders for evaluation, too. While not being active for the
+high-level `pipeline`, you can already use it explicitly:
 
 .. literalinclude:: ../examples/first_steps/evaluation_loop.py
     :lines: 3-
 
-
 Training Callbacks
 ------------------
-PyKEEN allows interaction with the training loop through callbacks.
-One particular use case is regular evaluation (outside of an early stopper).
-The following example shows how to evaluate on the training triples on every
-tenth epoch
+
+PyKEEN allows interaction with the training loop through callbacks. One particular use case is regular evaluation
+(outside of an early stopper). The following example shows how to evaluate on the training triples on every tenth epoch
 
 .. literalinclude:: ../examples/first_steps/callbacks.py
     :lines: 3-
 
-For further information about different result trackers, take a look at the section
-on :ref:`trackers`.
+For further information about different result trackers, take a look at the section on :ref:`trackers`.
 
 Next Steps
 ----------
-The first steps tutorial taught you how to train and use a model for some of the
-most common tasks. There are several other topic-specific tutorials in the section
-of the documentation. You might also want to jump ahead to the :ref:`troubleshooting`
-section in case you're having trouble, or look through
-`questions <https://github.com/pykeen/pykeen/issues?q=is%3Aissue+is%3Aopen+label%3Aquestion>`_
-and `discussions <https://github.com/pykeen/pykeen/discussions>`_ that others have posted
-on GitHub.
+
+The first steps tutorial taught you how to train and use a model for some of the most common tasks. There are several
+other topic-specific tutorials in the section of the documentation. You might also want to jump ahead to the
+:ref:`troubleshooting` section in case you're having trouble, or look through `questions
+<https://github.com/pykeen/pykeen/issues?q=is%3Aissue+is%3Aopen+label%3Aquestion>`_ and `discussions
+<https://github.com/pykeen/pykeen/discussions>`_ that others have posted on GitHub.

--- a/docs/source/tutorial/models.rst
+++ b/docs/source/tutorial/models.rst
@@ -1,76 +1,76 @@
 Knowledge Graph Embedding Models
 ================================
+
 In PyKEEN, the base class for Knowledge Graph Embedding Models is :class:`~pykeen.models.ERModel`.
 
-It combines entity and relation representations with an interaction function.
-On a very high-level, triple scores are obtained by first extracting the representations
-corresponding to the head and tail entity and relation (given as integer indices), and then
-uses the interaction function to calculate a scalar score from them.
+It combines entity and relation representations with an interaction function. On a very high-level, triple scores are
+obtained by first extracting the representations corresponding to the head and tail entity and relation (given as
+integer indices), and then uses the interaction function to calculate a scalar score from them.
 
-This tutorial gives a high-level overview of these components, and explains how to select them.
-A detailed discussions of possible representations can be found here: :ref:`representations`.
-Interaction functions are discussed in detail in :ref:`interactions`.
+This tutorial gives a high-level overview of these components, and explains how to select them. A detailed discussions
+of possible representations can be found here: :ref:`representations`. Interaction functions are discussed in detail in
+:ref:`interactions`.
 
 Representation
 --------------
-A :class:`~pykeen.nn.representation.Representation` provides a method to obtain *representations*, e.g.,
-vectors, for given integer indices. These indices may correspond to entity or relation indices.
-The representations are chosen by providing appropriate inputs to the parameters
 
-* ``entity_representations`` / ``entity_representations_kwargs`` for entity representations, or
-* ``relation_representations`` / ``relation_representations_kwargs`` for relation representations.
+A :class:`~pykeen.nn.representation.Representation` provides a method to obtain *representations*, e.g., vectors, for
+given integer indices. These indices may correspond to entity or relation indices. The representations are chosen by
+providing appropriate inputs to the parameters
 
-These inputs are then used to instantiate the representations using
-:meth:`pykeen.nn.representation_resolver.make_many`. Notice that
-:class:`~pykeen.models.ERModel`, takes care of filling in the ``max_id`` parameter into the ``..._kwargs``.
-The default is to use a single :class:`~pykeen.nn.representation.Embedding` for entities and relations, as
-encountered in many publications.
+- ``entity_representations`` / ``entity_representations_kwargs`` for entity representations, or
+- ``relation_representations`` / ``relation_representations_kwargs`` for relation representations.
+
+These inputs are then used to instantiate the representations using :meth:`pykeen.nn.representation_resolver.make_many`.
+Notice that :class:`~pykeen.models.ERModel`, takes care of filling in the ``max_id`` parameter into the ``..._kwargs``.
+The default is to use a single :class:`~pykeen.nn.representation.Embedding` for entities and relations, as encountered
+in many publications.
 
 The following examples are for entity representations, but can be equivalently used for relation representations.
 
-* a single :class:`~pykeen.nn.representation.Embedding` with dimensionality 64, suitable, e.g., for interactions such as
+- a single :class:`~pykeen.nn.representation.Embedding` with dimensionality 64, suitable, e.g., for interactions such as
   :class:`~pykeen.nn.modules.TransEInteraction`, or :class:`~pykeen.nn.modules.DistMultInteraction`.
 
-    .. code-block:: python
+      .. code-block:: python
 
-        model = ERModel(
-            # the default:
-            # entity_representations=None,
-            # equivalent to
-            # entity_representations=[None],
-            # equivalent to
-            # entity_representations=[pykeen.nn.Embedding],
-            entity_representations_kwargs=dict(shape=64),
-            ...,
-        )
+          model = ERModel(
+              # the default:
+              # entity_representations=None,
+              # equivalent to
+              # entity_representations=[None],
+              # equivalent to
+              # entity_representations=[pykeen.nn.Embedding],
+              entity_representations_kwargs=dict(shape=64),
+              ...,
+          )
 
-*  two :class:`~pykeen.nn.representation.Embedding` with same dimensionality 64, suitable,
-   e.g., for interactions such as :class:`~pykeen.nn.modules.BoxEInteraction`
+- two :class:`~pykeen.nn.representation.Embedding` with same dimensionality 64, suitable, e.g., for interactions such as
+  :class:`~pykeen.nn.modules.BoxEInteraction`
 
-    .. code-block:: python
+      .. code-block:: python
 
-        model = ERModel(
-            entity_representations=[None, None],
-            # note: ClassResolver.make_many supports "broad-casting" kwargs
-            entity_representations_kwargs=dict(shape=64),
-            # equivalent:
-            # entity_representations_kwargs=[dict(shape=64), dict(shape=64)],
-            ...,
-        )
+          model = ERModel(
+              entity_representations=[None, None],
+              # note: ClassResolver.make_many supports "broad-casting" kwargs
+              entity_representations_kwargs=dict(shape=64),
+              # equivalent:
+              # entity_representations_kwargs=[dict(shape=64), dict(shape=64)],
+              ...,
+          )
 
-.. note ::
+.. note::
 
-    Internally, the :mod:`class_resolver` library is used to support various alternative parametrization, e.g.,
-    the string name of a representation class, the `class` object, or instances of the
+    Internally, the :mod:`class_resolver` library is used to support various alternative parametrization, e.g., the
+    string name of a representation class, the `class` object, or instances of the
     :class:`~pykeen.nn.representation.Representation` class. You can also register your own classes to the resolver.
     Detailed information can be found in the documentation of the package or in the :ref:`using_resolvers` tutorial
 
-
 Interaction Function
 --------------------
-An interaction function calculates scalar scores from head, relation, and tail representations.
-These scores can be interpreted as the plausibility of a triple, i.e., the higher the score, the more plausible
-the triple is. Good models thus should output high scores for true triples and low scores for false triples.
+
+An interaction function calculates scalar scores from head, relation, and tail representations. These scores can be
+interpreted as the plausibility of a triple, i.e., the higher the score, the more plausible the triple is. Good models
+thus should output high scores for true triples and low scores for false triples.
 
 In PyKEEN, interactions are provided as subclasses of :class:`~pykeen.nn.Interaction`, which is a
 :class:`torch.nn.Module`, i.e., it can hold additional (trainable) parameters, and can also be used outside of PyKEEN.
@@ -81,8 +81,8 @@ As with the representations, interactions passed to :class:`~pykeen.models.ERMod
 :meth:`pykeen.nn.interaction_resolver.make`. Hence, we can provide, e.g., strings corresponding to the interaction
 function instead of an instantiated class. Further information can be found at :ref:`using_resolvers`.
 
-.. note ::
+.. note::
 
-    Interaction functions can require different numbers or shapes of entity and relation representations.
-    A symbolic description of the expected number of representations and their shape can be accessed by
+    Interaction functions can require different numbers or shapes of entity and relation representations. A symbolic
+    description of the expected number of representations and their shape can be accessed by
     :attr:`pykeen.nn.Interaction.entity_shape` and :attr:`pykeen.nn.Interaction.relation_shape`.

--- a/docs/source/tutorial/node_piece.rst
+++ b/docs/source/tutorial/node_piece.rst
@@ -1,594 +1,502 @@
 .. _getting_started_with_node_piece:
 
-################################
- Getting Started with NodePiece
-################################
+Getting Started with NodePiece
+==============================
 
-This page gives more practical examples on using and configuring
-NodePiece.
+This page gives more practical examples on using and configuring NodePiece.
 
-*************
- Basic Usage
-*************
+Basic Usage
+-----------
 
-We'll use :class:`pykeen.datasets.FB15k237` for illustrating purposes
-throughout the following examples.
+We'll use :class:`pykeen.datasets.FB15k237` for illustrating purposes throughout the following examples.
 
-.. code:: python
+.. code-block:: python
 
-   from pykeen.models import NodePiece
-   from pykeen.datasets import FB15k237
+    from pykeen.models import NodePiece
+    from pykeen.datasets import FB15k237
 
-   # inverses are necessary for the current version of NodePiece
-   dataset = FB15k237(create_inverse_triples=True)
+    # inverses are necessary for the current version of NodePiece
+    dataset = FB15k237(create_inverse_triples=True)
 
-In the simplest usage of :class:`pykeen.models.NodePiece`, we'll only
-use relations for tokenization. We can do this by with the following
-arguments:
+In the simplest usage of :class:`pykeen.models.NodePiece`, we'll only use relations for tokenization. We can do this by
+with the following arguments:
 
-#. Set the ``tokenizers="RelationTokenizer"`` to
-   :class:`pykeen.nn.node_piece.RelationTokenizer`. We can simply refer
-   to the class name and it gets automatically resolved to the correct
-   subclass of :class:`pykeen.nn.node_piece.Tokenizer` by the
-   :mod:`class_resolver`.
-
-#. Set the ``num_tokens=12`` to sample 12 unique relations per node. If,
-   for some entities, there are less than 12 unique relations, the
-   difference will be padded with the auxiliary padding token.
+1. Set the ``tokenizers="RelationTokenizer"`` to :class:`pykeen.nn.node_piece.RelationTokenizer`. We can simply refer to
+   the class name and it gets automatically resolved to the correct subclass of :class:`pykeen.nn.node_piece.Tokenizer`
+   by the :mod:`class_resolver`.
+2. Set the ``num_tokens=12`` to sample 12 unique relations per node. If, for some entities, there are less than 12
+   unique relations, the difference will be padded with the auxiliary padding token.
 
 Here's how the code looks:
 
-.. code:: python
+.. code-block:: python
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers="RelationTokenizer",
-       num_tokens=12,
-       embedding_dim=64,
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers="RelationTokenizer",
+        num_tokens=12,
+        embedding_dim=64,
+    )
 
-Next, we'll use a combination of tokenizers
-(:class:`pykeen.nn.node_piece.AnchorTokenizer` and
-:class:`pykeen.nn.node_piece.RelationTokenizer`) to replicate the full
-NodePiece tokenization with $k$ anchors and $m$ relational context. It's
-as easy as sending a list of tokenizers to ``tokenizers`` and sending a
-list of arguments to ``num_tokens``:
+Next, we'll use a combination of tokenizers (:class:`pykeen.nn.node_piece.AnchorTokenizer` and
+:class:`pykeen.nn.node_piece.RelationTokenizer`) to replicate the full NodePiece tokenization with $k$ anchors and $m$
+relational context. It's as easy as sending a list of tokenizers to ``tokenizers`` and sending a list of arguments to
+``num_tokens``:
 
-.. code:: python
+.. code-block:: python
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-       num_tokens=[20, 12],
-       embedding_dim=64,
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+        num_tokens=[20, 12],
+        embedding_dim=64,
+    )
 
-Class resolver will automatically instantiate
-:class:`pykeen.nn.node_piece.AnchorTokenizer` with 20 anchors per node
-and :class:`pykeen.nn.node_piece.RelationTokenizer` with 12 relations
-per node, so the order of specifying ``tokenizers`` and ``num_tokens``
-matters here.
+Class resolver will automatically instantiate :class:`pykeen.nn.node_piece.AnchorTokenizer` with 20 anchors per node and
+:class:`pykeen.nn.node_piece.RelationTokenizer` with 12 relations per node, so the order of specifying ``tokenizers``
+and ``num_tokens`` matters here.
 
-********************************
- Anchor Selection and Searching
-********************************
+Anchor Selection and Searching
+------------------------------
 
 The :class:`pykeen.nn.node_piece.AnchorTokenizer` has two fields:
 
-#. ``selection`` controls how we sample anchors from the graph (32
-   anchors by default)
-#. ``searcher`` controls how we tokenize nodes using selected anchors
+1. ``selection`` controls how we sample anchors from the graph (32 anchors by default)
+2. ``searcher`` controls how we tokenize nodes using selected anchors
    (:class:`pykeen.nn.node_piece.CSGraphAnchorSearcher` by default)
 
-By default, our models above use 32 anchors selected as top-degree nodes
-with :class:`pykeen.nn.node_piece.DegreeAnchorSelection` (those are
-default values for the anchor selection resolver) and nodes are
-tokenized using :class:`pykeen.nn.node_piece.CSGraphAnchorSearcher` - it
-uses :mod:`scipy.sparse` to explicitly compute shortest paths from all
-nodes in the graph to all anchors in the deterministic manner. We can
-afford that for relatively small graphs of FB15k237 size.
+By default, our models above use 32 anchors selected as top-degree nodes with
+:class:`pykeen.nn.node_piece.DegreeAnchorSelection` (those are default values for the anchor selection resolver) and
+nodes are tokenized using :class:`pykeen.nn.node_piece.CSGraphAnchorSearcher` - it uses :mod:`scipy.sparse` to
+explicitly compute shortest paths from all nodes in the graph to all anchors in the deterministic manner. We can afford
+that for relatively small graphs of FB15k237 size.
 
-For larger graphs, we recommend using the breadth-first search (BFS)
-procedure in :class:`pykeen.nn.node_piece.ScipySparseAnchorSearcher` -
-it applies BFS by iteratively expanding node neighborhood until it finds
-a desired number of anchors - this dramatically saves compute time on
-graphs of size like :class:`pykeen.datasets.OGBWikiKG2`.
+For larger graphs, we recommend using the breadth-first search (BFS) procedure in
+:class:`pykeen.nn.node_piece.ScipySparseAnchorSearcher` - it applies BFS by iteratively expanding node neighborhood
+until it finds a desired number of anchors - this dramatically saves compute time on graphs of size like
+:class:`pykeen.datasets.OGBWikiKG2`.
 
-32 unique anchors might be a bit too small for FB15k237 with 15k nodes -
-so let's create a :class:`pykeen.models.NodePiece` model with 100
-anchors selected with the top degree strategy by sending the
+32 unique anchors might be a bit too small for FB15k237 with 15k nodes - so let's create a
+:class:`pykeen.models.NodePiece` model with 100 anchors selected with the top degree strategy by sending the
 ``tokenizers_kwargs`` list:
 
-.. code:: python
+.. code-block:: python
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-       num_tokens=[20, 12],
-       tokenizers_kwargs=[
-           dict(
-               selection="Degree",
-               selection_kwargs=dict(
-                   num_anchors=100,
-               ),
-               searcher="CSGraph",
-           ),
-           dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
-       ],
-       embedding_dim=64,
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+        num_tokens=[20, 12],
+        tokenizers_kwargs=[
+            dict(
+                selection="Degree",
+                selection_kwargs=dict(
+                    num_anchors=100,
+                ),
+                searcher="CSGraph",
+            ),
+            dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
+        ],
+        embedding_dim=64,
+    )
 
-``tokenizers_kwargs`` expects the same number dictionaries as the number
-of tokenizers you used, so we have 2 dicts here - one for
-``AnchorTokenizer`` and another one for ``RelationTokenizer`` (but this
-one doesn't need any kwargs so we just put an empty dict there).
+``tokenizers_kwargs`` expects the same number dictionaries as the number of tokenizers you used, so we have 2 dicts here
+- one for ``AnchorTokenizer`` and another one for ``RelationTokenizer`` (but this one doesn't need any kwargs so we just
+put an empty dict there).
 
-Let's create a model with 500 top-pagerank anchors selected with the BFS
-strategy - we'll just modify the ``selection`` and ``searcher`` args:
+Let's create a model with 500 top-pagerank anchors selected with the BFS strategy - we'll just modify the ``selection``
+and ``searcher`` args:
 
-.. code:: python
+.. code-block:: python
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-       num_tokens=[20, 12],
-       tokenizers_kwargs=[
-           dict(
-               selection="PageRank",
-               selection_kwargs=dict(
-                   num_anchors=500,
-               ),
-               searcher="ScipySparse",
-           ),
-           dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
-       ],
-       embedding_dim=64,
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+        num_tokens=[20, 12],
+        tokenizers_kwargs=[
+            dict(
+                selection="PageRank",
+                selection_kwargs=dict(
+                    num_anchors=500,
+                ),
+                searcher="ScipySparse",
+            ),
+            dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
+        ],
+        embedding_dim=64,
+    )
 
-Looks nice, but fasten your seatbelts 🚀 - we can use several anchor
-selection strategies sequentially to select more diverse anchors!
-Mindblowing 😍
+Looks nice, but fasten your seatbelts 🚀 - we can use several anchor selection strategies sequentially to select more
+diverse anchors! Mindblowing 😍
 
-Let's create a model with 500 anchors where 50% of them will be top
-degree nodes and another 50% will be top PageRank nodes - for that we
-have a :class:`pykeen.nn.node_piece.MixtureAnchorSelection` class!
+Let's create a model with 500 anchors where 50% of them will be top degree nodes and another 50% will be top PageRank
+nodes - for that we have a :class:`pykeen.nn.node_piece.MixtureAnchorSelection` class!
 
-.. code:: python
+.. code-block:: python
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-       num_tokens=[20, 12],
-       tokenizers_kwargs=[
-           dict(
-               selection="MixtureAnchorSelection",
-               selection_kwargs=dict(
-                   selections=["degree", "pagerank"],
-                   ratios=[0.5, 0.5],
-                   num_anchors=500,
-               ),
-               searcher="ScipySparse",
-           ),
-           dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
-       ],
-       embedding_dim=64,
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+        num_tokens=[20, 12],
+        tokenizers_kwargs=[
+            dict(
+                selection="MixtureAnchorSelection",
+                selection_kwargs=dict(
+                    selections=["degree", "pagerank"],
+                    ratios=[0.5, 0.5],
+                    num_anchors=500,
+                ),
+                searcher="ScipySparse",
+            ),
+            dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
+        ],
+        embedding_dim=64,
+    )
 
-Now the ``selection_kwargs`` controls which strategies we'll be using
-and how many anchors each of them will sample - in our case
-``selections=['degree', 'pagerank']``. Using the ``ratios`` argument we
-control the ratio of those sampled anchors in the total pool - in our
-case ``ratios=[0.5, 0.5]`` which means that both ``degree`` and
-``pagerank`` strategies each will sample 50% from the total number of
-anchors. Since the total number is 500, there will be 250 top-degree
-anchors and 250 top-pagerank anchors. ``ratios`` **must** sum up to 1.0
+Now the ``selection_kwargs`` controls which strategies we'll be using and how many anchors each of them will sample - in
+our case ``selections=['degree', 'pagerank']``. Using the ``ratios`` argument we control the ratio of those sampled
+anchors in the total pool - in our case ``ratios=[0.5, 0.5]`` which means that both ``degree`` and ``pagerank``
+strategies each will sample 50% from the total number of anchors. Since the total number is 500, there will be 250
+top-degree anchors and 250 top-pagerank anchors. ``ratios`` **must** sum up to 1.0
 
-**Important**: sampled anchors are **unique** - that is, if a node
-appears to be in top-K degree and top-K pagerank, it will be used only
-once, the sampler will just skip it in the subsequent strategies.
+**Important**: sampled anchors are **unique** - that is, if a node appears to be in top-K degree and top-K pagerank, it
+will be used only once, the sampler will just skip it in the subsequent strategies.
 
-At the moment, we have 3 anchor selection strategies: **degree**,
-**pagerank**, and **random**. The latter just samples random nodes as
-anchors.
+At the moment, we have 3 anchor selection strategies: **degree**, **pagerank**, and **random**. The latter just samples
+random nodes as anchors.
 
-Let's create a tokenization setup reported in the original NodePiece
-paper for FB15k237 with 40% top degree anchors, 40% top pagerank, and
-20% random anchors:
+Let's create a tokenization setup reported in the original NodePiece paper for FB15k237 with 40% top degree anchors, 40%
+top pagerank, and 20% random anchors:
 
-.. code:: python
+.. code-block:: python
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-       num_tokens=[20, 12],
-       tokenizers_kwargs=[
-           dict(
-               selection="MixtureAnchorSelection",
-               selection_kwargs=dict(
-                   selections=["degree", "pagerank", "random"],
-                   ratios=[0.4, 0.4, 0.2],
-                   num_anchors=500,
-               ),
-               searcher="ScipySparse",
-           ),
-           dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
-       ],
-       embedding_dim=64,
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+        num_tokens=[20, 12],
+        tokenizers_kwargs=[
+            dict(
+                selection="MixtureAnchorSelection",
+                selection_kwargs=dict(
+                    selections=["degree", "pagerank", "random"],
+                    ratios=[0.4, 0.4, 0.2],
+                    num_anchors=500,
+                ),
+                searcher="ScipySparse",
+            ),
+            dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
+        ],
+        embedding_dim=64,
+    )
 
-**Note on Anchor Distances**: As of now, the anchor distances are
-considered implicitly, i.e., when performing actual tokenization via
-shortest paths or BFS we do sort anchors by proximity and keep top-K
-nearest. The anchor distance embedding as a positional feature to be
-added to anchor embedding is not yet implemented.
+**Note on Anchor Distances**: As of now, the anchor distances are considered implicitly, i.e., when performing actual
+tokenization via shortest paths or BFS we do sort anchors by proximity and keep top-K nearest. The anchor distance
+embedding as a positional feature to be added to anchor embedding is not yet implemented.
 
-***************************************************************************************************
- How many total anchors `num_anchors` and anchors & relations `num_tokens` do I need for my graph?
-***************************************************************************************************
+How many total anchors `num_anchors` and anchors & relations `num_tokens` do I need for my graph?
+-------------------------------------------------------------------------------------------------
 
-This is a good question with deep theoretical implications and NP-hard
-problems like `k-Dominating Sets
-<https://en.wikipedia.org/wiki/Dominating_set>`_ and `Vertex Cover Sets
-<https://en.wikipedia.org/wiki/Vertex_cover>`_ . We don't have a
-closed-form solution for each possible dataset, but we found some
-empirical heuristics:
+This is a good question with deep theoretical implications and NP-hard problems like `k-Dominating Sets
+<https://en.wikipedia.org/wiki/Dominating_set>`_ and `Vertex Cover Sets <https://en.wikipedia.org/wiki/Vertex_cover>`_ .
+We don't have a closed-form solution for each possible dataset, but we found some empirical heuristics:
 
--  keeping ``num_anchors`` as 1-10% of total nodes in the graph is a
-   good start
+- keeping ``num_anchors`` as 1-10% of total nodes in the graph is a good start
+- graph density is a major factor: the denser the graph, the fewer ``num_anchors`` you'd need. For dense FB15k237 100
+  total anchors (over 15k total nodes) seems to be good enough, while for sparser WN18RR we needed at least 500 anchors
+  (over 40k total nodes). For dense OGB WikiKG2 of 2.5M nodes a vocab of 20K anchors (< 1%) already leads to SOTA
+  results
+- the same applies to anchors per node: you'd need more tokens for sparser graphs and fewer for denser
+- the size of the relational context depends on the density and number of unique relations in the graph, eg, in FB15k237
+  we have 237 * 2 = 474 unique relations and only 11 * 2 = 22 in WN18RR. If we select a too large context, most tokens
+  will be ``PADDING_TOKEN`` and we don't want that.
+- reported relational context sizes (relations per node) in the NodePiece paper `are 66th percentiles
+  <https://github.com/migalkin/NodePiece/blob/9adc57efe302919d017d74fc648f853308cf75fd/lp_rp/pykeen105/nodepiece_rotate.py#L173>`_
+  of the number of unique incident relations per node, eg 12 for FB15k237 and 5 for WN18RR
 
--  graph density is a major factor: the denser the graph, the fewer
-   ``num_anchors`` you'd need. For dense FB15k237 100 total anchors
-   (over 15k total nodes) seems to be good enough, while for sparser
-   WN18RR we needed at least 500 anchors (over 40k total nodes). For
-   dense OGB WikiKG2 of 2.5M nodes a vocab of 20K anchors (< 1%) already
-   leads to SOTA results
-
--  the same applies to anchors per node: you'd need more tokens for
-   sparser graphs and fewer for denser
-
--  the size of the relational context depends on the density and number
-   of unique relations in the graph, eg, in FB15k237 we have 237 * 2 =
-   474 unique relations and only 11 * 2 = 22 in WN18RR. If we select a
-   too large context, most tokens will be ``PADDING_TOKEN`` and we don't
-   want that.
-
--  reported relational context sizes (relations per node) in the
-   NodePiece paper `are 66th percentiles
-   <https://github.com/migalkin/NodePiece/blob/9adc57efe302919d017d74fc648f853308cf75fd/lp_rp/pykeen105/nodepiece_rotate.py#L173>`_
-   of the number of unique incident relations per node, eg 12 for
-   FB15k237 and 5 for WN18RR
-
-In some tasks, you might not need anchors at all and could use
-RelationTokenizer only! Check the `paper
+In some tasks, you might not need anchors at all and could use RelationTokenizer only! Check the `paper
 <https://openreview.net/forum?id=xMJWUKJnFSw>`_ for more results.
 
--  In inductive link prediction tasks we don't use anchors as inference
-   graphs are disconnected from training ones;
+- In inductive link prediction tasks we don't use anchors as inference graphs are disconnected from training ones;
+- in relation prediction we found that just a relational context is better than anchors + relations;
+- in node classification (currently, this pipeline is not available in PyKEEN) on dense relation-rich graphs like
+  Wikidata, we found that just a relational context is better than anchors + relations.
 
--  in relation prediction we found that just a relational context is
-   better than anchors + relations;
-
--  in node classification (currently, this pipeline is not available in
-   PyKEEN) on dense relation-rich graphs like Wikidata, we found that
-   just a relational context is better than anchors + relations.
-
-*******************************************************
- Using NodePiece with :func:`pykeen.pipeline.pipeline`
-*******************************************************
+Using NodePiece with :func:`pykeen.pipeline.pipeline`
+-----------------------------------------------------
 
 Let's pack the last NodePiece model into the pipeline:
 
-.. code:: python
+.. code-block:: python
 
-   import torch.nn
+    import torch.nn
 
-   from pykeen.models import NodePiece
-   from pykeen.pipeline import pipeline
+    from pykeen.models import NodePiece
+    from pykeen.pipeline import pipeline
 
-   result = pipeline(
-       dataset="fb15k237",
-       dataset_kwargs=dict(
-           create_inverse_triples=True,
-       ),
-       model=NodePiece,
-       model_kwargs=dict(
-           tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-           num_tokens=[20, 12],
-           tokenizers_kwargs=[
-               dict(
-                   selection="MixtureAnchorSelection",
-                   selection_kwargs=dict(
-                       selections=["degree", "pagerank", "random"],
-                       ratios=[0.4, 0.4, 0.2],
-                       num_anchors=500,
-                   ),
-                   searcher="ScipySparse",
-               ),
-               dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
-           ],
-           embedding_dim=64,
-           interaction="rotate",
-       ),
-   )
+    result = pipeline(
+        dataset="fb15k237",
+        dataset_kwargs=dict(
+            create_inverse_triples=True,
+        ),
+        model=NodePiece,
+        model_kwargs=dict(
+            tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+            num_tokens=[20, 12],
+            tokenizers_kwargs=[
+                dict(
+                    selection="MixtureAnchorSelection",
+                    selection_kwargs=dict(
+                        selections=["degree", "pagerank", "random"],
+                        ratios=[0.4, 0.4, 0.2],
+                        num_anchors=500,
+                    ),
+                    searcher="ScipySparse",
+                ),
+                dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
+            ],
+            embedding_dim=64,
+            interaction="rotate",
+        ),
+    )
 
-***************************
- Pre-Computed Vocabularies
-***************************
+Pre-Computed Vocabularies
+-------------------------
 
-We have a :class:`pykeen.nn.node_piece.PrecomputedPoolTokenizer` that
-can be instantiated with a precomputed vocabulary either from a local
-file or using a downloadable link.
+We have a :class:`pykeen.nn.node_piece.PrecomputedPoolTokenizer` that can be instantiated with a precomputed vocabulary
+either from a local file or using a downloadable link.
 
 For a local file, specify ``path``:
 
-.. code:: python
+.. code-block:: python
 
-   precomputed_tokenizer = tokenizer_resolver.make(
-       "precomputedpool", path=Path("path/to/vocab.pkl")
-   )
+    precomputed_tokenizer = tokenizer_resolver.make("precomputedpool", path=Path("path/to/vocab.pkl"))
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       num_tokens=[20, 12],
-       tokenizers=[precomputed_tokenizer, "RelationTokenizer"],
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        num_tokens=[20, 12],
+        tokenizers=[precomputed_tokenizer, "RelationTokenizer"],
+    )
 
 For a remote file, specify the ``url``:
 
-.. code:: python
+.. code-block:: python
 
-   precomputed_tokenizer = tokenizer_resolver.make(
-       "precomputedpool", url="http://link/to/vocab.pkl"
-   )
+    precomputed_tokenizer = tokenizer_resolver.make("precomputedpool", url="http://link/to/vocab.pkl")
 
-Generally, :class:`pykeen.nn.node_piece.PrecomputedPoolTokenizer` can
-use any :class:`pykeen.nn.node_piece.PrecomputedTokenizerLoader` as a
-custom processor of vocabulary formats. Right now there is one such
-loader, :class:`pykeen.nn.node_piece.GalkinPrecomputedTokenizerLoader`
-that expects a dictionary of the following format:
+Generally, :class:`pykeen.nn.node_piece.PrecomputedPoolTokenizer` can use any
+:class:`pykeen.nn.node_piece.PrecomputedTokenizerLoader` as a custom processor of vocabulary formats. Right now there is
+one such loader, :class:`pykeen.nn.node_piece.GalkinPrecomputedTokenizerLoader` that expects a dictionary of the
+following format:
 
-.. code::
+::
 
-   node_id: {
-       "ancs": [a list of used UNMAPPED anchor nodes sorted from nearest to farthest],
-       "dists": [a list of anchor distances for each anchor in ancs, ascending]
-   }
+    node_id: {
+        "ancs": [a list of used UNMAPPED anchor nodes sorted from nearest to farthest],
+        "dists": [a list of anchor distances for each anchor in ancs, ascending]
+    }
 
-As of now, we don't use anchor distances, but we expect the anchors in
-``ancs`` to be already sorted from nearest to farthest, so the example
-of a precomputed vocab can be:
+As of now, we don't use anchor distances, but we expect the anchors in ``ancs`` to be already sorted from nearest to
+farthest, so the example of a precomputed vocab can be:
 
-.. code::
+::
 
-   1: {'ancs': [3, 10, 5, 9, 220, ...]}  # anchor 3 is the nearest for node 1
-   2: {'ancs': [22, 37, 14, 10, ...]}  # anchors 22 is the nearest for node 2
+    1: {'ancs': [3, 10, 5, 9, 220, ...]}  # anchor 3 is the nearest for node 1
+    2: {'ancs': [22, 37, 14, 10, ...]}  # anchors 22 is the nearest for node 2
 
-**Unmapped** anchors means that anchor IDs are the same node IDs from
-the total set of entities ``0... N-1``. In the pickle processing we'll
-convert them to a contiguous range ``0 ... num_anchors-1``. Any negative
-indices in the lists will be treated as padding tokens (we used -99 in
-the precomputed vocabularies).
+**Unmapped** anchors means that anchor IDs are the same node IDs from the total set of entities ``0... N-1``. In the
+pickle processing we'll convert them to a contiguous range ``0 ... num_anchors-1``. Any negative indices in the lists
+will be treated as padding tokens (we used -99 in the precomputed vocabularies).
 
 The original NodePiece repo has `an example
-<https://github.com/migalkin/NodePiece/blob/9adc57efe302919d017d74fc648f853308cf75fd/ogb/ogb_tokenizer.py#L180>`_
-of building such a vocabulary format for OGB WikiKG 2.
+<https://github.com/migalkin/NodePiece/blob/9adc57efe302919d017d74fc648f853308cf75fd/ogb/ogb_tokenizer.py#L180>`_ of
+building such a vocabulary format for OGB WikiKG 2.
 
-**************************************
- Configuring the Interaction Function
-**************************************
+Configuring the Interaction Function
+------------------------------------
 
-you can use literally any interaction function available in PyKEEN as a
-scoring function! By default, NodePiece uses DistMult, but it's easy to
-change as in any :class:`pykeen.models.ERModel`, let's use the RotatE
-interaction:
+you can use literally any interaction function available in PyKEEN as a scoring function! By default, NodePiece uses
+DistMult, but it's easy to change as in any :class:`pykeen.models.ERModel`, let's use the RotatE interaction:
 
-.. code:: python
+.. code-block:: python
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-       num_tokens=[20, 12],
-       interaction="rotate",
-       embedding_dim=64,
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+        num_tokens=[20, 12],
+        interaction="rotate",
+        embedding_dim=64,
+    )
 
-Well, for RotatE we might want to initialize relations as phases
-(``init_phases``) and use an additional relation constrainer to keep
-``|r| = 1`` (``complex_normalize``), and use ``xavier_uniform_`` for
-anchor embedding initialization - let's add that, too:
+Well, for RotatE we might want to initialize relations as phases (``init_phases``) and use an additional relation
+constrainer to keep ``|r| = 1`` (``complex_normalize``), and use ``xavier_uniform_`` for anchor embedding initialization
+- let's add that, too:
 
-.. code:: python
+.. code-block:: python
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-       num_tokens=[20, 12],
-       embedding_dim=64,
-       interaction="rotate",
-       relation_initializer="init_phases",
-       relation_constrainer="complex_normalize",
-       entity_initializer="xavier_uniform_",
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+        num_tokens=[20, 12],
+        embedding_dim=64,
+        interaction="rotate",
+        relation_initializer="init_phases",
+        relation_constrainer="complex_normalize",
+        entity_initializer="xavier_uniform_",
+    )
 
-**************************************
- Configuring the Aggregation Function
-**************************************
+Configuring the Aggregation Function
+------------------------------------
 
-This section is about the ``aggregation`` keyword argument. This is an
-encoder function that actually builds entity representations from token
-embeddings. It is supposed to be a function that maps a set of tokens
-(anchors, relations, or both) to a single vector:
+This section is about the ``aggregation`` keyword argument. This is an encoder function that actually builds entity
+representations from token embeddings. It is supposed to be a function that maps a set of tokens (anchors, relations, or
+both) to a single vector:
 
 .. math::
 
-   f([a_1, a_2, ...., a_k, r_1, r_2, ..., r_m]) \in \mathbb{R}^{(k+m) \times d} \rightarrow  \mathbb{R}^{d}
+    f([a_1, a_2, ...., a_k, r_1, r_2, ..., r_m]) \in \mathbb{R}^{(k+m) \times d} \rightarrow  \mathbb{R}^{d}
 
-Right now, by default we use a simple 2-layer MLP
-(:class:`pykeen.nn.perceptron.ConcatMLP`) that concatenates all tokens
+Right now, by default we use a simple 2-layer MLP (:class:`pykeen.nn.perceptron.ConcatMLP`) that concatenates all tokens
 to one long vector and projects it down to model's embedding dimension:
 
-.. code:: python
+.. code-block:: python
 
-   hidden_dim = int(ratio * embedding_dim)
-   super().__init__(
-       nn.Linear(num_tokens * embedding_dim, hidden_dim),
-       nn.Dropout(dropout),
-       nn.ReLU(),
-       nn.Linear(hidden_dim, embedding_dim),
-   )
+    hidden_dim = int(ratio * embedding_dim)
+    super().__init__(
+        nn.Linear(num_tokens * embedding_dim, hidden_dim),
+        nn.Dropout(dropout),
+        nn.ReLU(),
+        nn.Linear(hidden_dim, embedding_dim),
+    )
 
-Aggregation can be parameterized with any neural network
-(:class:`torch.nn.Module`) that would return a single vector from a set
-of inputs. Let's be fancy 😎 and create a `DeepSet
-<https://arxiv.org/abs/1703.06114>`_ encoder:
+Aggregation can be parameterized with any neural network (:class:`torch.nn.Module`) that would return a single vector
+from a set of inputs. Let's be fancy 😎 and create a `DeepSet <https://arxiv.org/abs/1703.06114>`_ encoder:
 
-.. code:: python
+.. code-block:: python
 
-   class DeepSet(torch.nn.Module):
-       def __init__(self, hidden_dim=64):
-           super().__init__()
-           self.encoder = torch.nn.Sequential(
-               torch.nn.Linear(hidden_dim, hidden_dim),
-               torch.nn.ReLU(),
-               torch.nn.Linear(hidden_dim, hidden_dim),
-               torch.nn.ReLU(),
-               torch.nn.Linear(hidden_dim, hidden_dim),
-           )
-           self.decoder = torch.nn.Sequential(
-               torch.nn.Linear(hidden_dim, hidden_dim),
-               torch.nn.ReLU(),
-               torch.nn.Linear(hidden_dim, hidden_dim),
-               torch.nn.ReLU(),
-               torch.nn.Linear(hidden_dim, hidden_dim),
-           )
+    class DeepSet(torch.nn.Module):
+        def __init__(self, hidden_dim=64):
+            super().__init__()
+            self.encoder = torch.nn.Sequential(
+                torch.nn.Linear(hidden_dim, hidden_dim),
+                torch.nn.ReLU(),
+                torch.nn.Linear(hidden_dim, hidden_dim),
+                torch.nn.ReLU(),
+                torch.nn.Linear(hidden_dim, hidden_dim),
+            )
+            self.decoder = torch.nn.Sequential(
+                torch.nn.Linear(hidden_dim, hidden_dim),
+                torch.nn.ReLU(),
+                torch.nn.Linear(hidden_dim, hidden_dim),
+                torch.nn.ReLU(),
+                torch.nn.Linear(hidden_dim, hidden_dim),
+            )
 
-       def forward(self, x, dim=-2):
-           x = self.encoder(x).mean(dim)
-           x = self.decoder(x)
-           return x
+        def forward(self, x, dim=-2):
+            x = self.encoder(x).mean(dim)
+            x = self.decoder(x)
+            return x
 
 
-   model = NodePiece(
-       triples_factory=dataset.training,
-       tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-       num_tokens=[20, 12],
-       embedding_dim=64,
-       interaction="rotate",
-       relation_initializer="init_phases",
-       relation_constrainer="complex_normalize",
-       entity_initializer="xavier_uniform_",
-       aggregation=DeepSet(hidden_dim=64),
-   )
+    model = NodePiece(
+        triples_factory=dataset.training,
+        tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+        num_tokens=[20, 12],
+        embedding_dim=64,
+        interaction="rotate",
+        relation_initializer="init_phases",
+        relation_constrainer="complex_normalize",
+        entity_initializer="xavier_uniform_",
+        aggregation=DeepSet(hidden_dim=64),
+    )
 
-We can even put a Transformer with pooling here. The only thing to keep
-in mind is the complexity of the encoder - we found
-:class:`pykeen.nn.perceptron.ConcatMLP` to be a good balance between
-speed and final performance, although at the cost of being not
-permutation invariant to the input set of tokens.
+We can even put a Transformer with pooling here. The only thing to keep in mind is the complexity of the encoder - we
+found :class:`pykeen.nn.perceptron.ConcatMLP` to be a good balance between speed and final performance, although at the
+cost of being not permutation invariant to the input set of tokens.
 
-The aggregation function resembles that of GNNs. Non-parametric
-avg/min/max did not work that well in the current tokenization setup, so
-some non-linearity is definitely useful - hence the choice for MLP /
-DeepSets / Transformer as an aggregation function.
+The aggregation function resembles that of GNNs. Non-parametric avg/min/max did not work that well in the current
+tokenization setup, so some non-linearity is definitely useful - hence the choice for MLP / DeepSets / Transformer as an
+aggregation function.
 
-Let's wrap our cool NodePiece model with 40/40/20 degree/pagerank/random
-tokenization with the BFS searcher and DeepSet aggregation into a
-pipeline:
+Let's wrap our cool NodePiece model with 40/40/20 degree/pagerank/random tokenization with the BFS searcher and DeepSet
+aggregation into a pipeline:
 
-.. code:: python
+.. code-block:: python
 
-   result = pipeline(
-       dataset="fb15k237",
-       dataset_kwargs=dict(
-           create_inverse_triples=True,
-       ),
-       model=NodePiece,
-       model_kwargs=dict(
-           tokenizers=["AnchorTokenizer", "RelationTokenizer"],
-           num_tokens=[20, 12],
-           tokenizers_kwargs=[
-               dict(
-                   selection="MixtureAnchorSelection",
-                   selection_kwargs=dict(
-                       selections=["degree", "pagerank", "random"],
-                       ratios=[0.4, 0.4, 0.2],
-                       num_anchors=500,
-                   ),
-                   searcher="ScipySparse",
-               ),
-               dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
-           ],
-           embedding_dim=64,
-           interaction="rotate",
-           relation_initializer="init_phases",
-           relation_constrainer="complex_normalize",
-           entity_initializer="xavier_uniform_",
-           aggregation=DeepSet(hidden_dim=64),
-       ),
-   )
+    result = pipeline(
+        dataset="fb15k237",
+        dataset_kwargs=dict(
+            create_inverse_triples=True,
+        ),
+        model=NodePiece,
+        model_kwargs=dict(
+            tokenizers=["AnchorTokenizer", "RelationTokenizer"],
+            num_tokens=[20, 12],
+            tokenizers_kwargs=[
+                dict(
+                    selection="MixtureAnchorSelection",
+                    selection_kwargs=dict(
+                        selections=["degree", "pagerank", "random"],
+                        ratios=[0.4, 0.4, 0.2],
+                        num_anchors=500,
+                    ),
+                    searcher="ScipySparse",
+                ),
+                dict(),  # empty dict for the RelationTokenizer - it doesn't need any kwargs
+            ],
+            embedding_dim=64,
+            interaction="rotate",
+            relation_initializer="init_phases",
+            relation_constrainer="complex_normalize",
+            entity_initializer="xavier_uniform_",
+            aggregation=DeepSet(hidden_dim=64),
+        ),
+    )
 
-*****************
- NodePiece + GNN
-*****************
+NodePiece + GNN
+---------------
 
-It is also possible to add a message passing GNN on top of obtained
-NodePiece representations to further enrich node states - we found it
-shows even better results in inductive LP tasks. We have that
-implemented with :class:`pykeen.models.InductiveNodePieceGNN` that uses
-a 2-layer `CompGCN <https://arxiv.org/abs/1911.03082>`_ encoder - please
-check the Inductive Link Prediction tutorial.
+It is also possible to add a message passing GNN on top of obtained NodePiece representations to further enrich node
+states - we found it shows even better results in inductive LP tasks. We have that implemented with
+:class:`pykeen.models.InductiveNodePieceGNN` that uses a 2-layer `CompGCN <https://arxiv.org/abs/1911.03082>`_ encoder -
+please check the Inductive Link Prediction tutorial.
 
-***********************************
- Tokenizing Large Graphs with METIS
-***********************************
+Tokenizing Large Graphs with METIS
+----------------------------------
 
-Mining anchors and running tokenization on whole graphs larger than 1M nodes
-might be computationally expensive. Due to the inherent locality of
-NodePiece, i.e., tokenization via nearest anchors and incident relations,
-we recommend using graph partitioning to reduce time and memory costs of
-tokenization. With graph partitioning, anchor search and tokenization can
-be performed independently within each partition with a final merging of
-all results into a single vocabulary.
+Mining anchors and running tokenization on whole graphs larger than 1M nodes might be computationally expensive. Due to
+the inherent locality of NodePiece, i.e., tokenization via nearest anchors and incident relations, we recommend using
+graph partitioning to reduce time and memory costs of tokenization. With graph partitioning, anchor search and
+tokenization can be performed independently within each partition with a final merging of all results into a single
+vocabulary.
 
-We designed the partitioning tokenization strategy using
-`METIS <https://en.wikipedia.org/wiki/METIS>`_, a min-cut graph partitioning algorithm
-with an efficient implementation available in `torch-sparse <https://github.com/rusty1s/pytorch_sparse>`_.
-Along with METIS, we leverage `torch-sparse` to offer a new, faster BFS
+We designed the partitioning tokenization strategy using `METIS <https://en.wikipedia.org/wiki/METIS>`_, a min-cut graph
+partitioning algorithm with an efficient implementation available in `torch-sparse
+<https://github.com/rusty1s/pytorch_sparse>`_. Along with METIS, we leverage `torch-sparse` to offer a new, faster BFS
 procedure that can run on a GPU.
 
-The main tokenizer class is :class:`pykeen.nn.node_piece.MetisAnchorTokenizer`.
-You can place it instead of the vanilla ``AnchorTokenizer``.
-With the Metis-based tokenizer, we first partition the input training graph
-into `k` separate partitions and then run anchor selection and anchor search
-sequentially and independently **for each partition**.
+The main tokenizer class is :class:`pykeen.nn.node_piece.MetisAnchorTokenizer`. You can place it instead of the vanilla
+``AnchorTokenizer``. With the Metis-based tokenizer, we first partition the input training graph into `k` separate
+partitions and then run anchor selection and anchor search sequentially and independently **for each partition**.
 
-You can use any existing anchor selection and anchor search strategy described above
-although for larger graphs we recommend using a new :class:`pykeen.nn.node_piece.SparseBFSSearcher`
-as anchor searcher -- it implements faster sparse matrix multiplication kernels and can be run on a GPU.
-The only difference from the vanilla tokenizer is that now the ``num_anchors``
-argument defines how many anchors will be mined **for each partition**.
+You can use any existing anchor selection and anchor search strategy described above although for larger graphs we
+recommend using a new :class:`pykeen.nn.node_piece.SparseBFSSearcher` as anchor searcher -- it implements faster sparse
+matrix multiplication kernels and can be run on a GPU. The only difference from the vanilla tokenizer is that now the
+``num_anchors`` argument defines how many anchors will be mined **for each partition**.
 
 The new tokenizer has two special arguments:
 
--   ``num_partitions`` - number of partitions the graph will be divided into.
-    You can expect METIS to produce partitions of about the same size, e.g.,
-    ``num_partitions=10`` for a graph of 1M nodes would produce 10 partitions
-    with about 100K nodes in each. The total number of mined anchors will
-    be ``num_partitions * num_anchors``
+- ``num_partitions`` - number of partitions the graph will be divided into. You can expect METIS to produce partitions
+  of about the same size, e.g., ``num_partitions=10`` for a graph of 1M nodes would produce 10 partitions with about
+  100K nodes in each. The total number of mined anchors will be ``num_partitions * num_anchors``
+- ``device`` - the device to run METIS on. It can be different from the device on which an ``AnchorSearcher`` will run.
+  We found ``device="cpu"`` works faster on larger graphs and does not require limited GPU memory, although you can keep
+  the device to be resolved automatically or put ``device="cuda"`` to try running it on a GPU.
 
--   ``device`` - the device to run METIS on. It can be different from the device
-    on which an ``AnchorSearcher`` will run. We found ``device="cpu"`` works
-    faster on larger graphs and does not require limited GPU memory,
-    although you can keep the device to be resolved automatically or put
-    ``device="cuda"`` to try running it on a GPU.
-
-It is still advisable to run large graph tokenization using :class:`pykeen.nn.node_piece.SparseBFSSearcher`
-on a GPU thanks to more efficient sparse CUDA kernels. If a GPU is available, it will
-be used automatically by default.
+It is still advisable to run large graph tokenization using :class:`pykeen.nn.node_piece.SparseBFSSearcher` on a GPU
+thanks to more efficient sparse CUDA kernels. If a GPU is available, it will be used automatically by default.
 
 Let's use the new tokenizer for the Wikidata5M graph of 5M nodes and 20M edges.
 
-.. code:: python
+.. code-block:: python
 
     from pykeen.datasets import Wikidata5M
 
@@ -606,30 +514,29 @@ Let's use the new tokenizer for the Wikidata5M graph of 5M nodes and 20M edges.
                 device="cpu",  # METIS on cpu tends to be faster
                 selection="MixtureAnchorSelection",  # we can use any anchor selection strategy here
                 selection_kwargs=dict(
-                    selections=['degree', 'random'],
+                    selections=["degree", "random"],
                     ratios=[0.5, 0.5],
                     num_anchors=1000,  # overall, we will have 20 * 1000 = 20000 anchors
                 ),
                 searcher="SparseBFSSearcher",  # a new efficient anchor searcher
-                searcher_kwargs=dict(
-                    max_iter=5  # each node will be tokenized with anchors in the 5-hop neighborhood
-                )
+                searcher_kwargs=dict(max_iter=5),  # each node will be tokenized with anchors in the 5-hop neighborhood
             ),
-            dict()
+            dict(),
         ],
-        aggregation="mlp"
+        aggregation="mlp",
     )
 
     # we can save the vocabulary of tokenized nodes
     from pathlib import Path
+
     model.entity_representations[0].base[0].save_assignment(Path("./anchors_assignment.pt"))
 
 On a machine with 32 GB RAM and 32 GB GPU, processing of Wikidata5M takes about 10 minutes:
 
-*   ~ 3 min for partitioning into 20 clusters on a cpu;
-*   ~ 7 min overall for anchor selection and search in each partition
+- ~ 3 min for partitioning into 20 clusters on a cpu;
+- ~ 7 min overall for anchor selection and search in each partition
 
 **How many partitions do I need for my graph?**
 
-It largely depends on the hardware and memory at hand, but
-as a rule of thumb we would recommend having partitions of size < 500K nodes each
+It largely depends on the hardware and memory at hand, but as a rule of thumb we would recommend having partitions of
+size < 500K nodes each

--- a/docs/source/tutorial/normalizer_constrainer_regularizer.rst
+++ b/docs/source/tutorial/normalizer_constrainer_regularizer.rst
@@ -3,66 +3,64 @@
 Normalizer, Constrainer & Regularizer
 =====================================
 
-Sometimes we want to impose constraints on parameters such as the embedding vector.
-This can be motivated by geometric importance of individual parameters (e.g., acting as a normal vector),
-indicating a preference for one solution over many otherwise equivalent solutions,
-or acting as a general regularization term to reduce the risk of overfitting.
+Sometimes we want to impose constraints on parameters such as the embedding vector. This can be motivated by geometric
+importance of individual parameters (e.g., acting as a normal vector), indicating a preference for one solution over
+many otherwise equivalent solutions, or acting as a general regularization term to reduce the risk of overfitting.
 
-There are several ways to impose these constraints.
-To better differentiate between them,
-PyKEEN distinguishes between *normalizers*, *constrainers*, and *regularizers*.
+There are several ways to impose these constraints. To better differentiate between them, PyKEEN distinguishes between
+*normalizers*, *constrainers*, and *regularizers*.
 
 Normalizer
 ----------
-A *normalizer* is essentially a re-parameterization:
-For instance, to normalize vector $\mathbf{x} \in \mathbb{R}^d$ to unit norm,
-we introduce a new variable $\overline{\mathbf{x}} = \frac{1}{\|\mathbf{x}\|}\mathbf{x}$,
-and use this variable instead of $\mathbf{x}$.
 
-This normalization is applied within the computational graph,
-so gradients for $\mathbf{x}$ will include the effect of the normalization constant,
-effectively canceling out any contribution
-that would not change the direction of the gradient,
-but rather re-scale its length.
+A *normalizer* is essentially a re-parameterization: For instance, to normalize vector $\mathbf{x} \in \mathbb{R}^d$ to
+unit norm, we introduce a new variable $\overline{\mathbf{x}} = \frac{1}{\|\mathbf{x}\|}\mathbf{x}$, and use this
+variable instead of $\mathbf{x}$.
+
+This normalization is applied within the computational graph, so gradients for $\mathbf{x}$ will include the effect of
+the normalization constant, effectively canceling out any contribution that would not change the direction of the
+gradient, but rather re-scale its length.
 
 Normalizers are strict, i.e. the normalized variable is guaranteed to satisfy the constraint.
 
-Since normalizers are part of the computational graph,
-they are usually implemented directly as part of a module,
-e.g., in :class:`pykeen.nn.representation.Embedding`.
-
+Since normalizers are part of the computational graph, they are usually implemented directly as part of a module, e.g.,
+in :class:`pykeen.nn.representation.Embedding`.
 
 Constrainer
 -----------
-A *constrainer* applies the same strict normalization, *but outside of the computational graph*.
-So we do the gradient computation without respecting the constraint,
-and only after applying the optimization update, e.g., we do a renormalization.
 
-This method can be seen as a `relaxation <https://en.wikipedia.org/wiki/Relaxation_(approximation)>`_
-of the constrained problem that ignores the constraints and projects the (approximate) solution of
-the unconstrained problem back into the constraint set.
+A *constrainer* applies the same strict normalization, *but outside of the computational graph*. So we do the gradient
+computation without respecting the constraint, and only after applying the optimization update, e.g., we do a
+renormalization.
+
+This method can be seen as a `relaxation <https://en.wikipedia.org/wiki/Relaxation_(approximation)>`_ of the constrained
+problem that ignores the constraints and projects the (approximate) solution of the unconstrained problem back into the
+constraint set.
 
 Constrainers guarantee the constraint *after each gradient step*, but may violate the constaints in between.
 
 Constrainers are applied in :meth:`pykeen.nn.representation.Representation.post_parameter_update`.
 
 .. warning::
+
     If you use PyKEEN modules outside of PyKEEN's training methods, you need to make sure to call
     :meth:`pykeen.nn.representation.Representation.post_parameter_update` yourself after each parameter update.
 
 .. seealso::
+
     - `Proximal gradient methods <https://en.wikipedia.org/wiki/Proximal_gradient_method>`_
 
 Regularizer
 -----------
-A *regularizer* does not impose strict normalization,
-but rather adds a term to the loss function that penalizes violation of the constraint.
-This allows constraints to be (severely) violated in the early stages of the optimization,
+
+A *regularizer* does not impose strict normalization, but rather adds a term to the loss function that penalizes
+violation of the constraint. This allows constraints to be (severely) violated in the early stages of the optimization,
 when the original loss term is still high and thus the relative contribution of the regularization term is small.
-However, once the optimization has found a sufficiently good solution for the original loss term,
-it can only further improve the total loss by also respecting the regularization term.
+However, once the optimization has found a sufficiently good solution for the original loss term, it can only further
+improve the total loss by also respecting the regularization term.
 
 You can find implementations of regularizers by looking at subclasses of :class:`pykeen.regularizers.Regularizer`.
 
 .. seealso::
+
     - A related concept in linear optimization are `slack variables <https://en.wikipedia.org/wiki/Slack_variable>`_.

--- a/docs/source/tutorial/performance.rst
+++ b/docs/source/tutorial/performance.rst
@@ -1,114 +1,113 @@
 Performance Tricks
 ==================
-PyKEEN uses a combination of techniques to promote efficient calculations during training/evaluation
-and tries to maximize the utilization of the available hardware (currently focused on single GPU usage).
+
+PyKEEN uses a combination of techniques to promote efficient calculations during training/evaluation and tries to
+maximize the utilization of the available hardware (currently focused on single GPU usage).
 
 .. _entity_and_relation_ids:
 
 Entity and Relation IDs
 -----------------------
-Entities and relations in triples are usually stored as strings.
-Because KGEMs aim at learning vector representations for these entities and relations such that the chosen
-interaction function learns a useful scoring on top of them, we need a mapping from the string representations
-to vectors. Moreover, for computational efficiency, we would like to store all entity/relation embeddings in matrices.
-Thus, the mapping process comprises two parts: Mapping strings to IDs, and using the IDs to access the embeddings
-(=row indices).
 
-In PyKEEN, the mapping process takes place in :class:`pykeen.triples.TriplesFactory`. The triples factory maintains
-the sets of unique entity and relation labels and ensures that they are mapped to unique integer IDs on
+Entities and relations in triples are usually stored as strings. Because KGEMs aim at learning vector representations
+for these entities and relations such that the chosen interaction function learns a useful scoring on top of them, we
+need a mapping from the string representations to vectors. Moreover, for computational efficiency, we would like to
+store all entity/relation embeddings in matrices. Thus, the mapping process comprises two parts: Mapping strings to IDs,
+and using the IDs to access the embeddings (=row indices).
+
+In PyKEEN, the mapping process takes place in :class:`pykeen.triples.TriplesFactory`. The triples factory maintains the
+sets of unique entity and relation labels and ensures that they are mapped to unique integer IDs on
 $[0,\text{num_unique_entities})$ for entities and $[0, \text{num_unique_relations})$. The mappings are respectively
 accessible via the attributes :data:``pykeen.triples.TriplesFactory.entity_label_to_id`` and
 :data:``pykeen.triples.TriplesFactory.relation_label_to_id``.
 
-To improve the performance, the mapping process takes place only once, and the ID-based
-triples are stored in a tensor :data:``pykeen.triples.TriplesFactory.mapped_triples``.
+To improve the performance, the mapping process takes place only once, and the ID-based triples are stored in a tensor
+:data:``pykeen.triples.TriplesFactory.mapped_triples``.
 
 .. _tuple_broadcasting:
 
 Tuple Broadcasting
 ------------------
+
 Interaction functions are usually only given for the standard case of scoring a single triple $(h, r, t)$. This function
 is implemented in PyKEEN in the :func:`pykeen.models.base.Model.score_hrt` method of each model, e.g.
-:func:`pykeen.models.DistMult.score_hrt` for :class:`pykeen.models.DistMult`. When training under the local closed
-world assumption (LCWA), evaluating a model, and performing the link prediction task, the goal is to score all
-entities/relations for a given tuple, i.e. $(h, r)$, $(r, t)$ or $(h, t)$. In these cases a single tuple is used
-many times for different entities/relations.
+:func:`pykeen.models.DistMult.score_hrt` for :class:`pykeen.models.DistMult`. When training under the local closed world
+assumption (LCWA), evaluating a model, and performing the link prediction task, the goal is to score all
+entities/relations for a given tuple, i.e. $(h, r)$, $(r, t)$ or $(h, t)$. In these cases a single tuple is used many
+times for different entities/relations.
 
 For example, we want to rank all entities for a single tuple $(h, r)$ with :class:`pykeen.models.DistMult` for the
 :class:`pykeen.datasets.FB15k237`. This dataset contains 14,505 entities, which means that there are 14,505 $(h, r, t)$
 combinations, whereas $h$ and $r$ are constant. Looking at the interaction function of :class:`pykeen.models.DistMult`,
-we can observe that the :math:`h \odot r` part causes half of the mathematical operations to calculate
-:math:`h \odot r \odot t`. Therefore, calculating the :math:`h \odot r` part only once and reusing it spares us
-half of the mathematical operations for the other 14,504 remaining entities, making the calculations roughly
-twice as fast in total. The speed-up might be significantly higher in cases where the broadcasted part has a high
-relative complexity compared to the overall interaction function, e.g. :class:`pykeen.models.ConvE`.
+we can observe that the :math:`h \odot r` part causes half of the mathematical operations to calculate :math:`h \odot r
+\odot t`. Therefore, calculating the :math:`h \odot r` part only once and reusing it spares us half of the mathematical
+operations for the other 14,504 remaining entities, making the calculations roughly twice as fast in total. The speed-up
+might be significantly higher in cases where the broadcasted part has a high relative complexity compared to the overall
+interaction function, e.g. :class:`pykeen.models.ConvE`.
 
 To make this technique possible, PyKEEN models have to provide an explicit broadcasting function via following methods
 in the model class:
 
- - :func:`pykeen.models.base.Model.score_h` - Scoring all possible head entities for a given $(r, t)$ tuple
- - :func:`pykeen.models.base.Model.score_r` - Scoring all possible relations for a given $(h, t)$ tuple
- - :func:`pykeen.models.base.Model.score_t` - Scoring all possible tail entities for a given $(h, r)$ tuple
+    - :func:`pykeen.models.base.Model.score_h` - Scoring all possible head entities for a given $(r, t)$ tuple
+    - :func:`pykeen.models.base.Model.score_r` - Scoring all possible relations for a given $(h, t)$ tuple
+    - :func:`pykeen.models.base.Model.score_t` - Scoring all possible tail entities for a given $(h, r)$ tuple
 
 The PyKEEN architecture natively supports these methods and makes use of this technique wherever possible without any
 additional modifications. Providing these methods is completely optional and not required when implementing new models.
 
 Filtering with Index-based Masking
 ----------------------------------
+
 In this example, it is given a knowledge graph $\mathcal{K} \subseteq \mathcal{E} \times \mathcal{R} \times \mathcal{E}$
 and disjoint unions of $\mathcal{K}$ in training triples $\mathcal{K}_{train}$, testing triples $\mathcal{K}_{test}$,
 and validation triples $\mathcal{K}_{val}$. The same operations are performed on $\mathcal{K}_{test}$ and
 $\mathcal{K}_{val}$, but only $\mathcal{K}_{test}$ will be given as example in this section.
 
-Two calculations are performed for each test triple $(h, r, t) \in \mathcal{K}_{test}$ during standard evaluation of
-a knowledge graph embedding model with interaction function
-$f:\mathcal{E} \times \mathcal{R} \times \mathcal{E} \rightarrow \mathbb{R}$ for the link prediction task:
+Two calculations are performed for each test triple $(h, r, t) \in \mathcal{K}_{test}$ during standard evaluation of a
+knowledge graph embedding model with interaction function $f:\mathcal{E} \times \mathcal{R} \times \mathcal{E}
+\rightarrow \mathbb{R}$ for the link prediction task:
 
-1. $(h, r)$ is combined with all possible tail entities $t' \in \mathcal{E}$ to make triples
-   $T_{h,r} = \{(h,r,t') \mid t' \in \mathcal{E}\}$
-2. $(r, t)$ is combined with all possible head entities $h' \in \mathcal{E}$ to make triples
-   $H_{r,t} = \{(h',r,t) \mid h' \in \mathcal{E}\}$
+1. $(h, r)$ is combined with all possible tail entities $t' \in \mathcal{E}$ to make triples $T_{h,r} = \{(h,r,t') \mid
+   t' \in \mathcal{E}\}$
+2. $(r, t)$ is combined with all possible head entities $h' \in \mathcal{E}$ to make triples $H_{r,t} = \{(h',r,t) \mid
+   h' \in \mathcal{E}\}$
 
-Finally, the ranking of $(h, r, t)$ is calculated against all $(h, r, t') \in T_{h,r}$
-and $(h', r, t) \in H_{r,t}$ triples with respect to the interaction function $f$.
+Finally, the ranking of $(h, r, t)$ is calculated against all $(h, r, t') \in T_{h,r}$ and $(h', r, t) \in H_{r,t}$
+triples with respect to the interaction function $f$.
 
-In the filtered setting, $T_{h,r}$ is not allowed to contain tail entities $(h, r, t') \in \mathcal{K}_{train}$
-and $H_{r,t}$ is not allowed to contain head entities leading to $(h', r, t) \in \mathcal{K}_{train}$ triples
-found in the train dataset. Therefore, their definitions could be amended like:
+In the filtered setting, $T_{h,r}$ is not allowed to contain tail entities $(h, r, t') \in \mathcal{K}_{train}$ and
+$H_{r,t}$ is not allowed to contain head entities leading to $(h', r, t) \in \mathcal{K}_{train}$ triples found in the
+train dataset. Therefore, their definitions could be amended like:
 
 - $T^{\text{filtered}}_{h,r} = \{(h,r,t') \mid t' \in \mathcal{E}\} \setminus \mathcal{K}_{train}$
 - $H^{\text{filtered}}_{r,t} = \{(h',r,t) \mid h' \in \mathcal{E}\} \setminus \mathcal{K}_{train}$
 
-While this easily defined theoretically, it poses several practical challenges.
-For example, it leads to the computational challenge that all new possible triples $(h, r, t') \in T_{h,r}$ and
-$(h', r, t) \in H_{r,t}$ must be enumerated and then checked for existence in $\mathcal{K}_{train}$.
-Considering a dataset like :class:`pykeen.datasets.FB15k237` that has almost 15,000 entities, each test triple
-$(h,r,t) \in \mathcal{K}_{test}$ leads to $2 * | \mathcal{E} | = 30,000$ possible new triples, which have to be
-checked against the train dataset and then removed.
+While this easily defined theoretically, it poses several practical challenges. For example, it leads to the
+computational challenge that all new possible triples $(h, r, t') \in T_{h,r}$ and $(h', r, t) \in H_{r,t}$ must be
+enumerated and then checked for existence in $\mathcal{K}_{train}$. Considering a dataset like
+:class:`pykeen.datasets.FB15k237` that has almost 15,000 entities, each test triple $(h,r,t) \in \mathcal{K}_{test}$
+leads to $2 * | \mathcal{E} | = 30,000$ possible new triples, which have to be checked against the train dataset and
+then removed.
 
-To obtain very fast filtering, PyKEEN combines the technique presented above in
-:ref:`entity_and_relation_ids` and :ref:`tuple_broadcasting` together with the following
-mechanism, which in our case has led to a 600,000 fold increase in speed for the filtered evaluation
-compared to the mechanisms used in previous versions.
+To obtain very fast filtering, PyKEEN combines the technique presented above in :ref:`entity_and_relation_ids` and
+:ref:`tuple_broadcasting` together with the following mechanism, which in our case has led to a 600,000 fold increase in
+speed for the filtered evaluation compared to the mechanisms used in previous versions.
 
-As a starting point, PyKEEN will always compute scores for all triples in $H_{r,t}$ and $T_{h,r}$, even in
-the filtered setting. Because the number of positive triples on average is very low, few results have to be removed.
-Additionally, due to the technique presented in :ref:`tuple_broadcasting`, scoring extra entities has a
-marginally low cost. Therefore, we start with the score vectors from :func:`pykeen.models.base.Model.score_t`
-for all triples $(h, r, t') \in H_{r,t}$ and from :func:`pykeen.models.base.Model.score_h`
-for all triples $(h', r, t) \in T_{h,r}$.
+As a starting point, PyKEEN will always compute scores for all triples in $H_{r,t}$ and $T_{h,r}$, even in the filtered
+setting. Because the number of positive triples on average is very low, few results have to be removed. Additionally,
+due to the technique presented in :ref:`tuple_broadcasting`, scoring extra entities has a marginally low cost.
+Therefore, we start with the score vectors from :func:`pykeen.models.base.Model.score_t` for all triples $(h, r, t') \in
+H_{r,t}$ and from :func:`pykeen.models.base.Model.score_h` for all triples $(h', r, t) \in T_{h,r}$.
 
-Following, the sparse filters $\mathbf{f}_t \in \mathbb{B}^{| \mathcal{E}|}$ and
-$\mathbf{f}_h \in \mathbb{B}^{| \mathcal{E}|}$ are created, which state which of the entities would lead to triples
-found in the train dataset. To achieve this we will rely on the technique presented in
-:ref:`entity_and_relation_ids`, i.e. all entity/relation IDs correspond to their
-exact position in the respective embedding tensor.
-As an example we take the tuple $(h, r)$ from the test triple $(h, r, t) \in \mathcal{K}_{test}$ and are interested
-in all tail entities $t'$ that should be removed from $T_{h,r}$ in order to obtain $T^{\text{filtered}}_{h,r}$.
-This is achieved by performing the following steps:
+Following, the sparse filters $\mathbf{f}_t \in \mathbb{B}^{| \mathcal{E}|}$ and $\mathbf{f}_h \in \mathbb{B}^{|
+\mathcal{E}|}$ are created, which state which of the entities would lead to triples found in the train dataset. To
+achieve this we will rely on the technique presented in :ref:`entity_and_relation_ids`, i.e. all entity/relation IDs
+correspond to their exact position in the respective embedding tensor. As an example we take the tuple $(h, r)$ from the
+test triple $(h, r, t) \in \mathcal{K}_{test}$ and are interested in all tail entities $t'$ that should be removed from
+$T_{h,r}$ in order to obtain $T^{\text{filtered}}_{h,r}$. This is achieved by performing the following steps:
 
-1. Take $r$ and compare it to the relations of all triples in the train dataset, leading to a boolean vector of the
-   size of number of triples contained in the train dataset, being true where any triple had the relation $r$
+1. Take $r$ and compare it to the relations of all triples in the train dataset, leading to a boolean vector of the size
+   of number of triples contained in the train dataset, being true where any triple had the relation $r$
 2. Take $h$ and compare it to the head entities of all triples in the train dataset, leading to a boolean vector of the
    size of number of triples contained in the train dataset, being true where any triple had the head entity $h$
 3. Combine both boolean vectors, leading to a boolean vector of the size of number of triples contained in the train
@@ -118,10 +117,9 @@ This is achieved by performing the following steps:
 5. The index vector is now applied on the tail entity column of the train dataset, returning all tail entity IDs $t'$
    that combined with $h$ and $r$ lead to triples contained in the train dataset
 6. Finally, the $t'$ tail entity ID index vector is applied on the initially mentioned vector returned by
-   :func:`pykeen.models.base.Model.score_t` for all possible
-   triples $(h, r, t')$ and all affected scores are set to ``float('nan')`` following the IEEE-754 specification, which
-   makes these scores non-comparable, effectively leading to the score vector for all possible novel triples
-   $(h, r, t') \in T^{\text{filtered}}_{h,r}$.
+   :func:`pykeen.models.base.Model.score_t` for all possible triples $(h, r, t')$ and all affected scores are set to
+   ``float('nan')`` following the IEEE-754 specification, which makes these scores non-comparable, effectively leading
+   to the score vector for all possible novel triples $(h, r, t') \in T^{\text{filtered}}_{h,r}$.
 
 $H^{\text{filtered}}_{r,t}$ is obtained from $H_{r,t}$ in a similar fashion.
 
@@ -129,40 +127,42 @@ $H^{\text{filtered}}_{r,t}$ is obtained from $H_{r,t}$ in a similar fashion.
 
 Sub-batching & Slicing
 ----------------------
+
 With growing model and dataset sizes the KGEM at hand is likely to exceed the memory provided by GPUs. Especially during
 training it might be desired to train using a certain batch size. When this batch size is too big for the hardware at
-hand, PyKEEN allows to set a sub-batch size in the range of :math:`[1, \text{batch_size}]`.
-When the sub-batch size is set, PyKEEN automatically accumulates the gradients after each sub-batch and clears the
-computational graph during training.
-This allows to train KGEMs on GPU that otherwise would be too big for the hardware at hand, while the obtained results
-are identical to training without sub-batching.
+hand, PyKEEN allows to set a sub-batch size in the range of :math:`[1, \text{batch_size}]`. When the sub-batch size is
+set, PyKEEN automatically accumulates the gradients after each sub-batch and clears the computational graph during
+training. This allows to train KGEMs on GPU that otherwise would be too big for the hardware at hand, while the obtained
+results are identical to training without sub-batching.
 
 .. note::
-    In order to guarantee equivalent results, not all models support sub-batching, since certain components,
-    e.g. batch normalization, require the entire batch to be calculated in one pass to avoid altering statistics.
+
+    In order to guarantee equivalent results, not all models support sub-batching, since certain components, e.g. batch
+    normalization, require the entire batch to be calculated in one pass to avoid altering statistics.
 
 .. note::
-    Sub-batching is sometimes also called *Gradient Accumulation*, e.g., by huggingface's
-    `transformer <https://huggingface.co/docs/transformers/master/en/main_classes/deepspeed#gradient-accumulation>`_
-    library, since we accumulate the gradients over multiple sub-batches before updating the parameters.
 
-For some large configurations, even after applying the sub-batching trick, out-of-memory errors may still occur.
-In this case,  PyKEEN implements another technique, called *slicing*.
-Note that we often compute more than one score for each batch element:
-in sLCWA, we have :math:`1 + \text{num_negative_samples}` scores, and in LCWA, we have
-:math:`\text{num_entities}` scores for each batch element.
-In slicing, we do not compute all of these scores at once, but rather in smaller "batches".
-For old-style models, i.e., those subclassing from :class:`pykeen.models.base._OldAbstractModel`, this has to be
-implemented individually for each of them.
-New-style models, i.e., those deriving from :class:`pykeen.models.nbase.ERModel` have a generic implementation enabling
-slicing for *all* interactions.
+    Sub-batching is sometimes also called *Gradient Accumulation*, e.g., by huggingface's `transformer
+    <https://huggingface.co/docs/transformers/master/en/main_classes/deepspeed#gradient-accumulation>`_ library, since
+    we accumulate the gradients over multiple sub-batches before updating the parameters.
+
+For some large configurations, even after applying the sub-batching trick, out-of-memory errors may still occur. In this
+case, PyKEEN implements another technique, called *slicing*. Note that we often compute more than one score for each
+batch element: in sLCWA, we have :math:`1 + \text{num_negative_samples}` scores, and in LCWA, we have
+:math:`\text{num_entities}` scores for each batch element. In slicing, we do not compute all of these scores at once,
+but rather in smaller "batches". For old-style models, i.e., those subclassing from
+:class:`pykeen.models.base._OldAbstractModel`, this has to be implemented individually for each of them. New-style
+models, i.e., those deriving from :class:`pykeen.models.nbase.ERModel` have a generic implementation enabling slicing
+for *all* interactions.
 
 .. note::
-    Slicing computes the scores in smaller batches, but still needs to compute the gradient over all scores,
-    since some loss functions require access to them.
+
+    Slicing computes the scores in smaller batches, but still needs to compute the gradient over all scores, since some
+    loss functions require access to them.
 
 Automated Memory Optimization
 -----------------------------
+
 Allowing high computational throughput while ensuring that the available hardware memory is not exceeded during training
 and evaluation requires the knowledge of the maximum possible training and evaluation batch size for the current model
 configuration. However, determining the training and evaluation batch sizes is a tedious process, and not feasible when
@@ -171,21 +171,21 @@ computes the maximum possible training and evaluation batch sizes for the curren
 hardware before the actual calculation starts. If the user-provided batch size is too large for the used hardware, the
 automatic memory optimization determines the maximum sub-batch size for training and accumulates the gradients with the
 above described process :ref:`sub_batching`. The batch sizes are determined using binary search taking into
-consideration the `CUDA architecture <https://developer.download.nvidia.com/video/gputechconf/gtc/2019/presentation/s9926-tensor-core-performance-the-ultimate-guide.pdf>`_
+consideration the `CUDA architecture
+<https://developer.download.nvidia.com/video/gputechconf/gtc/2019/presentation/s9926-tensor-core-performance-the-ultimate-guide.pdf>`_
 which ensures that the chosen batch size is the most CUDA efficient one.
 
 Usually the evaluation is performed on the GPU for faster speeds. Thanks for `torch_max_mem`, you can fully leave
-finding a maximal batch size to PyKEEN.
-In addition, users might choose a batch size upfront
-in their evaluation configuration to fully utilize the GPU to achieve the fastest evaluation speeds possible.
-However, during larger setups testing different model configurations and dataset partitions such as e.g. HPO the
-hardware requirements might change drastically, which might cause that the evaluation no longer can be run with the
-pre-set batch size or not on the GPU at all for larger datasets and memory intense models.
-In these cases, `torch_max_mem` will take care of lowering the actual batch size until no more out of memory errors
-occur.
+finding a maximal batch size to PyKEEN. In addition, users might choose a batch size upfront in their evaluation
+configuration to fully utilize the GPU to achieve the fastest evaluation speeds possible. However, during larger setups
+testing different model configurations and dataset partitions such as e.g. HPO the hardware requirements might change
+drastically, which might cause that the evaluation no longer can be run with the pre-set batch size or not on the GPU at
+all for larger datasets and memory intense models. In these cases, `torch_max_mem` will take care of lowering the actual
+batch size until no more out of memory errors occur.
 
 Evaluation Fallback
 -------------------
-In some cases, it is possible that evaluation cannot succeed on GPU even with minimal batch size and slicing.
-In these rare cases, PyKEEN offers to fall back to CPU.
-Note: This can lead to significantly longer evaluation times in cases where the evaluation falls back to using the CPU.
+
+In some cases, it is possible that evaluation cannot succeed on GPU even with minimal batch size and slicing. In these
+rare cases, PyKEEN offers to fall back to CPU. Note: This can lead to significantly longer evaluation times in cases
+where the evaluation falls back to using the CPU.

--- a/docs/source/tutorial/representations.rst
+++ b/docs/source/tutorial/representations.rst
@@ -2,226 +2,214 @@
 
 Representations
 ===============
-In PyKEEN, a :class:`~pykeen.nn.representation.Representation` is used to map
-*integer indices* to *numeric representations*. A simple example is an
-:class:`~pykeen.nn.representation.Embedding`, where the mapping is a simple
+
+In PyKEEN, a :class:`~pykeen.nn.representation.Representation` is used to map *integer indices* to *numeric
+representations*. A simple example is an :class:`~pykeen.nn.representation.Embedding`, where the mapping is a simple
 lookup. However, more advanced representation modules are available, too.
 
-This tutorial is intended to provide a comprehensive overview of possible components.
-Feel free to visit the pages of the individual representations for detailed technical information.
+This tutorial is intended to provide a comprehensive overview of possible components. Feel free to visit the pages of
+the individual representations for detailed technical information.
 
 .. contents:: Table of Contents
     :depth: 3
 
 Base
 ----
-The :class:`~pykeen.nn.representation.Representation` class defines a common
-interface for all representation modules.
-Each representation defines a :attr:`~pykeen.nn.representation.Representation.max_id` attribute.
-We can pass any integer index $i \in [0, \text{max_id})$ to a representation module
-to get a numeric representation of a fixed shape :attr:`~pykeen.nn.representation.Representation.shape`.
 
-.. note ::
-    To support efficient training and inference, all representations accept
-    batches of indices of arbitrary shape, and return batches of corresponding numeric representations.
-    The batch dimensions always precede the actual shape of the returned numerical representations.
+The :class:`~pykeen.nn.representation.Representation` class defines a common interface for all representation modules.
+Each representation defines a :attr:`~pykeen.nn.representation.Representation.max_id` attribute. We can pass any integer
+index $i \in [0, \text{max_id})$ to a representation module to get a numeric representation of a fixed shape
+:attr:`~pykeen.nn.representation.Representation.shape`.
+
+.. note::
+
+    To support efficient training and inference, all representations accept batches of indices of arbitrary shape, and
+    return batches of corresponding numeric representations. The batch dimensions always precede the actual shape of the
+    returned numerical representations.
 
 Combinations & Adapters
 -----------------------
+
 PyKEEN provides a rich set of generic tools to combine and adapt representations to form new representations.
 
 Transformed Representations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-A :class:`~pykeen.nn.representation.TransformedRepresentation` adds a (learnable)
-transformation to an existing representation. It can be particularly useful when we have
-some fixed features for entities or relations, e.g. from a pre-trained model, or encodings
-of other modalities like text or images, and want to learn a transformation on them to
+
+A :class:`~pykeen.nn.representation.TransformedRepresentation` adds a (learnable) transformation to an existing
+representation. It can be particularly useful when we have some fixed features for entities or relations, e.g. from a
+pre-trained model, or encodings of other modalities like text or images, and want to learn a transformation on them to
 make them suitable for simple interaction functions like :class:`~pykeen.nn.modules.DistMultInteraction`.
 
 Subset Representations
 ~~~~~~~~~~~~~~~~~~~~~~
-A :class:`~pykeen.nn.representation.SubsetRepresentation` allows to *"hide"* some indices.
-This can be useful e.g. if we want to share some representations between modules, while others
-should be exclusive, e.g. we want to use inverse relations for a message passing phase, but no
-inverses in scoring triples.
+
+A :class:`~pykeen.nn.representation.SubsetRepresentation` allows to *"hide"* some indices. This can be useful e.g. if we
+want to share some representations between modules, while others should be exclusive, e.g. we want to use inverse
+relations for a message passing phase, but no inverses in scoring triples.
 
 Partitioned Representations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-A :class:`~pykeen.nn.representation.PartitionRepresentation` uses multiple base representations
-and chooses exactly one of them for each index based on a fixed mapping.
-:class:`~pykeen.nn.representation.BackfillRepresentation` implements a frequently used
-special case, where we have two base representations, where one is the
-*"main"* representation and the other is used as a backup whenever
-the first one fails to provide a representation.
-This is useful when we want to use features or pre-trained embeddings whenever
-possible, and learn new embeddings for any entities or relations for which we have no features.
+
+A :class:`~pykeen.nn.representation.PartitionRepresentation` uses multiple base representations and chooses exactly one
+of them for each index based on a fixed mapping. :class:`~pykeen.nn.representation.BackfillRepresentation` implements a
+frequently used special case, where we have two base representations, where one is the *"main"* representation and the
+other is used as a backup whenever the first one fails to provide a representation. This is useful when we want to use
+features or pre-trained embeddings whenever possible, and learn new embeddings for any entities or relations for which
+we have no features.
 
 Combined Representations
 ~~~~~~~~~~~~~~~~~~~~~~~~
-:class:`~pykeen.nn.representation.CombinedRepresentation` can be used when we have multiple
-sources of representations and want to combine those into a single one.
-Use cases are multi-modal models, or :class:`~pykeen.nn.node_piece.representation.NodePieceRepresentation`.
+
+:class:`~pykeen.nn.representation.CombinedRepresentation` can be used when we have multiple sources of representations
+and want to combine those into a single one. Use cases are multi-modal models, or
+:class:`~pykeen.nn.node_piece.representation.NodePieceRepresentation`.
 
 Embedding
 ---------
-An :class:`~pykeen.nn.representation.Embedding` is the simplest representation,
-where the an index is mapped to a numerical representation by a simple lookup in a table.
-Despite its simplicity, almost all publications on transductive link prediction
-rely on embeddings to represent entities or relations.
+
+An :class:`~pykeen.nn.representation.Embedding` is the simplest representation, where the an index is mapped to a
+numerical representation by a simple lookup in a table. Despite its simplicity, almost all publications on transductive
+link prediction rely on embeddings to represent entities or relations.
 
 Decomposition
 -------------
-Since knowledge graphs can contain a large number of entities, having
-independent trainable embeddings for each of them can lead to an
-excessive number of trainable parameters. Therefore, methods have been
-developed that do not learn independent representations, but rather
-have a set of base representations and create individual representations
-by combining them.
+
+Since knowledge graphs can contain a large number of entities, having independent trainable embeddings for each of them
+can lead to an excessive number of trainable parameters. Therefore, methods have been developed that do not learn
+independent representations, but rather have a set of base representations and create individual representations by
+combining them.
 
 Low-Rank Factorization
 ~~~~~~~~~~~~~~~~~~~~~~
-A simple method to reduce the number of parameters is to use a low-rank
-decomposition of the embedding matrix, as implemented in
-:class:`~pykeen.nn.representation.LowRankRepresentation`. Here, each
-representation is a linear combination of shared base representations.
-Typically, the number of bases is chosen to be smaller than the dimension of
-each base representation.
-Low-rank factorization can also be seen as a special case of
-:class:`~pykeen.nn.representation.CombinedRepresentation` with a restricted (but very efficient)
-combination operation.
+
+A simple method to reduce the number of parameters is to use a low-rank decomposition of the embedding matrix, as
+implemented in :class:`~pykeen.nn.representation.LowRankRepresentation`. Here, each representation is a linear
+combination of shared base representations. Typically, the number of bases is chosen to be smaller than the dimension of
+each base representation. Low-rank factorization can also be seen as a special case of
+:class:`~pykeen.nn.representation.CombinedRepresentation` with a restricted (but very efficient) combination operation.
 
 Tensor Train Factorization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-:class:`~pykeen.nn.representation.TensorTrainRepresentation` uses a tensor factorization
-method, which can also be interpreted as a hierarchical decomposition.
-The tensor train decomposition is also known as matrix product states.
+
+:class:`~pykeen.nn.representation.TensorTrainRepresentation` uses a tensor factorization method, which can also be
+interpreted as a hierarchical decomposition. The tensor train decomposition is also known as matrix product states.
 
 NodePiece
 ~~~~~~~~~
-Another example is NodePiece, which takes inspiration
-from tokenization we encounter in, e.g.. NLP, and represents each entity
-as a set of tokens.
-The basic implementation can be found in
-:class:`~pykeen.nn.node_piece.representation.TokenizationRepresentation`,
-where each index is represented by a sequence of tokens, and the tokens
-have their own representation.
-:class:`~pykeen.nn.node_piece.representation.NodePieceRepresentation` builds upon them
-and uses one or more :class:`~pykeen.nn.node_piece.representation.TokenizationRepresentation`
-with are then combined into a single representation.
+
+Another example is NodePiece, which takes inspiration from tokenization we encounter in, e.g.. NLP, and represents each
+entity as a set of tokens. The basic implementation can be found in
+:class:`~pykeen.nn.node_piece.representation.TokenizationRepresentation`, where each index is represented by a sequence
+of tokens, and the tokens have their own representation.
+:class:`~pykeen.nn.node_piece.representation.NodePieceRepresentation` builds upon them and uses one or more
+:class:`~pykeen.nn.node_piece.representation.TokenizationRepresentation` with are then combined into a single
+representation.
 
 .. seealso::
+
     - https://towardsdatascience.com/nodepiece-tokenizing-knowledge-graphs-6dd2b91847aa
     - :ref:`getting_started_with_node_piece`
 
 Message Passing
 ---------------
-Message passing representation modules enrich the representations of
-entities by aggregating the information from their graph neighborhood.
+
+Message passing representation modules enrich the representations of entities by aggregating the information from their
+graph neighborhood.
 
 RGCN
 ~~~~
-The :class:`~pykeen.nn.message_passing.RGCNRepresentation` uses
-:class:`~pykeen.nn.message_passing.RGCNLayer` to pass messages between entities.
-These layers aggregate representations of neighboring entities,
-which are first transformed by a relation-specific linear transformation.
+
+The :class:`~pykeen.nn.message_passing.RGCNRepresentation` uses :class:`~pykeen.nn.message_passing.RGCNLayer` to pass
+messages between entities. These layers aggregate representations of neighboring entities, which are first transformed
+by a relation-specific linear transformation.
 
 CompGCN
 ~~~~~~~
-The :class:`~pykeen.nn.representation.SingleCompGCNRepresentation` enriches representations
-using :class:`~pykeen.nn.representation.CompGCNLayer`, which instead uses a more flexible composition
-of entity and relation representations along each edge.
-As a technical detail, since each :class:`~pykeen.nn.representation.CompGCNLayer` transforms
-entity and relation representations, we must first construct a
+
+The :class:`~pykeen.nn.representation.SingleCompGCNRepresentation` enriches representations using
+:class:`~pykeen.nn.representation.CompGCNLayer`, which instead uses a more flexible composition of entity and relation
+representations along each edge. As a technical detail, since each :class:`~pykeen.nn.representation.CompGCNLayer`
+transforms entity and relation representations, we must first construct a
 :class:`~pykeen.nn.representation.CombinedCompGCNRepresentations` and then split its output into separate
 :class:`~pykeen.nn.representation.SingleCompGCNRepresentation` for entities and relations, respectively.
 
 PyTorch Geometric
 ~~~~~~~~~~~~~~~~~
-Another way to utilize message passing is via the modules provided in :mod:`pykeen.nn.pyg`,
-which allow to use the message passing layers from PyTorch Geometric
-to enrich base representations via message passing.
-We include the following templates to easily create custom transformations:
 
-    - :class:`~pykeen.nn.pyg.MessagePassingRepresentation`:
-      Base class.
-    - :class:`~pykeen.nn.pyg.SimpleMessagePassingRepresentation`:
-      For message passing ignoring relation type information.
-    - :class:`~pykeen.nn.pyg.TypedMessagePassingRepresentation`
-      For message passing using categorical relation type information.
-    - :class:`~pykeen.nn.pyg.FeaturizedMessagePassingRepresentation`
-      For message passing using relation representations during message passing.
+Another way to utilize message passing is via the modules provided in :mod:`pykeen.nn.pyg`, which allow to use the
+message passing layers from PyTorch Geometric to enrich base representations via message passing. We include the
+following templates to easily create custom transformations:
+
+    - :class:`~pykeen.nn.pyg.MessagePassingRepresentation`: Base class.
+    - :class:`~pykeen.nn.pyg.SimpleMessagePassingRepresentation`: For message passing ignoring relation type
+      information.
+    - :class:`~pykeen.nn.pyg.TypedMessagePassingRepresentation` For message passing using categorical relation type
+      information.
+    - :class:`~pykeen.nn.pyg.FeaturizedMessagePassingRepresentation` For message passing using relation representations
+      during message passing.
 
 Text-based
 ----------
-Text-based representations use the entities' (or relations') labels to
-derive representations. To this end,
-:class:`~pykeen.nn.representation.TextRepresentation` uses a
-(pre-trained) transformer model from the :mod:`transformers` library to encode
-the labels. Since the transformer models have been trained on huge corpora
-of text, their text encodings often contain semantic information, i.e.,
-labels with similar semantic meaning get similar representations. While we
-can also benefit from these strong features by just initializing an
+
+Text-based representations use the entities' (or relations') labels to derive representations. To this end,
+:class:`~pykeen.nn.representation.TextRepresentation` uses a (pre-trained) transformer model from the
+:mod:`transformers` library to encode the labels. Since the transformer models have been trained on huge corpora of
+text, their text encodings often contain semantic information, i.e., labels with similar semantic meaning get similar
+representations. While we can also benefit from these strong features by just initializing an
 :class:`~pykeen.nn.representation.Embedding` with the vectors, e.g., using
-:class:`~pykeen.nn.init.LabelBasedInitializer`, the
-:class:`~pykeen.nn.representation.TextRepresentation` include the
-transformer model as part of the KGE model, and thus allow fine-tuning
-the language model for the KGE task. This is beneficial, e.g., since it
-allows a simple form of obtaining an inductive model, which can make
-predictions for entities not seen during training.
+:class:`~pykeen.nn.init.LabelBasedInitializer`, the :class:`~pykeen.nn.representation.TextRepresentation` include the
+transformer model as part of the KGE model, and thus allow fine-tuning the language model for the KGE task. This is
+beneficial, e.g., since it allows a simple form of obtaining an inductive model, which can make predictions for entities
+not seen during training.
 
 .. literalinclude:: ../examples/nn/representation/text_based.py
     :lines: 3-27
 
-We can use the label-encoder part to generate representations for
-unknown entities with labels. For instance, `"uk"` is an entity in
-`nations`, but we can also put in `"united kingdom"`, and get a
-roughly equivalent vector representations
+We can use the label-encoder part to generate representations for unknown entities with labels. For instance, `"uk"` is
+an entity in `nations`, but we can also put in `"united kingdom"`, and get a roughly equivalent vector representations
 
 .. literalinclude:: ../examples/nn/representation/text_based.py
     :lines: 30-33
 
-Thus, if we would put the resulting representations into the interaction
-function, we would get similar scores
+Thus, if we would put the resulting representations into the interaction function, we would get similar scores
 
 .. literalinclude:: ../examples/nn/representation/text_based.py
     :lines: 34-
 
-As a downside, this will usually substantially increase the
-computational cost of computing triple scores.
+As a downside, this will usually substantially increase the computational cost of computing triple scores.
 
 Wikidata
 ~~~~~~~~
-Since quite a few benchmark datasets for link prediction on knowledge graphs use
-`Wikidata <https://www.wikidata.org>`_ as a source, e.g.,
-:class:`~pykeen.datasets.codex.CoDExSmall` or :class:`~pykeen.datasets.wd50k.WD50KT`,
-we added a convenience class :class:`~pykeen.nn.representation.WikidataTextRepresentation`
-that looks up labels based on Wikidata QIDs
-(e.g., `Q42 <https://www.wikidata.org/wiki/Q42>`_ for Douglas Adams).
+
+Since quite a few benchmark datasets for link prediction on knowledge graphs use `Wikidata <https://www.wikidata.org>`_
+as a source, e.g., :class:`~pykeen.datasets.codex.CoDExSmall` or :class:`~pykeen.datasets.wd50k.WD50KT`, we added a
+convenience class :class:`~pykeen.nn.representation.WikidataTextRepresentation` that looks up labels based on Wikidata
+QIDs (e.g., `Q42 <https://www.wikidata.org/wiki/Q42>`_ for Douglas Adams).
 
 Biomedical Entities
 ~~~~~~~~~~~~~~~~~~~
-If your dataset is labeled with compact uniform resource identifiers (e.g., CURIEs)
-for biomedical entities like chemicals, proteins, diseases, and pathways, then
-the :class:`~pykeen.nn.representation.BiomedicalCURIERepresentation`
-representation can make use of :mod:`pyobo` to look up names (via CURIE) via the
-:func:`pyobo.get_name` function, then encode them using the text encoder.
 
-All biomedical knowledge graphs in PyKEEN (at the time of adding this representation),
-unfortunately do not use CURIEs for referencing biomedical entities. In the future, we hope
-this will change.
+If your dataset is labeled with compact uniform resource identifiers (e.g., CURIEs) for biomedical entities like
+chemicals, proteins, diseases, and pathways, then the :class:`~pykeen.nn.representation.BiomedicalCURIERepresentation`
+representation can make use of :mod:`pyobo` to look up names (via CURIE) via the :func:`pyobo.get_name` function, then
+encode them using the text encoder.
 
-To learn more about CURIEs, please take a look at the `Bioregistry <https://bioregistry.io>`_
-and `this blog post on CURIEs <https://cthoyt.com/2021/09/14/curies.html>`_.
+All biomedical knowledge graphs in PyKEEN (at the time of adding this representation), unfortunately do not use CURIEs
+for referencing biomedical entities. In the future, we hope this will change.
+
+To learn more about CURIEs, please take a look at the `Bioregistry <https://bioregistry.io>`_ and `this blog post on
+CURIEs <https://cthoyt.com/2021/09/14/curies.html>`_.
 
 Visual
 ------
-Sometimes, we also have visual information about entities, e.g., in the form of images.
-For these cases there is
-:class:`~pykeen.nn.vision.representation.VisualRepresentation` which uses an image encoder backbone
-to obtain representations.
+
+Sometimes, we also have visual information about entities, e.g., in the form of images. For these cases there is
+:class:`~pykeen.nn.vision.representation.VisualRepresentation` which uses an image encoder backbone to obtain
+representations.
 
 Wikidata
 ~~~~~~~~
+
 As for textual representations, we provide a convenience class
-:class:`~pykeen.nn.vision.representation.WikidataVisualRepresentation` for Wikidata-based datasets
-that looks up labels based on Wikidata QIDs.
+:class:`~pykeen.nn.vision.representation.WikidataVisualRepresentation` for Wikidata-based datasets that looks up labels
+based on Wikidata QIDs.

--- a/docs/source/tutorial/running_ablation.rst
+++ b/docs/source/tutorial/running_ablation.rst
@@ -1,27 +1,28 @@
 Running an Ablation Study
 =========================
-You want to find out which loss function and training approach is best-suited for your interaction model
-(model architecture)? Then performing an ablation study is the way to go!
+
+You want to find out which loss function and training approach is best-suited for your interaction model (model
+architecture)? Then performing an ablation study is the way to go!
 
 In general, an ablation study is a set of experiments in which components of a machine learning system are
 removed/replaced in order to measure the impact of these components on the performance of the system. In the context of
 knowledge graph embedding models, typical ablation studies involve investigating different loss functions, training
 approaches, negative samplers, and the explicit modeling of inverse relations. For a specific model composition based on
-these components, the best set of hyper-parameter values, e.g., embedding dimension, learning rate, batch size,
-loss function-specific hyper-parameters such as the margin value in the margin ranking loss need to be determined.
-This is accomplished by a process called hyper-parameter optimization. Different approaches have been proposed, of
-which random search and grid search are very popular.
+these components, the best set of hyper-parameter values, e.g., embedding dimension, learning rate, batch size, loss
+function-specific hyper-parameters such as the margin value in the margin ranking loss need to be determined. This is
+accomplished by a process called hyper-parameter optimization. Different approaches have been proposed, of which random
+search and grid search are very popular.
 
 In PyKEEN, we can define and execute an ablation study within our own program or from the command line interface using a
 configuration file (``file_name.json``).
 
 First, we show how to run an ablation study within your program. For this purpose, we provide the function
 :func:`pykeen.ablation.ablation_pipeline` that requires the ``datasets``, ``models``, ``losses``, ``optimizers``,
-``training_loops``, and ``directory`` arguments to define the datasets, models, loss functions,
-optimizers (e.g., Adam), training approaches for our ablation study, and the output directory in which the experimental
-artifacts should be saved. In the following, we define an ablation study for :class:`pykeen.models.ComplEx` over the
-:class:`pykeen.datasets.Nations` dataset in order to assess the effect of different loss functions (in our example,
-the binary cross entropy loss and the margin ranking loss) and the effect of explicitly modeling inverse relations.
+``training_loops``, and ``directory`` arguments to define the datasets, models, loss functions, optimizers (e.g., Adam),
+training approaches for our ablation study, and the output directory in which the experimental artifacts should be
+saved. In the following, we define an ablation study for :class:`pykeen.models.ComplEx` over the
+:class:`pykeen.datasets.Nations` dataset in order to assess the effect of different loss functions (in our example, the
+binary cross entropy loss and the margin ranking loss) and the effect of explicitly modeling inverse relations.
 
 Now, let's start with defining the minimal requirements, i.e., the dataset(s), interaction model(s), the loss
 function(s), training approach(es), and the optimizer(s) in order to run the ablation study.
@@ -44,8 +45,8 @@ function(s), training approach(es), and the optimizer(s) in order to run the abl
     ...     n_trials=1,
     ... )
 
-We can provide arbitrary additional information about our study with the ``metadata`` keyword. Some keys, such
-as ``title`` are special and used by PyKEEN and :mod:`optuna`.
+We can provide arbitrary additional information about our study with the ``metadata`` keyword. Some keys, such as
+``title`` are special and used by PyKEEN and :mod:`optuna`.
 
 .. code-block:: python
 
@@ -90,11 +91,11 @@ performance. Therefore, we extend the ablation study by including the ``create_i
 
 .. note::
 
-    Unlike ``models``, ``datasets``, ``losses``, ``training_loops``, and ``optimizers``,
-    ``create_inverse_triples`` has a default value, which is ``False``.
+    Unlike ``models``, ``datasets``, ``losses``, ``training_loops``, and ``optimizers``, ``create_inverse_triples`` has
+    a default value, which is ``False``.
 
-If there is only one value for either the ``models``, ``datasets``, ``losses``, ``training_loops``, ``optimizers``,
-or ``create_inverse_triples`` argument, it can be given as a single value instead of the list.
+If there is only one value for either the ``models``, ``datasets``, ``losses``, ``training_loops``, ``optimizers``, or
+``create_inverse_triples`` argument, it can be given as a single value instead of the list.
 
 .. code-block:: python
 
@@ -113,15 +114,15 @@ or ``create_inverse_triples`` argument, it can be given as a single value instea
     ...     n_trials=1,
     ... )
 
-.. note:: It doesn't make sense to run an ablation study if all of these values are fixed.
+.. note::
 
-For each of the components of a knowledge graph embedding model (KGEM) that requires hyper-parameters, i.e.,
-interaction model, loss function, and the training approach, we provide default hyper-parameter optimization (HPO)
-ranges within PyKEEN. Therefore, the definition of our ablation study would be complete at this stage. Because
-hyper-parameter ranges are dataset-dependent, users can/should define their own HPO ranges. We will show later how to
-accomplish this.
-To finalize the ablation study, we recommend defining early stopping for your ablation study, which is done as
-follows:
+    It doesn't make sense to run an ablation study if all of these values are fixed.
+
+For each of the components of a knowledge graph embedding model (KGEM) that requires hyper-parameters, i.e., interaction
+model, loss function, and the training approach, we provide default hyper-parameter optimization (HPO) ranges within
+PyKEEN. Therefore, the definition of our ablation study would be complete at this stage. Because hyper-parameter ranges
+are dataset-dependent, users can/should define their own HPO ranges. We will show later how to accomplish this. To
+finalize the ablation study, we recommend defining early stopping for your ablation study, which is done as follows:
 
 .. code-block:: python
 
@@ -151,12 +152,12 @@ arguments to the early stopper. We define that the early stopper should evaluate
 epochs on the validation set. In order to continue training, we expect the model to obtain an improvement > 0.2% in
 Hits@10.
 
-After defining the ablation study, we need to define the HPO settings for each experiment within our ablation
-study. Remember that for each ablation-experiment we perform an HPO in order to determine the best hyper-parameters
-for the currently investigated model. In PyKEEN, we use
-`Optuna <https://github.com/optuna/optunahttps://github.com/optuna/optuna>`_  as HPO framework. Again, we provide
-default values for the Optuna related arguments. However, they define a very limited HPO search which is meant for
-testing purposes. Therefore, we define the arguments required by Optuna by ourselves:
+After defining the ablation study, we need to define the HPO settings for each experiment within our ablation study.
+Remember that for each ablation-experiment we perform an HPO in order to determine the best hyper-parameters for the
+currently investigated model. In PyKEEN, we use `Optuna
+<https://github.com/optuna/optunahttps://github.com/optuna/optuna>`_ as HPO framework. Again, we provide default values
+for the Optuna related arguments. However, they define a very limited HPO search which is meant for testing purposes.
+Therefore, we define the arguments required by Optuna by ourselves:
 
 .. code-block:: python
 
@@ -183,11 +184,11 @@ testing purposes. Therefore, we define the arguments required by Optuna by ourse
 We set the number of HPO iterations for each experiment to 2 using the argument ``n_trials``, set a ``timeout`` of 300
 seconds (the HPO will be terminated after ``n_trials`` or ``timeout`` seconds depending on what occurs first), the
 ``metric`` to optimize, define whether the metric should be maximized or minimized using the argument ``direction``,
-define random search as HPO algorithm using the argument ``sampler``, and finally define that we do not use a pruner
-for pruning unpromising trials (note that we use early stopping instead).
+define random search as HPO algorithm using the argument ``sampler``, and finally define that we do not use a pruner for
+pruning unpromising trials (note that we use early stopping instead).
 
-To measure the variance in performance, we can additionally define how often we want to re-train and re-evaluate
-the best model of each ablation-experiment using the argument ``best_replicates``:
+To measure the variance in performance, we can additionally define how often we want to re-train and re-evaluate the
+best model of each ablation-experiment using the argument ``best_replicates``:
 
 .. code-block:: python
 
@@ -220,26 +221,27 @@ the best model of each ablation-experiment using the argument ``best_replicates`
     ...     best_replicates=5,
     ... )
 
-Eager to check out the results? Then navigate to your output directory ``path/to/output/directory``.
-Within your output directory, you will find subdirectories, e.g., ``0000_nations_complex`` which contains all
-experimental artifacts of one specific ablation experiment of the defined ablation study. The most relevant subdirectory
-is ``best_pipeline`` which comprises the artifacts of the best performing experiment, including its definition in
-``pipeline_config.json``,  the obtained results, and the trained model(s) in the sub-directory ``replicates``.
-The number of replicates in ``replicates`` corresponds to the number provided through the argument ``-r``.
-Additionally, you are provided with further information about the ablation study in the root directory: ``study.json``
-describes the ablation experiment, ``hpo_config.json`` describes the HPO setting of the ablation experiment,
-``trials.tsv`` provides an overview of each HPO experiment.
+Eager to check out the results? Then navigate to your output directory ``path/to/output/directory``. Within your output
+directory, you will find subdirectories, e.g., ``0000_nations_complex`` which contains all experimental artifacts of one
+specific ablation experiment of the defined ablation study. The most relevant subdirectory is ``best_pipeline`` which
+comprises the artifacts of the best performing experiment, including its definition in ``pipeline_config.json``, the
+obtained results, and the trained model(s) in the sub-directory ``replicates``. The number of replicates in
+``replicates`` corresponds to the number provided through the argument ``-r``. Additionally, you are provided with
+further information about the ablation study in the root directory: ``study.json`` describes the ablation experiment,
+``hpo_config.json`` describes the HPO setting of the ablation experiment, ``trials.tsv`` provides an overview of each
+HPO experiment.
 
 Define Your Own HPO Ranges
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-As mentioned above, we provide default hyper-parameters/hyper-parameter ranges for each hyper-parameter.
-However, these default values/ranges do not ensure good performance. Therefore,
-it is time that you define your own ranges, and we show you how to do it!
-For the definition of hyper-parameter values/ranges, two dictionaries are essential, ``kwargs`` that is used to assign
-the hyper-parameters fixed values, and ``kwargs_ranges`` to define ranges of values from which to sample from.
+--------------------------
 
-Let's start with assigning HPO ranges to hyper-parameters belonging to the interaction model. This can be achieved
-by using the dictionary ``model_to_model_kwargs_ranges``:
+As mentioned above, we provide default hyper-parameters/hyper-parameter ranges for each hyper-parameter. However, these
+default values/ranges do not ensure good performance. Therefore, it is time that you define your own ranges, and we show
+you how to do it! For the definition of hyper-parameter values/ranges, two dictionaries are essential, ``kwargs`` that
+is used to assign the hyper-parameters fixed values, and ``kwargs_ranges`` to define ranges of values from which to
+sample from.
+
+Let's start with assigning HPO ranges to hyper-parameters belonging to the interaction model. This can be achieved by
+using the dictionary ``model_to_model_kwargs_ranges``:
 
 .. code-block:: python
 
@@ -264,8 +266,8 @@ equals to 4, the upper bound ``high`` to 6, the embedding dimension is sampled f
 
 Next, we fix the number of training epochs to 50 using the argument ``model_to_training_loop_to_training_kwargs`` and
 define a range for the batch size using ``model_to_training_loop_to_training_kwargs_ranges``. We use these two
-dictionaries because the defined hyper-parameters are hyper-parameters of the training function (that is a function
-of the ``training_loop``):
+dictionaries because the defined hyper-parameters are hyper-parameters of the training function (that is a function of
+the ``training_loop``):
 
 .. code-block:: python
 
@@ -370,8 +372,8 @@ Finally, we define a range for the learning rate which is a hyper-parameter of t
 
     ...
 
-We decided to use Adam as an optimizer, and defined a ``log`` ``scale`` for the learning rate, i.e., the learning
-rate is sampled from the interval :math:`[0.001, 0.1)`.
+We decided to use Adam as an optimizer, and defined a ``log`` ``scale`` for the learning rate, i.e., the learning rate
+is sampled from the interval :math:`[0.001, 0.1)`.
 
 Now that we defined our own hyper-parameter values/ranges, let's have a look at the overall configuration:
 
@@ -466,18 +468,19 @@ Now that we defined our own hyper-parameter values/ranges, let's have a look at 
     ...    pruner="nop",
     ... )
 
-We are expected to provide the arguments ``datasets``, ``models``, ``losses``, ``optimizers``, and
-``training_loops`` to :func:`pykeen.ablation.ablation_pipeline`. For all other components and hype-parameters, PyKEEN
-provides default values/ranges. However, for achieving optimal performance, we should carefully define the
-hyper-parameter values/ranges ourselves, as explained above. Note that there are many more ranges to configure such
-hyper-parameters for the loss functions or the negative samplers. Check out the examples provided in
-`tests/resources/hpo_complex_nations.json`` how to define the ranges for other components.
+We are expected to provide the arguments ``datasets``, ``models``, ``losses``, ``optimizers``, and ``training_loops`` to
+:func:`pykeen.ablation.ablation_pipeline`. For all other components and hype-parameters, PyKEEN provides default
+values/ranges. However, for achieving optimal performance, we should carefully define the hyper-parameter values/ranges
+ourselves, as explained above. Note that there are many more ranges to configure such hyper-parameters for the loss
+functions or the negative samplers. Check out the examples provided in `tests/resources/hpo_complex_nations.json`` how
+to define the ranges for other components.
 
 Run an Ablation Study With Your Own Data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------
+
 We showed how to run an ablation study with a PyKEEN integrated dataset. Now you are asking yourself, whether you can
-run ablations studies with your own data? Yes, you can!
-It requires a minimal change compared to the previous configuration:
+run ablations studies with your own data? Yes, you can! It requires a minimal change compared to the previous
+configuration:
 
 .. code-block:: python
 
@@ -489,17 +492,18 @@ It requires a minimal change compared to the previous configuration:
     ...    }
     ... ]
 
-In the dataset field, you don't provide a list of dataset names but dictionaries containing the paths
-to your train-validation-test splits.
+In the dataset field, you don't provide a list of dataset names but dictionaries containing the paths to your
+train-validation-test splits.
 
 Run an Ablation Study From The Command Line Interface
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------------------------
+
 If you want to start an ablation study from the command line interface, we provide the function
-:func:`pykeen.experiments.cli.ablation`, which expects as an argument the path to a JSON configuration file.
-The configuration file consists of a dictionary with the sub-dictionaries ``ablation`` and ``optuna`` in which the
-ablation study and the Optuna related configuration are defined. Besides, similar to the programmatic interface, the
-``metadata`` dictionary can be provided. The configuration file corresponding to the  ablation study that we previously
-defined within our program would look as follows:
+:func:`pykeen.experiments.cli.ablation`, which expects as an argument the path to a JSON configuration file. The
+configuration file consists of a dictionary with the sub-dictionaries ``ablation`` and ``optuna`` in which the ablation
+study and the Optuna related configuration are defined. Besides, similar to the programmatic interface, the ``metadata``
+dictionary can be provided. The configuration file corresponding to the ablation study that we previously defined within
+our program would look as follows:
 
 .. code-block:: javascript
 

--- a/docs/source/tutorial/running_hpo.rst
+++ b/docs/source/tutorial/running_hpo.rst
@@ -1,4 +1,5 @@
 Optimizing a Model's Hyper-parameters
--------------------------------------
+=====================================
+
 .. automodule:: pykeen.hpo
     :noindex:

--- a/docs/source/tutorial/splitting.rst
+++ b/docs/source/tutorial/splitting.rst
@@ -2,61 +2,60 @@
 
 Splitting
 =========
-In the transductive setting, we require that all entities and relations encountered during evaluation are already
-known at the time of training, i.e. are contained in the training dataset.
-This makes the creation of evaluation splits more difficult.
 
-One way to deal with this situation is to randomly select training triples, and then discard any entity or relation
-from the remaining triples that is not part of any training triple.
-You can do this in PyKEEN by creating a :class:`TriplesFactory` for the training triples, and then passing its entity
-and relation to the ID mapping to create a :class:`TriplesFactory` for the evaluation triples.
-This will filter out any triple with an unknown ID (and warn you about it, so you know).
+In the transductive setting, we require that all entities and relations encountered during evaluation are already known
+at the time of training, i.e. are contained in the training dataset. This makes the creation of evaluation splits more
+difficult.
 
-PyKEEN also offers more advanced methods for creating splits that aim to preserve more of the underlying triples used
-to create the split.
-We have implemented several algorithms to achieve this goal, which are described below.
-The coverage-based algorithm is the default.
-All of them are capable of configuring the desired split ratios between the resulting triple sets.
-It may not always be possible to find a suitable split with the exact ratios, so the result may be slightly different.
-In this case you will see a warning about the different ratio.
+One way to deal with this situation is to randomly select training triples, and then discard any entity or relation from
+the remaining triples that is not part of any training triple. You can do this in PyKEEN by creating a
+:class:`TriplesFactory` for the training triples, and then passing its entity and relation to the ID mapping to create a
+:class:`TriplesFactory` for the evaluation triples. This will filter out any triple with an unknown ID (and warn you
+about it, so you know).
+
+PyKEEN also offers more advanced methods for creating splits that aim to preserve more of the underlying triples used to
+create the split. We have implemented several algorithms to achieve this goal, which are described below. The
+coverage-based algorithm is the default. All of them are capable of configuring the desired split ratios between the
+resulting triple sets. It may not always be possible to find a suitable split with the exact ratios, so the result may
+be slightly different. In this case you will see a warning about the different ratio.
 
 Coverage
 --------
+
 This method first selects one triple for each entity for the training part, and then randomly splits the remaining
-triples with an adjusted split ratio.
-In some cases with very sparse graphs or too small training ratios, it may not be possible to select the initial
-coverage, and the splitting method will fail.
+triples with an adjusted split ratio. In some cases with very sparse graphs or too small training ratios, it may not be
+possible to select the initial coverage, and the splitting method will fail.
 
 Cleanup
 -------
-The triples are first split randomly without taking into account the transductive requirements.
-After that, there may be entities or relations that only occur in evaluation triples.
-Thus, for each set of evaluation triples, we move triples from the evaluation set to the training set until all
-entities occur in at least one training triple.
-This may increase the number of training triples and thus tilt the split ratio towards training.
+
+The triples are first split randomly without taking into account the transductive requirements. After that, there may be
+entities or relations that only occur in evaluation triples. Thus, for each set of evaluation triples, we move triples
+from the evaluation set to the training set until all entities occur in at least one training triple. This may increase
+the number of training triples and thus tilt the split ratio towards training.
 
 We offer two different cleanup methods: `randomized` and `deterministic`.
 
 Deterministic
 ~~~~~~~~~~~~~
-The deterministic method finds all triples that contain at least one entity or relation that is not part of the
-training set and moves them all into the training set.
-It takes only a single iteration and is therefore very fast, but may move more triples into the training set than
-necessary, resulting in smaller evaluation sets than desired.
+
+The deterministic method finds all triples that contain at least one entity or relation that is not part of the training
+set and moves them all into the training set. It takes only a single iteration and is therefore very fast, but may move
+more triples into the training set than necessary, resulting in smaller evaluation sets than desired.
 
 Randomized
 ~~~~~~~~~~
-The randomized method is iterative:
-It determines all triples that have an entity or relation that is not covered by training triples, and randomly
-selects one of these triples to move into the training set.
-The process stops when all entities and relations are covered.
-Is usually requires multiple iterations and is therefore slower than the deterministic algorithm.
-However, it may find a smaller set of triples than the deterministic one and thus come closer to the desired split
-ratio.
 
+The randomized method is iterative: It determines all triples that have an entity or relation that is not covered by
+training triples, and randomly selects one of these triples to move into the training set. The process stops when all
+entities and relations are covered. Is usually requires multiple iterations and is therefore slower than the
+deterministic algorithm. However, it may find a smaller set of triples than the deterministic one and thus come closer
+to the desired split ratio.
 
-.. warning ::
-    PyKEEN currently only supports the creation of transductive splits.
-    One reason for this is that in the inductive setting, there are several different ways to create inductive splits and the literature uses different ones, cf. https://arxiv.org/abs/2107.04894.
-    You can still use PyKEEN for inductive link prediction with existing data sets, or with new inductive data sets that you create.
-    For a general discussion of inductive link prediction, see :ref:`inductive_lp`.
+.. warning::
+
+    PyKEEN currently only supports the creation of transductive splits. One reason for this is that in the inductive
+    setting, there are several different ways to create inductive splits and the literature uses different ones, cf.
+    https://arxiv.org/abs/2107.04894. You can still use PyKEEN for inductive link prediction with existing data sets, or
+    with new inductive data sets that you create. For a general discussion of inductive link prediction, see
+    :ref:`inductive_lp`.

--- a/docs/source/tutorial/trackers/index.rst
+++ b/docs/source/tutorial/trackers/index.rst
@@ -1,11 +1,12 @@
 Tracking Results during Training
 ================================
-.. toctree::
-   :name: trackers
-   :caption: Result Trackers
 
-   using_mlflow
-   using_neptune
-   using_wandb
-   using_tensorboard
-   using_file
+.. toctree::
+    :name: trackers
+    :caption: Result Trackers
+
+    using_mlflow
+    using_neptune
+    using_wandb
+    using_tensorboard
+    using_file

--- a/docs/source/tutorial/trackers/using_file.rst
+++ b/docs/source/tutorial/trackers/using_file.rst
@@ -1,10 +1,11 @@
 Using File-Based Tracking
 =========================
-Rather than logging to an external backend like MLflow or W&B, file based trackers
-write to local files.
+
+Rather than logging to an external backend like MLflow or W&B, file based trackers write to local files.
 
 Minimal Pipeline Example with CSV
 ---------------------------------
+
 A CSV log file can be generated with the following:
 
 .. code-block:: python
@@ -12,45 +13,46 @@ A CSV log file can be generated with the following:
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='csv',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="csv",
     )
 
-It is placed in a subdirectory of :mod:`pystow` default data directory with PyKEEN called ``logs``,
-which will likely be at ``~/.data/pykeen/logs/`` on your system. The file is named based on the
-current time.
+It is placed in a subdirectory of :mod:`pystow` default data directory with PyKEEN called ``logs``, which will likely be
+at ``~/.data/pykeen/logs/`` on your system. The file is named based on the current time.
 
 Specifying a Name
 -----------------
-If you want to specify the name of the log file in the default directory, use the ``name`` keyword
-argument like:
+
+If you want to specify the name of the log file in the default directory, use the ``name`` keyword argument like:
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='csv',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="csv",
         result_tracker_kwargs=dict(
-            name='test.csv',
+            name="test.csv",
         ),
     )
 
-Additional keyword arguments are passed through to the :func:`csv.writer`. This can include
-a ``delimiter``, ``dialect``, ``quotechar``, etc.
+Additional keyword arguments are passed through to the :func:`csv.writer`. This can include a ``delimiter``,
+``dialect``, ``quotechar``, etc.
 
-.. warning:: If you specify the file name, it will overwrite the previous log file there.
+.. warning::
 
-The ``path`` argument can be used instead of the ``name`` to specify an absolute path to the
-log file rather than using the PyStow directory.
+    If you specify the file name, it will overwrite the previous log file there.
+
+The ``path`` argument can be used instead of the ``name`` to specify an absolute path to the log file rather than using
+the PyStow directory.
 
 Combining with ``tail``
 -----------------------
-If you know the name of a file, you can monitor it with ``tail`` and the ``-f`` flag
-like in:
+
+If you know the name of a file, you can monitor it with ``tail`` and the ``-f`` flag like in:
 
 .. code-block::
 
@@ -58,24 +60,24 @@ like in:
 
 Pipeline Example with JSON
 --------------------------
-The JSON writer creates a JSONL file on which each line is a valid JSON object.
-Similarly to the CSV writer, the ``name`` argument can be omitted to create a time-based
-file name or given to pick the default name. The ``path`` argument can still be used to specify
-an absolute path.
+
+The JSON writer creates a JSONL file on which each line is a valid JSON object. Similarly to the CSV writer, the
+``name`` argument can be omitted to create a time-based file name or given to pick the default name. The ``path``
+argument can still be used to specify an absolute path.
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='json',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="json",
         result_tracker_kwargs=dict(
-            name='test.json',
+            name="test.json",
         ),
     )
 
-The same concepts can be applied in the HPO pipeline as in the previous tracker tutorials.
-Additional documentation of the valid keyword arguments can be found
-under :class:`pykeen.trackers.CSVResultTracker` and :class:`pykeen.trackers.JSONResultTracker`.
+The same concepts can be applied in the HPO pipeline as in the previous tracker tutorials. Additional documentation of
+the valid keyword arguments can be found under :class:`pykeen.trackers.CSVResultTracker` and
+:class:`pykeen.trackers.JSONResultTracker`.

--- a/docs/source/tutorial/trackers/using_mlflow.rst
+++ b/docs/source/tutorial/trackers/using_mlflow.rst
@@ -1,46 +1,46 @@
 Using MLflow
 ============
+
 `MLflow <https://mlflow.org>`_ is a graphical tool for tracking the results of machine learning. PyKEEN integrates
 MLflow into the pipeline and HPO pipeline.
 
-To use it, you'll first have to install MLflow with ``pip install mlflow`` and run it in the background
-with ``mlflow ui``. More information can be found on the
-`MLflow Quickstart <https://mlflow.org/docs/latest/quickstart.html>`_. It'll be running at http://localhost:5000
-by default.
+To use it, you'll first have to install MLflow with ``pip install mlflow`` and run it in the background with ``mlflow
+ui``. More information can be found on the `MLflow Quickstart <https://mlflow.org/docs/latest/quickstart.html>`_. It'll
+be running at http://localhost:5000 by default.
 
 Pipeline Example
 ----------------
-This example shows using MLflow with the :func:`pykeen.pipeline.pipeline` function.
-Minimally, the ``tracking_uri`` and ``experiment_name`` are required in the
-``result_tracker_kwargs``.
+
+This example shows using MLflow with the :func:`pykeen.pipeline.pipeline` function. Minimally, the ``tracking_uri`` and
+``experiment_name`` are required in the ``result_tracker_kwargs``.
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='mlflow',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="mlflow",
         result_tracker_kwargs=dict(
-            tracking_uri='http://localhost:5000',
-            experiment_name='Tutorial Training of RotatE on Kinships',
+            tracking_uri="http://localhost:5000",
+            experiment_name="Tutorial Training of RotatE on Kinships",
         ),
     )
 
-If you navigate to the MLflow UI at http://localhost:5000, you'll see the experiment appeared
-in the left column.
+If you navigate to the MLflow UI at http://localhost:5000, you'll see the experiment appeared in the left column.
 
 .. image:: ../../img/mlflow_tutorial_1.png
-  :alt: MLflow home
+    :alt: MLflow home
 
 If you click on the experiment, you'll see this:
 
 .. image:: ../../img/mlflow_tutorial_2.png
-  :alt: MLflow experiment view
+    :alt: MLflow experiment view
 
 HPO Example
 -----------
+
 This example shows using MLflow with the :func:`pykeen.hpo.hpo_pipeline` function.
 
 .. code-block:: python
@@ -48,12 +48,12 @@ This example shows using MLflow with the :func:`pykeen.hpo.hpo_pipeline` functio
     from pykeen.hpo import hpo_pipeline
 
     pipeline_result = hpo_pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='mlflow',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="mlflow",
         result_tracker_kwargs=dict(
-            tracking_uri='http://localhost:5000',
-            experiment_name='Tutorial HPO Training of RotatE on Kinships',
+            tracking_uri="http://localhost:5000",
+            experiment_name="Tutorial HPO Training of RotatE on Kinships",
         ),
     )
 
@@ -61,9 +61,9 @@ The same navigation through MLflow can be done for this example.
 
 Reusing Experiments
 -------------------
+
 In the MLflow UI, you'll see that experiments are assigned an ID. This means you can re-use the same ID to group
-different sub-experiments together using the ``experiment_id`` keyword argument instead of
-``experiment_name``.
+different sub-experiments together using the ``experiment_id`` keyword argument instead of ``experiment_name``.
 
 .. code-block:: python
 
@@ -82,12 +82,12 @@ different sub-experiments together using the ``experiment_id`` keyword argument 
 
 Adding Tags
 -----------
-Tags are additional key/value information that you might want to add to the experiment
-and store in MLflow. By default, MLflow adds the tags listed on
-https://www.mlflow.org/docs/latest/tracking.html#id41.
 
-For example, if you're using custom input,  you might want to add which version
-of the input file produced the results as follows:
+Tags are additional key/value information that you might want to add to the experiment and store in MLflow. By default,
+MLflow adds the tags listed on https://www.mlflow.org/docs/latest/tracking.html#id41.
+
+For example, if you're using custom input, you might want to add which version of the input file produced the results as
+follows:
 
 .. code-block:: python
 
@@ -96,19 +96,18 @@ of the input file produced the results as follows:
     data_version = ...
 
     pipeline_result = pipeline(
-        model='RotatE',
+        model="RotatE",
         training=...,
         testing=...,
         validation=...,
-        result_tracker='mlflow',
+        result_tracker="mlflow",
         result_tracker_kwargs=dict(
-            tracking_uri='http://localhost:5000',
-            experiment_name='Tutorial Training of RotatE on Kinships',
+            tracking_uri="http://localhost:5000",
+            experiment_name="Tutorial Training of RotatE on Kinships",
             tags={
                 "data_version": md5_hash,
             },
         ),
     )
 
-Additional documentation of the valid keyword arguments can be found
-under :class:`pykeen.trackers.MLFlowResultTracker`.
+Additional documentation of the valid keyword arguments can be found under :class:`pykeen.trackers.MLFlowResultTracker`.

--- a/docs/source/tutorial/trackers/using_neptune.rst
+++ b/docs/source/tutorial/trackers/using_neptune.rst
@@ -1,50 +1,53 @@
 Using Neptune.ai
 ================
+
 `Neptune <https://neptune.ai>`_ is a graphical tool for tracking the results of machine learning. PyKEEN integrates
 Neptune into the pipeline and HPO pipeline.
 
 Preparation
 -----------
-1. To use it, you'll first have to install Neptune's client with ``pip install neptune-client`` or
-   install PyKEEN with the ``neptune`` extra with ``pip install pykeen[neptune]``.
+
+1. To use it, you'll first have to install Neptune's client with ``pip install neptune-client`` or install PyKEEN with
+   the ``neptune`` extra with ``pip install pykeen[neptune]``.
 2. Create an account at `Neptune <https://neptune.ai>`_.
 
-   - Get an API token following `this tutorial <https://docs.neptune.ai/security-and-privacy/api-tokens/how-to-find-and-set-neptune-api-token.html>`_.
+   - Get an API token following `this tutorial
+     <https://docs.neptune.ai/security-and-privacy/api-tokens/how-to-find-and-set-neptune-api-token.html>`_.
    - [Optional] Set the ``NEPTUNE_API_TOKEN`` environment variable to your API token.
-3. [Optional] Create a new project by following `this tutorial for project and user
-   management <https://docs.neptune.ai/workspace-project-and-user-management/projects/create-project.html>`_.
-   Neptune automatically creates a project for all new users called ``sandbox`` which you
-   can directly use.
+
+3. [Optional] Create a new project by following `this tutorial for project and user management
+   <https://docs.neptune.ai/workspace-project-and-user-management/projects/create-project.html>`_. Neptune automatically
+   creates a project for all new users called ``sandbox`` which you can directly use.
 
 Pipeline Example
 ----------------
-This example shows using Neptune with the :func:`pykeen.pipeline.pipeline` function.
-Minimally, the ``project_qualified_name`` and ``experiment_name`` must be set.
+
+This example shows using Neptune with the :func:`pykeen.pipeline.pipeline` function. Minimally, the
+``project_qualified_name`` and ``experiment_name`` must be set.
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='neptune',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="neptune",
         result_tracker_kwargs=dict(
-            project_qualified_name='cthoyt/sandbox',
-            experiment_name='Tutorial Training of RotatE on Kinships',
+            project_qualified_name="cthoyt/sandbox",
+            experiment_name="Tutorial Training of RotatE on Kinships",
         ),
     )
 
 .. warning::
 
-    If you haven't set the ``NEPTUNE_API_TOKEN`` environment variable, the ``api_token`` becomes
-    a mandatory key.
+    If you haven't set the ``NEPTUNE_API_TOKEN`` environment variable, the ``api_token`` becomes a mandatory key.
 
 Reusing Experiments
 -------------------
-In the Neptune web application, you'll see that experiments are assigned an ID. This means you can re-use the same
-ID to group different sub-experiments together using the ``experiment_id`` keyword argument instead of
-``experiment_name``.
+
+In the Neptune web application, you'll see that experiments are assigned an ID. This means you can re-use the same ID to
+group different sub-experiments together using the ``experiment_id`` keyword argument instead of ``experiment_name``.
 
 .. code-block:: python
 
@@ -61,17 +64,16 @@ ID to group different sub-experiments together using the ``experiment_id`` keywo
         ),
     )
 
-Don't worry - you can keep using the ``experiment_name`` argument and the experiment's identifier will
-be automatically looked up eah time.
+Don't worry - you can keep using the ``experiment_name`` argument and the experiment's identifier will be automatically
+looked up eah time.
 
 Adding Tags
 -----------
-Tags are additional information that you might want to add to the experiment
-and store in Neptune. Note this is different from MLflow, which considers tags
-as key/value pairs.
 
-For example, if you're using custom input, you might want to add some labels
-about if the experiment is cool or not.
+Tags are additional information that you might want to add to the experiment and store in Neptune. Note this is
+different from MLflow, which considers tags as key/value pairs.
+
+For example, if you're using custom input, you might want to add some labels about if the experiment is cool or not.
 
 .. code-block:: python
 
@@ -80,17 +82,17 @@ about if the experiment is cool or not.
     data_version = ...
 
     pipeline_result = pipeline(
-        model='RotatE',
+        model="RotatE",
         training=...,
         testing=...,
         validation=...,
-        result_tracker='mlflow',
+        result_tracker="mlflow",
         result_tracker_kwargs=dict(
-            project_qualified_name='cthoyt/sandbox',
-            experiment_name='Tutorial Training of RotatE on Kinships',
-            tags={'cool', 'doggo'},
+            project_qualified_name="cthoyt/sandbox",
+            experiment_name="Tutorial Training of RotatE on Kinships",
+            tags={"cool", "doggo"},
         ),
     )
 
-Additional documentation of the valid keyword arguments can be found
-under :class:`pykeen.trackers.NeptuneResultTracker`.
+Additional documentation of the valid keyword arguments can be found under
+:class:`pykeen.trackers.NeptuneResultTracker`.

--- a/docs/source/tutorial/trackers/using_tensorboard.rst
+++ b/docs/source/tutorial/trackers/using_tensorboard.rst
@@ -1,20 +1,23 @@
 Using Tensorboard
 =================
-`Tensorboard <https://www.tensorflow.org/tensorboard/>`_ is a service for tracking experimental results
-during or after training. It is part of the larger Tensorflow project but can be used independently of it.
+
+`Tensorboard <https://www.tensorflow.org/tensorboard/>`_ is a service for tracking experimental results during or after
+training. It is part of the larger Tensorflow project but can be used independently of it.
 
 Installing Tensorboard
 ----------------------
-The :mod:`tensorboard` package can either be installed directly with ``pip install tensorboard``
-or with PyKEEN by using the ``tensorboard`` extra in ``pip install pykeen[tensorboard]``.
+
+The :mod:`tensorboard` package can either be installed directly with ``pip install tensorboard`` or with PyKEEN by using
+the ``tensorboard`` extra in ``pip install pykeen[tensorboard]``.
 
 .. note::
 
-    Tensorboard logs can created without actually installing tensorboard itself.
-    However, if you want to view and interact with the data created via the tracker, it must be installed.
+    Tensorboard logs can created without actually installing tensorboard itself. However, if you want to view and
+    interact with the data created via the tracker, it must be installed.
 
 Starting Tensorboard
 --------------------
+
 The :mod:`tensorboard` web application can be started from the command line with
 
 .. code-block:: shell
@@ -22,17 +25,18 @@ The :mod:`tensorboard` web application can be started from the command line with
     $ tensorboard --logdir=~/.data/pykeen/logs/tensorboard/
 
 where the value passed to the ``--logdir`` is location of log directory. By default, PyKEEN logs to
-``~/.data/pykeen/logs/tensorboard/``, but this is configurable.
-The Tensorboard can then be accessed via a browser at: http://localhost:6006/
+``~/.data/pykeen/logs/tensorboard/``, but this is configurable. The Tensorboard can then be accessed via a browser at:
+http://localhost:6006/
 
 .. note::
 
-    It is not required for the Tensorboard process to be running while the training is happening. Indeed,
-    it only needs to be started once you want to interact with and view the logs. It can be stopped at any
-    time and the logs will persist in the filesystem.
+    It is not required for the Tensorboard process to be running while the training is happening. Indeed, it only needs
+    to be started once you want to interact with and view the logs. It can be stopped at any time and the logs will
+    persist in the filesystem.
 
 Minimal Pipeline Example
 ------------------------
+
 The tensorboard tracker can be used during training with the :func:`pykeen.pipeline.pipeline` as follows:
 
 .. code-block:: python
@@ -40,58 +44,61 @@ The tensorboard tracker can be used during training with the :func:`pykeen.pipel
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='tensorboard',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="tensorboard",
     )
 
-It is placed in a subdirectory of :mod:`pystow` default data directory of PyKEEN called ``tensorboard``,
-which will likely be at ``~/.data/pykeen/logs/tensorboard`` on your system. The file is named based on the
-current time if no alternative is provided.
+It is placed in a subdirectory of :mod:`pystow` default data directory of PyKEEN called ``tensorboard``, which will
+likely be at ``~/.data/pykeen/logs/tensorboard`` on your system. The file is named based on the current time if no
+alternative is provided.
 
 Specifying a Log Name
 ---------------------
-If you want to specify the name of the log file in the default directory, use the ``experiment_name`` keyword
-argument like:
+
+If you want to specify the name of the log file in the default directory, use the ``experiment_name`` keyword argument
+like:
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='tensorboard',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="tensorboard",
         result_tracker_kwargs=dict(
-            experiment_name='rotate-kinships',
+            experiment_name="rotate-kinships",
         ),
     )
 
 Specifying a Custom Log Directory
 ---------------------------------
-If you want to specify a custom directory to store the tensorboard logs, use the ``experiment_path`` keyword
-argument like:
+
+If you want to specify a custom directory to store the tensorboard logs, use the ``experiment_path`` keyword argument
+like:
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='tensorboard',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="tensorboard",
         result_tracker_kwargs=dict(
-            experiment_path='tb-logs/rotate-kinships',
+            experiment_path="tb-logs/rotate-kinships",
         ),
     )
 
 .. warning::
 
-    Please be aware that if you re-run an experiment using the same directory, then the logs will be combined.
-    It is advisable to use a unique sub-directory for each experiment to allow for easy comparison.
+    Please be aware that if you re-run an experiment using the same directory, then the logs will be combined. It is
+    advisable to use a unique sub-directory for each experiment to allow for easy comparison.
 
 Minimal HPO Pipeline Example
 ----------------------------
+
 Tensorboard tracking can also be used in conjunction with a HPO pipeline as follows:
 
 .. code-block:: python
@@ -100,11 +107,10 @@ Tensorboard tracking can also be used in conjunction with a HPO pipeline as foll
 
     hpo_pipeline_result = hpo_pipeline(
         n_trials=30,
-        dataset='Nations',
-        model='TransE',
-        result_tracker='tensorboard',
+        dataset="Nations",
+        model="TransE",
+        result_tracker="tensorboard",
     )
 
-This provides a way to compare directly between different trails and parameter configurations. Please not that it
-is recommended to leave the experiment name as the default value here to allow for a directory to be created per
-trail.
+This provides a way to compare directly between different trails and parameter configurations. Please not that it is
+recommended to leave the experiment name as the default value here to allow for a directory to be created per trail.

--- a/docs/source/tutorial/trackers/using_wandb.rst
+++ b/docs/source/tutorial/trackers/using_wandb.rst
@@ -1,13 +1,13 @@
 Using Weights and Biases
 ========================
+
 `Weights and Biases <http://wandb.ai/>`_ (WANDB) is a service for tracking experimental results and various artifacts
 appearing whn training ML models.
 
-
 After `registering <https://app.wandb.ai/login?signup=true>`_ for WANDB, do the following:
 
-1. Create a project in WANDB, for example, with the name ``pykeen_project`` at
-   ``https://app.wandb.ai/<your username>/new``
+1. Create a project in WANDB, for example, with the name ``pykeen_project`` at ``https://app.wandb.ai/<your
+   username>/new``
 2. Install WANDB on your machine with ``pip install wandb``
 3. Setup your computer for use with WANDB by using either of the following two instructions from
    https://github.com/wandb/client#running-your-script:
@@ -19,6 +19,7 @@ Now you can simply specify this project name when initializing a pipeline, and e
 
 Pipeline Example
 ----------------
+
 This example shows using WANDB with the :func:`pykeen.pipeline.pipeline` function.
 
 .. code-block:: python
@@ -26,38 +27,37 @@ This example shows using WANDB with the :func:`pykeen.pipeline.pipeline` functio
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='wandb',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="wandb",
         result_tracker_kwargs=dict(
-            project='pykeen_project',
+            project="pykeen_project",
         ),
     )
 
-You can navigate to the created project in WANDB and observe a running experiment.
-Further tweaking of appearance, charts, and other settings is described in the official
-`documentation <https://docs.wandb.com/>`_
+You can navigate to the created project in WANDB and observe a running experiment. Further tweaking of appearance,
+charts, and other settings is described in the official `documentation <https://docs.wandb.com/>`_
 
-You can also specify optional ``tags`` which will appear on the website instead of randomly generated
-labels. All further keyword arguments are passed to :func:`wandb.init`.
+You can also specify optional ``tags`` which will appear on the website instead of randomly generated labels. All
+further keyword arguments are passed to :func:`wandb.init`.
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     pipeline_result = pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='wandb',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="wandb",
         result_tracker_kwargs=dict(
-            project='pykeen_project',
-            tags='experiment-1',
+            project="pykeen_project",
+            tags="experiment-1",
         ),
     )
 
-
 HPO Example
 -----------
+
 This example shows using WANDB with the :func:`pykeen.hpo.hpo_pipeline` function.
 
 .. code-block:: python
@@ -65,19 +65,17 @@ This example shows using WANDB with the :func:`pykeen.hpo.hpo_pipeline` function
     from pykeen.hpo import hpo_pipeline
 
     pipeline_result = hpo_pipeline(
-        model='RotatE',
-        dataset='Kinships',
-        result_tracker='wandb',
+        model="RotatE",
+        dataset="Kinships",
+        result_tracker="wandb",
         result_tracker_kwargs=dict(
-            project='pykeen_project',
-            tags='new run',
+            project="pykeen_project",
+            tags="new run",
             reinit=True,
         ),
     )
 
-It's safe to specify the experiment name during HPO. Several runs will be sent to the same experiment
-under different hashes. However, specifying the experiment name is advisable more for single runs and
-not for batches of multiple runs.
+It's safe to specify the experiment name during HPO. Several runs will be sent to the same experiment under different
+hashes. However, specifying the experiment name is advisable more for single runs and not for batches of multiple runs.
 
-Additional documentation of the valid keyword arguments can be found
-under :class:`pykeen.trackers.WANDBResultTracker`.
+Additional documentation of the valid keyword arguments can be found under :class:`pykeen.trackers.WANDBResultTracker`.

--- a/docs/source/tutorial/translational_toy_example.rst
+++ b/docs/source/tutorial/translational_toy_example.rst
@@ -1,107 +1,98 @@
 A Toy Example with Translational Distance Models
 ================================================
-The following tutorial is based on a question originally posed by
-Heiko Paulheim on the PyKEEN Issue Tracker
-`#97 <https://github.com/pykeen/pykeen/issues/97>`_.
 
-Given the following toy example comprising three entities in a triangle,
-a translational distance model like :class:`pykeen.models.TransE` should
-be able to exactly learn the geometric structure.
+The following tutorial is based on a question originally posed by Heiko Paulheim on the PyKEEN Issue Tracker `#97
+<https://github.com/pykeen/pykeen/issues/97>`_.
 
-+----------+------------+----------+
-| Head     | Relation   | Tail     |
-+==========+============+==========+
-| Brussels | locatedIn  | Belgium  |
-+----------+------------+----------+
-| Belgium  | partOf     | EU       |
-+----------+------------+----------+
-| EU       | hasCapital | Brussels |
-+----------+------------+----------+
+Given the following toy example comprising three entities in a triangle, a translational distance model like
+:class:`pykeen.models.TransE` should be able to exactly learn the geometric structure.
+
+======== ========== ========
+Head     Relation   Tail
+======== ========== ========
+Brussels locatedIn  Belgium
+Belgium  partOf     EU
+EU       hasCapital Brussels
+======== ========== ========
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
+
     tf = ...
     results = pipeline(
         training=tf,
         testing=...,
-        model = 'TransE',
+        model="TransE",
         model_kwargs=dict(embedding_dim=2),
         random_seed=1,
-        device='cpu',
+        device="cpu",
     )
     results.plot()
 
 .. image:: ../img/toy_1.png
-  :alt: Troubleshooting Image 1
+    :alt: Troubleshooting Image 1
 
-First, check if the model is converging using ``results.plot_losses``.
-Qualitatively, this means that the loss is smoothly decreasing and
-eventually evening out. If the model does not decrease, you might
-need to tune some parameters with the ``optimizer_kwargs`` and
-``training_kwargs`` to the ``pipeline()`` function.
+First, check if the model is converging using ``results.plot_losses``. Qualitatively, this means that the loss is
+smoothly decreasing and eventually evening out. If the model does not decrease, you might need to tune some parameters
+with the ``optimizer_kwargs`` and ``training_kwargs`` to the ``pipeline()`` function.
 
-For example, you can decrease the optimizer's learning rate to
-make the loss curve less bumpy. Second, you can increase the
-number of epochs during training.
+For example, you can decrease the optimizer's learning rate to make the loss curve less bumpy. Second, you can increase
+the number of epochs during training.
 
 .. code-block:: python
 
     results = pipeline(
         training=tf,
         testing=...,
-        model = 'TransE',
+        model="TransE",
         model_kwargs=dict(embedding_dim=2),
         optimizer_kwargs=dict(lr=1.0e-1),
         training_kwargs=dict(num_epochs=128, use_tqdm_batch=False),
         evaluation_kwargs=dict(use_tqdm=False),
         random_seed=1,
-        device='cpu',
+        device="cpu",
     )
     results.plot()
 
 .. image:: ../img/toy_2.png
-  :alt: Troubleshooting Image 2
+    :alt: Troubleshooting Image 2
 
-Please notice that there is some stochasticity in the training, since we sample
-negative examples for positive ones. Thus, the loss may fluctuate naturally.
-To better see the trend, you can smooth the loss by averaging over a window of
+Please notice that there is some stochasticity in the training, since we sample negative examples for positive ones.
+Thus, the loss may fluctuate naturally. To better see the trend, you can smooth the loss by averaging over a window of
 epochs.
 
-We use a margin-based loss with TransE by default. Thus, it suffices if the
-model predicts scores such that the scores of positive triples and negative
-triples are at least one margin apart. Once the model has reached this state,
-if will not improve further upon these examples, as the embeddings are
-"good enough". Hence, an optimal solution with margin-based loss might not
-look like the exact geometric solution. If you want to change that you can
-switch to a loss function which does not use a margin, e.g. the softplus
-loss. You can do this by passing ``loss="softplus"`` to the pipeline.
+We use a margin-based loss with TransE by default. Thus, it suffices if the model predicts scores such that the scores
+of positive triples and negative triples are at least one margin apart. Once the model has reached this state, if will
+not improve further upon these examples, as the embeddings are "good enough". Hence, an optimal solution with
+margin-based loss might not look like the exact geometric solution. If you want to change that you can switch to a loss
+function which does not use a margin, e.g. the softplus loss. You can do this by passing ``loss="softplus"`` to the
+pipeline.
 
 .. code-block:: python
 
     toy_results = pipeline(
         training=tf,
         testing=...,
-        model='TransE',
-        loss='softplus',
+        model="TransE",
+        loss="softplus",
         model_kwargs=dict(embedding_dim=2),
         optimizer_kwargs=dict(lr=1.0e-1),
         training_kwargs=dict(num_epochs=128, use_tqdm_batch=False),
         evaluation_kwargs=dict(use_tqdm=False),
         random_seed=1,
-        device='cpu',
+        device="cpu",
     )
     results.plot()
 
 .. image:: ../img/toy_3.png
-  :alt: Troubleshooting Image 3
+    :alt: Troubleshooting Image 3
 
-There was a lot of interesting follow-up discussion at `!99 <https://github.com/pykeen/pykeen/pull/99>`_
-during which this code was implemented for re-use. One of the interesting points is that the relation
-plot is only applicable for translational distance models like TransE. Further, when models whose
-embeddings are higher than 2, a dimensionality reduction method must be used. For this, one of many
-of the tools from scikit-learn can be chosen. However, to make sure that the entities and relations
-are projected on the same axis, the dimensionality reduction model is first trained on the entity
-embeddings, then applied on both the entity embeddings and relation embeddings. Further, non-linear
-models like KPCA should not be used when plotting relations, since these _should_ correspond to linear
-transformations in embedding space.
+There was a lot of interesting follow-up discussion at `!99 <https://github.com/pykeen/pykeen/pull/99>`_ during which
+this code was implemented for re-use. One of the interesting points is that the relation plot is only applicable for
+translational distance models like TransE. Further, when models whose embeddings are higher than 2, a dimensionality
+reduction method must be used. For this, one of many of the tools from scikit-learn can be chosen. However, to make sure
+that the entities and relations are projected on the same axis, the dimensionality reduction model is first trained on
+the entity embeddings, then applied on both the entity embeddings and relation embeddings. Further, non-linear models
+like KPCA should not be used when plotting relations, since these _should_ correspond to linear transformations in
+embedding space.

--- a/docs/source/tutorial/troubleshooting.rst
+++ b/docs/source/tutorial/troubleshooting.rst
@@ -1,104 +1,93 @@
 .. _troubleshooting:
 
-#################
- Troubleshooting
-#################
+Troubleshooting
+===============
 
-***********************************************
- Loading a Model from an Old Version of PyKEEN
-***********************************************
+Loading a Model from an Old Version of PyKEEN
+---------------------------------------------
 
-If your model was trained on a different version of PyKEEN, you might
-have difficulty loading the model using
+If your model was trained on a different version of PyKEEN, you might have difficulty loading the model using
 ``torch.load('trained_model.pkl')``.
 
 This could be due to one or both of the following:
 
-#. The model class structure might have changed.
-#. The model weight names might have changed.
+1. The model class structure might have changed.
+2. The model weight names might have changed.
 
-Note that PyKEEN currently cannot support model migration. Please
-attempt the following steps to load the model.
+Note that PyKEEN currently cannot support model migration. Please attempt the following steps to load the model.
 
 If the model class structure has changed
-========================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You will likely see an exception like this one: ``ModuleNotFoundError:
-No module named ...``
+You will likely see an exception like this one: ``ModuleNotFoundError: No module named ...``
 
-In this case, try to instantiate the model class directly and only load
-the state dict from the model file.
+In this case, try to instantiate the model class directly and only load the state dict from the model file.
 
-#. Save the model's ``state_dict`` using the version of PyKEEN used for
-   training:
+1. Save the model's ``state_dict`` using the version of PyKEEN used for training:
 
-      .. code:: python
+       .. code-block:: python
 
-         import torch
-         from pykeen.pipeline import pipeline
+           import torch
+           from pykeen.pipeline import pipeline
 
-         result = pipeline(dataset="Nations", model="RotatE")
-         torch.save(result.model.state_dict(), "v1.7.0/model.state_dict.pt")
+           result = pipeline(dataset="Nations", model="RotatE")
+           torch.save(result.model.state_dict(), "v1.7.0/model.state_dict.pt")
 
-#. Load the model using the version of PyKEEN you want to use. First
-   instantiate the model, then load the state dict:
+2. Load the model using the version of PyKEEN you want to use. First instantiate the model, then load the state dict:
 
-      .. code:: python
+       .. code-block:: python
 
-         import torch
-         from pykeen.datasets import get_dataset
-         from pykeen.models import RotatE
+           import torch
+           from pykeen.datasets import get_dataset
+           from pykeen.models import RotatE
 
-         dataset = get_dataset(dataset="Nations")
-         model = RotatE(triples_factory=dataset.training)
-         state_dict = torch.load("v1.7.0/model.state_dict.pt")
-         model.load_state_dict(state_dict)
+           dataset = get_dataset(dataset="Nations")
+           model = RotatE(triples_factory=dataset.training)
+           state_dict = torch.load("v1.7.0/model.state_dict.pt")
+           model.load_state_dict(state_dict)
 
 If the model weight names have changed
-======================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You will likely see an exception similar to this one:
 
-.. code::
+.. code-block::
 
-   RuntimeError: Error(s) in loading state_dict for RotatE:
-   Missing key(s) in state_dict: "entity_representations.0._embeddings.weight", "relation_representations.0._embeddings.weight".
-   Unexpected key(s) in state_dict: "regularizer.weight", "regularizer.regularization_term", "entity_embeddings._embeddings.weight", "relation_embeddings._embeddings.weight".
+    RuntimeError: Error(s) in loading state_dict for RotatE:
+    Missing key(s) in state_dict: "entity_representations.0._embeddings.weight", "relation_representations.0._embeddings.weight".
+    Unexpected key(s) in state_dict: "regularizer.weight", "regularizer.regularization_term", "entity_embeddings._embeddings.weight", "relation_embeddings._embeddings.weight".
 
-In this case, you need to inspect the state-dict dictionaries in the
-different version, and try to match the keys. Then modify the state dict
-accordingly before loading it. For example:
+In this case, you need to inspect the state-dict dictionaries in the different version, and try to match the keys. Then
+modify the state dict accordingly before loading it. For example:
 
-.. code:: python
+.. code-block:: python
 
-   import torch
-   from pykeen.datasets import get_dataset
-   from pykeen.models import RotatE
+    import torch
+    from pykeen.datasets import get_dataset
+    from pykeen.models import RotatE
 
-   dataset = get_dataset(dataset="Nations")
-   model = RotatE(triples_factory=dataset.training)
-   state_dict = torch.load("v1.7.0/model.state_dict.pt")
-   # these are some example changes in weight names for RotatE between two different pykeen versions
-   for old_name, new_name in [
-       (
-           "entity_embeddings._embeddings.weight",
-           "entity_representations.0._embeddings.weight",
-       ),
-       (
-           "relation_embeddings._embeddings.weight",
-           "relation_representations.0._embeddings.weight",
-       ),
-   ]:
-       state_dict[new_name] = state_dict.pop(old_name)
-   # in this example, the new model does not have a regularizer, so we need to delete corresponding data
-   for name in ["regularizer.weight", "regularizer.regularization_term"]:
-       state_dict.pop(name)
-   model.load_state_dict(state_dict)
+    dataset = get_dataset(dataset="Nations")
+    model = RotatE(triples_factory=dataset.training)
+    state_dict = torch.load("v1.7.0/model.state_dict.pt")
+    # these are some example changes in weight names for RotatE between two different pykeen versions
+    for old_name, new_name in [
+        (
+            "entity_embeddings._embeddings.weight",
+            "entity_representations.0._embeddings.weight",
+        ),
+        (
+            "relation_embeddings._embeddings.weight",
+            "relation_representations.0._embeddings.weight",
+        ),
+    ]:
+        state_dict[new_name] = state_dict.pop(old_name)
+    # in this example, the new model does not have a regularizer, so we need to delete corresponding data
+    for name in ["regularizer.weight", "regularizer.regularization_term"]:
+        state_dict.pop(name)
+    model.load_state_dict(state_dict)
 
 .. warning::
 
-   Even if the state dict can be loaded, there is still a risk that the
-   the weights are used differently. This can lead to a difference in
-   model behavior. To be sure that the model is still functioning the
-   same way, you should also check some model predictions and inspect
-   *how* the model definition has changed.
+    Even if the state dict can be loaded, there is still a risk that the the weights are used differently. This can lead
+    to a difference in model behavior. To be sure that the model is still functioning the same way, you should also
+    check some model predictions and inspect *how* the model definition has changed.

--- a/docs/source/tutorial/using_resolvers.rst
+++ b/docs/source/tutorial/using_resolvers.rst
@@ -2,12 +2,13 @@
 
 Using Resolvers
 ===============
-As PyKEEN is a heavily modular and extensible library, we make use of the :mod:`class_resolver` library
-to allow simple configuration of components. In this part of the tutorial, we explain how to use
-these configuration options, and how to figure out what values you can pass here.
 
-We use the initialization method of the base model class :meth:`pykeen.models.base.Model` and its handling of
-loss functions as an example. Its signature is given as
+As PyKEEN is a heavily modular and extensible library, we make use of the :mod:`class_resolver` library to allow simple
+configuration of components. In this part of the tutorial, we explain how to use these configuration options, and how to
+figure out what values you can pass here.
+
+We use the initialization method of the base model class :meth:`pykeen.models.base.Model` and its handling of loss
+functions as an example. Its signature is given as
 
 .. code-block:: python
 
@@ -20,20 +21,19 @@ loss functions as an example. Its signature is given as
         ...,
     ) -> None:
 
-Notice the two related parameters `loss: HintOrType[Loss] = None` and `loss_kwargs: OptionalKwargs = None`.
-The `loss_kwargs` thus takes a values of type `OptionalKwargs` as input, which is an abbreviation of
-`Union[None, Mapping[str, Any]]`. Hence, we can either pass a mapping of string keys to some values, or `Ǹone`.
-In the latter case of passing `None`, this is interpreted as an empty dictionary.
+Notice the two related parameters `loss: HintOrType[Loss] = None` and `loss_kwargs: OptionalKwargs = None`. The
+`loss_kwargs` thus takes a values of type `OptionalKwargs` as input, which is an abbreviation of `Union[None,
+Mapping[str, Any]]`. Hence, we can either pass a mapping of string keys to some values, or `Ǹone`. In the latter case of
+passing `None`, this is interpreted as an empty dictionary.
 
-The `loss` parameter takes inputs of type `HintOrType[Loss]`. `HintOrType[Loss]` is a abbreviation of
-`Union[None, str, Type[Loss], Loss]`. Thus, we can either pass
+The `loss` parameter takes inputs of type `HintOrType[Loss]`. `HintOrType[Loss]` is a abbreviation of `Union[None, str,
+Type[Loss], Loss]`. Thus, we can either pass
 
-1. an *instance*  of the :class:`pykeen.losses.Loss`, e.g., ``pykeen.losses.MarginRankingLoss(margin=2.0)``.
-   If an instance of :class:`pykeen.losses.Loss` is passed, it is used without modification. In this case,
-   `loss_kwargs` will be ignored.
-
-2. a *subclass* of :class:`pykeen.losses.Loss`, e.g., :class:`pykeen.losses.MarginRankingLoss`
-   In this case, the class is instantiated with the given `loss_kwargs` as (keyword-based) parameters. For instance,
+1. an *instance* of the :class:`pykeen.losses.Loss`, e.g., ``pykeen.losses.MarginRankingLoss(margin=2.0)``. If an
+   instance of :class:`pykeen.losses.Loss` is passed, it is used without modification. In this case, `loss_kwargs` will
+   be ignored.
+2. a *subclass* of :class:`pykeen.losses.Loss`, e.g., :class:`pykeen.losses.MarginRankingLoss` In this case, the class
+   is instantiated with the given `loss_kwargs` as (keyword-based) parameters. For instance,
 
    .. code-block:: python
 
@@ -49,34 +49,33 @@ The `loss` parameter takes inputs of type `HintOrType[Loss]`. `HintOrType[Loss]`
 
    which translates to `MarginRankingLoss(margin=2)`
 
-3. a *string*. This string is used to search for a matching class using the class-resolver's `lookup` function.
-   The lookup function performs some string normalization and compares the resulting key to the normalized
-   names of classes it is associated with. The found class is then used to instantiate the object as if we passed
-   this class instead of the string.
-   For instance, we can obtain instances `MarginRankingLoss` by passing `"MarginRankingLoss"`,
+3. a *string*. This string is used to search for a matching class using the class-resolver's `lookup` function. The
+   lookup function performs some string normalization and compares the resulting key to the normalized names of classes
+   it is associated with. The found class is then used to instantiate the object as if we passed this class instead of
+   the string. For instance, we can obtain instances `MarginRankingLoss` by passing `"MarginRankingLoss"`,
    `"marginrankingloss"`, `"marginranking"`, `"margin-ranking"`, or `"MRL"`.
-
 4. `None`. In this case, we use the `default` class set in the class-resolver, which happens to be
    :class:`MarginRankingLoss` for the `loss_resolver`. If no `default` is set, an exception will be raised.
 
 Determining Allowed Inputs
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-To keep PyKEEN easily extensible and maintainable, we often use `None` for the choice, e.g., `loss`, and
-the keyword-based parameters. This can sometimes make it hard to read what default values are used,
-what valid choices are available, and what parameters are allowed with these different choices.
-In the following, we describe a few ways how to find this information.
+--------------------------
 
-First, you should take a look at the type annotation. `HintOrType[X] = None` tells you that you can pass any
-subclass of `X`. Moreover, you can always pass the string of the class name instead, which often is easier to
-setup for you result tracking, command line arguments, or hyperparameter search. All resolvers for classes used
-in PyKEEN are instantiated using the `ClassResolver.from_subclasses` factory function, which automatically
-registers all subclasses for a given base class as valid choices. Moreover, it will allow you to pass class names
-without the base class' name as suffix, e.g., `loss_resolver` accepts `MarginRanking` instead of `MarginRankingLoss`,
-since the base class' name `Loss` is removed as suffix during the normalization. To utilize this feature, we
-try to follow an appropriate naming scheme for all configurable parts, e.g.,
-:class:`pykeen.nn.representation.Representation`, or :class:`pykeen.nn.modules.Interaction`.
+To keep PyKEEN easily extensible and maintainable, we often use `None` for the choice, e.g., `loss`, and the
+keyword-based parameters. This can sometimes make it hard to read what default values are used, what valid choices are
+available, and what parameters are allowed with these different choices. In the following, we describe a few ways how to
+find this information.
 
-The allowed parameters for `..._kwargs: OptionalKwargs` are a bit harder to determine, since they vary with
-your choice of the component! For instance, :class:`MarginRankingLoss` has a `margin` parameter, while
-:class:`pykeen.losses.BCEWithLogitsLoss` does not provide such. Hence, you should investigate the documentation
-of the individual classes to inform yourself about available parameters and allowed values.
+First, you should take a look at the type annotation. `HintOrType[X] = None` tells you that you can pass any subclass of
+`X`. Moreover, you can always pass the string of the class name instead, which often is easier to setup for you result
+tracking, command line arguments, or hyperparameter search. All resolvers for classes used in PyKEEN are instantiated
+using the `ClassResolver.from_subclasses` factory function, which automatically registers all subclasses for a given
+base class as valid choices. Moreover, it will allow you to pass class names without the base class' name as suffix,
+e.g., `loss_resolver` accepts `MarginRanking` instead of `MarginRankingLoss`, since the base class' name `Loss` is
+removed as suffix during the normalization. To utilize this feature, we try to follow an appropriate naming scheme for
+all configurable parts, e.g., :class:`pykeen.nn.representation.Representation`, or
+:class:`pykeen.nn.modules.Interaction`.
+
+The allowed parameters for `..._kwargs: OptionalKwargs` are a bit harder to determine, since they vary with your choice
+of the component! For instance, :class:`MarginRankingLoss` has a `margin` parameter, while
+:class:`pykeen.losses.BCEWithLogitsLoss` does not provide such. Hence, you should investigate the documentation of the
+individual classes to inform yourself about available parameters and allowed values.

--- a/src/pykeen/__main__.py
+++ b/src/pykeen/__main__.py
@@ -1,8 +1,8 @@
 """Entrypoint module, in case you use ``python -m pykeen``.
 
 Why does this file exist, and why ``__main__``? For more info, read:
- - https://www.python.org/dev/peps/pep-0338/
- - https://docs.python.org/3/using/cmdline.html#cmdoption-m
+    - https://www.python.org/dev/peps/pep-0338/
+    - https://docs.python.org/3/using/cmdline.html#cmdoption-m
 """
 
 from .cli import main

--- a/src/pykeen/ablation/ablation.py
+++ b/src/pykeen/ablation/ablation.py
@@ -80,13 +80,11 @@ def ablation_pipeline(
     best_replicates: int | None = None,
     discard_replicates: bool = False,
     create_unique_subdir: bool = False,
-):
+) -> None:
     """Run ablation study.
 
-    :param datasets:
-        A single or a list of dataset specifications.
-        Datasets can be specified either by name (referring to a single built-in dataset) or as a dictionary with
-        paths for training, validation, and testing.
+    :param datasets: A single or a list of dataset specifications. Datasets can be specified either by name (referring
+        to a single built-in dataset) or as a dictionary with paths for training, validation, and testing.
     :param directory: The directory in which the experimental artifacts will be saved.
     :param models: A model name or list of model names.
     :param losses: A loss function name or list of loss function names.
@@ -95,34 +93,34 @@ def ablation_pipeline(
     :param epochs: A quick way to set the ``num_epochs`` in the training kwargs.
     :param create_inverse_triples: Either a boolean for a single entry or a list of booleans.
     :param regularizers: A regularizer name, list of regularizer names, or None if no regularizer is desired.
-    :param negative_sampler: A negative sampler name, list of regularizer names, or None if no negative sampler
-        is desired. Negative sampling is used only in combination with :class:`pykeen.training.SLCWATrainingLoop`.
+    :param negative_sampler: A negative sampler name, list of regularizer names, or None if no negative sampler is
+        desired. Negative sampling is used only in combination with :class:`pykeen.training.SLCWATrainingLoop`.
     :param evaluator: The name of the evaluator to be used. Defaults to rank-based evaluator.
-    :param stopper: The name of the stopper to be used. Defaults to NopStopper which doesn't define a
-        stopping criterion.
-    :param model_to_model_kwargs: A mapping from model name to dictionaries of default keyword arguments for
-        the instantiation of that model.
-    :param model_to_model_kwargs_ranges: A mapping from model name to dictionaries of keyword argument
-        ranges for that model to be used in HPO.
-    :param model_to_loss_to_loss_kwargs: A mapping from model name to a mapping of loss name to a mapping
-        of default keyword arguments for the instantiation of that loss function. This is useful because for some
-        losses, have hyper-parameters such as :class:`pykeen.losses.MarginRankingLoss`.
-    :param model_to_loss_to_loss_kwargs_ranges: A mapping from model name to a mapping of loss name
-        to a mapping of keyword argument ranges for that loss to be used in HPO.
+    :param stopper: The name of the stopper to be used. Defaults to NopStopper which doesn't define a stopping
+        criterion.
+    :param model_to_model_kwargs: A mapping from model name to dictionaries of default keyword arguments for the
+        instantiation of that model.
+    :param model_to_model_kwargs_ranges: A mapping from model name to dictionaries of keyword argument ranges for that
+        model to be used in HPO.
+    :param model_to_loss_to_loss_kwargs: A mapping from model name to a mapping of loss name to a mapping of default
+        keyword arguments for the instantiation of that loss function. This is useful because for some losses, have
+        hyper-parameters such as :class:`pykeen.losses.MarginRankingLoss`.
+    :param model_to_loss_to_loss_kwargs_ranges: A mapping from model name to a mapping of loss name to a mapping of
+        keyword argument ranges for that loss to be used in HPO.
     :param model_to_optimizer_to_optimizer_kwargs: A mapping from model name to a mapping of optimizer name to a mapping
         of default keyword arguments for the instantiation of that optimizer. This is useful because the optimizers,
         have hyper-parameters such as the learning rate.
-    :param model_to_optimizer_to_optimizer_kwargs_ranges: A mapping from model name to a mapping of optimizer name
-        to a mapping of keyword argument ranges for that optimizer to be used in HPO.
+    :param model_to_optimizer_to_optimizer_kwargs_ranges: A mapping from model name to a mapping of optimizer name to a
+        mapping of keyword argument ranges for that optimizer to be used in HPO.
     :param model_to_regularizer_to_regularizer_kwargs: A mapping from model name to a mapping of regularizer name to a
         mapping of default keyword arguments for the instantiation of that regularizer. This is useful because the
         optimizers, have hyper-parameters such as the regularization weight.
     :param model_to_regularizer_to_regularizer_kwargs_ranges: A mapping from model name to a mapping of regularizer name
         to a mapping of keyword argument ranges for that regularizer to be used in HPO.
-    :param model_to_negative_sampler_to_negative_sampler_kwargs: A mapping from model name to a mapping of
-        negative sampler name to a mapping of default keyword arguments for the instantiation of that negative sampler.
-        This is useful because the negative samplers, have hyper-parameters such as the number of negatives that should
-        get generated for each positive training example.
+    :param model_to_negative_sampler_to_negative_sampler_kwargs: A mapping from model name to a mapping of negative
+        sampler name to a mapping of default keyword arguments for the instantiation of that negative sampler. This is
+        useful because the negative samplers, have hyper-parameters such as the number of negatives that should get
+        generated for each positive training example.
     :param model_to_negative_sampler_to_negative_sampler_kwargs_ranges: A mapping from model name to a mapping of
         negative sampler name to a mapping of keyword argument ranges for that negative sampler to be used in HPO.
     :param model_to_training_loop_to_training_loop_kwargs: A mapping from model name to a mapping of training loop name
@@ -130,8 +128,8 @@ def ablation_pipeline(
     :param model_to_training_loop_to_training_kwargs: A mapping from model name to a mapping of trainer name to a
         mapping of default keyword arguments for the training procedure. This is useful because you can set the
         hyper-parameters such as the number of training epochs and the batch size.
-    :param model_to_training_loop_to_training_kwargs_ranges:  A mapping from model name to a mapping of
-        trainer name to a mapping of keyword argument ranges for that trainer to be used in HPO.
+    :param model_to_training_loop_to_training_kwargs_ranges: A mapping from model name to a mapping of trainer name to a
+        mapping of keyword argument ranges for that trainer to be used in HPO.
     :param evaluator_kwargs: The keyword arguments passed to the evaluator.
     :param evaluation_kwargs: The keyword arguments passed during evaluation.
     :param stopper_kwargs: The keyword arguments passed to the stopper.
@@ -140,18 +138,18 @@ def ablation_pipeline(
     :param metric: The metric to optimize during HPO.
     :param direction: Defines, whether to 'maximize' or 'minimize' the metric during HPO.
     :param sampler: The HPO sampler, it defaults to random search.
-    :param pruner: Defines approach for pruning trials. Per default no pruning is used, i.e., pruner is
-        set to 'Nopruner'.
+    :param pruner: Defines approach for pruning trials. Per default no pruning is used, i.e., pruner is set to
+        'Nopruner'.
     :param metadata: A mapping of meta data arguments such as name of the ablation study.
     :param save_artifacts: Defines, whether each trained model sampled during HPO should be saved.
     :param move_to_cpu: Defines, whether a replicate of the best model should be moved to CPU.
-    :param dry_run: Defines whether only the configurations for the single experiments should be created without
-        running them.
+    :param dry_run: Defines whether only the configurations for the single experiments should be created without running
+        them.
     :param best_replicates: Defines how often the final model should be re-trained and evaluated based on the best
         hyper-parameters enabling to measure the variance in performance.
     :param discard_replicates: Defines, whether the best model should be discarded after training and evaluation.
-    :param create_unique_subdir: Defines, whether a unique sub-directory for the experimental artifacts should
-        be created. The sub-directory name is defined  by the  current  data + a unique id.
+    :param create_unique_subdir: Defines, whether a unique sub-directory for the experimental artifacts should be
+        created. The sub-directory name is defined by the current data + a unique id.
     """
     directory = normalize_path(directory, *iter_unique_ids(disable=not create_unique_subdir))
     directories = prepare_ablation(
@@ -252,22 +250,21 @@ def ablation_pipeline_from_config(
     save_artifacts: bool = True,
     move_to_cpu: bool = True,
     discard_replicates: bool = False,
-):
+) -> None:
     """Generate a set of HPO configurations.
 
     A sample file can be run with``pykeen experiment ablation tests/resources/hpo_complex_nations.json``.
 
     :param config: Dictionary defining the ablation studies.
     :param directory: The directory in which the experimental artifacts will be saved.
-    :param dry_run: Defines whether only the configurations for the single experiments should be created without
-        running them.
+    :param dry_run: Defines whether only the configurations for the single experiments should be created without running
+        them.
     :param best_replicates: Defines how often the final model should be re-trained and evaluated based on the best
         hyper-parameters enabling to measure the variance in performance.
     :param save_artifacts: Defines, whether each trained model sampled during HPO should be saved.
-    :param move_to_cpu: Defines, whether a replicate of the best model should be moved to CPU.
-        We recommend to set this flag to 'True' to avoid unnecessary GPU usage.
+    :param move_to_cpu: Defines, whether a replicate of the best model should be moved to CPU. We recommend to set this
+        flag to 'True' to avoid unnecessary GPU usage.
     :param discard_replicates: Defines, whether the best model should be discarded after training and evaluation.
-    :return: None.
     """
     return ablation_pipeline(
         **config,
@@ -288,11 +285,12 @@ def prepare_ablation_from_path(
     """Prepare a set of ablation study directories.
 
     :param path: Path to configuration file defining the ablation studies.
-    :param directory: The directory in which the experimental artifacts (including the ablation configurations)
-        will be saved.
+    :param directory: The directory in which the experimental artifacts (including the ablation configurations) will be
+        saved.
     :param save_artifacts: Defines, whether the output directories for the trained models sampled during HPO should be
         created.
-    :return: pairs of output directories and HPO config paths inside those directories
+
+    :returns: pairs of output directories and HPO config paths inside those directories
     """
     directory = normalize_path(directory, *iter_unique_ids())
     with open(path) as file:
@@ -308,12 +306,12 @@ def prepare_ablation_from_config(
     """Prepare a set of ablation study directories.
 
     :param config: Dictionary defining the ablation studies.
-    :param directory: The directory in which the experimental artifacts (including the ablation configurations)
-        will be saved.
+    :param directory: The directory in which the experimental artifacts (including the ablation configurations) will be
+        saved.
     :param save_artifacts: Defines, whether the output directories for the trained models sampled during HPO should be
         created.
 
-    :return: pairs of output directories and HPO config paths inside those directories
+    :returns: pairs of output directories and HPO config paths inside those directories
     """
     metadata = config["metadata"]
     optuna_config = config["optuna"]
@@ -376,10 +374,8 @@ def prepare_ablation(  # noqa:C901
 ) -> list[tuple[pathlib.Path, pathlib.Path]]:
     """Prepare an ablation directory.
 
-    :param datasets:
-        A single or a list of dataset specifications.
-        Datasets can be specified either by name (referring to a single built-in dataset) or as a dictionary with
-        paths for training, validation, and testing.
+    :param datasets: A single or a list of dataset specifications. Datasets can be specified either by name (referring
+        to a single built-in dataset) or as a dictionary with paths for training, validation, and testing.
     :param models: A model name or list of model names.
     :param losses: A loss function name or list of loss function names.
     :param optimizers: An optimizer name or list of optimizer names.
@@ -387,43 +383,43 @@ def prepare_ablation(  # noqa:C901
     :param epochs: A quick way to set the ``num_epochs`` in the training kwargs.
     :param create_inverse_triples: Either a boolean for a single entry or a list of booleans.
     :param regularizers: A regularizer name, list of regularizer names, or None if no regularizer is desired.
-    :param negative_sampler: A negative sampler name, list of regularizer names, or None if no negative sampler
-        is desired. Negative sampling is used only in combination with the pykeen.training.sclwa training loop.
+    :param negative_sampler: A negative sampler name, list of regularizer names, or None if no negative sampler is
+        desired. Negative sampling is used only in combination with the pykeen.training.sclwa training loop.
     :param evaluator: The name of the evaluator to be used. Defaults to rank-based evaluator.
-    :param stopper: The name of the stopper to be used. Defaults to NopStopper which doesn't define a
-        stopping criterion.
-    :param model_to_model_kwargs: A mapping from model name to dictionaries of default keyword arguments for
-        the instantiation of that model.
-    :param model_to_model_kwargs_ranges: A mapping from model name to dictionaries of keyword argument
-        ranges for that model to be used in HPO.
-    :param model_to_loss_to_loss_kwargs: A mapping from model name to a mapping of loss name to a mapping
-        of default keyword arguments for the instantiation of that loss function. This is useful because for some
-        losses, have hyper-parameters such as pykeen.losses.MarginRankingLoss
-    :param model_to_loss_to_loss_kwargs_ranges: A mapping from model name to a mapping of loss name
-        to a mapping of keyword argument ranges for that loss to be used in HPO.
+    :param stopper: The name of the stopper to be used. Defaults to NopStopper which doesn't define a stopping
+        criterion.
+    :param model_to_model_kwargs: A mapping from model name to dictionaries of default keyword arguments for the
+        instantiation of that model.
+    :param model_to_model_kwargs_ranges: A mapping from model name to dictionaries of keyword argument ranges for that
+        model to be used in HPO.
+    :param model_to_loss_to_loss_kwargs: A mapping from model name to a mapping of loss name to a mapping of default
+        keyword arguments for the instantiation of that loss function. This is useful because for some losses, have
+        hyper-parameters such as pykeen.losses.MarginRankingLoss
+    :param model_to_loss_to_loss_kwargs_ranges: A mapping from model name to a mapping of loss name to a mapping of
+        keyword argument ranges for that loss to be used in HPO.
     :param model_to_optimizer_to_optimizer_kwargs: A mapping from model name to a mapping of optimizer name to a mapping
         of default keyword arguments for the instantiation of that optimizer. This is useful because the optimizers,
         have hyper-parameters such as the learning rate.
-    :param model_to_optimizer_to_optimizer_kwargs_ranges: A mapping from model name to a mapping of optimizer name
-        to a mapping of keyword argument ranges for that optimizer to be used in HPO.
+    :param model_to_optimizer_to_optimizer_kwargs_ranges: A mapping from model name to a mapping of optimizer name to a
+        mapping of keyword argument ranges for that optimizer to be used in HPO.
     :param model_to_regularizer_to_regularizer_kwargs: A mapping from model name to a mapping of regularizer name to a
         mapping of default keyword arguments for the instantiation of that regularizer. This is useful because the
         optimizers, have hyper-parameters such as the regularization weight.
     :param model_to_regularizer_to_regularizer_kwargs_ranges: A mapping from model name to a mapping of regularizer name
         to a mapping of keyword argument ranges for that regularizer to be used in HPO.
-    :param model_to_neg_sampler_to_neg_sampler_kwargs: A mapping from model name to a mapping of
-        negative sampler name to a mapping of default keyword arguments for the instantiation of that negative sampler.
-        This is useful because the negative samplers, have hyper-parameters such as the number of negatives that should
-        get generated for each positive training example.
-    :param model_to_neg_sampler_to_neg_sampler_kwargs_ranges: A mapping from model name to a mapping of
-        negative sampler name to a mapping of keyword argument ranges for that negative sampler to be used in HPO.
+    :param model_to_neg_sampler_to_neg_sampler_kwargs: A mapping from model name to a mapping of negative sampler name
+        to a mapping of default keyword arguments for the instantiation of that negative sampler. This is useful because
+        the negative samplers, have hyper-parameters such as the number of negatives that should get generated for each
+        positive training example.
+    :param model_to_neg_sampler_to_neg_sampler_kwargs_ranges: A mapping from model name to a mapping of negative sampler
+        name to a mapping of keyword argument ranges for that negative sampler to be used in HPO.
     :param model_to_training_loop_to_training_loop_kwargs: A mapping from model name to a mapping of training loop name
         to a mapping of default keyword arguments for the training loop.
     :param model_to_training_loop_to_training_kwargs: A mapping from model name to a mapping of trainer name to a
         mapping of default keyword arguments for the training procedure. This is useful because you can set the
         hyper-parameters such as the number of training epochs and the batch size.
-    :param model_to_training_loop_to_training_kwargs_ranges:  A mapping from model name to a mapping of
-        trainer name to a mapping of keyword argument ranges for that trainer to be used in HPO.
+    :param model_to_training_loop_to_training_kwargs_ranges: A mapping from model name to a mapping of trainer name to a
+        mapping of keyword argument ranges for that trainer to be used in HPO.
     :param evaluator_kwargs: The keyword arguments passed to the evaluator.
     :param evaluation_kwargs: The keyword arguments passed during evaluation.
     :param stopper_kwargs: The keyword arguments passed to the stopper.
@@ -432,16 +428,16 @@ def prepare_ablation(  # noqa:C901
     :param metric: The metric to optimize during HPO.
     :param direction: Defines, whether to 'maximize' or 'minimize' the metric during HPO.
     :param sampler: The HPO sampler, it defaults to random search.
-    :param pruner: Defines approach for pruning trials. Per default no pruning is used, i.e., pruner is
-        set to 'Nopruner'.
+    :param pruner: Defines approach for pruning trials. Per default no pruning is used, i.e., pruner is set to
+        'Nopruner'.
     :param metadata: A mapping of meta data arguments such as name of the ablation study.
     :param directory: The directory in which the experimental artifacts will be saved.
     :param save_artifacts: Defines, whether each trained model sampled during HPO should be saved.
 
-    :return: pairs of output directories and HPO config paths inside those directories.
-    :raises ValueError:
-            If the dataset is not specified correctly, i.e., dataset is not of type str, or a dictionary containing
-            the paths to the training, testing, and validation data.
+    :returns: pairs of output directories and HPO config paths inside those directories.
+
+    :raises ValueError: If the dataset is not specified correctly, i.e., dataset is not of type str, or a dictionary
+        containing the paths to the training, testing, and validation data.
     """
     directory = normalize_path(path=directory)
     datasets = upgrade_to_sequence(datasets)

--- a/src/pykeen/ablation/ablation.py
+++ b/src/pykeen/ablation/ablation.py
@@ -266,7 +266,7 @@ def ablation_pipeline_from_config(
         flag to 'True' to avoid unnecessary GPU usage.
     :param discard_replicates: Defines, whether the best model should be discarded after training and evaluation.
     """
-    return ablation_pipeline(
+    ablation_pipeline(
         **config,
         directory=directory,
         dry_run=dry_run,

--- a/src/pykeen/checkpoints/__init__.py
+++ b/src/pykeen/checkpoints/__init__.py
@@ -1,49 +1,52 @@
-"""
-This module contains methods for deciding when to write and clear checkpoints.
+"""This module contains methods for deciding when to write and clear checkpoints.
 
-.. warning ::
+.. warning::
+
     While this module provides a flexible and modular way to describe a desired checkpoint behavior, it currently only
-    stores the model's weights (more precisely, its :meth:`torch.nn.Module.state_dict`).
-    Thus, it does not yet replace the full training loop checkpointing mechanism described in
-    :ref:`regular_checkpoints_how_to`.
+    stores the model's weights (more precisely, its :meth:`torch.nn.Module.state_dict`). Thus, it does not yet replace
+    the full training loop checkpointing mechanism described in :ref:`regular_checkpoints_how_to`.
 
-It consists of two main components: checkpoint *schedules* decide whether to write a checkpoint at a given epoch.
-If we have multiple checkpoints, we can use multiple *keep strategies* to decide which checkpoints to keep and
-which to discard. For both, we provide a set of basic rules, as well as a way to combine them via union.
-Those should be sufficient to easily model most of the desired checkpointing behaviours.
+It consists of two main components: checkpoint *schedules* decide whether to write a checkpoint at a given epoch. If we
+have multiple checkpoints, we can use multiple *keep strategies* to decide which checkpoints to keep and which to
+discard. For both, we provide a set of basic rules, as well as a way to combine them via union. Those should be
+sufficient to easily model most of the desired checkpointing behaviours.
 
 Examples
 ========
 
-Below you can find a few examples of how to use them inside the training pipeline.
-If you want to check before an actual training how (static) checkpoint schedules behave,
-you can take a look at :meth:`pykeen.checkpoints.final_checkpoints`
+Below you can find a few examples of how to use them inside the training pipeline. If you want to check before an actual
+training how (static) checkpoint schedules behave, you can take a look at :meth:`pykeen.checkpoints.final_checkpoints`
 and :meth:`pykeen.checkpoints.simulate_checkpoints`.
 
-To reduce the number of necessary imports, the examples all use dictionaries/strings to
-specify components instead of passing classes or actual instances.
-You can find more information about resolution in general at :ref:`using_resolvers`.
-The resolver for the schedule component is :data:`pykeen.checkpoints.schedule.schedule_resolver`,
-and for the keeper component it is :data:`pykeen.checkpoints.keeper_resolver`.
+To reduce the number of necessary imports, the examples all use dictionaries/strings to specify components instead of
+passing classes or actual instances. You can find more information about resolution in general at
+:ref:`using_resolvers`. The resolver for the schedule component is
+:data:`pykeen.checkpoints.schedule.schedule_resolver`, and for the keeper component it is
+:data:`pykeen.checkpoints.keeper_resolver`.
 
 Example 1
-~~~~~~~~~
+---------
+
 .. literalinclude:: ../examples/checkpoints/ex_01.py
 
 Example 2
-~~~~~~~~~
+---------
+
 .. literalinclude:: ../examples/checkpoints/ex_02.py
 
 Example 3
-~~~~~~~~~
+---------
+
 .. literalinclude:: ../examples/checkpoints/ex_03.py
 
 Example 4
-~~~~~~~~~
+---------
+
 .. literalinclude:: ../examples/checkpoints/ex_04.py
 
 Example 5
-~~~~~~~~~
+---------
+
 .. literalinclude:: ../examples/checkpoints/ex_05.py
 """
 

--- a/src/pykeen/checkpoints/base.py
+++ b/src/pykeen/checkpoints/base.py
@@ -43,15 +43,12 @@ def load_state_torch(file: pathlib.Path | str | BinaryIO) -> ModelState:
 
 
 def save_model(model: Model, file: pathlib.Path | str | BinaryIO) -> None:
-    """
-    Save a model to a file.
+    """Save a model to a file.
 
-    :param model:
-        the model to save
-    :param file:
-        the file to save to, either as a path, or a binary file-like object
+    :param model: the model to save
+    :param file: the file to save to, either as a path, or a binary file-like object
 
-    Example::
+    .. code-block:: python
 
         from pykeen.pipeline import pipeline
         from pykeen.checkpoints import save_model, load_state_torch

--- a/src/pykeen/checkpoints/keeper.py
+++ b/src/pykeen/checkpoints/keeper.py
@@ -1,8 +1,7 @@
-"""
-Checkpoint cleanup methods.
+"""Checkpoint cleanup methods.
 
-The cleanup methods determine, for any given set of existing checkpoints, which of them can be pruned.
-We provide a set of basic rules that can be easily combined into more complex logic.
+The cleanup methods determine, for any given set of existing checkpoints, which of them can be pruned. We provide a set
+of basic rules that can be easily combined into more complex logic.
 """
 
 import abc
@@ -32,11 +31,11 @@ class CheckpointKeeper(abc.ABC):
     def __call__(self, steps: Sequence[int]) -> Iterator[int]:
         """Iterate over the steps for which checkpoints should be kept.
 
-        :param steps:
-            the sorted list of steps at which checkpoints were written.
+        :param steps: the sorted list of steps at which checkpoints were written.
 
-        :yields:
-            the steps for which checkpoints should be kept
+        :yields: the steps for which checkpoints should be kept
+
+        # noqa:DAR302
         """
 
 

--- a/src/pykeen/cli.py
+++ b/src/pykeen/cli.py
@@ -5,10 +5,12 @@ later, but that will cause problems - the code will get executed twice:
 
 - When you run ``python -m pykeen`` python will execute``__main__.py`` as a script. That means there won't be any
   ``pykeen.__main__`` in ``sys.modules``.
-- When you import __main__ it will get executed again (as a module) because
-  there's no ``pykeen.__main__`` in ``sys.modules``.
+- When you import __main__ it will get executed again (as a module) because there's no ``pykeen.__main__`` in
+  ``sys.modules``.
 
-.. seealso:: http://click.pocoo.org/5/setuptools/#setuptools-integration
+.. seealso::
+
+    http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
 
 import importlib
@@ -87,16 +89,12 @@ def models(tablefmt: str):
 
 
 def format_class(cls: type, module: str | None = None) -> str:
-    """
-    Generate the fully-qualified class name.
+    """Generate the fully-qualified class name.
 
-    :param cls:
-        the class
-    :param module:
-        the module name to use instead of `cls.__module__`
+    :param cls: the class
+    :param module: the module name to use instead of `cls.__module__`
 
-    :return:
-        the fully qualified class name
+    :returns: the fully qualified class name
     """
     if module is None:
         module = cls.__module__
@@ -111,17 +109,13 @@ def _citation(dd):
 
 
 def _format_reference(reference: str | None, link_fmt: str | None, alt_reference: str | None = None) -> str:
-    """
-    Format a reference.
+    """Format a reference.
 
-    :param reference:
-        the reference
-    :param link_fmt:
-        the link format
-    :param alt_reference:
-        the link target. Defaults to the reference.
-    :return:
-        a Markdown reference
+    :param reference: the reference
+    :param link_fmt: the link format
+    :param alt_reference: the link target. Defaults to the reference.
+
+    :returns: a Markdown reference
     """
     if reference is None:
         return ""

--- a/src/pykeen/contrib/lightning.py
+++ b/src/pykeen/contrib/lightning.py
@@ -1,8 +1,7 @@
 """PyTorch Lightning integration.
 
-PyTorch Lightning poses an alternative way to implement a training
-loop and evaluation loop for knowledge graph embedding models that
-has some nice features:
+PyTorch Lightning poses an alternative way to implement a training loop and evaluation loop for knowledge graph
+embedding models that has some nice features:
 
 - mixed precision training
 - multi-gpu training
@@ -22,7 +21,6 @@ has some nice features:
         precision=16,  # mixed precision training
     )
     trainer.fit(model=model)
-
 """
 
 from abc import abstractmethod
@@ -55,10 +53,10 @@ __all__ = [
 
 
 class LitModule(pytorch_lightning.LightningModule):
-    """
-    A base module for training models with PyTorch Lightning.
+    """A base module for training models with PyTorch Lightning.
 
     .. seealso::
+
         :class:`pykeen.training.training_loop.TrainingLoop`
     """
 
@@ -79,32 +77,19 @@ class LitModule(pytorch_lightning.LightningModule):
         optimizer: HintOrType[torch.optim.Optimizer] = None,
         optimizer_kwargs: OptionalKwargs = None,
     ):
-        """
-        Create the lightning module.
+        """Create the lightning module.
 
-        :param dataset:
-            the dataset, or a hint thereof
-        :param dataset_kwargs:
-            additional keyword-based parameters passed to the dataset
-        :param mode:
-            the inductive mode; defaults to transductive training
-
-        :param model:
-            the model, or a hint thereof
-        :param model_kwargs:
-            additional keyword-based parameters passed to the model
-
-        :param batch_size:
-            the training batch size
-        :param learning_rate:
-            the learning rate
-        :param label_smoothing:
-            the label smoothing
-
-        :param optimizer:
-            the optimizer, or a hint thereof
-        :param optimizer_kwargs:
-            additional keyword-based parameters passed to the optimizer. should not contain `lr`, or `params`.
+        :param dataset: the dataset, or a hint thereof
+        :param dataset_kwargs: additional keyword-based parameters passed to the dataset
+        :param mode: the inductive mode; defaults to transductive training
+        :param model: the model, or a hint thereof
+        :param model_kwargs: additional keyword-based parameters passed to the model
+        :param batch_size: the training batch size
+        :param learning_rate: the learning rate
+        :param label_smoothing: the label smoothing
+        :param optimizer: the optimizer, or a hint thereof
+        :param optimizer_kwargs: additional keyword-based parameters passed to the optimizer. should not contain `lr`,
+            or `params`.
         """
         super().__init__()
         self.dataset = get_dataset(dataset=dataset, dataset_kwargs=dataset_kwargs)
@@ -118,15 +103,14 @@ class LitModule(pytorch_lightning.LightningModule):
         self.label_smoothing = label_smoothing
 
     def forward(self, hr_batch: LongTensor) -> FloatTensor:
-        """
-        Perform the prediction or inference step by wrapping :meth:`pykeen.models.ERModel.predict_t`.
+        """Perform the prediction or inference step by wrapping :meth:`pykeen.models.ERModel.predict_t`.
 
-        :param hr_batch: shape: (batch_size, 2), dtype: long
-            The indices of (head, relation) pairs.
-        :return: shape: (batch_size, num_entities), dtype: float
-            For each h-r pair, the scores for all possible tails.
+        :param hr_batch: shape: (batch_size, 2), dtype: long The indices of (head, relation) pairs.
+
+        :returns: shape: (batch_size, num_entities), dtype: float For each h-r pair, the scores for all possible tails.
 
         .. note::
+
             in lightning, forward defines the prediction/inference actions
         """
         return self.model.predict_t(hr_batch)
@@ -182,16 +166,13 @@ class SLCWALitModule(LitModule):
         negative_sampler_kwargs: OptionalKwargs = None,
         **kwargs,
     ):
-        """
-        Initialize the lightning module.
+        """Initialize the lightning module.
 
-        :param negative_sampler:
-            the negative sampler, cf. :meth:`pykeen.triples.CoreTriplesFactory.create_slcwa_instances`
-        :param negative_sampler_kwargs:
-            keyword-based parameters passed to the negative sampler, cf.
+        :param negative_sampler: the negative sampler, cf.
             :meth:`pykeen.triples.CoreTriplesFactory.create_slcwa_instances`
-        :param kwargs:
-            additional keyword-based parameters passed to :meth:`LitModule.__init__`
+        :param negative_sampler_kwargs: keyword-based parameters passed to the negative sampler, cf.
+            :meth:`pykeen.triples.CoreTriplesFactory.create_slcwa_instances`
+        :param kwargs: additional keyword-based parameters passed to :meth:`LitModule.__init__`
         """
         super().__init__(**kwargs)
         self.negative_sampler = negative_sampler
@@ -236,7 +217,9 @@ class SLCWALitModule(LitModule):
 class LCWALitModule(LitModule):
     """A PyTorch Lightning module for training a model with LCWA training loop.
 
-    .. seealso:: https://github.com/pykeen/pykeen/pull/905
+    .. seealso::
+
+        https://github.com/pykeen/pykeen/pull/905
     """
 
     # docstr-coverage: inherited
@@ -282,18 +265,16 @@ def lit_pipeline(
     training_loop_kwargs: OptionalKwargs = None,
     trainer_kwargs: OptionalKwargs = None,
 ) -> None:
-    """
-    Create a :class:`LitModule` and run :class:`pytorch_lightning.Trainer` with it.
+    """Create a :class:`LitModule` and run :class:`pytorch_lightning.Trainer` with it.
 
     .. note::
+
         this method modifies the model's parameters in-place.
 
-    :param training_loop:
-        the training loop or a hint thereof
-    :param training_loop_kwargs:
-        keyword-based parameters passed to the respective :class:`LitModule` subclass upon instantiation.
-    :param trainer_kwargs:
-        keyword-based parameters passed to :class:`pytorch_lightning.Trainer`
+    :param training_loop: the training loop or a hint thereof
+    :param training_loop_kwargs: keyword-based parameters passed to the respective :class:`LitModule` subclass upon
+        instantiation.
+    :param trainer_kwargs: keyword-based parameters passed to :class:`pytorch_lightning.Trainer`
     """
     pytorch_lightning.Trainer(**(trainer_kwargs or {})).fit(
         model=lit_module_resolver.make(training_loop, pos_kwargs=training_loop_kwargs)

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -1,9 +1,9 @@
 """Built-in datasets for PyKEEN.
 
 New datasets (inheriting from :class:`pykeen.datasets.Dataset`) can be registered with PyKEEN using the
-:mod:`pykeen.datasets` group in Python entrypoints in your own `setup.py`, `setup.cfg`, `pyproject.toml`,
-or other package configuration. They are loaded automatically with :func:`importlib.metadata.entry_points`
-via :mod:`class_resolver`.
+:mod:`pykeen.datasets` group in Python entrypoints in your own `setup.py`, `setup.cfg`, `pyproject.toml`, or other
+package configuration. They are loaded automatically with :func:`importlib.metadata.entry_points` via
+:mod:`class_resolver`.
 """
 
 import logging

--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -56,13 +56,13 @@ def dataset_similarity(a: Dataset, b: Dataset, metric: str | None = None) -> flo
 
     :param a: The reference dataset
     :param b: The target dataset
-    :param metric: The similarity metric to use. Defaults to `tanimoto`. Could either be a symmetric
-        or asymmetric metric.
-    :returns: A scalar value between 0 and 1 where closer to 1 means the datasets are more
-        similar based on the metric.
+    :param metric: The similarity metric to use. Defaults to `tanimoto`. Could either be a symmetric or asymmetric
+        metric.
 
-    :raises ValueError: if an invalid metric type is passed. Right now, there's only `tanimoto`,
-        but this could change in later.
+    :returns: A scalar value between 0 and 1 where closer to 1 means the datasets are more similar based on the metric.
+
+    :raises ValueError: if an invalid metric type is passed. Right now, there's only `tanimoto`, but this could change
+        in later.
     """
     if metric == "tanimoto" or metric is None:
         return splits_similarity(a._tup(), b._tup())
@@ -344,9 +344,12 @@ class Dataset(ExtraReprMixin):
 
         :param other: The other shuffling of the dataset
         :param metric: The metric to use. Defaults to `tanimoto`.
-        :return: A float of the similarity
 
-        .. seealso:: :func:`pykeen.triples.triples_factory.splits_similarity`.
+        :returns: A float of the similarity
+
+        .. seealso::
+
+            :func:`pykeen.triples.triples_factory.splits_similarity`.
         """
         return dataset_similarity(self, other, metric=metric)
 
@@ -364,30 +367,25 @@ class Dataset(ExtraReprMixin):
     ) -> EagerDataset | Self:
         """Restrict a dataset to the given entities/relations.
 
-        Example::
-
         >>> from pykeen.datasets import get_dataset
         >>> full_dataset = get_dataset(dataset="nations")
-        >>> restricted_dataset = dataset.restrict(entities={"burma", "china", "india", "indonesia"})
+        >>> restricted_dataset = full_dataset.restrict(entities={"burma", "china", "india", "indonesia"})
 
-        :param entities:
-            The entities to keep (or discard, cf. `invert_entity_selection`).
-            `None` corresponds to selecting all entities (but is handled more efficiently).
-        :param relations:
-            The relations to keep (or discard, cf. `invert_relation_selection`).
-            `None` corresponds to selecting all relations (but is handled more efficiently).
-        :param invert_entity_selection:
-            Whether to invert the entity selection, i.e., discard the selected entities rather than all remaining ones.
-        :param invert_relation_selection:
-            Whether to invert the relation selection, i.e., discard the selected relations rather than all remaining
-            ones.
+        :param entities: The entities to keep (or discard, cf. `invert_entity_selection`). `None` corresponds to
+            selecting all entities (but is handled more efficiently).
+        :param relations: The relations to keep (or discard, cf. `invert_relation_selection`). `None` corresponds to
+            selecting all relations (but is handled more efficiently).
+        :param invert_entity_selection: Whether to invert the entity selection, i.e., discard the selected entities
+            rather than all remaining ones.
+        :param invert_relation_selection: Whether to invert the relation selection, i.e., discard the selected relations
+            rather than all remaining ones.
 
-        :returns:
-            a new dataset with different entity and relation mappins and a restricted set of triples.
+        :returns: a new dataset with different entity and relation mappins and a restricted set of triples.
 
-        .. warning ::
-            This is different to :meth:`pykeen.triples.triples_factory.CoreTriplesFactory.new_with_restriction`
-            as it does modify the label to id mapping.
+        .. warning::
+
+            This is different to :meth:`pykeen.triples.triples_factory.CoreTriplesFactory.new_with_restriction` as it
+            does modify the label to id mapping.
         """
         # early termination for simple case
         if entities is None and relations is None:
@@ -576,10 +574,10 @@ class LazyDataset(Dataset):
     def _help_cache(self, cache_root: None | str | pathlib.Path) -> pathlib.Path:
         """Get the appropriate cache root directory.
 
-        :param cache_root: If none is passed, defaults to a subfolder of the
-            PyKEEN home directory defined in :data:`pykeen.constants.PYKEEN_HOME`.
-            The subfolder is named based on the class inheriting from
+        :param cache_root: If none is passed, defaults to a subfolder of the PyKEEN home directory defined in
+            :data:`pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
             :class:`pykeen.datasets.base.Dataset`.
+
         :returns: A path object for the calculated cache root directory
         """
         cache_root = normalize_path(cache_root, *self._cache_sub_directories(), mkdir=True, default=PYKEEN_DATASETS)
@@ -611,8 +609,8 @@ class PathDataset(LazyDataset):
         :param validation_path: Path to the validation triples file or validation triples file.
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param load_triples_kwargs: Arguments to pass through to :func:`TriplesFactory.from_path`
-            and ultimately through to :func:`pykeen.triples.utils.load_triples`.
+        :param load_triples_kwargs: Arguments to pass through to :func:`TriplesFactory.from_path` and ultimately through
+            to :func:`pykeen.triples.utils.load_triples`.
         """
         self.training_path = pathlib.Path(training_path)
         self.testing_path = pathlib.Path(testing_path)
@@ -683,14 +681,14 @@ class UnpackedRemoteDataset(PathDataset):
         :param training_url: The URL of the training file
         :param testing_url: The URL of the testing file
         :param validation_url: The URL of the validation file
-        :param cache_root:
-            An optional directory to store the extracted files. Is none is given, the default PyKEEN directory is used.
-            This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to ``~/.data/pykeen``.
+        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
+            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
+            ``~/.data/pykeen``.
         :param force: If true, redownload any cached files
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param load_triples_kwargs: Arguments to pass through to :func:`TriplesFactory.from_path`
-            and ultimately through to :func:`pykeen.triples.utils.load_triples`.
+        :param load_triples_kwargs: Arguments to pass through to :func:`TriplesFactory.from_path` and ultimately through
+            to :func:`pykeen.triples.utils.load_triples`.
         :param download_kwargs: Keyword arguments to pass to :func:`pystow.utils.download`
         """
         self.cache_root = self._help_cache(cache_root)
@@ -740,14 +738,13 @@ class RemoteDataset(PathDataset):
     ):
         """Initialize dataset.
 
-        :param url:
-            The url where to download the dataset from.
+        :param url: The url where to download the dataset from.
         :param relative_training_path: The path inside the cache root where the training path gets extracted
         :param relative_testing_path: The path inside the cache root where the testing path gets extracted
         :param relative_validation_path: The path inside the cache root where the validation path gets extracted
-        :param cache_root:
-            An optional directory to store the extracted files. Is none is given, the default PyKEEN directory is used.
-            This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to ``~/.data/pykeen``.
+        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
+            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
+            ``~/.data/pykeen``.
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         :param timeout: The timeout number of seconds for waiting to download the dataset. Defaults to 60.
@@ -834,13 +831,11 @@ class PackedZipRemoteDataset(LazyDataset):
         :param relative_training_path: The path inside the zip file for the training data
         :param relative_testing_path: The path inside the zip file for the testing data
         :param relative_validation_path: The path inside the zip file for the validation data
-        :param url:
-            The url where to download the dataset from
-        :param name:
-            The name of the file. If not given, tries to get the name from the end of the URL
-        :param cache_root:
-            An optional directory to store the extracted files. Is none is given, the default PyKEEN directory is used.
-            This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to ``~/.pykeen``.
+        :param url: The url where to download the dataset from
+        :param name: The name of the file. If not given, tries to get the name from the end of the URL
+        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
+            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
+            ``~/.pykeen``.
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
 
@@ -931,20 +926,16 @@ class CompressedSingleDataset(LazyDataset):
     ):
         """Initialize dataset.
 
-        :param url:
-            The url where to download the dataset from
-        :param relative_path:
-            The path inside the archive to the contained dataset.
-        :param name:
-            The name of the file. If not given, tries to get the name from the end of the URL
-        :param cache_root:
-            An optional directory to store the extracted files. Is none is given, the default PyKEEN directory is used.
-            This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to ``~/.pykeen``.
+        :param url: The url where to download the dataset from
+        :param relative_path: The path inside the archive to the contained dataset.
+        :param name: The name of the file. If not given, tries to get the name from the end of the URL
+        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
+            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
+            ``~/.pykeen``.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param random_state: An optional random state to make the training/testing/validation split reproducible.
-        :param delimiter:
-            The delimiter for the contained dataset.
+        :param delimiter: The delimiter for the contained dataset.
         :param read_csv_kwargs: Keyword arguments to pass through to :func:`pandas.read_csv`.
         """
         self.cache_root = self._help_cache(cache_root)
@@ -1047,9 +1038,9 @@ class TabbedDataset(LazyDataset):
     ):
         """Initialize dataset.
 
-        :param cache_root:
-            An optional directory to store the extracted files. Is none is given, the default PyKEEN directory is used.
-            This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to ``~/.pykeen``.
+        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
+            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
+            ``~/.pykeen``.
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         :param random_state: An optional random state to make the training/testing/validation split reproducible.
@@ -1114,13 +1105,11 @@ class SingleTabbedDataset(TabbedDataset):
     ):
         """Initialize dataset.
 
-        :param url:
-            The url where to download the dataset from
-        :param name:
-            The name of the file. If not given, tries to get the name from the end of the URL
-        :param cache_root:
-            An optional directory to store the extracted files. Is none is given, the default PyKEEN directory is used.
-            This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to ``~/.pykeen``.
+        :param url: The url where to download the dataset from
+        :param name: The name of the file. If not given, tries to get the name from the end of the URL
+        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
+            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
+            ``~/.pykeen``.
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         :param random_state: An optional random state to make the training/testing/validation split reproducible.

--- a/src/pykeen/datasets/ea/base.py
+++ b/src/pykeen/datasets/ea/base.py
@@ -37,27 +37,18 @@ class EADataset(EagerDataset):
         combination_kwargs: OptionalKwargs = None,
         **kwargs,
     ) -> None:
-        """
-        Initialize the dataset.
+        """Initialize the dataset.
 
-        :param side:
-            the side, if only a single graph should be considered, or `None` to combine the two graphs into a
+        :param side: the side, if only a single graph should be considered, or `None` to combine the two graphs into a
             single one, using `combination`.
-        :param create_inverse_triples:
-            whether to create inverse triples.
-        :param random_state:
-            the random state to use for reproducible splits
-        :param split_ratios:
-            the split ratios used to perform the train/test/validation split.
-        :param combination:
-            the graph combination. only effective if side is `None`
-        :param combination_kwargs:
-            additional keyword-based parameters for the graph combination
-        :param kwargs:
-            any additional keyword-based parameters are passed to :meth:`EagerDataset.__init__`.
+        :param create_inverse_triples: whether to create inverse triples.
+        :param random_state: the random state to use for reproducible splits
+        :param split_ratios: the split ratios used to perform the train/test/validation split.
+        :param combination: the graph combination. only effective if side is `None`
+        :param combination_kwargs: additional keyword-based parameters for the graph combination
+        :param kwargs: any additional keyword-based parameters are passed to :meth:`EagerDataset.__init__`.
 
-        :raises ValueError:
-            if an invalid side is passed
+        :raises ValueError: if an invalid side is passed
         """
         if side is None:
             # load both graphs

--- a/src/pykeen/datasets/inductive/base.py
+++ b/src/pykeen/datasets/inductive/base.py
@@ -162,12 +162,12 @@ class LazyInductiveDataset(InductiveDataset):
     ) -> pathlib.Path:
         """Get the appropriate cache root directory.
 
-        :param cache_root: If none is passed, defaults to a subfolder of the
-            PyKEEN home directory defined in :data:`pykeen.constants.PYKEEN_HOME`.
-            The subfolder is named based on the class inheriting from
+        :param cache_root: If none is passed, defaults to a subfolder of the PyKEEN home directory defined in
+            :data:`pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
             :class:`pykeen.datasets.base.Dataset`.
         :param version: accepts a string "v1" to "v4" to select among Teru et al inductive datasets
         :param sep_train_inference: a flag to store training and inference splits in different folders
+
         :returns: A path object for the calculated cache root directory
         """
         cache_root = normalize_path(
@@ -214,8 +214,8 @@ class DisjointInductivePathDataset(LazyInductiveDataset):
         :param inductive_validation_path: Path to the validation triples file or validation triples file.
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param load_triples_kwargs: Arguments to pass through to :func:`TriplesFactory.from_path`
-            and ultimately through to :func:`pykeen.triples.utils.load_triples`.
+        :param load_triples_kwargs: Arguments to pass through to :func:`TriplesFactory.from_path` and ultimately through
+            to :func:`pykeen.triples.utils.load_triples`.
         """
         self.transductive_training_path = pathlib.Path(transductive_training_path)
         self.inductive_inference_path = pathlib.Path(inductive_inference_path)
@@ -295,14 +295,14 @@ class UnpackedRemoteDisjointInductiveDataset(DisjointInductivePathDataset):
         :param inductive_inference_url: The URL of the inductive inference graph file
         :param inductive_testing_url: The URL of the inductive testing file
         :param inductive_validation_url: The URL of the inductive validation file
-        :param cache_root:
-            An optional directory to store the extracted files. Is none is given, the default PyKEEN directory is used.
-            This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to ``~/.data/pykeen``.
+        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
+            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
+            ``~/.data/pykeen``.
         :param force: If true, redownload any cached files
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param load_triples_kwargs: Arguments to pass through to :func:`TriplesFactory.from_path`
-            and ultimately through to :func:`pykeen.triples.utils.load_triples`.
+        :param load_triples_kwargs: Arguments to pass through to :func:`TriplesFactory.from_path` and ultimately through
+            to :func:`pykeen.triples.utils.load_triples`.
         :param download_kwargs: Keyword arguments to pass to :func:`pystow.utils.download`
         :param version: accepts a string "v1" to "v4" to select among Teru et al inductive datasets
         """

--- a/src/pykeen/datasets/mocks.py
+++ b/src/pykeen/datasets/mocks.py
@@ -19,28 +19,18 @@ def create_inductive_dataset(
     create_inverse_triples: bool = False,
     # num_triples_validation: Optional[int],
 ) -> InductiveDataset:
-    """
-    Create a random inductive dataset.
+    """Create a random inductive dataset.
 
-    :param num_relations:
-        the number of relations
-    :param num_entities_transductive:
-        the number of entities in the transductive part
-    :param num_triples_training:
-        the number of (transductive) training triples
-    :param num_entities_inductive:
-        the number of entities in the inductive part. defaults to `num_entities_transductive`
-    :param num_triples_inference:
-        the number of (inductive) inference triples. defaults to `num_triples_training`
-    :param num_triples_testing:
-        the number of (inductive) testing triples. defaults to `num_triples_training`
-    :param create_inverse_triples:
-        whether to create inverse triples
-    :param random_state:
-        the random state to use.
+    :param num_relations: the number of relations
+    :param num_entities_transductive: the number of entities in the transductive part
+    :param num_triples_training: the number of (transductive) training triples
+    :param num_entities_inductive: the number of entities in the inductive part. defaults to `num_entities_transductive`
+    :param num_triples_inference: the number of (inductive) inference triples. defaults to `num_triples_training`
+    :param num_triples_testing: the number of (inductive) testing triples. defaults to `num_triples_training`
+    :param create_inverse_triples: whether to create inverse triples
+    :param random_state: the random state to use.
 
-    :return:
-        an inductive dataset with random triples
+    :returns: an inductive dataset with random triples
     """
     return EagerInductiveDataset(
         transductive_training=generate_triples_factory(

--- a/src/pykeen/datasets/utils.py
+++ b/src/pykeen/datasets/utils.py
@@ -36,6 +36,7 @@ def iter_dataset_classes(
     :param max_triples: An optional maximum number of triples for the dataset
     :param min_triples: An optional minimum number of triples for the dataset
     :param use_tqdm: Should a progress bar be shown?
+
     :yields: Pairs of dataset names and dataset classes
     """
     from . import dataset_resolver
@@ -76,6 +77,7 @@ def iter_dataset_instances(
     :param max_triples: An optional maximum number of triples for the dataset
     :param min_triples: An optional minimum number of triples for the dataset
     :param use_tqdm: Should a progress bar be shown?
+
     :yields: Pairs of dataset names and dataset instances
     """
     for name, cls in iter_dataset_classes(
@@ -99,17 +101,17 @@ def get_dataset(
     """Get a dataset, cached based on the given kwargs.
 
     :param dataset: The name of a dataset, an instance of a dataset, or the class for a dataset.
-    :param dataset_kwargs: The keyword arguments, only to be used when a class for a dataset is used for
-        the ``dataset`` keyword argument.
+    :param dataset_kwargs: The keyword arguments, only to be used when a class for a dataset is used for the ``dataset``
+        keyword argument.
     :param training: A triples factory for training triples or a path to a training triples file if ``dataset=None``
-    :param testing: A triples factory for testing triples or a path to a testing triples file  if ``dataset=None``
-    :param validation: A triples factory for validation triples or a path to a validation triples file
-        if ``dataset=None``
+    :param testing: A triples factory for testing triples or a path to a testing triples file if ``dataset=None``
+    :param validation: A triples factory for validation triples or a path to a validation triples file if
+        ``dataset=None``
+
     :returns: An instantiated dataset
 
     :raises ValueError: for incorrect usage of the input of the function
-    :raises TypeError: If a type is given for ``dataset`` but it's not a subclass of
-        :class:`pykeen.datasets.Dataset`
+    :raises TypeError: If a type is given for ``dataset`` but it's not a subclass of :class:`pykeen.datasets.Dataset`
     """
     from . import dataset_resolver, has_dataset
 

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -99,11 +99,9 @@ class ClassificationEvaluator(Evaluator[ClassificationMetricKey]):
     all_positives: MutableMapping[Target, MutableMapping[tuple[int, int], np.ndarray]]
 
     def __init__(self, **kwargs):
-        """
-        Initialize the evaluator.
+        """Initialize the evaluator.
 
-        :param kwargs:
-            keyword-based parameters passed to :meth:`Evaluator.__init__`.
+        :param kwargs: keyword-based parameters passed to :meth:`Evaluator.__init__`.
         """
         super().__init__(
             filtered=False,

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -39,16 +39,13 @@ AdditionalFilterTriplesHint: TypeAlias = OneOrSequence[MappedTriples | CoreTripl
 
 
 def _hasher(d: Mapping[str, Any]) -> int:
-    """
-    Calculate hash based on ID of dataset.
+    """Calculate hash based on ID of dataset.
 
     This means that we can have separate batch sizes for different evaluation datasets.
 
-    :param d:
-        the dictionary of keyword-based parameters
+    :param d: the dictionary of keyword-based parameters
 
-    :return:
-        the dataset's ID
+    :returns: the dataset's ID
     """
     obj = d["loop"]
     assert isinstance(obj, EvaluationLoop)
@@ -64,25 +61,19 @@ def _evaluate(
     tqdm_kwargs: OptionalKwargs,
     **kwargs,
 ) -> MetricResults:
-    """
-    Run the evaluation loop for a given batch size.
+    """Run the evaluation loop for a given batch size.
 
     .. note::
+
         This method is wrapped into a `MemoryUtilizationMaximizer` instance to automatically tune the `batch_size`.
 
-    :param loop:
-        the evaluation loop instance.
-    :param batch_size:
-        the batch size
-    :param use_tqdm:
-        whether to use tqdm progress bar
-    :param tqdm_kwargs:
-        additional keyword-based parameters for the progress bar
-    :param kwargs:
-        additional keyword-based parameters passed to :meth:`EvaluationLoop.get_loader`
+    :param loop: the evaluation loop instance.
+    :param batch_size: the batch size
+    :param use_tqdm: whether to use tqdm progress bar
+    :param tqdm_kwargs: additional keyword-based parameters for the progress bar
+    :param kwargs: additional keyword-based parameters passed to :meth:`EvaluationLoop.get_loader`
 
-    :return:
-        the evaluation results
+    :returns: the evaluation results
     """
     loop.model.eval()
     loader = loop.get_loader(batch_size=batch_size, **kwargs)
@@ -110,15 +101,11 @@ class EvaluationLoop(Generic[BatchType]):
         dataset: Dataset[BatchType],
         evaluator: Evaluator,
     ) -> None:
-        """
-        Initialize the evaluation loop.
+        """Initialize the evaluation loop.
 
-        :param model:
-            the model to evaluate.
-        :param dataset:
-            the evaluation dataset
-        :param evaluator:
-            the evaluator instance
+        :param model: the model to evaluate.
+        :param dataset: the evaluation dataset
+        :param evaluator: the evaluator instance
         """
         self.model = model
         self.evaluator = evaluator
@@ -126,11 +113,9 @@ class EvaluationLoop(Generic[BatchType]):
 
     @abstractmethod
     def process_batch(self, batch: BatchType) -> None:
-        """
-        Process a single batch.
+        """Process a single batch.
 
-        :param batch:
-            one batch of evaluation samples from the dataset.
+        :param batch: one batch of evaluation samples from the dataset.
         """
         raise NotImplementedError
 
@@ -139,18 +124,13 @@ class EvaluationLoop(Generic[BatchType]):
         return None
 
     def get_loader(self, batch_size: int, pin_memory: bool = True, **kwargs) -> DataLoader:
-        """
-        Create a data loader for a single evaluation round.
+        """Create a data loader for a single evaluation round.
 
-        :param batch_size:
-            the batch size
-        :param pin_memory:
-            whether to pin memory, cf. :meth:`DataLoader.__init__`
-        :param kwargs:
-            additional keyword-based parameters passed to :meth:`DataLoader.__init__`
+        :param batch_size: the batch size
+        :param pin_memory: whether to pin memory, cf. :meth:`DataLoader.__init__`
+        :param kwargs: additional keyword-based parameters passed to :meth:`DataLoader.__init__`
 
-        :return:
-            a dataloader for the evaluation dataset of the given batch size
+        :returns: a dataloader for the evaluation dataset of the given batch size
         """
         return DataLoader(
             dataset=self.dataset,
@@ -172,23 +152,18 @@ class EvaluationLoop(Generic[BatchType]):
         # data loader
         **kwargs,
     ) -> MetricResults:
-        """
-        Evaluate the loop's model on the loop's dataset.
+        """Evaluate the loop's model on the loop's dataset.
 
         .. note::
+
             the contained model will be set to evaluation mode.
 
-        :param batch_size:
-            the batch size. If None, enable automatic memory optimization to maximize memory utilization.
-        :param use_tqdm:
-            whether to use tqdm progress bar
-        :param tqdm_kwargs:
-            additional keyword-based parameters passed to tqdm
-        :param kwargs:
-            additional keyword-based parameters passed to :meth:`get_loader`
+        :param batch_size: the batch size. If None, enable automatic memory optimization to maximize memory utilization.
+        :param use_tqdm: whether to use tqdm progress bar
+        :param tqdm_kwargs: additional keyword-based parameters passed to tqdm
+        :param kwargs: additional keyword-based parameters passed to :meth:`get_loader`
 
-        :return:
-            the evaluation results.
+        :returns: the evaluation results.
         """
         # set upper limit of batch size for automatic memory optimization
         batch_size = determine_maximum_batch_size(
@@ -221,19 +196,14 @@ class FilterIndex:
 
     @classmethod
     def from_df(cls, df: pandas.DataFrame, target: Target) -> "FilterIndex":
-        """
-        Create index from dataframe.
+        """Create index from dataframe.
 
-        :param df:
-            the dataframe, comprising columns [LABEL_HEAD, LABEL_RELATION, LABEL_TAIL]
-        :param target:
-            the prediction target
+        :param df: the dataframe, comprising columns [LABEL_HEAD, LABEL_RELATION, LABEL_TAIL]
+        :param target: the prediction target
 
-        :raises ValueError:
-            if some of the expected columns are missing
+        :returns: a filter index object
 
-        :return:
-            a filter index object
+        :raises ValueError: if some of the expected columns are missing
         """
         # input verification
         expected_columns = set(COLUMN_LABELS)
@@ -279,19 +249,13 @@ class LCWAEvaluationDataset(Dataset[Mapping[Target, tuple[MappedTriples, torch.T
         filtered: bool = True,
         additional_filter_triples: AdditionalFilterTriplesHint = None,
     ) -> None:
-        """
-        Create a PyTorch dataset for link prediction evaluation.
+        """Create a PyTorch dataset for link prediction evaluation.
 
-        :param mapped_triples: shape: (n, 3)
-            the ID-based triples
-        :param factory:
-            the triples factory. Only used of `mapped_triples` is None
-        :param targets:
-            the prediction targets. Defaults to head and tail prediction
-        :param filtered:
-            whether to use filtered evaluation, i.e., prepare filter indices
-        :param additional_filter_triples:
-            additional filter triples to use for creating the filter
+        :param mapped_triples: shape: (n, 3) the ID-based triples
+        :param factory: the triples factory. Only used of `mapped_triples` is None
+        :param targets: the prediction targets. Defaults to head and tail prediction
+        :param filtered: whether to use filtered evaluation, i.e., prepare filter indices
+        :param additional_filter_triples: additional filter triples to use for creating the filter
         """
         super().__init__()
 
@@ -372,8 +336,7 @@ class LCWAEvaluationDataset(Dataset[Mapping[Target, tuple[MappedTriples, torch.T
 
 
 class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
-    r"""
-    Evaluation loop using 1:n scoring.
+    r"""Evaluation loop using 1:n scoring.
 
     For brevity, we only describe evaluation for tail prediction. Let $(h, r, t) \in \mathcal{T}_{eval}$ denote an
     evaluation triple. Then, we calculate scores for all triples $(h, r, t')$ with $t' \in \mathcal{E}$, i.e., for
@@ -390,24 +353,16 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
         additional_filter_triples: AdditionalFilterTriplesHint = None,
         **kwargs,
     ) -> None:
-        """
-        Initialize the evaluation loop.
+        """Initialize the evaluation loop.
 
-        :param triples_factory:
-            the evaluation triples factory
-        :param evaluator:
-            the evaluator, or a hint thereof
-        :param evaluator_kwargs:
-            additional keyword-based parameters for instantiating the evaluator
-        :param targets:
-            the prediction targets.
-        :param mode:
-            the inductive mode, or None for transductive evaluation
-        :param additional_filter_triples:
-            additional filter triples to use for creating the filter
-        :param kwargs:
-            additional keyword-based parameters passed to :meth:`EvaluationLoop.__init__`. Should not contain the keys
-            `dataset` or `evaluator`.
+        :param triples_factory: the evaluation triples factory
+        :param evaluator: the evaluator, or a hint thereof
+        :param evaluator_kwargs: additional keyword-based parameters for instantiating the evaluator
+        :param targets: the prediction targets.
+        :param mode: the inductive mode, or None for transductive evaluation
+        :param additional_filter_triples: additional filter triples to use for creating the filter
+        :param kwargs: additional keyword-based parameters passed to :meth:`EvaluationLoop.__init__`. Should not contain
+            the keys `dataset` or `evaluator`.
         """
         # avoid cyclic imports
         from . import evaluator_resolver

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -65,14 +65,11 @@ class MetricResults(Generic[MetricKeyType]):
     @classmethod
     @abstractmethod
     def key_from_string(cls, s: str | None) -> MetricKeyType:
-        """
-        Parse the metric key from a (un-normalized) string.
+        """Parse the metric key from a (un-normalized) string.
 
-        :param s:
-            the metric key, or `None` to get the default key.
+        :param s: the metric key, or `None` to get the default key.
 
-        :return:
-            the fully resolved key as a named tuple
+        :returns: the fully resolved key as a named tuple
         """
         raise NotImplementedError
 
@@ -92,6 +89,7 @@ class MetricResults(Generic[MetricKeyType]):
         """Get the given metric from the results.
 
         :param name: The name of the metric
+
         :returns: The value for the metric
         """
         return self.data[self.string_or_key_to_key(name)]
@@ -146,8 +144,7 @@ class Evaluator(ABC, Generic[MetricKeyType]):
         :param requires_positive_mask: Does the evaluator need access to the masks?
         :param batch_size: >0. Evaluation batch size.
         :param slice_size: >0. The divisor for the scoring function when using slicing
-        :param mode:
-            the inductive mode, or None for transductive evaluation
+        :param mode: the inductive mode, or None for transductive evaluation
         """
         self.filtered = filtered
         self.requires_positive_mask = requires_positive_mask
@@ -172,12 +169,11 @@ class Evaluator(ABC, Generic[MetricKeyType]):
         """Process a batch of triples with their computed scores for all entities.
 
         :param hrt_batch: shape: (batch_size, 3)
-        :param target:
-            the prediction target
+        :param target: the prediction target
         :param scores: shape: (batch_size, num_entities)
         :param true_scores: shape: (batch_size, 1)
-        :param dense_positive_mask: shape: (batch_size, num_entities)
-            An optional binary (0/1) tensor indicating other true entities.
+        :param dense_positive_mask: shape: (batch_size, num_entities) An optional binary (0/1) tensor indicating other
+            true entities.
         """
         raise NotImplementedError
 
@@ -209,58 +205,44 @@ class Evaluator(ABC, Generic[MetricKeyType]):
     ) -> MetricResults[MetricKeyType]:
         """Evaluate metrics for model on mapped triples.
 
-        :param model:
-            The model to evaluate.
-        :param mapped_triples:
-            The triples on which to evaluate. The mapped triples should *never* contain inverse triples - these are
-            created by the model class on the fly.
-        :param batch_size: >0
-            A positive integer used as batch size. Generally chosen as large as possible. Defaults to 1 if None.
-        :param slice_size: >0
-            The divisor for the scoring function when using slicing.
-        :param device:
-            The device on which the evaluation shall be run. If None is given, use the model's device.
-        :param use_tqdm:
-            Should a progress bar be displayed?
-        :param tqdm_kwargs:
-            Additional keyword based arguments passed to the progress bar.
-        :param restrict_entities_to:
-            Optionally restrict the evaluation to the given entity IDs. This may be useful if one is only interested in
-            a part of the entities, e.g. due to type constraints, but wants to train on all available data. For ranking
-            the entities, we still compute all scores for all possible replacement entities to avoid irregular access
-            patterns which might decrease performance, but the scores will afterward be filtered to only keep those of
-            interest. If provided, we assume by default that the triples are already filtered, such that it only
-            contains the entities of interest. To explicitly filter within this method, pass
+        :param model: The model to evaluate.
+        :param mapped_triples: The triples on which to evaluate. The mapped triples should *never* contain inverse
+            triples - these are created by the model class on the fly.
+        :param batch_size: >0 A positive integer used as batch size. Generally chosen as large as possible. Defaults to
+            1 if None.
+        :param slice_size: >0 The divisor for the scoring function when using slicing.
+        :param device: The device on which the evaluation shall be run. If None is given, use the model's device.
+        :param use_tqdm: Should a progress bar be displayed?
+        :param tqdm_kwargs: Additional keyword based arguments passed to the progress bar.
+        :param restrict_entities_to: Optionally restrict the evaluation to the given entity IDs. This may be useful if
+            one is only interested in a part of the entities, e.g. due to type constraints, but wants to train on all
+            available data. For ranking the entities, we still compute all scores for all possible replacement entities
+            to avoid irregular access patterns which might decrease performance, but the scores will afterward be
+            filtered to only keep those of interest. If provided, we assume by default that the triples are already
+            filtered, such that it only contains the entities of interest. To explicitly filter within this method, pass
             `pre_filtered_triples=False`.
-        :param restrict_relations_to:
-            Optionally restrict the evaluation to the given relation IDs. This may be useful if one is only interested
-            in a part of the relations, e.g. due to relation types, but wants to train on all available data.
-            If provided, we assume by default that the triples are already filtered, such that it only contains the
-            relations of interest. To explicitly filter within this method, pass `pre_filtered_triples=False`.
-        :param do_time_consuming_checks:
-            Whether to perform some time-consuming checks on the provided arguments. Currently, this encompasses only:
-            If `restrict_entities_to` or `restrict_relations_to` is not `None`, check whether the triples have been
-            filtered. Disabling this option can accelerate the method. Only effective if `pre_filtered_triples` is set
-            to `True`.
-        :param pre_filtered_triples:
-            Whether the triples have been pre-filtered to adhere to `restrict_entities_to` / `restrict_relations_to`.
-            When set to `True`, and the triples have *not* been filtered, the results may be invalid. Pre-filtering the
-            triples accelerates this method, and is recommended when evaluating multiple times on the same set of
-            triples.
-        :param additional_filter_triples:
-            additional true triples to filter out during filtered evaluation.
-        :param targets:
-            the prediction targets
+        :param restrict_relations_to: Optionally restrict the evaluation to the given relation IDs. This may be useful
+            if one is only interested in a part of the relations, e.g. due to relation types, but wants to train on all
+            available data. If provided, we assume by default that the triples are already filtered, such that it only
+            contains the relations of interest. To explicitly filter within this method, pass
+            `pre_filtered_triples=False`.
+        :param do_time_consuming_checks: Whether to perform some time-consuming checks on the provided arguments.
+            Currently, this encompasses only: If `restrict_entities_to` or `restrict_relations_to` is not `None`, check
+            whether the triples have been filtered. Disabling this option can accelerate the method. Only effective if
+            `pre_filtered_triples` is set to `True`.
+        :param pre_filtered_triples: Whether the triples have been pre-filtered to adhere to `restrict_entities_to` /
+            `restrict_relations_to`. When set to `True`, and the triples have *not* been filtered, the results may be
+            invalid. Pre-filtering the triples accelerates this method, and is recommended when evaluating multiple
+            times on the same set of triples.
+        :param additional_filter_triples: additional true triples to filter out during filtered evaluation.
+        :param targets: the prediction targets
 
-        :raises NotImplementedError:
-            if relation prediction evaluation is requested
-        :raises ValueError:
-            if the pre_filtered_triples contain unwanted entities (can only be detected with the time-consuming checks).
-        :raises MemoryError:
-            if the evaluation fails on cpu
+        :returns: the evaluation results
 
-        :return:
-            the evaluation results
+        :raises NotImplementedError: if relation prediction evaluation is requested
+        :raises ValueError: if the pre_filtered_triples contain unwanted entities (can only be detected with the
+            time-consuming checks).
+        :raises MemoryError: if the evaluation fails on cpu
         """
         if LABEL_RELATION in targets:
             raise NotImplementedError("cf. https://github.com/pykeen/pykeen/pull/728")
@@ -402,20 +384,14 @@ class Evaluator(ABC, Generic[MetricKeyType]):
 
     @staticmethod
     def _check_slicing_availability(model: Model, batch_size: int, entities: bool, relations: bool) -> None:
-        """
-        Raise an error if the necessary slicing operations are not supported.
+        """Raise an error if the necessary slicing operations are not supported.
 
-        :param model:
-            the model
-        :param batch_size:
-            the batch-size; only used for creating the error message
-        :param entities:
-            whether entities need to be scored
-        :param relations:
-            whether relations need to be scored
+        :param model: the model
+        :param batch_size: the batch-size; only used for creating the error message
+        :param entities: whether entities need to be scored
+        :param relations: whether relations need to be scored
 
-        :raises MemoryError:
-            if the necessary slicing operations are not supported by the model
+        :raises MemoryError: if the necessary slicing operations are not supported by the model
         """
         reasons = []
         if entities:
@@ -473,31 +449,23 @@ def evaluate(
     targets: Collection[Target],
     **kwargs,
 ) -> MetricResults:
-    """
-    Evaluate a model with the given evaluator.
+    """Evaluate a model with the given evaluator.
 
-    .. note ::
+    .. note::
+
         This method is decorated by maximize_memory_utilization, which reduce the parameters `batch_size` and
         `slice_size`, if necessary due to memory constraints.
 
-    :param evaluator:
-        the evaluator instance that is used for evaluation
-    :param mapped_triples:
-        the evaluation triples
-    :param batch_size:
-        the (maximum) batch size. It will be reduced when (GPU) out-of-memory problems occur.
-    :param slice_size:
-        the (maximum) slice size. It will be reduced when (GPU) out-of-memory problems occur, and batch size reduction
-        could not resolve the issue.
-    :param progress_bar:
-        whether to display a progress bar
-    :param targets:
-        the evaluation targets
-    :param kwargs:
-        additional keyword-based parameters are passed to :meth:`_evaluate_batch`.
+    :param evaluator: the evaluator instance that is used for evaluation
+    :param mapped_triples: the evaluation triples
+    :param batch_size: the (maximum) batch size. It will be reduced when (GPU) out-of-memory problems occur.
+    :param slice_size: the (maximum) slice size. It will be reduced when (GPU) out-of-memory problems occur, and batch
+        size reduction could not resolve the issue.
+    :param progress_bar: whether to display a progress bar
+    :param targets: the evaluation targets
+    :param kwargs: additional keyword-based parameters are passed to :meth:`_evaluate_batch`.
 
-    :return:
-        the evaluation result
+    :returns: the evaluation result
     """
     # todo: maybe we want to have some more keys outside of kwargs for hashing / have more visibility about
     #  what is passed around
@@ -537,24 +505,18 @@ def create_sparse_positive_filter_(
     For each (h, r, t) triple in the batch, the entity identifiers are computed such that (h', r, t) exists in all
     positive triples.
 
-    :param hrt_batch: shape: (batch_size, 3)
-        A batch of triples.
-    :param all_pos_triples: shape: (num_positive_triples, 3)
-        All positive triples to base the filtering on.
-    :param relation_filter: shape: (batch_size, num_positive_triples)
-        A boolean mask R[i, j] which is True iff the j-th positive triple contains the same relation as the i-th triple
-        in the batch.
-    :param filter_col:
-        The column along which to filter. Allowed are {0, 2}, where 0 corresponds to filtering head-based and 2
-        corresponds to filtering tail-based.
+    :param hrt_batch: shape: (batch_size, 3) A batch of triples.
+    :param all_pos_triples: shape: (num_positive_triples, 3) All positive triples to base the filtering on.
+    :param relation_filter: shape: (batch_size, num_positive_triples) A boolean mask R[i, j] which is True iff the j-th
+        positive triple contains the same relation as the i-th triple in the batch.
+    :param filter_col: The column along which to filter. Allowed are {0, 2}, where 0 corresponds to filtering head-based
+        and 2 corresponds to filtering tail-based.
 
-    :return:
-        - positives, shape: (2, m)
-            The indices of positives in format [(batch_index, entity_id)].
+    :returns: - positives, shape: (2, m)
+              The indices of positives in format [(batch_index, entity_id)].
         - the relation filter for re-usage.
 
-    :raises NotImplementedError:
-        if the `filter_col` is not in `{0, 2}`
+    :raises NotImplementedError: if the `filter_col` is not in `{0, 2}`
     """
     if filter_col not in {0, 2}:
         raise NotImplementedError(
@@ -583,12 +545,10 @@ def create_dense_positive_mask_(
 ) -> FloatTensor:
     """Construct dense positive mask.
 
-    :param zero_tensor: shape: (batch_size, num_entities)
-        A tensor of zeros of suitable shape.
-    :param filter_batch: shape: (m, 2)
-        The indices of all positives in format (batch_index, entity_id)
-    :return:
-        The dense positive mask with x[b, i] = 1 iff (b, i) in filter_batch.
+    :param zero_tensor: shape: (batch_size, num_entities) A tensor of zeros of suitable shape.
+    :param filter_batch: shape: (m, 2) The indices of all positives in format (batch_index, entity_id)
+
+    :returns: The dense positive mask with x[b, i] = 1 iff (b, i) in filter_batch.
     """
     zero_tensor[filter_batch[:, 0], filter_batch[:, 1]] = 1
 
@@ -601,13 +561,11 @@ def filter_scores_(
 ) -> FloatTensor:
     """Filter scores by setting true scores to NaN.
 
-    :param scores: shape: (batch_size, num_entities)
-        The scores for all corrupted triples (including the currently considered true triple). Are modified *in-place*.
-    :param filter_batch: (m, 2)
-        The indices of all positives.
+    :param scores: shape: (batch_size, num_entities) The scores for all corrupted triples (including the currently
+        considered true triple). Are modified *in-place*.
+    :param filter_batch: (m, 2) The indices of all positives.
 
-    :return:
-        A reference to the scores, which have been updated in-place.
+    :returns: A reference to the scores, which have been updated in-place.
     """
     # Bind shape
     num_entities = scores.shape[1]
@@ -637,33 +595,22 @@ def _evaluate_batch(
     *,
     mode: InductiveMode | None,
 ) -> BoolTensor:
-    """
-    Evaluate ranking for batch.
+    """Evaluate ranking for batch.
 
-    :param batch: shape: (batch_size, 3)
-        The batch of currently evaluated triples.
-    :param model:
-        The model to evaluate.
-    :param target:
-        The prediction target.
-    :param evaluator:
-        The evaluator
-    :param slice_size:
-        An optional slice size for computing the scores.
-    :param all_pos_triples:
-        All positive triples (required if filtering is necessary).
-    :param relation_filter:
-        The relation filter. Can be re-used.
-    :param restrict_entities_to:
-        Restriction to evaluate only for these entities.
-    :param mode:
-        the inductive mode, or None for transductive evaluation
+    :param batch: shape: (batch_size, 3) The batch of currently evaluated triples.
+    :param model: The model to evaluate.
+    :param target: The prediction target.
+    :param evaluator: The evaluator
+    :param slice_size: An optional slice size for computing the scores.
+    :param all_pos_triples: All positive triples (required if filtering is necessary).
+    :param relation_filter: The relation filter. Can be re-used.
+    :param restrict_entities_to: Restriction to evaluate only for these entities.
+    :param mode: the inductive mode, or None for transductive evaluation
 
-    :raises ValueError:
-        if all positive triples are required (either due to filtered evaluation, or requiring dense masks).
+    :returns: The relation filter, which can be re-used for the same batch.
 
-    :return:
-        The relation filter, which can be re-used for the same batch.
+    :raises ValueError: if all positive triples are required (either due to filtered evaluation, or requiring dense
+        masks).
     """
     scores = model.predict(hrt_batch=batch, target=target, slice_size=slice_size, mode=mode)
 
@@ -730,22 +677,19 @@ def get_candidate_set_size(
     additional_filter_triples: None | MappedTriples | list[MappedTriples] = None,
     num_entities: int | None = None,
 ) -> pandas.DataFrame:
-    """
-    Calculate the candidate set sizes for head/tail prediction for the given triples.
+    """Calculate the candidate set sizes for head/tail prediction for the given triples.
 
-    :param mapped_triples: shape: (n, 3)
-        the evaluation triples
-    :param restrict_entities_to:
-        The entity IDs of interest. If None, defaults to all entities. cf. :func:`restrict_triples`.
-    :param restrict_relations_to:
-        The relations IDs of interest. If None, defaults to all relations. cf. :func:`restrict_triples`.
-    :param additional_filter_triples: shape: (n, 3)
-        additional filter triples besides the evaluation triples themselves. cf. `_prepare_filter_triples`.
-    :param num_entities:
-        the number of entities. If not given, this number is inferred from all triples
+    :param mapped_triples: shape: (n, 3) the evaluation triples
+    :param restrict_entities_to: The entity IDs of interest. If None, defaults to all entities. cf.
+        :func:`restrict_triples`.
+    :param restrict_relations_to: The relations IDs of interest. If None, defaults to all relations. cf.
+        :func:`restrict_triples`.
+    :param additional_filter_triples: shape: (n, 3) additional filter triples besides the evaluation triples themselves.
+        cf. `_prepare_filter_triples`.
+    :param num_entities: the number of entities. If not given, this number is inferred from all triples
 
-    :return: columns: "index" | "head" | "relation" | "tail" | "head_candidates" | "tail_candidates"
-        a dataframe of all evaluation triples, with the number of head and tail candidates
+    :returns: columns: "index" | "head" | "relation" | "tail" | "head_candidates" | "tail_candidates" a dataframe of all
+        evaluation triples, with the number of head and tail candidates
     """
     # optionally restrict triples (nop if no restriction)
     mapped_triples = restrict_triples(
@@ -802,16 +746,12 @@ def get_candidate_set_size(
 def normalize_flattened_metric_results(
     result: Mapping[str, Any], metric_result_cls: type[MetricResults] | None = None
 ) -> Mapping[str, Any]:
-    """
-    Flatten metric result dictionary and normalize metric keys.
+    """Flatten metric result dictionary and normalize metric keys.
 
-    :param result:
-        the result dictionary.
-    :param metric_result_cls:
-        the metric result class providing metric name normalization
+    :param result: the result dictionary.
+    :param metric_result_cls: the metric result class providing metric name normalization
 
-    :return:
-        the flattened metric results with normalized metric names.
+    :returns: the flattened metric results with normalized metric names.
     """
     # avoid cyclic imports
     from .rank_based_evaluator import RankBasedMetricResults

--- a/src/pykeen/evaluation/ogb_evaluator.py
+++ b/src/pykeen/evaluation/ogb_evaluator.py
@@ -96,39 +96,27 @@ def evaluate_ogb(
     tqdm_kwargs: Mapping[str, Any] | None = None,
     targets: Collection[Target] = (LABEL_HEAD, LABEL_TAIL),
 ) -> MetricResults:
-    """
-    Evaluate a model using OGB's evaluator.
+    """Evaluate a model using OGB's evaluator.
 
-    :param evaluator:
-        An evaluator
-    :param model:
-        the model; will be set to evaluation mode.
-    :param mapped_triples:
-        the evaluation triples
+    :param evaluator: An evaluator
+    :param model: the model; will be set to evaluation mode.
+    :param mapped_triples: the evaluation triples
 
-        .. note ::
+        .. note::
+
             the evaluation triples have to match with the stored explicit negatives
-    :param device:
-            The device on which the evaluation shall be run. If None is given, use the model's device.
 
-    :param batch_size:
-        the batch size
-    :param slice_size: >0
-        The divisor for the scoring function when using slicing.
-    :param use_tqdm:
-        Should a progress bar be displayed?
-    :param tqdm_kwargs:
-        Additional keyword based arguments passed to the progress bar.
-    :param targets:
-        the prediction targets
+    :param device: The device on which the evaluation shall be run. If None is given, use the model's device.
+    :param batch_size: the batch size
+    :param slice_size: >0 The divisor for the scoring function when using slicing.
+    :param use_tqdm: Should a progress bar be displayed?
+    :param tqdm_kwargs: Additional keyword based arguments passed to the progress bar.
+    :param targets: the prediction targets
 
-    :return:
-        the evaluation results
+    :returns: the evaluation results
 
-    :raises ImportError:
-        if ogb is not installed
-    :raises ValueError:
-        if illegal ``additional_filter_triples`` argument is given in the kwargs
+    :raises ImportError: if ogb is not installed
+    :raises ValueError: if illegal ``additional_filter_triples`` argument is given in the kwargs
     """
     try:
         import ogb.linkproppred

--- a/src/pykeen/experiments/cli.py
+++ b/src/pykeen/experiments/cli.py
@@ -170,8 +170,7 @@ def _help_reproduce(
     :param save_replicates: Should the artifacts of the replicates be saved?
     :param file_name: Name of JSON/YAML file (optional)
     :param extra_config: Extra configuration path
-    :param keep_seed:
-        whether to keep a random seed if given as part of the configuration
+    :param keep_seed: whether to keep a random seed if given as part of the configuration
     """
     from pykeen.pipeline import replicate_pipeline_from_path
 

--- a/src/pykeen/experiments/inverse_stability.py
+++ b/src/pykeen/experiments/inverse_stability.py
@@ -1,7 +1,6 @@
 """Inverse Stability Workflow.
 
 This experiment investigates the differences between
-
 """
 
 import itertools as itt

--- a/src/pykeen/hpo/__main__.py
+++ b/src/pykeen/hpo/__main__.py
@@ -1,8 +1,8 @@
 """Entrypoint module, in case you use ``python -m pykeen.hpo``.
 
 Why does this file exist, and why ``__main__``? For more info, read:
- - https://www.python.org/dev/peps/pep-0338/
- - https://docs.python.org/3/using/cmdline.html#cmdoption-m
+    - https://www.python.org/dev/peps/pep-0338/
+    - https://docs.python.org/3/using/cmdline.html#cmdoption-m
 """
 
 from .cli import optimize

--- a/src/pykeen/metrics/classification.py
+++ b/src/pykeen/metrics/classification.py
@@ -1,9 +1,9 @@
-"""
-Classification metrics.
+"""Classification metrics.
 
 The metrics in this module assume the link prediction setting to be a (binary) classification of individual triples.
 
-.. note ::
+.. note::
+
     many metrics in this module use `scikit-learn` under the hood, cf.
     https://scikit-learn.org/stable/modules/model_evaluation.html#classification-metrics
 """
@@ -35,18 +35,13 @@ ZeroDivisionPolicy = Literal["warn", 0, 1]
 
 
 def safe_divide(numerator: float, denominator: float, zero_division: ZeroDivisionPolicy = "warn") -> float:
-    """
-    Perform division and handle divide-by-zero similar to scikit-learn.
+    """Perform division and handle divide-by-zero similar to scikit-learn.
 
-    :param numerator:
-        the numerator
-    :param denominator:
-        the denominator
-    :param zero_division:
-        the zero-division policy; If "warn", act like 0, but warn about the case.
+    :param numerator: the numerator
+    :param denominator: the denominator
+    :param zero_division: the zero-division policy; If "warn", act like 0, but warn about the case.
 
-    :return:
-        the division result
+    :returns: the division result
     """
     # todo: do we need numpy support?
     if denominator != 0:
@@ -64,24 +59,21 @@ def safe_divide(numerator: float, denominator: float, zero_division: ZeroDivisio
 def construct_indicator(*, y_score: numpy.ndarray, y_true: numpy.ndarray) -> numpy.ndarray:
     """Construct binary indicators from a list of scores.
 
-    If there are $n$ positively labeled entries in ``y_true``, this function
-    assigns the top $n$ highest scores in ``y_score`` as positive and remainder
-    as negative.
+    If there are $n$ positively labeled entries in ``y_true``, this function assigns the top $n$ highest scores in
+    ``y_score`` as positive and remainder as negative.
 
-    .. note ::
-        Since the method uses the number of true labels to determine a threshold, the
-        results will typically be overly optimistic estimates of the generalization performance.
+    .. note::
 
-    .. todo ::
-        Add a method which estimates a threshold based on a validation set, and applies this
-        threshold for binarization on the test set.
+        Since the method uses the number of true labels to determine a threshold, the results will typically be overly
+        optimistic estimates of the generalization performance.
 
-    :param y_score:
-        A 1-D array of the score values
-    :param y_true:
-        A 1-D array of binary values (1 and 0)
-    :return:
-        A 1-D array of indicator values
+    .. todo:: Add a method which estimates a threshold based on a validation set, and applies this
+    threshold for binarization on the test set.
+
+    :param y_score: A 1-D array of the score values
+    :param y_true: A 1-D array of binary values (1 and 0)
+
+    :returns: A 1-D array of indicator values
 
     .. seealso::
 
@@ -102,21 +94,18 @@ class ClassificationMetric(Metric, abc.ABC):
     def __call__(self, y_true: numpy.ndarray, y_score: numpy.ndarray, weights: numpy.ndarray | None = None) -> float:
         """Evaluate the metric.
 
-        :param y_true: shape: (num_samples,)
-            the true labels, either 0 or 1.
-        :param y_score: shape: (num_samples,)
-            the predictions, either continuous or binarized.
-        :param weights: shape: (num_samples,)
-            weights for individual predictions
+        :param y_true: shape: (num_samples,) the true labels, either 0 or 1.
+        :param y_score: shape: (num_samples,) the predictions, either continuous or binarized.
+        :param weights: shape: (num_samples,) weights for individual predictions
 
-            .. warning ::
+            .. warning::
+
                 not all metrics support sample weights - check :attr:`supports_weights` first
 
-        :return:
-            the scalar metric value
 
-        :raises ValueError:
-            when weights are provided but the function does not support them.
+        :returns: the scalar metric value
+
+        :raises ValueError: when weights are provided but the function does not support them.
         """
         if weights is None:
             return self.forward(y_true=y_true, y_score=y_score)
@@ -128,19 +117,14 @@ class ClassificationMetric(Metric, abc.ABC):
     def forward(
         self, y_true: numpy.ndarray, y_score: numpy.ndarray, sample_weight: numpy.ndarray | None = None
     ) -> float:
-        """
-        Calculate the metric.
+        """Calculate the metric.
 
-        :param y_true: shape: (num_samples,)
-            the true label, either 0 or 1.
-        :param y_score: shape: (num_samples,)
-            the predictions, either as continuous scores, or as binarized prediction
+        :param y_true: shape: (num_samples,) the true label, either 0 or 1.
+        :param y_score: shape: (num_samples,) the predictions, either as continuous scores, or as binarized prediction
             (depending on the concrete metric at hand).
-        :param sample_weight: shape: (num_samples,)
-            sample weights
+        :param sample_weight: shape: (num_samples,) sample weights
 
-        :return:
-            a scalar metric value
+        :returns: a scalar metric value
 
         # noqa:DAR202
         """
@@ -148,8 +132,7 @@ class ClassificationMetric(Metric, abc.ABC):
 
 @parse_docdata
 class NumScores(ClassificationMetric):
-    """
-    The number of scores.
+    """The number of scores.
 
     Lower numbers may indicate unreliable results.
     ---
@@ -181,8 +164,7 @@ class BinarizedClassificationMetric(ClassificationMetric, abc.ABC):
 
 @parse_docdata
 class BalancedAccuracyScore(BinarizedClassificationMetric):
-    """
-    The average of recall obtained on each class.
+    """The average of recall obtained on each class.
 
     ---
     link: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.balanced_accuracy_score.html
@@ -206,9 +188,10 @@ class BalancedAccuracyScore(BinarizedClassificationMetric):
 class AveragePrecisionScore(ClassificationMetric):
     """The average precision from prediction scores.
 
-    .. note ::
-        this metric is different from the area under the precision-recall curve, which uses
-        interpolation and can be too optimistic.
+    .. note::
+
+        this metric is different from the area under the precision-recall curve, which uses interpolation and can be too
+        optimistic.
 
     ---
     link: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.average_precision_score.html
@@ -232,8 +215,7 @@ class AveragePrecisionScore(ClassificationMetric):
 
 @parse_docdata
 class AreaUnderTheReceiverOperatingCharacteristicCurve(ClassificationMetric):
-    """
-    The area under the receiver operating characteristic curve.
+    """The area under the receiver operating characteristic curve.
 
     ---
     link: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html
@@ -286,10 +268,10 @@ class ConfusionMatrixClassificationMetric(ClassificationMetric, abc.ABC):
 
 @parse_docdata
 class TruePositiveRate(ConfusionMatrixClassificationMetric):
-    """
-    The true positive rate is the probability that the prediction is positive, given the triple is truly positive.
+    """The true positive rate is the probability that the prediction is positive, given the triple is truly positive.
 
-    .. math ::
+    .. math::
+
         TPR = TP / (TP + FN)
 
     ---
@@ -311,15 +293,16 @@ class TruePositiveRate(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class TrueNegativeRate(ConfusionMatrixClassificationMetric):
-    """
-    The true negative rate is the probability that the prediction is negative, given the triple is truly negative.
+    """The true negative rate is the probability that the prediction is negative, given the triple is truly negative.
 
-    .. math ::
+    .. math::
+
         TNR = TN / (TN + FP)
 
-    .. warning ::
-        most knowledge graph datasets do not have true negatives, i.e., verified false facts, but rather are
-        collection of (mostly) true facts, where the missing ones are generally unknown rather than false.
+    .. warning::
+
+        most knowledge graph datasets do not have true negatives, i.e., verified false facts, but rather are collection
+        of (mostly) true facts, where the missing ones are generally unknown rather than false.
 
     ---
     link: https://en.wikipedia.org/wiki/Specificity_(tests)
@@ -340,10 +323,10 @@ class TrueNegativeRate(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class FalsePositiveRate(ConfusionMatrixClassificationMetric):
-    """
-    The false positive rate is the probability that the prediction is positive, given the triple is truly negative.
+    """The false positive rate is the probability that the prediction is positive, given the triple is truly negative.
 
-    .. math ::
+    .. math::
+
         FPR = FP / (FP + TN)
 
     ---
@@ -365,10 +348,10 @@ class FalsePositiveRate(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class FalseNegativeRate(ConfusionMatrixClassificationMetric):
-    """
-    The false negative rate is the probability that the prediction is negative, given the triple is truly positive.
+    """The false negative rate is the probability that the prediction is negative, given the triple is truly positive.
 
-    .. math ::
+    .. math::
+
         FNR = FN / (FN + TP)
 
     ---
@@ -390,10 +373,10 @@ class FalseNegativeRate(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class PositivePredictiveValue(ConfusionMatrixClassificationMetric):
-    """
-    The positive predictive value is the proportion of predicted positives which are true positive.
+    """The positive predictive value is the proportion of predicted positives which are true positive.
 
-    .. math ::
+    .. math::
+
         PPV = TP / (TP + FP)
 
     ---
@@ -415,10 +398,10 @@ class PositivePredictiveValue(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class NegativePredictiveValue(ConfusionMatrixClassificationMetric):
-    """
-    The negative predictive value is the proportion of predicted negatives which are true negative.
+    """The negative predictive value is the proportion of predicted negatives which are true negative.
 
-    .. math ::
+    .. math::
+
         NPV = TN / (TN + FN)
 
     ---
@@ -440,10 +423,10 @@ class NegativePredictiveValue(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class FalseDiscoveryRate(ConfusionMatrixClassificationMetric):
-    """
-    The false discovery rate is the proportion of predicted negatives which are true positive.
+    """The false discovery rate is the proportion of predicted negatives which are true positive.
 
-    .. math ::
+    .. math::
+
         FDR = FP / (FP + TP)
 
     ---
@@ -465,10 +448,10 @@ class FalseDiscoveryRate(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class FalseOmissionRate(ConfusionMatrixClassificationMetric):
-    """
-    The false omission rate is the proportion of predicted positives which are true negative.
+    """The false omission rate is the proportion of predicted positives which are true negative.
 
-    .. math ::
+    .. math::
+
         FOR = FN / (FN + TN)
 
     ---
@@ -490,10 +473,10 @@ class FalseOmissionRate(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class PositiveLikelihoodRatio(ConfusionMatrixClassificationMetric):
-    r"""
-    The positive likelihood ratio is the ratio of true positive rate to false positive rate.
+    r"""The positive likelihood ratio is the ratio of true positive rate to false positive rate.
 
-    .. math ::
+    .. math::
+
         LR+ = TPR / FPR = \frac{TP / (TP + FN)}{FP / (FP + TN)} = \frac{TP \cdot (FP + TN)}{FP \cdot (TP + FN)}
 
     ---
@@ -517,10 +500,10 @@ class PositiveLikelihoodRatio(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class NegativeLikelihoodRatio(ConfusionMatrixClassificationMetric):
-    r"""
-    The negative likelihood ratio is the ratio of false negative rate to true negative rate.
+    r"""The negative likelihood ratio is the ratio of false negative rate to true negative rate.
 
-    .. math ::
+    .. math::
+
         LR- = FNR / TNR = \frac{FN / (TP + FN)}{TN / (FP + TN)} = \frac{FN \cdot (FP + TN)}{TN \cdot (TP + FN)}
 
     ---
@@ -544,10 +527,10 @@ class NegativeLikelihoodRatio(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class DiagnosticOddsRatio(ConfusionMatrixClassificationMetric):
-    r"""
-    The ratio of positive and negative likelihood ratio.
+    r"""The ratio of positive and negative likelihood ratio.
 
-    .. math ::
+    .. math::
+
         DOR = \frac{LR+}{LR-} = \frac{TP \cdot TN}{FP \cdot FN}
 
     ---
@@ -573,10 +556,10 @@ class DiagnosticOddsRatio(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class Accuracy(ConfusionMatrixClassificationMetric):
-    r"""
-    The ratio of the number of correct classifications to the total number.
+    r"""The ratio of the number of correct classifications to the total number.
 
-    .. math ::
+    .. math::
+
         ACC = (TP + TN) / (TP + TN + FP + FN)
 
     ---
@@ -600,10 +583,10 @@ class Accuracy(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class F1Score(ConfusionMatrixClassificationMetric):
-    r"""
-    The harmonic mean of precision and recall.
+    r"""The harmonic mean of precision and recall.
 
-    .. math ::
+    .. math::
+
         F1 = 2TP / (2TP + FP + FN)
 
     ---
@@ -627,10 +610,10 @@ class F1Score(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class PrevalenceThreshold(ConfusionMatrixClassificationMetric):
-    r"""
-    The prevalence threshold.
+    r"""The prevalence threshold.
 
-    .. math ::
+    .. math::
+
         PT = √FPR / (√TPR + √FPR)
 
     ---
@@ -657,10 +640,10 @@ class PrevalenceThreshold(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class ThreatScore(ConfusionMatrixClassificationMetric):
-    r"""
-    The threat score.
+    r"""The threat score.
 
-    .. math ::
+    .. math::
+
         TS = TP / (TP + FN + FP)
 
     ---
@@ -684,10 +667,10 @@ class ThreatScore(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class FowlkesMallowsIndex(ConfusionMatrixClassificationMetric):
-    r"""
-    The Fowlkes Mallows index.
+    r"""The Fowlkes Mallows index.
 
-    .. math ::
+    .. math::
+
         FM = \sqrt{\frac{TP^2}{(2TP + FP + FN)}}
 
     ---
@@ -713,10 +696,10 @@ class FowlkesMallowsIndex(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class Informedness(ConfusionMatrixClassificationMetric):
-    r"""
-    The informedness metric.
+    r"""The informedness metric.
 
-    .. math ::
+    .. math::
+
         YI = TPR + TNR - 1 = TP / (TP + FN) + TN / (TN + FP) - 1
 
     ---
@@ -744,12 +727,12 @@ class Informedness(ConfusionMatrixClassificationMetric):
 
 @parse_docdata
 class MatthewsCorrelationCoefficient(ConfusionMatrixClassificationMetric):
-    r"""
-    The Matthews Correlation Coefficient (MCC).
+    r"""The Matthews Correlation Coefficient (MCC).
 
     A balanced measure applicable even with class imbalance.
 
-    .. math ::
+    .. math::
+
         MCC = (TP * TN - FP * FN) / sqrt((TP + FP) * (TP + FN) * (TN + FP) * (TN + FN))
 
     ---

--- a/src/pykeen/metrics/utils.py
+++ b/src/pykeen/metrics/utils.py
@@ -141,45 +141,39 @@ class Metric(ExtraReprMixin):
 
 
 def weighted_mean_expectation(individual: np.ndarray, weights: np.ndarray | None) -> float:
-    r"""
-    Calculate the expectation of a weighted sum of variables with given individual expected value.
+    r"""Calculate the expectation of a weighted sum of variables with given individual expected value.
 
     .. math::
+
         \mathbb{E}\left[\sum \limits_{i=1}^{n} w_i x_i\right]
             = \sum \limits_{i=1}^{n} w_i \mathbb{E}\left[x_i\right]
 
-    where $w_i = \frac{1}{n}$, if no explicit weights are given. Moreover, the weights are normalized such that
-    $\sum w_i = 1$.
+    where $w_i = \frac{1}{n}$, if no explicit weights are given. Moreover, the weights are normalized such that $\sum
+    w_i = 1$.
 
-    :param individual:
-        the individual variables' expectations, $\mathbb{E}[x_i]$
-    :param weights:
-        the individual variables' weights
+    :param individual: the individual variables' expectations, $\mathbb{E}[x_i]$
+    :param weights: the individual variables' weights
 
-    :return:
-        the variance of the weighted mean
+    :returns: the variance of the weighted mean
     """
     return np.average(individual, weights=weights).item()
 
 
 def weighted_mean_variance(individual: np.ndarray, weights: np.ndarray | None) -> float:
-    r"""
-    Calculate the variance of a weighted mean of variables with given individual variances.
+    r"""Calculate the variance of a weighted mean of variables with given individual variances.
 
     .. math::
+
         \mathbb{V}\left[\sum \limits_{i=1}^{n} w_i x_i\right]
             = \sum \limits_{i=1}^{n} w_i^2 \mathbb{V}\left[x_i\right]
 
-    where $w_i = \frac{1}{n}$, if no explicit weights are given. Moreover, the weights are normalized such that
-    $\sum w_i = 1$.
+    where $w_i = \frac{1}{n}$, if no explicit weights are given. Moreover, the weights are normalized such that $\sum
+    w_i = 1$.
 
-    :param individual:
-        the individual variables' variances, $\mathbb{V}[x_i]$
-    :param weights:
-        the individual variables' weights
+    :param individual: the individual variables' variances, $\mathbb{V}[x_i]$
+    :param weights: the individual variables' weights
 
-    :return:
-        the variance of the weighted mean
+    :returns: the variance of the weighted mean
     """
     n = individual.size
     if weights is None:
@@ -189,8 +183,7 @@ def weighted_mean_variance(individual: np.ndarray, weights: np.ndarray | None) -
 
 
 def stable_product(a: np.ndarray, is_log: bool = False) -> np.ndarray:
-    r"""
-    Compute the product using the log-trick for increased numerical stability.
+    r"""Compute the product using the log-trick for increased numerical stability.
 
     .. math::
 
@@ -214,13 +207,10 @@ def stable_product(a: np.ndarray, is_log: bool = False) -> np.ndarray:
 
     where the first part is computed without the log-trick.
 
-    :param a:
-        the array
-    :param is_log:
-        whether the array already contains the logarithm of the elements
+    :param a: the array
+    :param is_log: whether the array already contains the logarithm of the elements
 
-    :return:
-        the product of elements
+    :returns: the product of elements
     """
     if is_log:
         sign = 1
@@ -231,18 +221,15 @@ def stable_product(a: np.ndarray, is_log: bool = False) -> np.ndarray:
 
 
 def weighted_harmonic_mean(a: np.ndarray, weights: np.ndarray | None = None) -> np.ndarray:
-    """
-    Calculate weighted harmonic mean.
+    """Calculate weighted harmonic mean.
 
-    :param a:
-        the array
-    :param weights:
-        the weight for individual array members
+    :param a: the array
+    :param weights: the weight for individual array members
 
-    :return:
-        the weighted harmonic mean over the array
+    :returns: the weighted harmonic mean over the array
 
     .. seealso::
+
         https://en.wikipedia.org/wiki/Harmonic_mean#Weighted_harmonic_mean
     """
     if weights is None:

--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -1,49 +1,49 @@
-r"""
-A knowledge graph embedding model is capable of computing real-valued scores representing the plausibility
-of a triple $(h,r,t) \in \mathbb{K}$, where a larger score indicates a higher plausibility. The interpretation
-of the score value is model-dependent, and usually it cannot be directly interpreted as a probability.
+r"""A knowledge graph.
+
+A knowledge graph embedding model is capable of computing real-valued scores representing the plausibility of a triple
+$(h,r,t) \in \mathbb{K}$, where a larger score indicates a higher plausibility. The interpretation of the score value is
+model-dependent, and usually it cannot be directly interpreted as a probability.
 
 In PyKEEN, the API of a model is defined in :class:`Model`, where the scoring function is exposed as
-:meth:`Model.score_hrt`, which can be used to compute plausibility scores for (a batch of) triples.
-In addition, the :class:`Model` class also offers additional scoring methods, which can be used to
-(efficiently) compute scores for a large number of triples sharing some parts, e.g., to compute scores
-for triples $(h, r, e)$ for a given $(h, r)$ pair and all available entities $e \in \mathcal{E}$.
+:meth:`Model.score_hrt`, which can be used to compute plausibility scores for (a batch of) triples. In addition, the
+:class:`Model` class also offers additional scoring methods, which can be used to (efficiently) compute scores for a
+large number of triples sharing some parts, e.g., to compute scores for triples $(h, r, e)$ for a given $(h, r)$ pair
+and all available entities $e \in \mathcal{E}$.
 
-.. note ::
+.. note::
 
-    The implementations of the knowledge graph embedding models provided here all operate on entity / relation
-    indices rather than string representations, cf. `here <../tutorial/performance.html#entity-and-relation-ids>`_.
+    The implementations of the knowledge graph embedding models provided here all operate on entity / relation indices
+    rather than string representations, cf. `here <../tutorial/performance.html#entity-and-relation-ids>`_.
 
-On top of these scoring methods, there are also corresponding prediction methods, e.g.,
-:meth:`Model.predict_hrt`. These methods extend the scoring ones, by ensuring the model is in evaluation
-mode, cf. :meth:`torch.nn.Module.eval`, and optionally applying a sigmoid activation on the scores to
-ensure a value range of $[0, 1]$.
+On top of these scoring methods, there are also corresponding prediction methods, e.g., :meth:`Model.predict_hrt`. These
+methods extend the scoring ones, by ensuring the model is in evaluation mode, cf. :meth:`torch.nn.Module.eval`, and
+optionally applying a sigmoid activation on the scores to ensure a value range of $[0, 1]$.
 
-.. warning ::
+.. warning::
 
-    Depending on the model at hand, directly applying sigmoid might not always be sensible. For instance,
-    distance-based interaction functions, such as :class:`pykeen.nn.modules.TransEInteraction`, result in non-positive
-    scores (since they use the *negative* distance as scoring function), and thus the output of the sigmoid
-    only covers the interval $[0.5, 1]$.
+    Depending on the model at hand, directly applying sigmoid might not always be sensible. For instance, distance-based
+    interaction functions, such as :class:`pykeen.nn.modules.TransEInteraction`, result in non-positive scores (since
+    they use the *negative* distance as scoring function), and thus the output of the sigmoid only covers the interval
+    $[0.5, 1]$.
 
-Most models derive from :class:`ERModel`, which is a generic implementation of a knowledge graph embedding model.
-It combines a variable number of *representations* for entities and relations, cf.
+Most models derive from :class:`ERModel`, which is a generic implementation of a knowledge graph embedding model. It
+combines a variable number of *representations* for entities and relations, cf.
 :class:`pykeen.nn.representation.Representation`, and an interaction function, cf.
-:class:`pykeen.nn.modules.Interaction`. The representation modules convert integer entity or relation indices to
-numeric representations, e.g., vectors. The interaction function takes the representations of the head entities,
-relations and tail entities as input and computes a scalar plausibility score for triples.
+:class:`pykeen.nn.modules.Interaction`. The representation modules convert integer entity or relation indices to numeric
+representations, e.g., vectors. The interaction function takes the representations of the head entities, relations and
+tail entities as input and computes a scalar plausibility score for triples.
 
-.. note ::
+.. note::
 
-    An in-depth discussion of representation modules can be found in
-    `the corresponding tutorial <../tutorial/representations.html>`_.
+    An in-depth discussion of representation modules can be found in `the corresponding tutorial
+    <../tutorial/representations.html>`_.
 
-.. note ::
+.. note::
 
     The specific models from this module, e.g., :class:`RESCAL`, package given specific entity and relation
-    representations with an interaction function. For more flexible combinations, consider using
-    :class:`ERModel` directly.
-"""  # noqa: D205, D400
+    representations with an interaction function. For more flexible combinations, consider using :class:`ERModel`
+    directly.
+"""  # noqa: D205,D400
 
 from class_resolver import ClassResolver, get_subclasses
 

--- a/src/pykeen/models/baseline/utils.py
+++ b/src/pykeen/models/baseline/utils.py
@@ -23,22 +23,15 @@ def get_csr_matrix(
     dtype: numpy.dtype = numpy.float32,
     norm: str | None = "l1",
 ) -> scipy.sparse.csr_matrix:
-    """
-    Create a sparse matrix, with ones for the given non-zero locations.
+    """Create a sparse matrix, with ones for the given non-zero locations.
 
-    :param row_indices: shape: (nnz,)
-        the non-zero row indices
-    :param col_indices: shape: (nnz,)
-        the non-zero column indices
-    :param shape:
-        the matrix' shape
-    :param dtype:
-        the data type to use
-    :param norm:
-        if not None, perform row-wise normalization with :func:`sklearn.preprocessing.normalize`
+    :param row_indices: shape: (nnz,) the non-zero row indices
+    :param col_indices: shape: (nnz,) the non-zero column indices
+    :param shape: the matrix' shape
+    :param dtype: the data type to use
+    :param norm: if not None, perform row-wise normalization with :func:`sklearn.preprocessing.normalize`
 
-    :return: shape: shape
-        a sparse csr matrix
+    :returns: shape: shape a sparse csr matrix
     """
     # create sparse matrix of absolute counts
     matrix = scipy.sparse.coo_matrix(
@@ -87,16 +80,12 @@ def sparsify(
     matrix: numpy.ndarray,
     threshold: float | None = None,
 ) -> scipy.sparse.spmatrix:
-    """
-    Sparsify a matrix.
+    """Sparsify a matrix.
 
-    :param matrix: shape: (m, n)
-        the (dense) matrix
-    :param threshold:
-        the absolute threshold for sparsification
+    :param matrix: shape: (m, n) the (dense) matrix
+    :param threshold: the absolute threshold for sparsification
 
-    :return: shape: (m, n)
-        a sparsified matrix
+    :returns: shape: (m, n) a sparsified matrix
     """
     if threshold is not None:
         matrix = numpy.copy(matrix)
@@ -110,16 +99,12 @@ def get_relation_similarity(
     triples_factory: CoreTriplesFactory,
     threshold: float | None = None,
 ) -> tuple[scipy.sparse.csr_matrix, scipy.sparse.csr_matrix]:
-    """
-    Compute Jaccard similarity of relations' (and their inverse's) entity-pair sets.
+    """Compute Jaccard similarity of relations' (and their inverse's) entity-pair sets.
 
-    :param triples_factory:
-        the triples factory
-    :param threshold:
-        an absolute sparsification threshold.
+    :param triples_factory: the triples factory
+    :param threshold: an absolute sparsification threshold.
 
-    :return: shape: (num_relations, num_relations)
-        a pair of similarity matrices.
+    :returns: shape: (num_relations, num_relations) a pair of similarity matrices.
     """
     r, r_inv = triples_factory_to_sparse_matrices(triples_factory=triples_factory)
     sim, sim_inv = (sparsify(jaccard_similarity_scipy(r, r2), threshold=threshold) for r2 in (r, r_inv))

--- a/src/pykeen/models/cli/builders.py
+++ b/src/pykeen/models/cli/builders.py
@@ -60,14 +60,12 @@ _SKIP_HINTS = {
 def build_cli_from_cls(model: type[Model]) -> click.Command:  # noqa: D202
     """Build a :mod:`click` command line interface for a KGE model.
 
-    Allows users to specify all of the (hyper)parameters to the
-    model via command line options using :class:`click.Option`.
+    Allows users to specify all of the (hyper)parameters to the model via command line options using
+    :class:`click.Option`.
 
-    :param model:
-        the model class
+    :param model: the model class
 
-    :return:
-        a click command for training a model of the given class
+    :returns: a click command for training a model of the given class
     """
     signature = inspect.signature(model.__init__)
 

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -13,12 +13,11 @@ from ...typing import TESTING, TRAINING, VALIDATION, InductiveMode
 
 
 class InductiveERModel(ERModel):
-    """
-    A base class for inductive models.
+    """A base class for inductive models.
 
-    This model assumes a shared set of relations between all triple sets (e.g., training and validation), and a
-    separate inference factory used during validation. During testing time, either the validation factory is re-used
-    or another separate testing factory may be provided.
+    This model assumes a shared set of relations between all triple sets (e.g., training and validation), and a separate
+    inference factory used during validation. During testing time, either the validation factory is re-used or another
+    separate testing factory may be provided.
     """
 
     #: a mapping from inductive mode to corresponding entity representations
@@ -38,19 +37,14 @@ class InductiveERModel(ERModel):
     ) -> None:
         """Initialize the inductive model.
 
-        :param triples_factory:
-            the (training) factory
-        :param entity_representations:
-            the training entity representations
-        :param entity_representations_kwargs:
-            additional keyword-based parameters for the training entity representations
-        :param validation_factory:
-            the validation factory
-        :param testing_factory:
-            the testing factory. If None, the validation factory is re-used, i.e., validation and test entities come
-            from the same (unseen) set of entities.
-        :param kwargs:
-            additional keyword-based parameters passed to :meth:`ERModel.__init__`
+        :param triples_factory: the (training) factory
+        :param entity_representations: the training entity representations
+        :param entity_representations_kwargs: additional keyword-based parameters for the training entity
+            representations
+        :param validation_factory: the validation factory
+        :param testing_factory: the testing factory. If None, the validation factory is re-used, i.e., validation and
+            test entities come from the same (unseen) set of entities.
+        :param kwargs: additional keyword-based parameters passed to :meth:`ERModel.__init__`
         """
         super().__init__(
             triples_factory=triples_factory,

--- a/src/pykeen/models/inductive/inductive_nodepiece_gnn.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece_gnn.py
@@ -43,13 +43,11 @@ class InductiveNodePieceGNN(InductiveNodePiece):
         gnn_encoder: Iterable[nn.Module] | None = None,
         **kwargs,
     ) -> None:
-        """
-        Initialize the model.
+        """Initialize the model.
 
-        :param gnn_encoder:
-            an iterable of message passing layers. Defaults to 2-layer CompGCN with Hadamard composition.
-        :param kwargs:
-            additional keyword-based parameters passed to `InductiveNodePiece.__init__`.
+        :param gnn_encoder: an iterable of message passing layers. Defaults to 2-layer CompGCN with Hadamard
+            composition.
+        :param kwargs: additional keyword-based parameters passed to `InductiveNodePiece.__init__`.
         """
         super().__init__(**kwargs)
 

--- a/src/pykeen/models/multimodal/base.py
+++ b/src/pykeen/models/multimodal/base.py
@@ -37,23 +37,16 @@ class LiteralModel(
         combination_kwargs: OptionalKwargs = None,
         **kwargs,
     ):
-        """
-        Initialize the model.
+        """Initialize the model.
 
-        :param triples_factory:
-            the (training) triples factory
-        :param interaction:
-            the interaction function
-        :param entity_representations:
-            the entity representations (excluding the ones from literals)
-        :param entity_representations_kwargs:
-            the entity representations keyword-based parameters (excluding the ones from literals)
-        :param combination:
-            the combination for entity and literal representations
-        :param combination_kwargs:
-            keyword-based parameters for instantiating the combination
-        :param kwargs:
-            additional keyword-based parameters passed to :meth:`ERModel.__init__`
+        :param triples_factory: the (training) triples factory
+        :param interaction: the interaction function
+        :param entity_representations: the entity representations (excluding the ones from literals)
+        :param entity_representations_kwargs: the entity representations keyword-based parameters (excluding the ones
+            from literals)
+        :param combination: the combination for entity and literal representations
+        :param combination_kwargs: keyword-based parameters for instantiating the combination
+        :param kwargs: additional keyword-based parameters passed to :meth:`ERModel.__init__`
         """
         literals = triples_factory.get_numeric_literals_tensor()
         _max_id, *shape = literals.shape

--- a/src/pykeen/nn/compositions.py
+++ b/src/pykeen/nn/compositions.py
@@ -36,11 +36,10 @@ class CompositionModule(nn.Module, ABC):
 
         The tensors have to be broadcastable.
 
-        :param a: shape: s_1
-            The first tensor.
-        :param b: shape: s_2
-            The second tensor.
-        :return: shape: s
+        :param a: shape: s_1 The first tensor.
+        :param b: shape: s_2 The second tensor.
+
+        :returns: shape: s
         """
 
 

--- a/src/pykeen/nn/node_piece/__init__.py
+++ b/src/pykeen/nn/node_piece/__init__.py
@@ -1,25 +1,23 @@
-"""
-NodePiece modules.
+"""NodePiece modules.
 
-A :class:`NodePieceRepresentation` contains a collection of :class:`TokenizationRepresentation`.
-A :class:`TokenizationRepresentation` is defined as :class:`Representation` module mapping token
-indices to representations, also called the `vocabulary` in resemblance of token representations
-known from NLP applications, and an assignment from entities to (multiple) tokens.
+A :class:`NodePieceRepresentation` contains a collection of :class:`TokenizationRepresentation`. A
+:class:`TokenizationRepresentation` is defined as :class:`Representation` module mapping token indices to
+representations, also called the `vocabulary` in resemblance of token representations known from NLP applications, and
+an assignment from entities to (multiple) tokens.
 
-In order to obtain the vocabulary and assignment, multiple options are available, which often
-follow a two-step approach of first selecting a vocabulary, and afterwards assigning the entities
-to the set of tokens, usually using the graph structure of the KG.
+In order to obtain the vocabulary and assignment, multiple options are available, which often follow a two-step approach
+of first selecting a vocabulary, and afterwards assigning the entities to the set of tokens, usually using the graph
+structure of the KG.
 
-One way of tokenization, is tokenization by :class:`AnchorTokenizer`, which selects some anchor
-entities from the graph as vocabulary. The anchor selection process is controlled by an
-:class:`AnchorSelection` instance. In order to obtain the assignment, some measure of graph
-distance is used. To this end, a :class:`AnchorSearcher` instance calculates the closest
-anchor entities from the vocabulary for each of the entities in the graph.
+One way of tokenization, is tokenization by :class:`AnchorTokenizer`, which selects some anchor entities from the graph
+as vocabulary. The anchor selection process is controlled by an :class:`AnchorSelection` instance. In order to obtain
+the assignment, some measure of graph distance is used. To this end, a :class:`AnchorSearcher` instance calculates the
+closest anchor entities from the vocabulary for each of the entities in the graph.
 
 Since some tokenizations are expensive to compute, we offer a mechanism to use precomputed tokenizations via
 :class:`PrecomputedPoolTokenizer`. To enable loading from different formats, a loader subclassing from
-:class:`PrecomputedTokenizerLoader` can be selected accordingly. To precompute anchor-based tokenizations,
-you can use the command
+:class:`PrecomputedTokenizerLoader` can be selected accordingly. To precompute anchor-based tokenizations, you can use
+the command
 
 .. code-block:: console
 

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -38,20 +38,14 @@ class AnchorSearcher(ExtraReprMixin, ABC):
     def __call__(
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
     ) -> numpy.ndarray:
-        """
-        Find the $k$ closest anchor nodes for each entity.
+        """Find the $k$ closest anchor nodes for each entity.
 
-        :param edge_index: shape: (2, m)
-            the edge index
-        :param anchors: shape: (a,)
-            the selected anchor entity Ids
-        :param k:
-            the number of closest anchors to return
-        :param num_entities:
-            the number of entities
+        :param edge_index: shape: (2, m) the edge index
+        :param anchors: shape: (a,) the selected anchor entity Ids
+        :param k: the number of closest anchors to return
+        :param num_entities: the number of entities
 
-        :return: shape: (n, k), -1 <= res < a
-            the Ids of the closest anchors
+        :returns: shape: (n, k), -1 <= res < a the Ids of the closest anchors
         """
         raise NotImplementedError
 
@@ -65,13 +59,10 @@ class CSGraphAnchorSearcher(AnchorSearcher):
 
         Its complexity is $O(m * n log n)$.
 
-        :param array: shape: (n, m)
-            the array
-        :param k:
-            the value of $k$
+        :param array: shape: (n, m) the array
+        :param k: the value of $k$
 
-        :return: shape: (m, k)
-            the indices of the $k$ smallest values sorted in descending order
+        :returns: shape: (m, k) the indices of the $k$ smallest values sorted in descending order
         """
         return numpy.argsort(array, axis=0)[:k, :]
 
@@ -81,13 +72,10 @@ class CSGraphAnchorSearcher(AnchorSearcher):
 
         Its complexity is $O(m * (n + k log k))$.
 
-        :param array: shape: (n, m)
-            the array
-        :param k:
-            the value of $k$
+        :param array: shape: (n, m) the array
+        :param k: the value of $k$
 
-        :return: shape: (m, k)
-            the indices of the $k$ smallest values sorted in descending order
+        :returns: shape: (m, k) the indices of the $k$ smallest values sorted in descending order
         """
         # this array contains the indices of the k closest anchors nodes, but without guarantee that they are sorted
         top_k_indices = numpy.argpartition(array, kth=min(k, array.shape[0] - 1), axis=0)[:k, :]
@@ -119,11 +107,9 @@ class ScipySparseAnchorSearcher(AnchorSearcher):
     """Find closest anchors using :mod:`scipy.sparse`."""
 
     def __init__(self, max_iter: int = 5) -> None:
-        """
-        Initialize the searcher.
+        """Initialize the searcher.
 
-        :param max_iter:
-            the maximum number of hops to consider
+        :param max_iter: the maximum number of hops to consider
         """
         self.max_iter = max_iter
 
@@ -134,16 +120,12 @@ class ScipySparseAnchorSearcher(AnchorSearcher):
 
     @staticmethod
     def create_adjacency(edge_index: numpy.ndarray, num_entities: int | None = None) -> scipy.sparse.spmatrix:
-        """
-        Create a sparse adjacency matrix from a given edge index.
+        """Create a sparse adjacency matrix from a given edge index.
 
-        :param edge_index: shape: (2, m)
-            the edge index
-        :param num_entities:
-            the number of entities. Can be inferred from `edge_index`
+        :param edge_index: shape: (2, m) the edge index
+        :param num_entities: the number of entities. Can be inferred from `edge_index`
 
-        :return: shape: (n, n)
-            a square sparse adjacency matrix
+        :returns: shape: (n, n) a square sparse adjacency matrix
         """
         # infer shape
         num_entities = ensure_num_entities(edge_index, num_entities=num_entities)
@@ -172,20 +154,15 @@ class ScipySparseAnchorSearcher(AnchorSearcher):
         max_iter: int,
         k: int,
     ) -> numpy.ndarray:
-        """
-        Determine the candidate pool using breadth-first search.
+        """Determine the candidate pool using breadth-first search.
 
-        :param anchors: shape: (a,)
-            the anchor node IDs
-        :param adjacency: shape: (n, n)
-            the adjacency matrix
-        :param max_iter:
-            the maximum number of hops to consider
-        :param k:
-            the minimum number of anchor nodes to reach
+        :param anchors: shape: (a,) the anchor node IDs
+        :param adjacency: shape: (n, n) the adjacency matrix
+        :param max_iter: the maximum number of hops to consider
+        :param k: the minimum number of anchor nodes to reach
 
-        :return: shape: (n, a)
-            a boolean array indicating whether anchor $j$ is in the set of $k$ closest anchors for node $i$
+        :returns: shape: (n, a) a boolean array indicating whether anchor $j$ is in the set of $k$ closest anchors for
+            node $i$
         """
         num_entities = adjacency.shape[0]
         # for each entity, determine anchor pool by BFS
@@ -232,16 +209,12 @@ class ScipySparseAnchorSearcher(AnchorSearcher):
         pool: numpy.ndarray,
         k: int,
     ) -> numpy.ndarray:
-        """
-        Select $k$ anchors from the given pools.
+        """Select $k$ anchors from the given pools.
 
-        :param pool: shape: (n, a)
-            the anchor candidates for each node (a binary array)
-        :param k:
-            the number of candidates to select
+        :param pool: shape: (n, a) the anchor candidates for each node (a binary array)
+        :param k: the number of candidates to select
 
-        :return: shape: (n, k)
-            the selected anchors. May contain -1 if there is an insufficient number of  candidates
+        :returns: shape: (n, k) the selected anchors. May contain -1 if there is an insufficient number of candidates
         """
         tokens = numpy.full(shape=(pool.shape[0], k), fill_value=-1, dtype=int)
         generator = numpy.random.default_rng()
@@ -267,10 +240,8 @@ class SparseBFSSearcher(AnchorSearcher):
     def __init__(self, max_iter: int = 5, device: DeviceHint = None):
         """Initialize the tokenizer.
 
-        :param max_iter:
-            the number of partitions obtained through Metis.
-        :param device:
-            the device to use for tokenization
+        :param max_iter: the number of partitions obtained through Metis.
+        :param device: the device to use for tokenization
         """
         self.max_iter = max_iter
         self.device = resolve_device(device)
@@ -285,16 +256,12 @@ class SparseBFSSearcher(AnchorSearcher):
         edge_index: numpy.ndarray,
         num_entities: int | None = None,
     ) -> torch.tensor:
-        """
-        Create a sparse adjacency matrix (in the form of the edge list) from a given edge index.
+        """Create a sparse adjacency matrix (in the form of the edge list) from a given edge index.
 
-        :param edge_index: shape: (2, m)
-            the edge index
-        :param num_entities:
-            The number of entities. If not given, inferred from the edge index
+        :param edge_index: shape: (2, m) the edge index
+        :param num_entities: The number of entities. If not given, inferred from the edge index
 
-        :return: shape: (2, 2m + n)
-            edge list with inverse edges and self-loops
+        :returns: shape: (2, 2m + n) edge list with inverse edges and self-loops
         """
         num_entities = ensure_num_entities(edge_index, num_entities=num_entities)
         edge_index = torch.as_tensor(edge_index, dtype=torch.long)
@@ -314,25 +281,18 @@ class SparseBFSSearcher(AnchorSearcher):
         k: int,
         device: torch.device,
     ) -> numpy.ndarray:
-        """
-        Determine the candidate pool using breadth-first search.
+        """Determine the candidate pool using breadth-first search.
 
-        :param anchors: shape: (a,)
-            the anchor node IDs
-        :param edge_list: shape: (2, n)
-            the edge list with symmetric edges and self-loops
-        :param max_iter:
-            the maximum number of hops to consider
-        :param k:
-            the minimum number of anchor nodes to reach
-        :param device:
-            the device on which the calculations are done
+        :param anchors: shape: (a,) the anchor node IDs
+        :param edge_list: shape: (2, n) the edge list with symmetric edges and self-loops
+        :param max_iter: the maximum number of hops to consider
+        :param k: the minimum number of anchor nodes to reach
+        :param device: the device on which the calculations are done
 
-        :return: shape: (n, a)
-            a boolean array indicating whether anchor $j$ is in the set of $k$ closest anchors for node $i$
+        :returns: shape: (n, a) a boolean array indicating whether anchor $j$ is in the set of $k$ closest anchors for
+            node $i$
 
-        :raises ImportError:
-            If :mod:`torch_sparse` is not installed
+        :raises ImportError: If :mod:`torch_sparse` is not installed
         """
         try:
             import torch_sparse
@@ -402,16 +362,12 @@ class SparseBFSSearcher(AnchorSearcher):
         pool: torch.tensor,
         k: int,
     ) -> numpy.ndarray:
-        """
-        Select $k$ anchors from the given pools.
+        """Select $k$ anchors from the given pools.
 
-        :param pool: shape: (n, a)
-            the anchor candidates for each node with distances
-        :param k:
-            the number of candidates to select
+        :param pool: shape: (n, a) the anchor candidates for each node with distances
+        :param k: the number of candidates to select
 
-        :return: shape: (n, k)
-            the selected anchors. May contain -1 if there is an insufficient number of  candidates
+        :returns: shape: (n, k) the selected anchors. May contain -1 if there is an insufficient number of candidates
         """
         # sort the pool by nearest to farthest anchors
         values, indices = torch.sort(pool, dim=-1)
@@ -431,23 +387,20 @@ class SparseBFSSearcher(AnchorSearcher):
 
 
 class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
-    """
-    Select closest anchors as the nodes with the largest personalized page rank.
+    """Select closest anchors as the nodes with the largest personalized page rank.
 
     .. seealso::
+
         http://web.stanford.edu/class/cs224w/slides/04-pagerank.pdf
     """
 
     def __init__(self, batch_size: int = 1, use_tqdm: bool = False, page_rank_kwargs: OptionalKwargs = None):
-        """
-        Initialize the searcher.
+        """Initialize the searcher.
 
-        :param batch_size:
-            the batch size to use.
-        :param use_tqdm:
-            whether to use tqdm
-        :param page_rank_kwargs:
-            keyword-based parameters used for :func:`page_rank`. Must not include `edge_index`, or `x0`.
+        :param batch_size: the batch size to use.
+        :param use_tqdm: whether to use tqdm
+        :param page_rank_kwargs: keyword-based parameters used for :func:`page_rank`. Must not include `edge_index`, or
+            `x0`.
         """
         self.batch_size = batch_size
         self.page_rank_kwargs = page_rank_kwargs or {}
@@ -460,16 +413,12 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
         yield f"page_rank_kwargs={self.page_rank_kwargs}"
 
     def precalculate_anchor_ppr(self, edge_index: numpy.ndarray, anchors: numpy.ndarray) -> numpy.ndarray:
-        """
-        Sort anchors nodes by PPR values from each node.
+        """Sort anchors nodes by PPR values from each node.
 
-        :param edge_index: shape: (2, m)
-            the edge index.
-        :param anchors: shape: `(num_anchors,)`
-            the anchor IDs.
+        :param edge_index: shape: (2, m) the edge index.
+        :param anchors: shape: `(num_anchors,)` the anchor IDs.
 
-        :return: shape: `(num_entities, num_anchors)`
-            the PPR values for each anchor
+        :returns: shape: `(num_entities, num_anchors)` the PPR values for each anchor
         """
         return (
             torch.cat(
@@ -504,18 +453,13 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
     def _iter_ppr(
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, num_entities: int | None = None
     ) -> Iterable[torch.Tensor]:
-        """
-        Yield batches of PPR values for each anchor from each entities' perspective.
+        """Yield batches of PPR values for each anchor from each entities' perspective.
 
-        :param edge_index: shape: (2, m)
-            the edge index.
-        :param anchors: shape: `(num_anchors,)`
-            the anchor IDs.
-        :param num_entities:
-            The number of entities. Will be calculated on-the-fly if not given
+        :param edge_index: shape: (2, m) the edge index.
+        :param anchors: shape: `(num_anchors,)` the anchor IDs.
+        :param num_entities: The number of entities. Will be calculated on-the-fly if not given
 
-        :yields: shape: (batch_size, num_anchors)
-            batches of anchor PPRs.
+        :yields: shape: (batch_size, num_anchors) batches of anchor PPRs.
         """
         # prepare adjacency matrix only once
         adj = prepare_page_rank_adjacency(

--- a/src/pykeen/nn/node_piece/anchor_selection.py
+++ b/src/pykeen/nn/node_piece/anchor_selection.py
@@ -1,9 +1,8 @@
-"""
-Anchor selection for NodePiece.
+"""Anchor selection for NodePiece.
 
 An anchor selection method selects a given number of entities from the KG which serve as *anchors* to describe other
-entities. Most of these methods rely on some form of
-`(graph) centrality measure <https://en.wikipedia.org/wiki/Centrality>`_ to select central entities.
+entities. Most of these methods rely on some form of `(graph) centrality measure
+<https://en.wikipedia.org/wiki/Centrality>`_ to select central entities.
 """
 
 import logging
@@ -39,12 +38,9 @@ class AnchorSelection(ExtraReprMixin, ABC):
     """Anchor entity selection strategy."""
 
     def __init__(self, num_anchors: int = 32) -> None:
-        """
-        Initialize the strategy.
+        """Initialize the strategy.
 
-        :param num_anchors:
-            the number of anchor nodes to select.
-            # TODO: allow relative
+        :param num_anchors: the number of anchor nodes to select. # TODO: allow relative
         """
         self.num_anchors = num_anchors
 
@@ -54,21 +50,17 @@ class AnchorSelection(ExtraReprMixin, ABC):
         edge_index: numpy.ndarray,
         known_anchors: numpy.ndarray | None = None,
     ) -> numpy.ndarray:
-        """
-        Select anchor nodes.
+        """Select anchor nodes.
 
-        .. note ::
-            the number of selected anchors may be smaller than $k$, if there
-            are less entities present in the edge index.
+        .. note::
 
-        :param edge_index: shape: (m, 2)
-            the edge_index, i.e., adjacency list.
+            the number of selected anchors may be smaller than $k$, if there are less entities present in the edge
+            index.
 
-        :param known_anchors: numpy.ndarray
-            an array of already known anchors for getting only unique anchors
+        :param edge_index: shape: (m, 2) the edge_index, i.e., adjacency list.
+        :param known_anchors: numpy.ndarray an array of already known anchors for getting only unique anchors
 
-        :return: (k,)
-            the selected entity ids
+        :returns: (k,) the selected entity ids
         """
         raise NotImplementedError
 
@@ -81,19 +73,17 @@ class AnchorSelection(ExtraReprMixin, ABC):
         anchor_ranking: numpy.ndarray,
         known_anchors: numpy.ndarray | None,
     ) -> numpy.ndarray:
-        """
-        Filter out already known anchors, and select from remaining ones afterwards.
+        """Filter out already known anchors, and select from remaining ones afterwards.
 
-        .. note ::
+        .. note::
+
             the output size may be smaller, if there are not enough candidates remaining.
 
-        :param anchor_ranking: shape: (n,)
-            the anchor node IDs sorted by preference, where the first one is the most preferrable.
-        :param known_anchors: shape: (m,)
-            a collection of already known anchors
+        :param anchor_ranking: shape: (n,) the anchor node IDs sorted by preference, where the first one is the most
+            preferrable.
+        :param known_anchors: shape: (m,) a collection of already known anchors
 
-        :return: shape: (m + num_anchors,)
-            the extended anchors, i.e., the known ones and `num_anchors` novel ones.
+        :returns: shape: (m + num_anchors,) the extended anchors, i.e., the known ones and `num_anchors` novel ones.
         """
         if known_anchors is None:
             return anchor_ranking[: self.num_anchors]
@@ -112,34 +102,27 @@ class SingleSelection(AnchorSelection, ABC):
         edge_index: numpy.ndarray,
         known_anchors: numpy.ndarray | None = None,
     ) -> numpy.ndarray:
-        """
-        Select anchor nodes.
+        """Select anchor nodes.
 
-        .. note ::
-            the number of selected anchors may be smaller than $k$, if there
-            are less entities present in the edge index.
+        .. note::
 
-        :param edge_index: shape: (m, 2)
-            the edge_index, i.e., adjacency list.
+            the number of selected anchors may be smaller than $k$, if there are less entities present in the edge
+            index.
 
-        :param known_anchors: numpy.ndarray
-            an array of already known anchors for getting only unique anchors
+        :param edge_index: shape: (m, 2) the edge_index, i.e., adjacency list.
+        :param known_anchors: numpy.ndarray an array of already known anchors for getting only unique anchors
 
-        :return: (k,)
-            the selected entity ids
+        :returns: (k,) the selected entity ids
         """
         return self.filter_unique(anchor_ranking=self.rank(edge_index=edge_index), known_anchors=known_anchors)
 
     @abstractmethod
     def rank(self, edge_index: numpy.ndarray) -> numpy.ndarray:
-        """
-        Rank nodes.
+        """Rank nodes.
 
-        :param edge_index: shape: (m, 2)
-            the edge_index, i.e., adjacency list.
+        :param edge_index: shape: (m, 2) the edge_index, i.e., adjacency list.
 
-        :return: (n,)
-            the node IDs sorted decreasingly by anchor selection preference.
+        :returns: (n,) the node IDs sorted decreasingly by anchor selection preference.
         """
         raise NotImplementedError
 
@@ -156,10 +139,10 @@ class DegreeAnchorSelection(SingleSelection):
 
 
 class PageRankAnchorSelection(SingleSelection):
-    """
-    Select entities according to their page rank.
+    """Select entities according to their page rank.
 
     .. seealso::
+
         http://web.stanford.edu/class/cs224w/slides/04-pagerank.pdf
     """
 
@@ -168,13 +151,10 @@ class PageRankAnchorSelection(SingleSelection):
         num_anchors: int = 32,
         **kwargs,
     ) -> None:
-        """
-        Initialize the selection strategy.
+        """Initialize the selection strategy.
 
-        :param num_anchors:
-            the number of anchors to select
-        :param kwargs:
-            additional keyword-based parameters passed to :func:`page_rank`.
+        :param num_anchors: the number of anchors to select
+        :param kwargs: additional keyword-based parameters passed to :func:`page_rank`.
         """
         super().__init__(num_anchors=num_anchors)
         self.kwargs = kwargs
@@ -200,13 +180,10 @@ class RandomAnchorSelection(SingleSelection):
         num_anchors: int = 32,
         random_seed: int | None = None,
     ) -> None:
-        """
-        Initialize the selection stragegy.
+        """Initialize the selection stragegy.
 
-        :param num_anchors:
-            the number of anchors to select
-        :param random_seed:
-            the random seed to use.
+        :param num_anchors: the number of anchors to select
+        :param random_seed: the random seed to use.
         """
         super().__init__(num_anchors=num_anchors)
         self.generator: numpy.random.Generator = numpy.random.default_rng(random_seed)
@@ -226,20 +203,15 @@ class MixtureAnchorSelection(AnchorSelection):
         selections_kwargs: OneOrSequence[OptionalKwargs] = None,
         **kwargs,
     ) -> None:
-        """
-        Initialize the selection strategy.
+        """Initialize the selection strategy.
 
-        :param selections:
-            the individual selections.
-            For the sake of selecting unique anchors, selections will be executed in the given order
-            eg, ['degree', 'pagerank'] will be executed differently from ['pagerank', 'degree']
-        :param ratios:
-            the ratios, cf. normalize_ratios. None means uniform ratios
-        :param selections_kwargs:
-            additional keyword-based arguments for the individual selection strategies
-        :param kwargs:
-            additional keyword-based arguments passed to AnchorSelection.__init__,
-            in particular, the total number of anchors.
+        :param selections: the individual selections. For the sake of selecting unique anchors, selections will be
+            executed in the given order eg, ['degree', 'pagerank'] will be executed differently from ['pagerank',
+            'degree']
+        :param ratios: the ratios, cf. normalize_ratios. None means uniform ratios
+        :param selections_kwargs: additional keyword-based arguments for the individual selection strategies
+        :param kwargs: additional keyword-based arguments passed to AnchorSelection.__init__, in particular, the total
+            number of anchors.
         """
         super().__init__(**kwargs)
         n_selections = len(selections)

--- a/src/pykeen/nn/node_piece/loader.py
+++ b/src/pykeen/nn/node_piece/loader.py
@@ -34,10 +34,10 @@ class PrecomputedTokenizerLoader(ABC):
 
 
 class GalkinPrecomputedTokenizerLoader(PrecomputedTokenizerLoader):
-    """
-    A loader for pickle files provided by Galkin *et al*.
+    """A loader for pickle files provided by Galkin *et al*.
 
-    .. seealso ::
+    .. seealso::
+
         https://github.com/migalkin/NodePiece/blob/9adc57efe302919d017d74fc648f853308cf75fd/download_data.sh
         https://github.com/migalkin/NodePiece/blob/9adc57efe302919d017d74fc648f853308cf75fd/ogb/download.sh
     """
@@ -63,15 +63,11 @@ class TorchPrecomputedTokenizerLoader(PrecomputedTokenizerLoader):
 
     @staticmethod
     def save(path: pathlib.Path, order: numpy.ndarray, anchor_ids: numpy.ndarray) -> None:
-        """
-        Save tokenization to path.
+        """Save tokenization to path.
 
-        :param path:
-            the output path
-        :param order: shape: (num_entities, num_anchors)
-            the sorted `anchor_ids`' ids per entity
-        :param anchor_ids: shape: (num_anchors,)
-            the anchor entity IDs
+        :param path: the output path
+        :param order: shape: (num_entities, num_anchors) the sorted `anchor_ids`' ids per entity
+        :param anchor_ids: shape: (num_anchors,) the anchor entity IDs
         """
         # ensure parent directory exists
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/pykeen/nn/node_piece/tokenization.py
+++ b/src/pykeen/nn/node_piece/tokenization.py
@@ -45,20 +45,15 @@ class Tokenizer:
         num_entities: int,
         num_relations: int,
     ) -> tuple[int, LongTensor]:
-        """
-        Tokenize the entities contained given the triples.
+        """Tokenize the entities contained given the triples.
 
-        :param mapped_triples: shape: (n, 3)
-            the ID-based triples
-        :param num_tokens:
-            the number of tokens to select for each entity
-        :param num_entities:
-            the number of entities
-        :param num_relations:
-            the number of relations
+        :param mapped_triples: shape: (n, 3) the ID-based triples
+        :param num_tokens: the number of tokens to select for each entity
+        :param num_entities: the number of entities
+        :param num_relations: the number of relations
 
-        :return: shape: (num_entities, num_tokens), -1 <= res < vocabulary_size
-            the selected relation IDs for each entity. -1 is used as a padding token.
+        :returns: shape: (num_entities, num_tokens), -1 <= res < vocabulary_size the selected relation IDs for each
+            entity. -1 is used as a padding token.
         """
         raise NotImplementedError
 
@@ -99,8 +94,7 @@ class RelationTokenizer(Tokenizer):
 
 
 class AnchorTokenizer(Tokenizer):
-    """
-    Tokenize entities by representing them as a bag of anchor entities.
+    """Tokenize entities by representing them as a bag of anchor entities.
 
     The entities are chosen by shortest path distance.
     """
@@ -116,17 +110,12 @@ class AnchorTokenizer(Tokenizer):
         searcher: HintOrType[AnchorSearcher] = None,
         searcher_kwargs: OptionalKwargs = None,
     ) -> None:
-        """
-        Initialize the tokenizer.
+        """Initialize the tokenizer.
 
-        :param selection:
-            the anchor node selection strategy.
-        :param selection_kwargs:
-            additional keyword-based arguments passed to the selection strategy
-        :param searcher:
-            the component for searching the closest anchors for each entity
-        :param searcher_kwargs:
-            additional keyword-based arguments passed to the searcher
+        :param selection: the anchor node selection strategy.
+        :param selection_kwargs: additional keyword-based arguments passed to the selection strategy
+        :param searcher: the component for searching the closest anchors for each entity
+        :param searcher_kwargs: additional keyword-based arguments passed to the searcher
         """
         self.anchor_selection = anchor_selection_resolver.make(selection, pos_kwargs=selection_kwargs)
         self.searcher = anchor_searcher_resolver.make(searcher, pos_kwargs=searcher_kwargs)
@@ -170,8 +159,7 @@ class AnchorTokenizer(Tokenizer):
 
 
 class MetisAnchorTokenizer(AnchorTokenizer):
-    """
-    An anchor tokenizer, which first partitions the graph using METIS.
+    """An anchor tokenizer, which first partitions the graph using METIS.
 
     We use the binding by :mod:`torch_sparse`. The METIS graph partitioning algorithm is described here:
     http://glaros.dtc.umn.edu/gkhome/metis/metis/overview
@@ -180,13 +168,10 @@ class MetisAnchorTokenizer(AnchorTokenizer):
     def __init__(self, num_partitions: int = 2, device: DeviceHint = None, **kwargs):
         """Initialize the tokenizer.
 
-        :param num_partitions:
-            the number of partitions obtained through Metis.
-        :param device:
-            the device to use for tokenization
-        :param kwargs:
-            additional keyword-based parameters passed to :meth:`AnchorTokenizer.__init__`. note that there will be one
-            anchor tokenizer per partition, i.e., the vocabulary size will grow respectively.
+        :param num_partitions: the number of partitions obtained through Metis.
+        :param device: the device to use for tokenization
+        :param kwargs: additional keyword-based parameters passed to :meth:`AnchorTokenizer.__init__`. note that there
+            will be one anchor tokenizer per partition, i.e., the vocabulary size will grow respectively.
         """
         super().__init__(**kwargs)
         self.num_partitions = num_partitions
@@ -296,25 +281,21 @@ class PrecomputedPoolTokenizer(Tokenizer):
         randomize_selection: bool = False,
         loader: HintOrType[PrecomputedTokenizerLoader] = None,
     ):
-        r"""
-        Initialize the tokenizer.
+        r"""Initialize the tokenizer.
 
-        .. note ::
+        .. note::
+
             the preference order for loading the precomputed pools is (1) from the given pool (2) from the given path,
             and (3) by downloading from the given url
 
-        :param path:
-            a path for a file containing the precomputed pools
-        :param url:
-            an url to download the file with precomputed pools from
-        :param download_kwargs:
-            additional download parameters, passed to pystow.Module.ensure
-        :param pool:
-            the precomputed pools.
-        :param randomize_selection:
-            whether to randomly choose from tokens, or always take the first `num_token` precomputed tokens.
-        :param loader:
-            the loader to use for loading the pool
+        :param path: a path for a file containing the precomputed pools
+        :param url: an url to download the file with precomputed pools from
+        :param download_kwargs: additional download parameters, passed to pystow.Module.ensure
+        :param pool: the precomputed pools.
+        :param randomize_selection: whether to randomly choose from tokens, or always take the first `num_token`
+            precomputed tokens.
+        :param loader: the loader to use for loading the pool
+
         :raises ValueError: If the pool's keys are not contiguous on $0 \dots N-1$.
         """
         self.pool, self.vocabulary_size = self._load_pool(

--- a/src/pykeen/nn/node_piece/utils.py
+++ b/src/pykeen/nn/node_piece/utils.py
@@ -27,16 +27,13 @@ def random_sample_no_replacement(
 
     If a graph has disconnected nodes, then num_entities > number of rows in the pool.
 
-    :param pool:
-        a dictionary of entity: [relations]
-    :param num_tokens:
-        the number of tokens to sample for each entity
-    :param num_entities:
-        the total number of nodes in the graph, might be bigger than the pool size for graphs with disconnected nodes.
-        If not given, is calculated based the length of ``pool``.
+    :param pool: a dictionary of entity: [relations]
+    :param num_tokens: the number of tokens to sample for each entity
+    :param num_entities: the total number of nodes in the graph, might be bigger than the pool size for graphs with
+        disconnected nodes. If not given, is calculated based the length of ``pool``.
 
-    :return: shape: (num_entities, num_tokens), -1 <= res < vocabulary_size
-        the selected relation IDs for each entity. -1 is used as a padding token.
+    :returns: shape: (num_entities, num_tokens), -1 <= res < vocabulary_size the selected relation IDs for each entity.
+        -1 is used as a padding token.
     """
     if num_entities is None:
         num_entities = len(pool)

--- a/src/pykeen/nn/perceptron.py
+++ b/src/pykeen/nn/perceptron.py
@@ -15,7 +15,9 @@ class ConcatMLP(nn.Sequential):
     This is for conveniently choosing a configuration similar to the paper. For more complex aggregation mechanisms,
     pass an arbitrary callable instead.
 
-    .. seealso:: https://github.com/migalkin/NodePiece/blob/d731c9990/lp_rp/pykeen105/nodepiece_rotate.py#L57-L65
+    .. seealso::
+
+        https://github.com/migalkin/NodePiece/blob/d731c9990/lp_rp/pykeen105/nodepiece_rotate.py#L57-L65
     """
 
     def __init__(
@@ -28,16 +30,11 @@ class ConcatMLP(nn.Sequential):
     ):
         """Initialize the module.
 
-        :param input_dim:
-            the input dimension
-        :param output_dim:
-            the output dimension. defaults to input dim
-        :param dropout:
-            the dropout value on the hidden layer
-        :param ratio:
-            the ratio of the output dimension to the hidden layer size.
-        :param flatten_dims:
-            the number of trailing dimensions to flatten
+        :param input_dim: the input dimension
+        :param output_dim: the output dimension. defaults to input dim
+        :param dropout: the dropout value on the hidden layer
+        :param ratio: the ratio of the output dimension to the hidden layer size.
+        :param flatten_dims: the number of trailing dimensions to flatten
         """
         output_dim = output_dim or input_dim
         hidden_dim = int(ratio * output_dim)
@@ -53,8 +50,9 @@ class ConcatMLP(nn.Sequential):
         """Forward the MLP on the given dimension.
 
         :param xs: The tensor to forward
-        :param dim: Only a parameter to match the signature of :func:`torch.mean` / :func:`torch.sum`
-            this class is not thought to be usable from outside
+        :param dim: Only a parameter to match the signature of :func:`torch.mean` / :func:`torch.sum` this class is not
+            thought to be usable from outside
+
         :returns: The tensor after applying this MLP
         """
         assert dim == -2

--- a/src/pykeen/nn/pyg.py
+++ b/src/pykeen/nn/pyg.py
@@ -1,5 +1,4 @@
-"""
-PyTorch Geometric based representation modules.
+"""PyTorch Geometric based representation modules.
 
 The modules enable entity representations which are linked to their graph neighbors' representations. Similar
 representations are those by CompGCN or R-GCN. However, this module offers generic modules to combine many of the
@@ -8,12 +7,12 @@ layers can be found at :mod:`torch_geometric.nn.conv`.
 
 The three classes differ in how the make use of the relation type information:
 
-* :class:`SimpleMessagePassingRepresentation` only uses the connectivity information from the training triples,
-  but ignores the relation type, e.g., :class:`torch_geometric.nn.conv.GCNConv`.
-* :class:`TypedMessagePassingRepresentation` is for message passing layer, which internally handle the
-  categorical relation type information via an `edge_type` input, e.g., :class:`torch_geometric.nn.conv.RGCNConv`.
-* :class:`FeaturizedMessagePassingRepresentation` is for message passing layer which can use edge attributes
-  via the parameter `edge_attr`, e.g., :class:`torch_geometric.nn.conv.GMMConv`.
+- :class:`SimpleMessagePassingRepresentation` only uses the connectivity information from the training triples, but
+  ignores the relation type, e.g., :class:`torch_geometric.nn.conv.GCNConv`.
+- :class:`TypedMessagePassingRepresentation` is for message passing layer, which internally handle the categorical
+  relation type information via an `edge_type` input, e.g., :class:`torch_geometric.nn.conv.RGCNConv`.
+- :class:`FeaturizedMessagePassingRepresentation` is for message passing layer which can use edge attributes via the
+  parameter `edge_attr`, e.g., :class:`torch_geometric.nn.conv.GMMConv`.
 
 We can also easily utilize these representations with :class:`~pykeen.models.ERModel`. Here, we showcase how to combine
 static label-based entity features with a trainable GCN encoder for entity representations, with learned embeddings for
@@ -99,17 +98,14 @@ def _extract_flow(layers: Sequence[MessagePassing]) -> FlowDirection:
 
 
 class MessagePassingRepresentation(Representation, ABC):
-    """
-    An abstract representation class utilizing PyTorch Geometric message passing layers.
+    """An abstract representation class utilizing PyTorch Geometric message passing layers.
 
     It comprises:
-        * Base (entity) representations, which can also be passed as hints.
-        * A sequence of message passing layers. They are utilized in an abstract
-          :meth:`pass_messages` to enrich the base representations
-          by neighborhood information.
-        * A sequence of activation layers in between the message passing layers.
-        * An ``edge_index`` buffer, which stores the edge index and is moved to the device alongside
-          the module.
+        - Base (entity) representations, which can also be passed as hints.
+        - A sequence of message passing layers. They are utilized in an abstract :meth:`pass_messages` to enrich the
+          base representations by neighborhood information.
+        - A sequence of activation layers in between the message passing layers.
+        - An ``edge_index`` buffer, which stores the edge index and is moved to the device alongside the module.
     """
 
     #: the message passing layers
@@ -140,44 +136,25 @@ class MessagePassingRepresentation(Representation, ABC):
         restrict_k_hop: bool = False,
         **kwargs,
     ):
-        """
-        Initialize the representation.
+        """Initialize the representation.
 
-        :param triples_factory:
-            The factory comprising the training triples used for message passing.
+        :param triples_factory: The factory comprising the training triples used for message passing.
+        :param layers: The message passing layer(s) or hints thereof.
+        :param layers_kwargs: Additional keyword-based parameters passed to the layers upon instantiation.
+        :param base: The base representations for entities, or a hint thereof.
+        :param base_kwargs: Additional keyword-based parameters passed to the base representations upon instantiation.
+        :param shape: The output shape. Defaults to the base representation shape. Has to match to output shape of the
+            last message passing layer.
+        :param max_id: The number of representations. If provided, has to match the base representation's max_id.
+        :param activations: The activation(s), or hints thereof.
+        :param activations_kwargs: Additional keyword-based parameters passed to the activations upon instantiation
+        :param restrict_k_hop: Whether to restrict the message passing only to the k-hop neighborhood, when only some
+            indices are requested. This utilizes :func:`torch_geometric.utils.k_hop_subgraph`.
+        :param kwargs: Additional keyword-based parameters passed to :class:`~pykeen.nn.representation.Representation`.
 
-        :param layers:
-            The message passing layer(s) or hints thereof.
-        :param layers_kwargs:
-            Additional keyword-based parameters passed to the layers upon instantiation.
-
-        :param base:
-            The base representations for entities, or a hint thereof.
-        :param base_kwargs:
-            Additional keyword-based parameters passed to the base representations upon instantiation.
-
-        :param shape:
-            The output shape. Defaults to the base representation shape. Has to match to output shape of the last
-            message passing layer.
-        :param max_id:
-            The number of representations. If provided, has to match the base representation's max_id.
-
-        :param activations:
-            The activation(s), or hints thereof.
-        :param activations_kwargs:
-            Additional keyword-based parameters passed to the activations upon instantiation
-
-        :param restrict_k_hop:
-            Whether to restrict the message passing only to the k-hop neighborhood, when only some indices
-            are requested. This utilizes :func:`torch_geometric.utils.k_hop_subgraph`.
-
-        :param kwargs:
-            Additional keyword-based parameters passed to :class:`~pykeen.nn.representation.Representation`.
-
-        :raises ImportError:
-            If PyTorch Geometric is not installed.
-        :raises ValueError:
-            If the number of activations and message passing layers do not match (after input normalization).
+        :raises ImportError: If PyTorch Geometric is not installed.
+        :raises ValueError: If the number of activations and message passing layers do not match (after input
+            normalization).
         """
         # fail if dependencies are missing
         if MessagePassing is None or layer_resolver is None or k_hop_subgraph is None:
@@ -264,30 +241,25 @@ class MessagePassingRepresentation(Representation, ABC):
 
     @abstractmethod
     def pass_messages(self, x: FloatTensor, edge_index: LongTensor, edge_mask: BoolTensor | None = None) -> FloatTensor:
-        """
-        Perform the message passing steps.
+        """Perform the message passing steps.
 
-        :param x: shape: ``(n, d_in)``
-            the base entity representations
-        :param edge_index: shape: ``(num_selected_edges,)``
-            the edge index (which may already be a selection of the full edge index)
-        :param edge_mask: shape: ``(num_edges,)``
-            an edge mask if message passing is restricted
+        :param x: shape: ``(n, d_in)`` the base entity representations
+        :param edge_index: shape: ``(num_selected_edges,)`` the edge index (which may already be a selection of the full
+            edge index)
+        :param edge_mask: shape: ``(num_edges,)`` an edge mask if message passing is restricted
 
-        :return: shape: ``(n, d_out)``
-            the enriched entity representations
+        :returns: shape: ``(n, d_out)`` the enriched entity representations
         """
         raise NotImplementedError
 
 
 @parse_docdata
 class SimpleMessagePassingRepresentation(MessagePassingRepresentation):
-    """
-    A representation with message passing not making use of the relation type.
+    """A representation with message passing not making use of the relation type.
 
-    By only using the connectivity information, but not the relation type information, this module
-    can utilize message passing layers defined on uni-relational graphs, which are the majority of
-    available layers from the PyTorch Geometric library.
+    By only using the connectivity information, but not the relation type information, this module can utilize message
+    passing layers defined on uni-relational graphs, which are the majority of available layers from the PyTorch
+    Geometric library.
 
     Here, we create a two-layer :class:`torch_geometric.nn.conv.GCNConv` on top of an
     :class:`~pykeen.nn.representation.Embedding`.
@@ -307,12 +279,10 @@ class SimpleMessagePassingRepresentation(MessagePassingRepresentation):
 
 @parse_docdata
 class TypedMessagePassingRepresentation(MessagePassingRepresentation):
-    """
-    A representation with message passing with uses categorical relation type information.
+    """A representation with message passing with uses categorical relation type information.
 
-    The message passing layers of this module internally handle the categorical relation type information
-    via an `edge_type` input, e.g., :class:`torch_geometric.nn.conv.RGCNConv`, or
-    :class:`torch_geometric.nn.conv.RGATConv`.
+    The message passing layers of this module internally handle the categorical relation type information via an
+    `edge_type` input, e.g., :class:`torch_geometric.nn.conv.RGCNConv`, or :class:`torch_geometric.nn.conv.RGATConv`.
 
     The following example creates a one-layer RGCN using the basis decomposition:
 
@@ -326,27 +296,21 @@ class TypedMessagePassingRepresentation(MessagePassingRepresentation):
     edge_type: LongTensor
 
     def __init__(self, triples_factory: CoreTriplesFactory, **kwargs):
-        """
-        Initialize the representation.
+        """Initialize the representation.
 
-        :param triples_factory:
-            The factory comprising the training triples used for message passing
-        :param kwargs:
-            Additional keyword-based parameters passed to :class:`pykeen.nn.pyg.MessagePassingRepresentation`
+        :param triples_factory: The factory comprising the training triples used for message passing
+        :param kwargs: Additional keyword-based parameters passed to :class:`pykeen.nn.pyg.MessagePassingRepresentation`
         """
         super().__init__(triples_factory=triples_factory, **kwargs)
         # register an additional buffer for the categorical edge type
         self.register_buffer(name="edge_type", tensor=triples_factory.mapped_triples[:, 1])
 
     def _get_edge_type(self, edge_mask: BoolTensor | None = None) -> LongTensor:
-        """
-        Return the (selected part of the) edge type.
+        """Return the (selected part of the) edge type.
 
-        :param edge_mask: shape: ``(num_edges,)``
-            The edge mask.
+        :param edge_mask: shape: ``(num_edges,)`` The edge mask.
 
-        :return: shape: ``(num_selected_edges,)``
-            The selected edge types, or all edge types if ``edge_mask`` is None.
+        :returns: shape: ``(num_selected_edges,)`` The selected edge types, or all edge types if ``edge_mask`` is None.
         """
         if edge_mask is None:
             return self.edge_type
@@ -362,13 +326,11 @@ class TypedMessagePassingRepresentation(MessagePassingRepresentation):
 
 @parse_docdata
 class FeaturizedMessagePassingRepresentation(TypedMessagePassingRepresentation):
-    """
-    A representation with message passing with uses edge features obtained from relation representations.
+    """A representation with message passing with uses edge features obtained from relation representations.
 
-    It (re-)uses a representation layer for relations to obtain edge features, which are then utilized
-    by appropriate message passing layers, e.g., :class:`torch_geometric.nn.conv.GMMConv`, or
-    :class:`torch_geometric.nn.conv.GATConv`. We further allow a (shared) transformation of edge features
-    between layers.
+    It (re-)uses a representation layer for relations to obtain edge features, which are then utilized by appropriate
+    message passing layers, e.g., :class:`torch_geometric.nn.conv.GMMConv`, or :class:`torch_geometric.nn.conv.GATConv`.
+    We further allow a (shared) transformation of edge features between layers.
 
     The following example creates a two-layer GAT on top of the base representations:
 
@@ -392,23 +354,15 @@ class FeaturizedMessagePassingRepresentation(TypedMessagePassingRepresentation):
         relation_transformation: nn.Module | None = None,
         **kwargs,
     ):
-        """
-        Initialize the representation.
+        """Initialize the representation.
 
-        :param triples_factory:
-            The factory comprising the training triples used for message passing.
-
-        :param relation_representation:
-            The base representations for relations, or a hint thereof.
-        :param relation_representation_kwargs:
-            Additional keyword-based parameters passed to the base representations upon instantiation.
-
-        :param relation_transformation:
-            An optional transformation to apply to the relation representations after each message passing step.
-            If ``None``, do not modify the representations.
-
-        :param kwargs:
-            Additional keyword-based parameters passed to
+        :param triples_factory: The factory comprising the training triples used for message passing.
+        :param relation_representation: The base representations for relations, or a hint thereof.
+        :param relation_representation_kwargs: Additional keyword-based parameters passed to the base representations
+            upon instantiation.
+        :param relation_transformation: An optional transformation to apply to the relation representations after each
+            message passing step. If ``None``, do not modify the representations.
+        :param kwargs: Additional keyword-based parameters passed to
             :class:`pykeen.nn.pyg.TypedMessagePassingRepresentation`, except the ``triples_factory``.
         """
         super().__init__(triples_factory=triples_factory, **kwargs)

--- a/src/pykeen/nn/quaternion.py
+++ b/src/pykeen/nn/quaternion.py
@@ -14,8 +14,7 @@ __all__ = [
 
 
 def normalize(x: FloatTensor) -> FloatTensor:
-    r"""
-    Normalize the length of relation vectors, if the forward constraint has not been applied yet.
+    r"""Normalize the length of relation vectors, if the forward constraint has not been applied yet.
 
     Absolute value of a quaternion
 
@@ -26,14 +25,13 @@ def normalize(x: FloatTensor) -> FloatTensor:
     L2 norm of quaternion vector:
 
     .. math::
+
         \|x\|^2 = \sum_{i=1}^d |x_i|^2
                  = \sum_{i=1}^d (x_i.re^2 + x_i.im_1^2 + x_i.im_2^2 + x_i.im_3^2)
 
-    :param x: shape: ``(*batch_dims, 4 \cdot d)``
-        The vector in flat form.
+    :param x: shape: ``(*batch_dims, 4 \cdot d)`` The vector in flat form.
 
-    :return: shape: ``(*batch_dims, 4 \cdot d)``
-        The normalized vector.
+    :returns: shape: ``(*batch_dims, 4 \cdot d)`` The normalized vector.
     """
     # Normalize relation embeddings
     shape = x.shape
@@ -57,11 +55,9 @@ def hamiltonian_product(qa: FloatTensor, qb: FloatTensor) -> FloatTensor:
 
 @lru_cache(1)
 def multiplication_table() -> FloatTensor:
-    """
-    Create the quaternion basis multiplication table.
+    """Create the quaternion basis multiplication table.
 
-    :return: shape: (4, 4, 4)
-        the table of products of basis elements.
+    :returns: shape: (4, 4, 4) the table of products of basis elements.
 
     ..seealso:: https://en.wikipedia.org/wiki/Quaternion#Multiplication_of_basis_elements
     """

--- a/src/pykeen/nn/sim.py
+++ b/src/pykeen/nn/sim.py
@@ -25,33 +25,25 @@ class KG2ESimilarity(nn.Module, abc.ABC):
     """
 
     def __init__(self, exact: bool = True):
-        """
-        Initialize the similarity module.
+        """Initialize the similarity module.
 
-        :param exact:
-            Whether to return the exact similarity, or leave out constant offsets for slightly improved speed.
+        :param exact: Whether to return the exact similarity, or leave out constant offsets for slightly improved speed.
         """
         super().__init__()
         self.exact = exact
 
     @abc.abstractmethod
     def forward(self, h: GaussianDistribution, r: GaussianDistribution, t: GaussianDistribution) -> FloatTensor:
+        """Calculate the similarity.
+
+        :param h: shape: (`*batch_dims`, `d`) The head entity Gaussian distribution.
+        :param r: shape: (`*batch_dims`, `d`) The relation Gaussian distribution.
+        :param t: shape: (`*batch_dims`, `d`) The tail entity Gaussian distribution.
+
+        :returns: torch.Tensor, shape: (`*batch_dims`) # noqa: DAR202 The similarity.
+
+        # noqa:DAR202
         """
-        Calculate the similarity.
-
-        # noqa: DAR401
-
-        :param h: shape: (`*batch_dims`, `d`)
-            The head entity Gaussian distribution.
-        :param r: shape: (`*batch_dims`, `d`)
-            The relation Gaussian distribution.
-        :param t: shape: (`*batch_dims`, `d`)
-            The tail entity Gaussian distribution.
-
-        :return: torch.Tensor, shape: (`*batch_dims`)  # noqa: DAR202
-            The similarity.
-        """
-        raise NotImplementedError
 
 
 class ExpectedLikelihood(KG2ESimilarity):
@@ -101,6 +93,7 @@ class NegativeKullbackLeiblerDivergence(KG2ESimilarity):
     Since all covariance matrices are diagonal, we can further simplify:
 
     .. math::
+
         tr\left(\Sigma_r^{-1} \Sigma_e\right)
         &=&
         \sum_i \Sigma_e[i] / \Sigma_r[i]
@@ -113,7 +106,8 @@ class NegativeKullbackLeiblerDivergence(KG2ESimilarity):
         &=&
         \sum_i \ln \Sigma_r[i] - \sum_i \ln \Sigma_e[i]
 
-    .. seealso ::
+    .. seealso::
+
         `Wikipedia: Multivariate_normal_distribution > Kullback-Leibler Divergence
         <https://en.wikipedia.org/wiki/Multivariate_normal_distribution#Kullback%E2%80%93Leibler_divergence>`_
     """

--- a/src/pykeen/nn/text/cache.py
+++ b/src/pykeen/nn/text/cache.py
@@ -42,8 +42,7 @@ class TextCache(ABC):
 
 
 class IdentityCache(TextCache):
-    """
-    A cache without functionality.
+    """A cache without functionality.
 
     Mostly used for testing.
     """
@@ -72,12 +71,10 @@ class PyOBOTextCache(TextCache):
     def get_texts(self, identifiers: Sequence[str]) -> Sequence[str | None]:
         """Get text for the given CURIEs.
 
-        :param identifiers:
-            The compact URIs for each entity (e.g., ``['doid:1234', ...]``)
+        :param identifiers: The compact URIs for each entity (e.g., ``['doid:1234', ...]``)
 
-        :return:
-            the label for each entity, looked up via :func:`pyobo.get_name`.
-            Might be none if no label is available.
+        :returns: the label for each entity, looked up via :func:`pyobo.get_name`. Might be none if no label is
+            available.
         """
         # This import doesn't need a wrapper since it's a transitive
         # requirement of PyOBO
@@ -134,14 +131,11 @@ class WikidataTextCache(TextCache):
 
     @staticmethod
     def verify_ids(ids: Sequence[str]):
-        """
-        Raise error if invalid IDs are encountered.
+        """Raise error if invalid IDs are encountered.
 
-        :param ids:
-            the ids to verify
+        :param ids: the ids to verify
 
-        :raises ValueError:
-            if any invalid ID is encountered
+        :raises ValueError: if any invalid ID is encountered
         """
         pattern = re.compile(r"Q(\d+)")
         invalid_ids = [one_id for one_id in ids if not pattern.match(one_id)]
@@ -156,21 +150,15 @@ class WikidataTextCache(TextCache):
         batch_size: int = 256,
         timeout=None,
     ) -> Iterable[Mapping[str, Any]]:
-        """
-        Batched SPARQL query execution for the given IDS.
+        """Batched SPARQL query execution for the given IDS.
 
-        :param sparql:
-            the SPARQL query with a placeholder `ids`
-        :param wikidata_ids:
-            the Wikidata IDs
-        :param batch_size:
-            the batch size, i.e., maximum number of IDs per query
-        :param timeout:
-            the timeout for the GET request to the SPARQL endpoint
+        :param sparql: the SPARQL query with a placeholder `ids`
+        :param wikidata_ids: the Wikidata IDs
+        :param batch_size: the batch size, i.e., maximum number of IDs per query
+        :param timeout: the timeout for the GET request to the SPARQL endpoint
 
-        :return:
-            an iterable over JSON results, where the keys correspond to query variables,
-            and the values to the corresponding binding
+        :returns: an iterable over JSON results, where the keys correspond to query variables, and the values to the
+            corresponding binding
         """
         if not wikidata_ids:
             return {}
@@ -203,18 +191,13 @@ class WikidataTextCache(TextCache):
     def query_text(
         cls, wikidata_ids: Sequence[str], language: str = "en", batch_size: int = 256
     ) -> Mapping[str, Mapping[str, str]]:
-        """
-        Query the SPARQL endpoints about information for the given IDs.
+        """Query the SPARQL endpoints about information for the given IDs.
 
-        :param wikidata_ids:
-            the Wikidata IDs
-        :param language:
-            the label language
-        :param batch_size:
-            the batch size; if more ids are provided, break the big request into multiple smaller ones
+        :param wikidata_ids: the Wikidata IDs
+        :param language: the label language
+        :param batch_size: the batch size; if more ids are provided, break the big request into multiple smaller ones
 
-        :return:
-            a mapping from Wikidata Ids to dictionaries with the label and description of the entities
+        :returns: a mapping from Wikidata Ids to dictionaries with the label and description of the entities
         """
         res_json = cls.query(
             sparql=functools.partial(
@@ -258,19 +241,16 @@ class WikidataTextCache(TextCache):
             self.module.dump_json(name=name, obj=entry)
 
     def _get(self, ids: Sequence[str], component: Literal["label", "description"]) -> Sequence[str]:
-        """
-        Get the requested component for the given IDs.
+        """Get the requested component for the given IDs.
 
-        .. note ::
+        .. note::
+
             this method uses file-based caching to avoid excessive requests to the Wikidata API.
 
-        :param ids:
-            the Wikidata IDs
-        :param component:
-            the selected component
+        :param ids: the Wikidata IDs
+        :param component: the selected component
 
-        :return:
-            the selected component for each Wikidata ID
+        :returns: the selected component for each Wikidata ID
         """
         self.verify_ids(ids=ids)
         # try to load cached first
@@ -295,11 +275,9 @@ class WikidataTextCache(TextCache):
     def get_texts(self, identifiers: Sequence[str]) -> Sequence[str]:
         """Get a concatenation of the title and description for each Wikidata identifier.
 
-        :param identifiers:
-            the Wikidata identifiers, each starting with Q (e.g., ``['Q42']``)
+        :param identifiers: the Wikidata identifiers, each starting with Q (e.g., ``['Q42']``)
 
-        :return:
-            the label and description for each Wikidata entity concatenated
+        :returns: the label and description for each Wikidata entity concatenated
         """
         # get labels & descriptions
         titles = self.get_labels(wikidata_identifiers=identifiers)
@@ -308,26 +286,20 @@ class WikidataTextCache(TextCache):
         return [f"{title}: {description}" for title, description in zip(titles, descriptions, strict=False)]
 
     def get_labels(self, wikidata_identifiers: Sequence[str]) -> Sequence[str]:
-        """
-        Get entity labels for the given IDs.
+        """Get entity labels for the given IDs.
 
-        :param wikidata_identifiers:
-            the Wikidata identifiers, each starting with Q (e.g., ``['Q42']``)
+        :param wikidata_identifiers: the Wikidata identifiers, each starting with Q (e.g., ``['Q42']``)
 
-        :return:
-            the label for each Wikidata entity
+        :returns: the label for each Wikidata entity
         """
         return self._get(ids=wikidata_identifiers, component="label")
 
     def get_descriptions(self, wikidata_identifiers: Sequence[str]) -> Sequence[str]:
-        """
-        Get entity descriptions for the given IDs.
+        """Get entity descriptions for the given IDs.
 
-        :param wikidata_identifiers:
-            the Wikidata identifiers, each starting with Q (e.g., ``['Q42']``)
+        :param wikidata_identifiers: the Wikidata identifiers, each starting with Q (e.g., ``['Q42']``)
 
-        :return:
-            the description for each Wikidata entity
+        :returns: the description for each Wikidata entity
         """
         return self._get(ids=wikidata_identifiers, component="description")
 

--- a/src/pykeen/nn/vision/cache.py
+++ b/src/pykeen/nn/vision/cache.py
@@ -50,15 +50,11 @@ class WikidataImageCache(WikidataTextCache):
     ) -> Sequence[pathlib.Path | None]:
         """Get paths to images for the given IDs.
 
-        :param ids:
-            the Wikidata IDs.
-        :param extensions:
-            the allowed file extensions
-        :param progress:
-            whether to display a progress bar
+        :param ids: the Wikidata IDs.
+        :param extensions: the allowed file extensions
+        :param progress: whether to display a progress bar
 
-        :return:
-            the paths to images for the given IDs.
+        :returns: the paths to images for the given IDs.
         """
         id_to_path = self._discover_images(extensions=extensions)
         missing = sorted(set(ids).difference(id_to_path.keys()))

--- a/src/pykeen/nn/vision/representation.py
+++ b/src/pykeen/nn/vision/representation.py
@@ -1,5 +1,4 @@
-"""
-A module of vision related components.
+"""A module of vision related components.
 
 Generally requires :mod:`torchvision` to be installed.
 """
@@ -51,10 +50,10 @@ ImageHints: TypeAlias = Sequence[ImageHint]
 
 
 class VisionDataset(torch.utils.data.Dataset):
-    """
-    A dataset of images with data augmentation.
+    """A dataset of images with data augmentation.
 
-    .. note ::
+    .. note::
+
         requires :mod:`torchvision` to be installed.
     """
 
@@ -64,16 +63,12 @@ class VisionDataset(torch.utils.data.Dataset):
         transforms: Sequence | None = None,
         root: pathlib.Path | None = None,
     ) -> None:
-        """
-        Initialize the dataset.
+        """Initialize the dataset.
 
-        :param images:
-            The images, either as (relative) path, or preprocessed tensors.
-        :param transforms:
-            A sequence of transformations to apply to the images, cf. :mod:`torchvision.transforms`.
+        :param images: The images, either as (relative) path, or preprocessed tensors.
+        :param transforms: A sequence of transformations to apply to the images, cf. :mod:`torchvision.transforms`.
             Defaults to random size crops.
-        :param root:
-            The root directory for images.
+        :param root: The root directory for images.
         """
         _ensure_vision(self, vision_transforms)
         super().__init__()
@@ -126,34 +121,22 @@ class VisualRepresentation(Representation):
         trainable: bool = True,
         **kwargs,
     ):
-        """
-        Initialize the representations.
+        """Initialize the representations.
 
-        :param images:
-            The images, either as tensors, or paths to image files.
-        :param encoder:
-            The encoder to use. If given as a string, lookup in :mod:`torchvision.models`.
-        :param layer_name:
-            The model's layer name to use for extracting the features, cf.
+        :param images: The images, either as tensors, or paths to image files.
+        :param encoder: The encoder to use. If given as a string, lookup in :mod:`torchvision.models`.
+        :param layer_name: The model's layer name to use for extracting the features, cf.
             :func:`torchvision.models.feature_extraction.create_feature_extractor`
-        :param max_id:
-            The number of representations. If given, it must match the number of images.
-        :param shape:
-            The shape of an individual representation. If provided, it must match the encoder output dimension
-        :param transforms:
-            Transformations to apply to the images. Notice that stochastic transformations will result in
+        :param max_id: The number of representations. If given, it must match the number of images.
+        :param shape: The shape of an individual representation. If provided, it must match the encoder output dimension
+        :param transforms: Transformations to apply to the images. Notice that stochastic transformations will result in
             stochastic representations, too.
-        :param encoder_kwargs:
-            Additional keyword-based parameters passed to encoder upon instantiation.
-        :param batch_size:
-            The batch size to use during encoding.
-        :param trainable:
-            Whether the encoder should be trainable.
-        :param kwargs:
-            Additional keyword-based parameters passed to :class:`~pykeen.nn.representation.Representation`.
+        :param encoder_kwargs: Additional keyword-based parameters passed to encoder upon instantiation.
+        :param batch_size: The batch size to use during encoding.
+        :param trainable: Whether the encoder should be trainable.
+        :param kwargs: Additional keyword-based parameters passed to :class:`~pykeen.nn.representation.Representation`.
 
-        :raises ValueError:
-            If `max_id` is provided and does not match the number of images.
+        :raises ValueError: If `max_id` is provided and does not match the number of images.
         """
         _ensure_vision(self, models)
         self.images = VisionDataset(images=images, transforms=transforms)
@@ -193,17 +176,13 @@ class VisualRepresentation(Representation):
     def _encode(
         images: FloatTensor, encoder: torch.nn.Module, pool: Callable[[FloatTensor], FloatTensor]
     ) -> FloatTensor:
-        """
-        Encode images with the given encoder and pooling methods.
+        """Encode images with the given encoder and pooling methods.
 
-        :param images: shape: ``(batch_size, num_channels, height, width)``
-            A batch of images.
-        :param encoder:
-            The encoder, returning a dictionary with key "features".
-        :param pool:
-            The pooling method to use.
-        :return: shape: (batch_size, dim)
-            The encoded representations.
+        :param images: shape: ``(batch_size, num_channels, height, width)`` A batch of images.
+        :param encoder: The encoder, returning a dictionary with key "features".
+        :param pool: The pooling method to use.
+
+        :returns: shape: (batch_size, dim) The encoded representations.
         """
         return pool(encoder(images)["feature"])
 
@@ -222,8 +201,7 @@ class VisualRepresentation(Representation):
 
 @parse_docdata
 class WikidataVisualRepresentation(BackfillRepresentation):
-    """
-    Visual representations obtained from Wikidata and encoded with a vision encoder.
+    """Visual representations obtained from Wikidata and encoded with a vision encoder.
 
     If no image could be found for a certain Wikidata ID, a plain (trainable) embedding will be used instead.
 
@@ -238,20 +216,16 @@ class WikidataVisualRepresentation(BackfillRepresentation):
     def __init__(
         self, wikidata_ids: Sequence[str], max_id: int | None = None, image_kwargs: OptionalKwargs = None, **kwargs
     ):
-        """
-        Initialize the representation.
+        """Initialize the representation.
 
-        :param wikidata_ids:
-            The Wikidata IDs.
-        :param max_id:
-            The total number of IDs. If provided, must match the length of ``wikidata_ids``.
-        :param image_kwargs:
-            Keyword-based parameters passed to :meth:`pykeen.nn.vision.cache.WikidataImageCache.get_image_paths`.
-        :param kwargs:
-            Additional keyword-based parameters passed to :class:`pykeen.nn.vision.representation.VisualRepresentation`.
+        :param wikidata_ids: The Wikidata IDs.
+        :param max_id: The total number of IDs. If provided, must match the length of ``wikidata_ids``.
+        :param image_kwargs: Keyword-based parameters passed to
+            :meth:`pykeen.nn.vision.cache.WikidataImageCache.get_image_paths`.
+        :param kwargs: Additional keyword-based parameters passed to
+            :class:`pykeen.nn.vision.representation.VisualRepresentation`.
 
-        :raises ValueError:
-            If the max_id does not match the number of Wikidata IDs.
+        :raises ValueError: If the max_id does not match the number of Wikidata IDs.
         """
         max_id = max_id or len(wikidata_ids)
         if len(wikidata_ids) != max_id:
@@ -270,19 +244,14 @@ class WikidataVisualRepresentation(BackfillRepresentation):
         for_entities: bool = True,
         **kwargs,
     ) -> Self:
-        """
-        Prepare a visual representations for Wikidata entities from a triples factory.
+        """Prepare a visual representations for Wikidata entities from a triples factory.
 
-        :param triples_factory:
-            The triples factory.
-        :param for_entities:
-            Whether to create the initializer for entities (or relations).
-        :param kwargs:
-            Additional keyword-based arguments passed to
+        :param triples_factory: The triples factory.
+        :param for_entities: Whether to create the initializer for entities (or relations).
+        :param kwargs: Additional keyword-based arguments passed to
             :class:`pykeen.nn.vision.representation.WikidataVisualRepresentation`.
 
-        :returns:
-            A visual representation from the triples factory.
+        :returns: A visual representation from the triples factory.
         """
         return cls(
             wikidata_ids=(
@@ -300,20 +269,14 @@ class WikidataVisualRepresentation(BackfillRepresentation):
     ) -> Self:
         """Prepare representations from a dataset.
 
-        :param dataset:
-            The dataset; needs to have Wikidata IDs as entity names.
-        :param for_entities:
-            Whether to create the initializer for entities (or relations).
-
-        :param kwargs:
-            Additional keyword-based arguments passed to
+        :param dataset: The dataset; needs to have Wikidata IDs as entity names.
+        :param for_entities: Whether to create the initializer for entities (or relations).
+        :param kwargs: Additional keyword-based arguments passed to
             :class:`pykeen.nn.vision.representation.WikidataVisualRepresentation`.
 
-        :return:
-            A visual representation from the training factory in the dataset.
+        :returns: A visual representation from the training factory in the dataset.
 
-        :raises TypeError:
-            If the triples factory does not provide labels.
+        :raises TypeError: If the triples factory does not provide labels.
         """
         if not isinstance(dataset.training, TriplesFactory):
             raise TypeError(f"{cls.__name__} requires access to labels, but dataset.training does not provide such.")

--- a/src/pykeen/nn/weighting.py
+++ b/src/pykeen/nn/weighting.py
@@ -31,24 +31,17 @@ def softmax(
     num_nodes: None | int | torch.Tensor = None,
     dim: int = 0,
 ) -> torch.Tensor:
-    r"""
-    Compute a sparsely evaluated softmax.
+    r"""Compute a sparsely evaluated softmax.
 
-    Given a value tensor :attr:`src`, this function first groups the values
-    along the given dimension based on the indices specified in :attr:`index`,
-    and then proceeds to compute the softmax individually for each group.
+    Given a value tensor :attr:`src`, this function first groups the values along the given dimension based on the
+    indices specified in :attr:`index`, and then proceeds to compute the softmax individually for each group.
 
-    :param src:
-        The source tensor.
-    :param index:
-        The indices of elements for applying the softmax.
-    :param num_nodes:
-        The number of nodes, i.e., :obj:`max_val + 1` of :attr:`index`. (default: :obj:`None`)
-    :param dim:
-        The dimension along which to compute the softmax.
+    :param src: The source tensor.
+    :param index: The indices of elements for applying the softmax.
+    :param num_nodes: The number of nodes, i.e., :obj:`max_val + 1` of :attr:`index`. (default: :obj:`None`)
+    :param dim: The dimension along which to compute the softmax.
 
-    :returns:
-        The softmax-ed tensor.
+    :returns: The softmax-ed tensor.
 
     :raises ImportError: if :mod:`torch_scatter` is not installed
     """
@@ -72,11 +65,9 @@ class EdgeWeighting(nn.Module):
     needs_message: ClassVar[bool] = False
 
     def __init__(self, **kwargs):
-        """
-        Initialize the module.
+        """Initialize the module.
 
-        :param kwargs:
-            ignored keyword-based parameters.
+        :param kwargs: ignored keyword-based parameters.
         """
         # stub init to enable arbitrary arguments in subclasses
         super().__init__()
@@ -91,17 +82,12 @@ class EdgeWeighting(nn.Module):
     ) -> FloatTensor:
         """Compute edge weights.
 
-        :param source: shape: (num_edges,)
-                The source indices.
-        :param target: shape: (num_edges,)
-            The target indices.
-        :param message: shape (num_edges, dim)
-            Actual messages to weight
-        :param x_e: shape (num_nodes, dim)
-            Node states up to the weighting point
+        :param source: shape: (num_edges,) The source indices.
+        :param target: shape: (num_edges,) The target indices.
+        :param message: shape (num_edges, dim) Actual messages to weight
+        :param x_e: shape (num_nodes, dim) Node states up to the weighting point
 
-        :return: shape: (num_edges, dim)
-             Messages weighted with the edge weights.
+        :returns: shape: (num_edges, dim) Messages weighted with the edge weights.
         """
         raise NotImplementedError
 
@@ -179,16 +165,13 @@ class AttentionEdgeWeighting(EdgeWeighting):
         num_heads: int = 8,
         dropout: float = 0.1,
     ):
-        """
-        Initialize the module.
+        """Initialize the module.
 
-        :param message_dim: >0
-            the message dimension. has to be divisible by num_heads
-            .. todo:: change to multiplicative instead of divisive to make this easier to use
-        :param num_heads: >0
-            the number of attention heads
-        :param dropout:
-            the attention dropout
+        :param message_dim: >0 the message dimension. has to be divisible by num_heads .. todo:: change to
+            multiplicative instead of divisive to make this easier to use
+        :param num_heads: >0 the number of attention heads
+        :param dropout: the attention dropout
+
         :raises ValueError: If ``message_dim`` is not divisible by ``num_heads``
         """
         super().__init__()

--- a/src/pykeen/pipeline/plot_utils.py
+++ b/src/pykeen/pipeline/plot_utils.py
@@ -55,27 +55,20 @@ def plot_early_stopping(pipeline_result, *, ax=None, lineplot_kwargs=None):
 
 
 def build_representation_getter(relation: bool = False, index: int = 0) -> Callable[[ERModel], Representation]:
-    """
-    Build a representation getter.
+    """Build a representation getter.
 
-    :param relation:
-        whether to get relation representations, or entity representations.
-    :param index:
-        the index of the representation to get
+    :param relation: whether to get relation representations, or entity representations.
+    :param index: the index of the representation to get
 
-    :return:
-        a function to get the representation.
+    :returns: a function to get the representation.
     """
 
     def getter(model: ERModel) -> Representation:
-        """
-        Get a specific representation from model.
+        """Get a specific representation from model.
 
-        :param model:
-            the model
+        :param model: the model
 
-        :return:
-            the representation
+        :returns: the representation
         """
         # cf. also https://github.com/pykeen/pykeen/issues/1071
         representations = model.relation_representations if relation else model.entity_representations
@@ -105,35 +98,35 @@ def plot_er(  # noqa: C901
     """Plot the reduced entities and relation vectors in 2D.
 
     :param pipeline_result: The result returned by :func:`pykeen.pipeline.pipeline`.
-    :param model: The dimensionality reduction model from :mod:`sklearn`. Defaults to PCA.
-        Can also use KPCA, GRP, SRP, TSNE, LLE, ISOMAP, MDS, or SE.
+    :param model: The dimensionality reduction model from :mod:`sklearn`. Defaults to PCA. Can also use KPCA, GRP, SRP,
+        TSNE, LLE, ISOMAP, MDS, or SE.
     :param entities: A subset of entities to plot
     :param relations: A subset of relations to plot
     :param apply_limits: Should the x and y limits be applied?
     :param margin: The margin size around the minimum/maximum x and y values
     :param plot_entities: If true, plot the entities based on their reduced embeddings
-    :param plot_relations: By default, this is only enabled on translational distance models
-        like :class:`pykeen.models.TransE`.
+    :param plot_relations: By default, this is only enabled on translational distance models like
+        :class:`pykeen.models.TransE`.
     :param annotation_x_offset: X offset of label from entity position
     :param annotation_y_offset: Y offset of label from entity position
-    :param entity_embedding_getter: A function that takes a model and returns its entity embeddings. If none,
-        defaults to :func:`_default_entity_embedding_getter`, which just gets ``model.entity_embeddings``. Note,
-        the default only works with old-style PyKEEN models.
+    :param entity_embedding_getter: A function that takes a model and returns its entity embeddings. If none, defaults
+        to :func:`_default_entity_embedding_getter`, which just gets ``model.entity_embeddings``. Note, the default only
+        works with old-style PyKEEN models.
     :param relation_embedding_getter: A function that takes a model and returns its relation embeddings. If none,
-        defaults to :func:`_default_relation_embedding_getter`, which just gets ``model.relation_embeddings``. Note,
-        the default only works with old-style PyKEEN models.
+        defaults to :func:`_default_relation_embedding_getter`, which just gets ``model.relation_embeddings``. Note, the
+        default only works with old-style PyKEEN models.
     :param ax: The matplotlib axis, if pre-defined
     :param subtitle: A user-defined subtitle. Is inferred if not given. Pass an empty string to not use a subtitle.
-    :param kwargs: The keyword arguments passed to `__init__()` of
-        the reducer class (e.g., PCA, TSNE)
+    :param kwargs: The keyword arguments passed to `__init__()` of the reducer class (e.g., PCA, TSNE)
+
     :returns: The axis
 
     :raises ValueError: if entity plotting and relation plotting are both turned off
 
     .. warning::
 
-        Plotting relations and entities on the same plot is only
-        meaningful for translational distance models like TransE.
+        Plotting relations and entities on the same plot is only meaningful for translational distance models like
+        TransE.
     """
     import seaborn as sns
 
@@ -261,10 +254,10 @@ def _reduce_embeddings(embedding: Representation, reducer, fit: bool = False):
 def _get_reducer_cls(model: str, **kwargs):
     """Get the model class by name and default kwargs.
 
-    :param model: The name of the model. Can choose from: PCA, KPCA, GRP,
-        SRP, TSNE, LLE, ISOMAP, MDS, or SE.
+    :param model: The name of the model. Can choose from: PCA, KPCA, GRP, SRP, TSNE, LLE, ISOMAP, MDS, or SE.
     :param kwargs: Keyword arguments that will get passed through and modified based on the chosen model.
-    :return: A pair of a reducer class from :mod:`sklearn` and the modified kwargs.
+
+    :returns: A pair of a reducer class from :mod:`sklearn` and the modified kwargs.
 
     :raises ValueError: if invalid model name is passed
     """

--- a/src/pykeen/sampling/__init__.py
+++ b/src/pykeen/sampling/__init__.py
@@ -1,60 +1,64 @@
-r"""For entities $\mathcal{E}$ and relations $\mathcal{R}$, the set of all possible triples $\mathcal{T}$ is
-constructed through their cartesian product $\mathcal{T} = \mathcal{E} \times \mathcal{R} \times \mathcal{E}$.
-A given knowledge graph $\mathcal{K}$ is a subset of all possible triples $\mathcal{K} \subseteq \mathcal{T}$.
+r"""Sampling.
+
+For entities $\mathcal{E}$ and relations $\mathcal{R}$, the set of all possible triples $\mathcal{T}$ is constructed
+through their cartesian product $\mathcal{T} = \mathcal{E} \times \mathcal{R} \times \mathcal{E}$. A given knowledge
+graph $\mathcal{K}$ is a subset of all possible triples $\mathcal{K} \subseteq \mathcal{T}$.
 
 Construction of Knowledge Graphs
---------------------------------
-When constructing a knowledge graph $\mathcal{K}_{\text{closed}}$ under the closed world assumption, the labels of the
-remaining triples $(h,r,t) \in \mathcal{T} \setminus \mathcal{K}_{\text{closed}}$ are defined as negative.
-When constructing a knowledge graph $\mathcal{K}_{\text{open}}$ under the open world assumption, the labels of the
-remaining triples $(h,r,t) \in \mathcal{T} \setminus \mathcal{K}_{\text{open}}$ are unknown.
+================================
 
-Becuase most knowledge graphs are generated under the open world assumption, negative sampling techniques
-must be employed during the training of knowledge graph embedding models to avoid over-generalization.
+When constructing a knowledge graph $\mathcal{K}_{\text{closed}}$ under the closed world assumption, the labels of the
+remaining triples $(h,r,t) \in \mathcal{T} \setminus \mathcal{K}_{\text{closed}}$ are defined as negative. When
+constructing a knowledge graph $\mathcal{K}_{\text{open}}$ under the open world assumption, the labels of the remaining
+triples $(h,r,t) \in \mathcal{T} \setminus \mathcal{K}_{\text{open}}$ are unknown.
+
+Becuase most knowledge graphs are generated under the open world assumption, negative sampling techniques must be
+employed during the training of knowledge graph embedding models to avoid over-generalization.
 
 Corruption
-----------
-Negative sampling techniques often generate negative triples by corrupting a known positive triple
-$(h,r,t) \in \mathcal{K}$ by replacing either $h$, $r$, or $t$ with one of the following operations:
+==========
 
-=================  =====================================================================================
-Corrupt heads      :math:`\mathcal{H}(h, r, t) = \{(h', r, t) \mid h' \in \mathcal{E} \land h' \neq h\}`
-Corrupt relations  :math:`\mathcal{R}(h, r, t) = \{(h, r', t) \mid r' \in \mathcal{E} \land r' \neq r\}`
-Corrupt tails      :math:`\mathcal{T}(h, r, t) = \{(h, r, t') \mid t' \in \mathcal{E} \land t' \neq t\}`
-=================  =====================================================================================
+Negative sampling techniques often generate negative triples by corrupting a known positive triple $(h,r,t) \in
+\mathcal{K}$ by replacing either $h$, $r$, or $t$ with one of the following operations:
 
-Typically, the corrupt relations operation $\mathcal{R}(h, r, t)$ is omitted becuase the evaluation of knowledge
-graph embedding models on the link prediction task only consideres the goodness of head prediction and tail
-prediction, but not relation prediction. Therefore, the set of candidate negative triples $\mathcal{N}(h, r, t)$ for
-a given known positive triple $(h,r,t) \in \mathcal{K}$ is given by:
+================= =====================================================================================
+Corrupt heads     :math:`\mathcal{H}(h, r, t) = \{(h', r, t) \mid h' \in \mathcal{E} \land h' \neq h\}`
+Corrupt relations :math:`\mathcal{R}(h, r, t) = \{(h, r', t) \mid r' \in \mathcal{E} \land r' \neq r\}`
+Corrupt tails     :math:`\mathcal{T}(h, r, t) = \{(h, r, t') \mid t' \in \mathcal{E} \land t' \neq t\}`
+================= =====================================================================================
+
+Typically, the corrupt relations operation $\mathcal{R}(h, r, t)$ is omitted becuase the evaluation of knowledge graph
+embedding models on the link prediction task only consideres the goodness of head prediction and tail prediction, but
+not relation prediction. Therefore, the set of candidate negative triples $\mathcal{N}(h, r, t)$ for a given known
+positive triple $(h,r,t) \in \mathcal{K}$ is given by:
 
 .. math::
 
     \mathcal{N}(h, r, t) = \mathcal{T}(h, r, t) \cup \mathcal{H}(h, r, t)
 
-Generally, the set of potential negative triples $\mathcal{N}$ over all positive triples $(h,r,t) \in \mathcal{K}$
-is defined as:
+Generally, the set of potential negative triples $\mathcal{N}$ over all positive triples $(h,r,t) \in \mathcal{K}$ is
+defined as:
 
 .. math::
 
     \mathcal{N} = \bigcup_{(h,r,t) \in \mathcal{K}} \mathcal{N}(h, r, t)
 
 Uniform Negative Sampling
-~~~~~~~~~~~~~~~~~~~~~~~~~
-The default negative sampler :class:`pykeen.sampling.BasicNegativeSampler` generates corrupted triples from
-a known positive triple $(h,r,t) \in \mathcal{K}$ by uniformly randomly either using the corrupt heads operation
-or the corrupt tails operation. The default negative sampler is automatically used in the following code:
+-------------------------
+
+The default negative sampler :class:`pykeen.sampling.BasicNegativeSampler` generates corrupted triples from a known
+positive triple $(h,r,t) \in \mathcal{K}$ by uniformly randomly either using the corrupt heads operation or the corrupt
+tails operation. The default negative sampler is automatically used in the following code:
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     results = pipeline(
-        dataset='YAGO3-10',
-        model='PairRE',
-        training_loop='sLCWA',
+        dataset="YAGO3-10",
+        model="PairRE",
+        training_loop="sLCWA",
     )
-
 
 It can be set explicitly with:
 
@@ -63,47 +67,48 @@ It can be set explicitly with:
     from pykeen.pipeline import pipeline
 
     results = pipeline(
-        dataset='YAGO3-10',
-        model='PairRE',
-        training_loop='sLCWA',
-        negative_sampler='basic',
+        dataset="YAGO3-10",
+        model="PairRE",
+        training_loop="sLCWA",
+        negative_sampler="basic",
     )
 
 In general, the behavior of the negative sampler can be modified when using the :func:`pykeen.pipeline.pipeline` by
-passing the ``negative_sampler_kwargs`` argument. In order to explicitly specifiy which of the head, relation, and
-tail corruption methods are used, the ``corruption_schema`` argument can be used. For example, to use all three,
-the collection ``('h', 'r', 't')`` can be passed as in the following:
+passing the ``negative_sampler_kwargs`` argument. In order to explicitly specifiy which of the head, relation, and tail
+corruption methods are used, the ``corruption_schema`` argument can be used. For example, to use all three, the
+collection ``('h', 'r', 't')`` can be passed as in the following:
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     results = pipeline(
-        dataset='YAGO3-10',
-        model='PairRE',
-        training_loop='sLCWA',
-        negative_sampler='basic',
+        dataset="YAGO3-10",
+        model="PairRE",
+        training_loop="sLCWA",
+        negative_sampler="basic",
         negative_sampler_kwargs=dict(
-            corruption_scheme=('h', 'r', 't'),
+            corruption_scheme=("h", "r", "t"),
         ),
     )
 
 Bernoulli Negative Sampling
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Bernoulli negative sampler :class:`pykeen.sampling.BernoulliNegativeSampler` generates corrupted triples from
-a known positive triple $(h,r,t) \in \mathcal{K}$ similarly to the uniform negative sampler, but it pre-computes
-a probability $p_r$ for each relation $r$ to weight whether the head corruption is used with probability $p_r$ or
-if tail corruption is used with probability $1 - p_r$.
+---------------------------
+
+The Bernoulli negative sampler :class:`pykeen.sampling.BernoulliNegativeSampler` generates corrupted triples from a
+known positive triple $(h,r,t) \in \mathcal{K}$ similarly to the uniform negative sampler, but it pre-computes a
+probability $p_r$ for each relation $r$ to weight whether the head corruption is used with probability $p_r$ or if tail
+corruption is used with probability $1 - p_r$.
 
 .. code-block:: python
 
     from pykeen.pipeline import pipeline
 
     results = pipeline(
-        dataset='YAGO3-10',
-        model='PairRE',
-        training_loop='sLCWA',
-        negative_sampler='bernoulli',
+        dataset="YAGO3-10",
+        model="PairRE",
+        training_loop="sLCWA",
+        negative_sampler="bernoulli",
     )
 """  # noqa
 

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -16,19 +16,13 @@ __all__ = [
 
 
 def random_replacement_(batch: LongTensor, index: int, selection: slice, size: int, max_index: int) -> None:
-    """
-    Replace a column of a batch of indices by random indices.
+    """Replace a column of a batch of indices by random indices.
 
-    :param batch: shape: `(*batch_dims, d)`
-        the batch of indices
-    :param index:
-        the index (of the last axis) which to replace
-    :param selection:
-        a selection of the batch, e.g., a slice or a mask
-    :param size:
-        the size of the selection
-    :param max_index:
-        the maximum index value at the chosen position
+    :param batch: shape: `(*batch_dims, d)` the batch of indices
+    :param index: the index (of the last axis) which to replace
+    :param selection: a selection of the batch, e.g., a slice or a mask
+    :param size: the size of the selection
+    :param max_index: the maximum index value at the chosen position
     """
     # At least make sure to not replace the triples by the original value
     # To make sure we don't replace the {head, relation, tail} by the
@@ -51,16 +45,17 @@ class BasicNegativeSampler(NegativeSampler):
 
     Steps:
 
-    1. Randomly (uniformly) determine whether $h$, $r$ or $t$ shall be corrupted for a positive triple
-       $(h,r,t) \in \mathcal{K}$.
+    1. Randomly (uniformly) determine whether $h$, $r$ or $t$ shall be corrupted for a positive triple $(h,r,t) \in
+       \mathcal{K}$.
     2. Randomly (uniformly) sample an entity $e \in \mathcal{E}$ or relation $r' \in \mathcal{R}$ for selection to
        corrupt the triple.
 
        - If $h$ was selected before, the corrupted triple is $(e,r,t)$
        - If $r$ was selected before, the corrupted triple is $(h,r',t)$
        - If $t$ was selected before, the corrupted triple is $(h,r,e)$
-    3. If ``filtered`` is set to ``True``, all proposed corrupted triples that also exist as
-       actual positive triples $(h,r,t) \in \mathcal{K}$ will be removed.
+
+    3. If ``filtered`` is set to ``True``, all proposed corrupted triples that also exist as actual positive triples
+       $(h,r,t) \in \mathcal{K}$ will be removed.
     """
 
     def __init__(
@@ -71,10 +66,8 @@ class BasicNegativeSampler(NegativeSampler):
     ) -> None:
         """Initialize the basic negative sampler with the given entities.
 
-        :param corruption_scheme:
-            What sides ('h', 'r', 't') should be corrupted. Defaults to head and tail ('h', 't').
-        :param kwargs:
-            Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
+        :param corruption_scheme: What sides ('h', 'r', 't') should be corrupted. Defaults to head and tail ('h', 't').
+        :param kwargs: Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
         """
         super().__init__(**kwargs)
         self.corruption_scheme = corruption_scheme or (LABEL_HEAD, LABEL_TAIL)

--- a/src/pykeen/sampling/negative_sampler.py
+++ b/src/pykeen/sampling/negative_sampler.py
@@ -43,21 +43,15 @@ class NegativeSampler(nn.Module):
     ) -> None:
         """Initialize the negative sampler with the given entities.
 
-        :param mapped_triples:
-            the positive training triples
-        :param num_entities:
-            the number of entities. If None, will be inferred from the triples.
-        :param num_relations:
-            the number of relations. If None, will be inferred from the triples.
-        :param num_negs_per_pos:
-            number of negative samples to make per positive triple. Defaults to 1.
-        :param filtered: Whether proposed corrupted triples that are in the training data should be filtered.
-            Defaults to False. See explanation in :func:`filter_negative_triples` for why this is
-            a reasonable default.
+        :param mapped_triples: the positive training triples
+        :param num_entities: the number of entities. If None, will be inferred from the triples.
+        :param num_relations: the number of relations. If None, will be inferred from the triples.
+        :param num_negs_per_pos: number of negative samples to make per positive triple. Defaults to 1.
+        :param filtered: Whether proposed corrupted triples that are in the training data should be filtered. Defaults
+            to False. See explanation in :func:`filter_negative_triples` for why this is a reasonable default.
         :param filterer: If filtered is set to True, this can be used to choose which filter module from
             :mod:`pykeen.sampling.filtering` is used.
-        :param filterer_kwargs:
-            Additional keyword-based arguments passed to the filterer upon construction.
+        :param filterer_kwargs: Additional keyword-based arguments passed to the filterer upon construction.
         """
         super().__init__()
         self.num_entities = num_entities or mapped_triples[:, [0, 2]].max().item() + 1
@@ -79,20 +73,16 @@ class NegativeSampler(nn.Module):
         return normalize_string(cls.__name__, suffix=NegativeSampler.__name__)
 
     def sample(self, positive_batch: LongTensor) -> tuple[LongTensor, BoolTensor | None]:
-        """
-        Generate negative samples from the positive batch.
+        """Generate negative samples from the positive batch.
 
-        :param positive_batch: shape: (batch_size, 3)
-            The positive triples.
+        :param positive_batch: shape: (batch_size, 3) The positive triples.
 
-        :return:
-            A pair `(negative_batch, filter_mask)` where
+        :returns: A pair `(negative_batch, filter_mask)` where
 
-            1. `negative_batch`: shape: (batch_size, num_negatives, 3)
-               The negative batch. ``negative_batch[i, :, :]`` contains the negative examples generated from
-               ``positive_batch[i, :]``.
-            2. filter_mask: shape: (batch_size, num_negatives)
-               An optional filter mask. True where negative samples are valid.
+            1. `negative_batch`: shape: (batch_size, num_negatives, 3) The negative batch. ``negative_batch[i, :, :]``
+               contains the negative examples generated from ``positive_batch[i, :]``.
+            2. filter_mask: shape: (batch_size, num_negatives) An optional filter mask. True where negative samples are
+               valid.
         """
         # create unfiltered negative batch by corruption
         negative_batch = self.corrupt_batch(positive_batch=positive_batch)
@@ -105,14 +95,11 @@ class NegativeSampler(nn.Module):
 
     @abstractmethod
     def corrupt_batch(self, positive_batch: LongTensor) -> LongTensor:
-        """
-        Generate negative samples from the positive batch without application of any filter.
+        """Generate negative samples from the positive batch without application of any filter.
 
-        :param positive_batch: shape: `(*batch_dims, 3)`
-            The positive triples.
+        :param positive_batch: shape: `(*batch_dims, 3)` The positive triples.
 
-        :return: shape: `(*batch_dims, num_negs_per_pos, 3)`
-            The negative triples. ``result[*bi, :, :]`` contains the negative examples generated from
-            ``positive_batch[*bi, :]``.
+        :returns: shape: `(*batch_dims, num_negs_per_pos, 3)` The negative triples. ``result[*bi, :, :]`` contains the
+            negative examples generated from ``positive_batch[*bi, :]``.
         """
         raise NotImplementedError

--- a/src/pykeen/sampling/pseudo_type.py
+++ b/src/pykeen/sampling/pseudo_type.py
@@ -20,25 +20,21 @@ def create_index(
     mapped_triples: MappedTriples,
     num_relations: int,
 ) -> tuple[LongTensor, LongTensor]:
-    """
-    Create an index for efficient vectorized pseudo-type negative sampling.
+    """Create an index for efficient vectorized pseudo-type negative sampling.
 
-    For this sampling, we need to store for each relation the set of head / tail entities. For efficient
-    vectorized sampling, the following data structure is employed, which is partially inspired by the
-    CSR format of sparse matrices (cf. :class:`scipy.sparse.csr_matrix`).
+    For this sampling, we need to store for each relation the set of head / tail entities. For efficient vectorized
+    sampling, the following data structure is employed, which is partially inspired by the CSR format of sparse matrices
+    (cf. :class:`scipy.sparse.csr_matrix`).
 
-    We use two arrays, ``offsets`` and ``data``. The `offsets` array is of shape ``(2 * num_relations + 1,)``.
-    The ``data`` array contains the sorted set of heads and tails for each relation, i.e.
+    We use two arrays, ``offsets`` and ``data``. The `offsets` array is of shape ``(2 * num_relations + 1,)``. The
+    ``data`` array contains the sorted set of heads and tails for each relation, i.e.
     ``data[offsets[2*r]:offsets[2*r+1]]`` are the IDs of head entities for relation ``r``, and
     ``data[offsets[2*r+1]:offsets[2*r+2]]`` the ID of tail entities.
 
-    :param mapped_triples:
-        the mapped triples
-    :param num_relations:
-        the number of relations
+    :param mapped_triples: the mapped triples
+    :param num_relations: the number of relations
 
-    :return:
-        A pair (data, offsets) containing the compressed triples.
+    :returns: A pair (data, offsets) containing the compressed triples.
     """
     heads, tails = create_relation_to_entity_set_mapping(triples=mapped_triples.tolist())
     relations = set(heads.keys()).union(tails.keys())
@@ -62,10 +58,12 @@ def create_index(
 class PseudoTypedNegativeSampler(NegativeSampler):
     r"""A sampler that accounts for which entities co-occur with a relation.
 
-    To generate a corrupted head entity for triple $(h, r, t)$, only those entities are considered which occur as a
-    head entity in a triple with the relation $r$.
+    To generate a corrupted head entity for triple $(h, r, t)$, only those entities are considered which occur as a head
+    entity in a triple with the relation $r$.
 
-    .. warning:: With this type of sampler, filtering for false negatives is more important.
+    .. warning::
+
+        With this type of sampler, filtering for false negatives is more important.
     """
 
     #: The array of offsets within the data array, shape: (2 * num_relations + 1,)
@@ -80,13 +78,10 @@ class PseudoTypedNegativeSampler(NegativeSampler):
         mapped_triples: MappedTriples,
         **kwargs,
     ):
-        """
-        Instantiate the pseudo-typed negative sampler.
+        """Instantiate the pseudo-typed negative sampler.
 
-        :param mapped_triples:
-            the positive training triples
-        :param kwargs:
-            Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
+        :param mapped_triples: the positive training triples
+        :param kwargs: Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
         """
         super().__init__(mapped_triples=mapped_triples, **kwargs)
         self.data, self.offsets = create_index(mapped_triples=mapped_triples, num_relations=self.num_relations)

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -37,20 +37,14 @@ def is_improvement(
     larger_is_better: bool,
     relative_delta: float = 0.0,
 ) -> bool:
-    """
-    Decide whether the current value is an improvement over the best value.
+    """Decide whether the current value is an improvement over the best value.
 
-    :param best_value:
-        The best value so far.
-    :param current_value:
-        The current value.
-    :param larger_is_better:
-        Whether a larger value is better.
-    :param relative_delta:
-        A minimum relative improvement until it is considered as an improvement.
+    :param best_value: The best value so far.
+    :param current_value: The current value.
+    :param larger_is_better: Whether a larger value is better.
+    :param relative_delta: A minimum relative improvement until it is considered as an improvement.
 
-    :return:
-        Whether the current value is better.
+    :returns: Whether the current value is better.
     """
     better = current_value > best_value if larger_is_better else current_value < best_value
     return better and not math.isclose(current_value, best_value, rel_tol=relative_delta)
@@ -93,19 +87,14 @@ class EarlyStoppingLogic:
         )
 
     def report_result(self, metric: float, epoch: int) -> bool:
-        """
-        Report a result at the given epoch.
+        """Report a result at the given epoch.
 
-        :param metric:
-            The result metric.
-        :param epoch:
-            The epoch.
+        :param metric: The result metric.
+        :param epoch: The epoch.
 
-        :return:
-            If the result did not improve more than delta for patience evaluations
+        :returns: If the result did not improve more than delta for patience evaluations
 
-        :raises ValueError:
-            if more than one metric is reported for a single epoch
+        :raises ValueError: if more than one metric is reported for a single epoch
         """
         if self.best_epoch is not None and epoch <= self.best_epoch:
             raise ValueError("Cannot report more than one metric for one epoch")

--- a/src/pykeen/stoppers/stopper.py
+++ b/src/pykeen/stoppers/stopper.py
@@ -20,13 +20,10 @@ class Stopper(ABC):
     """A harness for stopping training."""
 
     def __init__(self, *args, **kwargs):
-        """
-        Initialize the stopper.
+        """Initialize the stopper.
 
-        :param args:
-            ignored positional parameters
-        :param kwargs:
-            ignored keyword-based parameters
+        :param args: ignored positional parameters
+        :param kwargs: ignored keyword-based parameters
         """
         # To make MyPy happy
         self.best_epoch = None
@@ -65,11 +62,9 @@ class Stopper(ABC):
     def load_summary_dict_from_training_loop_checkpoint(path: str | pathlib.Path) -> Mapping[str, Any]:
         """Load the summary dict from a training loop checkpoint.
 
-        :param path:
-            Path of the file where to store the state in.
+        :param path: Path of the file where to store the state in.
 
-        :return:
-            The summary dict of the stopper at the time of saving the checkpoint.
+        :returns: The summary dict of the stopper at the time of saving the checkpoint.
         """
         logger.info(f"=> loading stopper summary dict from training loop checkpoint in '{path}'")
         checkpoint = torch.load(path, weights_only=False)

--- a/src/pykeen/trackers/__init__.py
+++ b/src/pykeen/trackers/__init__.py
@@ -44,12 +44,12 @@ def resolve_result_trackers(
 ) -> MultiResultTracker:
     """Resolve and compose result trackers.
 
-    :param result_tracker: Either none (will result in a Python result tracker),
-        a single tracker (as either a class, instance, or string for class name), or a list
-        of trackers (as either a class, instance, or string for class name
-    :param result_tracker_kwargs: Either none (will use all defaults), a single dictionary
-        (will be used for all trackers), or a list of dictionaries with the same length
-        as the result trackers
+    :param result_tracker: Either none (will result in a Python result tracker), a single tracker (as either a class,
+        instance, or string for class name), or a list of trackers (as either a class, instance, or string for class
+        name
+    :param result_tracker_kwargs: Either none (will use all defaults), a single dictionary (will be used for all
+        trackers), or a list of dictionaries with the same length as the result trackers
+
     :returns: A multi-result trackers that offloads to all contained result trackers
     """
     if result_tracker is None:

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -46,8 +46,7 @@ class ResultTracker:
 
         HAS to be called after the experiment is finished.
 
-        :param success:
-            Can be used to signal failed runs. May be ignored.
+        :param success: Can be used to signal failed runs. May be ignored.
         """
 
 
@@ -70,7 +69,6 @@ class PythonResultTracker(ResultTracker):
         print("Default configuration:")
         for k, v in tracker.configuration.items():
             print(f"{k:20} = {v}")
-
     """
 
     #: The name of the run
@@ -131,21 +129,14 @@ class ConsoleResultTracker(ResultTracker):
         start_end_run: bool = False,
         writer: str = "tqdm",
     ):
-        """
-        Initialize the tracker.
+        """Initialize the tracker.
 
-        :param track_parameters:
-            Whether to print parameters.
-        :param parameter_filter:
-            A regular expression to filter parameters. If None, print all parameters.
-        :param track_metrics:
-            Whether to print metrics.
-        :param metric_filter:
-            A regular expression to filter metrics. If None, print all parameters.
-        :param start_end_run:
-            Whether to print start/end run messages.
-        :param writer:
-            The writer to use - one of "tqdm", "builtin", or "logger".
+        :param track_parameters: Whether to print parameters.
+        :param parameter_filter: A regular expression to filter parameters. If None, print all parameters.
+        :param track_metrics: Whether to print metrics.
+        :param metric_filter: A regular expression to filter metrics. If None, print all parameters.
+        :param start_end_run: Whether to print start/end run messages.
+        :param writer: The writer to use - one of "tqdm", "builtin", or "logger".
         """
         self.start_end_run = start_end_run
 
@@ -213,11 +204,9 @@ class MultiResultTracker(ResultTracker):
     trackers: list[ResultTracker]
 
     def __init__(self, trackers: TrackerHint = None) -> None:
-        """
-        Initialize the tracker.
+        """Initialize the tracker.
 
-        :param trackers:
-            the base tracker(s).
+        :param trackers: the base tracker(s).
         """
         if trackers is None:
             self.trackers = []

--- a/src/pykeen/trackers/file.py
+++ b/src/pykeen/trackers/file.py
@@ -51,10 +51,9 @@ class FileResultTracker(ResultTracker):
     ):
         """Initialize the tracker.
 
-        :param path:
-            The path of the log file.
-        :param name: The default file name for a file if no path is given. If no default is given,
-            the current time is used.
+        :param path: The path of the log file.
+        :param name: The default file name for a file if no path is given. If no default is given, the current time is
+            used.
         """
         if name is None:
             name = datetime.datetime.now().isoformat()
@@ -90,12 +89,10 @@ class CSVResultTracker(FileResultTracker):
     ):
         """Initialize the tracker.
 
-        :param path:
-            The path of the log file.
-        :param name: The default file name for a file if no path is given. If no default is given,
-            the current time is used.
-        :param kwargs:
-            Additional keyword based arguments forwarded to csv.writer.
+        :param path: The path of the log file.
+        :param name: The default file name for a file if no path is given. If no default is given, the current time is
+            used.
+        :param kwargs: Additional keyword based arguments forwarded to csv.writer.
         """
         super().__init__(path=path, name=name)
         self.csv_writer = csv.writer(self.file, **kwargs)

--- a/src/pykeen/trackers/mlflow.py
+++ b/src/pykeen/trackers/mlflow.py
@@ -21,19 +21,14 @@ class MLFlowResultTracker(ResultTracker):
         experiment_name: str | None = None,
         tags: dict[str, Any] | None = None,
     ):
-        """
-        Initialize result tracking via MLFlow.
+        """Initialize result tracking via MLFlow.
 
-        :param tracking_uri:
-            The tracking uri.
-        :param experiment_id:
-            The experiment ID. If given, this has to be the ID of an existing experiment in MFLow. Has priority over
-            experiment_name.
-        :param experiment_name:
-            The experiment name. If this experiment name exists, add the current run to this experiment. Otherwise
-            create an experiment of the given name.
-        :param tags:
-            The additional run details which are presented as tags to be logged
+        :param tracking_uri: The tracking uri.
+        :param experiment_id: The experiment ID. If given, this has to be the ID of an existing experiment in MFLow. Has
+            priority over experiment_name.
+        :param experiment_name: The experiment name. If this experiment name exists, add the current run to this
+            experiment. Otherwise create an experiment of the given name.
+        :param tags: The additional run details which are presented as tags to be logged
         """
         import mlflow as _mlflow
 

--- a/src/pykeen/trackers/neptune.py
+++ b/src/pykeen/trackers/neptune.py
@@ -33,28 +33,25 @@ class NeptuneResultTracker(ResultTracker):
     ):
         """Initialize the Neptune result tracker.
 
-        :param project_qualified_name:
-            Qualified name of a project in a form of ``namespace/project_name``.
-            If ``None``, the value of ``NEPTUNE_PROJECT`` environment variable will be taken. For testing,
-            should be `<your username>/sandbox`
-        :param api_token:
-            User's API token. If ``None``, the value of ``NEPTUNE_API_TOKEN`` environment variable will be taken.
+        :param project_qualified_name: Qualified name of a project in a form of ``namespace/project_name``. If ``None``,
+            the value of ``NEPTUNE_PROJECT`` environment variable will be taken. For testing, should be `<your
+            username>/sandbox`
+        :param api_token: User's API token. If ``None``, the value of ``NEPTUNE_API_TOKEN`` environment variable will be
+            taken.
 
             .. note::
 
-                It is strongly recommended to use ``NEPTUNE_API_TOKEN`` environment variable rather than
-                placing your API token in plain text in your source code.
-        :param offline:
-            Run neptune in offline mode (uses :class:`neptune.OfflineBackend` as the backend)
-        :param experiment_id:
-            The identifier of a pre-existing experiment to use. If not given, will rely
-            on the ``experiment_name``.
-        :param experiment_name:
-            The name of the experiment. If no ``experiment_id`` is given, one will be created based
+                It is strongly recommended to use ``NEPTUNE_API_TOKEN`` environment variable rather than placing your
+                API token in plain text in your source code.
+
+        :param offline: Run neptune in offline mode (uses :class:`neptune.OfflineBackend` as the backend)
+        :param experiment_id: The identifier of a pre-existing experiment to use. If not given, will rely on the
+            ``experiment_name``.
+        :param experiment_name: The name of the experiment. If no ``experiment_id`` is given, one will be created based
             on the name.
         :param tags: A collection of tags to add to the experiment
-        :raises ValueError:
-            If neither an experiment name nor experiment ID is given
+
+        :raises ValueError: If neither an experiment name nor experiment ID is given
         """
         import neptune
 

--- a/src/pykeen/trackers/tensorboard.py
+++ b/src/pykeen/trackers/tensorboard.py
@@ -28,14 +28,11 @@ class TensorBoardResultTracker(ResultTracker):
         experiment_path: None | str | pathlib.Path = None,
         experiment_name: str | None = None,
     ):
-        """
-        Initialize result tracking via Tensorboard.
+        """Initialize result tracking via Tensorboard.
 
-        :param experiment_path:
-            The experiment path. A custom path at which the tensorboard logs will be saved.
-        :param experiment_name:
-            The name of the experiment, will be used as a sub directory name for the logging. If no default is given,
-            the current time is used. If set, experiment_path is set, this argument has no effect.
+        :param experiment_path: The experiment path. A custom path at which the tensorboard logs will be saved.
+        :param experiment_name: The name of the experiment, will be used as a sub directory name for the logging. If no
+            default is given, the current time is used. If set, experiment_path is set, this argument has no effect.
         """
         import torch.utils.tensorboard
 

--- a/src/pykeen/trackers/wandb.py
+++ b/src/pykeen/trackers/wandb.py
@@ -32,14 +32,11 @@ class WANDBResultTracker(ResultTracker):
     ):
         """Initialize result tracking via WANDB.
 
-        :param project:
-            project name your WANDB login has access to.
-        :param offline:
-            whether to run in offline mode, i.e, without syncing with the wandb server.
-        :param kwargs:
-            additional keyword arguments passed to :func:`wandb.init`.
-        :raises ValueError:
-            If the project name is given as None
+        :param project: project name your WANDB login has access to.
+        :param offline: whether to run in offline mode, i.e, without syncing with the wandb server.
+        :param kwargs: additional keyword arguments passed to :func:`wandb.init`.
+
+        :raises ValueError: If the project name is given as None
         """
         import wandb as _wandb
 

--- a/src/pykeen/triples/__init__.py
+++ b/src/pykeen/triples/__init__.py
@@ -1,65 +1,59 @@
-r"""
-A module to handle triples.
+r"""A module to handle triples.
 
-A knowledge graph can be thought of as a collection of facts, where each individual fact is represented
-as a triple of a head entity $h$, a relation $r$ and a tail entity $t$. In order to operate efficiently
-on them, most of PyKEEN assumes that the set of entities has been that the set of entities has been
-transformed so that they are identified by integers from $[0, \ldots, E)$, where $E$ is the number of
-entities. A similar assumption is made for relations with their indices of $[0, \ldots, R]$.
+A knowledge graph can be thought of as a collection of facts, where each individual fact is represented as a triple of a
+head entity $h$, a relation $r$ and a tail entity $t$. In order to operate efficiently on them, most of PyKEEN assumes
+that the set of entities has been that the set of entities has been transformed so that they are identified by integers
+from $[0, \ldots, E)$, where $E$ is the number of entities. A similar assumption is made for relations with their
+indices of $[0, \ldots, R]$.
 
-This module includes classes and methods for loading and transforming triples from other formats
-into the index-based format, as well as advanced methods for creating leakage-free training and
-test splits and analyzing data distribution.
+This module includes classes and methods for loading and transforming triples from other formats into the index-based
+format, as well as advanced methods for creating leakage-free training and test splits and analyzing data distribution.
 
 Basic Handling
---------------
-The most basic information about a knowledge graph is stored in :class:`KGInfo`. It contains the
-minimal information needed to create a knowledge graph embedding: the number of entities and
-relations, as well as information about the use of inverse relations (which artificially increases
-the number of relations).
+==============
 
-To store information about triples, there is the :class:`CoreTriplesFactory`. It extends
-:class:`KGInfo` by additionally storing a set of index-based triples, in the form of a
-3-column matrix. It also allows to store arbitrary metadata in the form of a
-(JSON-compatible) dictionary. It also adds support for serialization, i.e. saving and loading
-to a file, as well as filter operations and utility methods to create dataframes for
-further (external) processing.
+The most basic information about a knowledge graph is stored in :class:`KGInfo`. It contains the minimal information
+needed to create a knowledge graph embedding: the number of entities and relations, as well as information about the use
+of inverse relations (which artificially increases the number of relations).
 
-Finally, there is :class:`TriplesFactory`, which adds mapping of string-based entity and relation
-names to IDs. This class also provides rich factory methods that allow creating mappings from
-string-based triples alone, loading triples from sufficiently similar external file formats such
-as TSV or CSV, and converting back and forth between label-based and index-based formats.
-It also extends serialization to ensure that the string-to-index mappings are included along
+To store information about triples, there is the :class:`CoreTriplesFactory`. It extends :class:`KGInfo` by additionally
+storing a set of index-based triples, in the form of a 3-column matrix. It also allows to store arbitrary metadata in
+the form of a (JSON-compatible) dictionary. It also adds support for serialization, i.e. saving and loading to a file,
+as well as filter operations and utility methods to create dataframes for further (external) processing.
+
+Finally, there is :class:`TriplesFactory`, which adds mapping of string-based entity and relation names to IDs. This
+class also provides rich factory methods that allow creating mappings from string-based triples alone, loading triples
+from sufficiently similar external file formats such as TSV or CSV, and converting back and forth between label-based
+and index-based formats. It also extends serialization to ensure that the string-to-index mappings are included along
 with the files.
 
 Splitting
----------
-To evaluate knowledge graph embedding models, we need training, validation, and test sets.
-In classical machine learning settings, we often have a large number of independent samples and can use simple random
-sampling.
-In graph learning settings, however, we are interested in learning relational patterns, i.e. patterns between different
-samples.
-In these settings, we need to be more careful.
+=========
+
+To evaluate knowledge graph embedding models, we need training, validation, and test sets. In classical machine learning
+settings, we often have a large number of independent samples and can use simple random sampling. In graph learning
+settings, however, we are interested in learning relational patterns, i.e. patterns between different samples. In these
+settings, we need to be more careful.
 
 For example, to evaluate models in a transductive setting, we need to make sure that all entities and relations of the
-triples used in the evaluation are also present in the training triples.
-PyKEEN includes methods to construct splits that ensure the presence of all entities and relations in the training part.
-Those can be found in :mod:`pykeen.triples.splitting`.
+triples used in the evaluation are also present in the training triples. PyKEEN includes methods to construct splits
+that ensure the presence of all entities and relations in the training part. Those can be found in
+:mod:`pykeen.triples.splitting`.
 
 In addition, knowledge graphs may contain inverse relationships, such as a *predecessor* and *successor* relationship.
 In this case, careless splitting can lead to test leakage, where models that only check whether the inverse relationship
 exists in training can produce significantly strong results, inflating scores without learning meaningful relationship
-patterns.
-PyKEEN includes methods to check knowledge graph splits for leakage, which can be found in
+patterns. PyKEEN includes methods to check knowledge graph splits for leakage, which can be found in
 :mod:`pykeen.triples.leakage`.
 
 In :mod:`pykeen.triples.remix`, we offer methods to examine the effects of a particular choice of splits.
 
 Analysis
---------
-We also provide methods for analyzing knowledge graphs.
-These include simple statistics such as the number of entities or relations (in :mod:`pykeen.triples.stats`),
-as well as advanced analysis of relational patterns (:mod:`pykeen.triples.analysis`).
+========
+
+We also provide methods for analyzing knowledge graphs. These include simple statistics such as the number of entities
+or relations (in :mod:`pykeen.triples.stats`), as well as advanced analysis of relational patterns
+(:mod:`pykeen.triples.analysis`).
 """
 
 from .instances import Instances, LCWAInstances, SLCWAInstances

--- a/src/pykeen/triples/deteriorate.py
+++ b/src/pykeen/triples/deteriorate.py
@@ -29,10 +29,12 @@ def deteriorate(
 
     :param reference: The reference triples factory
     :param others: Other triples factories to deteriorate
-    :param n: The ratio to deteriorate. If given as a float, should be between 0 and 1.
-        If an integer, deteriorates that many triples
+    :param n: The ratio to deteriorate. If given as a float, should be between 0 and 1. If an integer, deteriorates that
+        many triples
     :param random_state: The random state
+
     :returns: A concatenated list of the processed reference and other triples factories
+
     :raises NotImplementedError: if the reference triples factory has inverse triples
     :raises ValueError: If a float is given for n that isn't between 0 and 1
     """

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -66,22 +66,17 @@ class Instances(data.Dataset[BatchType], Generic[SampleType, BatchType], ABC):
     ) -> Instances:
         """Create instances from mapped triples.
 
-        :param mapped_triples: shape: (num_triples, 3)
-            The ID-based triples.
-        :param num_entities: >0
-            The number of entities.
-        :param num_relations: >0
-            The number of relations.
-        :param kwargs:
-            additional keyword-based parameters.
+        :param mapped_triples: shape: (num_triples, 3) The ID-based triples.
+        :param num_entities: >0 The number of entities.
+        :param num_relations: >0 The number of relations.
+        :param kwargs: additional keyword-based parameters.
 
-        :return:
-            The instances.
+        :returns: The instances.
 
+        # noqa:DAR201
         # noqa:DAR202
         # noqa:DAR401
         """
-        raise NotImplementedError
 
 
 class SLCWAInstances(Instances[SLCWASampleType, SLCWABatch]):
@@ -98,16 +93,11 @@ class SLCWAInstances(Instances[SLCWASampleType, SLCWABatch]):
     ):
         """Initialize the sLCWA instances.
 
-        :param mapped_triples: shape: (num_triples, 3)
-            the ID-based triples, passed to the negative sampler
-        :param num_entities: >0
-            the number of entities, passed to the negative sampler
-        :param num_relations: >0
-            the number of relations, passed to the negative sampler
-        :param negative_sampler:
-            the negative sampler, or a hint thereof
-        :param negative_sampler_kwargs:
-            additional keyword-based arguments passed to the negative sampler
+        :param mapped_triples: shape: (num_triples, 3) the ID-based triples, passed to the negative sampler
+        :param num_entities: >0 the number of entities, passed to the negative sampler
+        :param num_relations: >0 the number of relations, passed to the negative sampler
+        :param negative_sampler: the negative sampler, or a hint thereof
+        :param negative_sampler_kwargs: additional keyword-based arguments passed to the negative sampler
         """
         self.mapped_triples = mapped_triples
         self.sampler = negative_sampler_resolver.make(
@@ -162,10 +152,10 @@ class SLCWAInstances(Instances[SLCWASampleType, SLCWABatch]):
 
 
 class BaseBatchedSLCWAInstances(data.IterableDataset[SLCWABatch]):
-    """
-    Pre-batched training instances for the sLCWA training loop.
+    """Pre-batched training instances for the sLCWA training loop.
 
-    .. note ::
+    .. note::
+
         this class is intended to be used with automatic batching disabled, i.e., both parameters `batch_size` and
         `batch_sampler` of torch.utils.data.DataLoader` are set to `None`.
     """
@@ -180,23 +170,15 @@ class BaseBatchedSLCWAInstances(data.IterableDataset[SLCWABatch]):
         negative_sampler: HintOrType[NegativeSampler] = None,
         negative_sampler_kwargs: OptionalKwargs = None,
     ):
-        """
-        Initialize the dataset.
+        """Initialize the dataset.
 
-        :param mapped_triples: shape: (num_triples, 3)
-            the mapped triples
-        :param batch_size:
-            the batch size
-        :param drop_last:
-            whether to drop the last (incomplete) batch
-        :param num_entities: >0
-            the number of entities, passed to the negative sampler
-        :param num_relations: >0
-            the number of relations, passed to the negative sampler
-        :param negative_sampler:
-            the negative sampler, or a hint thereof
-        :param negative_sampler_kwargs:
-            additional keyword-based parameters used to instantiate the negative sampler
+        :param mapped_triples: shape: (num_triples, 3) the mapped triples
+        :param batch_size: the batch size
+        :param drop_last: whether to drop the last (incomplete) batch
+        :param num_entities: >0 the number of entities, passed to the negative sampler
+        :param num_relations: >0 the number of relations, passed to the negative sampler
+        :param negative_sampler: the negative sampler, or a hint thereof
+        :param negative_sampler_kwargs: additional keyword-based parameters used to instantiate the negative sampler
         """
         self.mapped_triples = mapped_triples
         self.batch_size = batch_size
@@ -249,11 +231,9 @@ class SubGraphSLCWAInstances(BaseBatchedSLCWAInstances):
     """Pre-batched training instances for SLCWA of coherent subgraphs."""
 
     def __init__(self, **kwargs):
-        """
-        Initialize the instances.
+        """Initialize the instances.
 
-        :param kwargs:
-            keyword-based parameters passed to :meth:`BaseBatchedSLCWAInstances.__init__`
+        :param kwargs: keyword-based parameters passed to :meth:`BaseBatchedSLCWAInstances.__init__`
         """
         super().__init__(**kwargs)
         # indexing
@@ -340,22 +320,15 @@ class LCWAInstances(Instances[LCWASampleType, LCWABatchType]):
         target: int | None = None,
         **kwargs,
     ) -> Instances:
-        """
-        Create LCWA instances from triples.
+        """Create LCWA instances from triples.
 
-        :param mapped_triples: shape: (num_triples, 3)
-            The ID-based triples.
-        :param num_entities:
-            The number of entities.
-        :param num_relations:
-            The number of relations.
-        :param target:
-            The column to predict
-        :param kwargs:
-            Keyword arguments (thrown out)
+        :param mapped_triples: shape: (num_triples, 3) The ID-based triples.
+        :param num_entities: The number of entities.
+        :param num_relations: The number of relations.
+        :param target: The column to predict
+        :param kwargs: Keyword arguments (thrown out)
 
-        :return:
-            The instances.
+        :returns: The instances.
         """
         if target is None:
             target = 2

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -77,6 +77,7 @@ class Instances(data.Dataset[BatchType], Generic[SampleType, BatchType], ABC):
         # noqa:DAR202
         # noqa:DAR401
         """
+        raise NotImplementedError
 
 
 class SLCWAInstances(Instances[SLCWASampleType, SLCWABatch]):

--- a/src/pykeen/triples/leakage.py
+++ b/src/pykeen/triples/leakage.py
@@ -1,10 +1,8 @@
 """Tools for removing the leakage from datasets.
 
-Leakage is when the inverse of a given training triple appears in either
-the testing or validation set. This scenario generally leads to inflated
-and misleading evaluation because predicting an inverse triple is usually
-very easy and not a sign of the generalizability of a model to predict
-novel triples.
+Leakage is when the inverse of a given training triple appears in either the testing or validation set. This scenario
+generally leads to inflated and misleading evaluation because predicting an inverse triple is usually very easy and not
+a sign of the generalizability of a model to predict novel triples.
 """
 
 import logging
@@ -52,19 +50,17 @@ def jaccard_similarity_scipy(
 
     The similarity is computed as
 
-    .. math ::
+    .. math::
+
         J(A, B) = \frac{|A \cap B|}{|A \cup B|}
                 = \frac{|A \cap B|}{|A| + |B| - |A \cap B|}
 
     where the intersection can be computed in one batch as matrix product.
 
-    :param a: shape: (m, max_num_elements)
-        The first sets.
-    :param b: shape: (n, max_num_elements)
-        The second sets.
+    :param a: shape: (m, max_num_elements) The first sets.
+    :param b: shape: (n, max_num_elements) The second sets.
 
-    :return: shape: (m, n)
-        The pairwise Jaccard similarity.
+    :returns: shape: (m, n) The pairwise Jaccard similarity.
     """
     sum_size = numpy.asarray(a.sum(axis=1) + b.sum(axis=1).T)
     intersection_size = numpy.asarray((a @ b.T).todense())
@@ -78,15 +74,14 @@ def triples_factory_to_sparse_matrices(
 ) -> tuple[scipy.sparse.spmatrix, scipy.sparse.spmatrix]:
     """Compute relation representations as sparse matrices of entity pairs.
 
-    .. note ::
+    .. note::
+
         Both sets, head-tail-set, tail-head-set, have to be created at once since they need to share the same entity
         pair to Id mapping.
 
-    :param triples_factory:
-        The triples factory.
+    :param triples_factory: The triples factory.
 
-    :return: shape: (num_relations, num_entity_pairs)
-        head-tail-set, tail-head-set matrices as {0, 1} integer matrices.
+    :returns: shape: (num_relations, num_entity_pairs) head-tail-set, tail-head-set matrices as {0, 1} integer matrices.
     """
     return mapped_triples_to_sparse_matrices(
         triples_factory.mapped_triples,
@@ -115,17 +110,15 @@ def mapped_triples_to_sparse_matrices(
 ) -> tuple[scipy.sparse.spmatrix, scipy.sparse.spmatrix]:
     """Compute relation representations as sparse matrices of entity pairs.
 
-    .. note ::
+    .. note::
+
         Both sets, head-tail-set, tail-head-set, have to be created at once since they need to share the same entity
         pair to Id mapping.
 
-    :param mapped_triples:
-        The input triples.
-    :param num_relations:
-        The number of input relations
+    :param mapped_triples: The input triples.
+    :param num_relations: The number of input relations
 
-    :return: shape: (num_relations, num_entity_pairs)
-        head-tail-set, tail-head-set matrices as {0, 1} integer matrices.
+    :returns: shape: (num_relations, num_entity_pairs) head-tail-set, tail-head-set matrices as {0, 1} integer matrices.
     """
     num_triples = mapped_triples.shape[0]
     # compute unique pairs in triples *and* inverted triples for consistent pair-to-id mapping
@@ -154,17 +147,12 @@ def get_candidate_pairs(
 ) -> set[tuple[int, int]]:
     """Find pairs of sets with Jaccard similarity above threshold using :func:`jaccard_similarity_scipy`.
 
-    :param a:
-        The first set.
-    :param b:
-        The second set. If not specified, reuse the first set.
-    :param threshold:
-        The threshold above which the similarity has to be.
-    :param no_self:
-        Whether to exclude (i, i) pairs.
+    :param a: The first set.
+    :param b: The second set. If not specified, reuse the first set.
+    :param threshold: The threshold above which the similarity has to be.
+    :param no_self: Whether to exclude (i, i) pairs.
 
-    :return:
-        A set of index pairs.
+    :returns: A set of index pairs.
     """
     if b is None:
         b = a
@@ -199,8 +187,8 @@ class Sealant:
             default value, 0.97, is taken from `Toutanova and Chen (2015)
             <https://www.aclweb.org/anthology/W15-4007/>`_, who originally described the generation of FB15k-237.
         :param symmetric: If the similarities are computed as symmetric
-        :raises NotImplementedError:
-            If symmetric is False
+
+        :raises NotImplementedError: If symmetric is False
         """
         self.triples_factory = triples_factory
         if minimum_frequency is None:
@@ -245,13 +233,13 @@ def unleak(
 
     :param train: The target triples factory
     :param triples_factories: All other triples factories (test, validate, etc.)
-    :param n: Either the (integer) number of top relations to keep or the (float) percentage of top relationships
-        to keep. If left none, frequent relations are not removed.
+    :param n: Either the (integer) number of top relations to keep or the (float) percentage of top relationships to
+        keep. If left none, frequent relations are not removed.
     :param minimum_frequency: The minimum overlap between two relations' triples to consider them as inverses or
         duplicates. The default value, 0.97, is taken from `Toutanova and Chen (2015)
         <https://www.aclweb.org/anthology/W15-4007/>`_, who originally described the generation of FB15k-237.
-    :returns:
-        A sequence of reindexed triples factories
+
+    :returns: A sequence of reindexed triples factories
     """
     if n is not None:
         frequent_relations = train.get_most_frequent_relations(n=n)
@@ -277,20 +265,16 @@ def _generate_compact_vectorized_lookup(
     ids: LongTensor,
     label_to_id: Mapping[str, int],
 ) -> tuple[Mapping[str, int], LongTensor]:
-    """
-    Given a tensor of IDs and a label to ID mapping, retain only occurring IDs, and compact the mapping.
+    """Given a tensor of IDs and a label to ID mapping, retain only occurring IDs, and compact the mapping.
 
     Additionally, returns a vectorized translation, i.e. a tensor `translation` of shape (max_old_id,) with
-    `translation[old_id] = new_id` for all translated IDs and `translation[old_id] = -1` for non-occurring IDs.
-    This allows to use `translation[ids]` to translate the IDs as a simple integer index based lookup.
+    `translation[old_id] = new_id` for all translated IDs and `translation[old_id] = -1` for non-occurring IDs. This
+    allows to use `translation[ids]` to translate the IDs as a simple integer index based lookup.
 
-    :param ids:
-        The tensor of IDs.
-    :param label_to_id:
-        The label to ID mapping.
+    :param ids: The tensor of IDs.
+    :param label_to_id: The label to ID mapping.
 
-    :return:
-        A tuple new_label_to_id, vectorized_translation.
+    :returns: A tuple new_label_to_id, vectorized_translation.
     """
     # get existing IDs
     existing_ids = set(ids.view(-1).unique().tolist())
@@ -310,18 +294,13 @@ def _translate_triples(
     entity_translation: LongTensor,
     relation_translation: LongTensor,
 ) -> MappedTriples:
-    """
-    Translate triples given vectorized translations for entities and relations.
+    """Translate triples given vectorized translations for entities and relations.
 
-    :param triples: shape: (num_triples, 3)
-        The original triples
-    :param entity_translation: shape: (num_old_entity_ids,)
-        The translation from old to new entity IDs.
-    :param relation_translation: shape: (num_old_relation_ids,)
-        The translation from old to new relation IDs.
+    :param triples: shape: (num_triples, 3) The original triples
+    :param entity_translation: shape: (num_old_entity_ids,) The translation from old to new entity IDs.
+    :param relation_translation: shape: (num_old_relation_ids,) The translation from old to new relation IDs.
 
-    :return: shape: (num_triples, 3)
-        The translated triples.
+    :returns: shape: (num_triples, 3) The translated triples.
     """
     triples = torch.stack(
         [

--- a/src/pykeen/triples/remix.py
+++ b/src/pykeen/triples/remix.py
@@ -1,12 +1,12 @@
 """Remixing and dataset distance utilities.
 
-Most datasets are given in with a pre-defined split, but it's often not discussed
-how this split was created. This module contains utilities for investigating the
-effects of remixing pre-split datasets like :class`pykeen.datasets.Nations`.
+Most datasets are given in with a pre-defined split, but it's often not discussed how this split was created. This
+module contains utilities for investigating the effects of remixing pre-split datasets like
+:class`pykeen.datasets.Nations`.
 
-Further, it defines a metric for the "distance" between two splits of a given dataset.
-Later, this will be used to map the landscape and see if there is a smooth, continuous
-relationship between datasets' splits' distances and their maximum performance.
+Further, it defines a metric for the "distance" between two splits of a given dataset. Later, this will be used to map
+the landscape and see if there is a smooth, continuous relationship between datasets' splits' distances and their
+maximum performance.
 """
 
 from collections.abc import Sequence
@@ -26,6 +26,7 @@ def remix(*triples_factories: CoreTriplesFactory, **kwargs) -> list[CoreTriplesF
 
     :param triples_factories: A sequence of triples factories
     :param kwargs: Keyword arguments to be passed to :func:`split`
+
     :returns: A sequence of triples factories of the same sizes but randomly re-assigned triples
 
     :raises NotImplementedError: if any of the triples factories have ``create_inverse_triples``

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -57,12 +57,10 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
     ) -> None:
         """Initialize the multi-modal triples factory.
 
-        :param numeric_literals: shape: (num_entities, num_literals)
-            the numeric literals as a dense matrix.
-        :param literals_to_id:
-            a mapping from literal names to their IDs, i.e., the columns in the `numeric_literals` matrix.
-        :param kwargs:
-            additional keyword-based parameters passed to :meth:`TriplesFactory.__init__`.
+        :param numeric_literals: shape: (num_entities, num_literals) the numeric literals as a dense matrix.
+        :param literals_to_id: a mapping from literal names to their IDs, i.e., the columns in the `numeric_literals`
+            matrix.
+        :param kwargs: additional keyword-based parameters passed to :meth:`TriplesFactory.__init__`.
         """
         super().__init__(**kwargs)
         self.numeric_literals = numeric_literals

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -42,13 +42,14 @@ def load_triples(
 ) -> LabeledTriples:
     """Load triples saved as tab separated values.
 
-    :param path: The key for the data to be loaded. Typically, this will be a file path ending in ``.tsv``
-        that points to a file with three columns - the head, relation, and tail. This can also be used to
-        invoke PyKEEN data importer entrypoints (see below).
+    :param path: The key for the data to be loaded. Typically, this will be a file path ending in ``.tsv`` that points
+        to a file with three columns - the head, relation, and tail. This can also be used to invoke PyKEEN data
+        importer entrypoints (see below).
     :param delimiter: The delimiter between the columns in the file
     :param encoding: The encoding for the file. Defaults to utf-8.
-    :param column_remapping: A remapping if the three columns do not follow the order head-relation-tail.
-        For example, if the order is head-tail-relation, pass ``(0, 2, 1)``
+    :param column_remapping: A remapping if the three columns do not follow the order head-relation-tail. For example,
+        if the order is head-tail-relation, pass ``(0, 2, 1)``
+
     :returns: A numpy array representing "labeled" triples.
 
     :raises ValueError: if a column remapping was passed, but it was not a length 3 sequence
@@ -103,17 +104,13 @@ def tensor_to_df(
 ) -> pandas.DataFrame:
     """Take a tensor of triples and make a pandas dataframe with labels.
 
-    :param tensor: shape: (n, 3)
-        The triples, ID-based and in format (head_id, relation_id, tail_id).
-    :param kwargs:
-        Any additional number of columns. Each column needs to be of shape (n,). Reserved column names:
+    :param tensor: shape: (n, 3) The triples, ID-based and in format (head_id, relation_id, tail_id).
+    :param kwargs: Any additional number of columns. Each column needs to be of shape (n,). Reserved column names:
         {"head_id", "head_label", "relation_id", "relation_label", "tail_id", "tail_label"}.
 
-    :return:
-        A dataframe with n rows, and 3 + len(kwargs) columns.
+    :returns: A dataframe with n rows, and 3 + len(kwargs) columns.
 
-    :raises ValueError:
-        If a reserved column name appears in kwargs.
+    :raises ValueError: If a reserved column name appears in kwargs.
     """
     # Input validation
     additional_columns = set(kwargs.keys())
@@ -150,12 +147,10 @@ def compute_compressed_adjacency_list(
 
     The compressed adjacency list format is inspired by CSR sparse matrix format.
 
-    :param mapped_triples:
-        the ID-based triples
-    :param num_entities:
-        the number of entities.
+    :param mapped_triples: the ID-based triples
+    :param num_entities: the number of entities.
 
-    :return: a tuple `(degrees, offsets, compressed_adj_lists)` where
+    :returns: a tuple `(degrees, offsets, compressed_adj_lists)` where
 
             - degrees: shape: `(num_entities,)`
             - offsets: shape: `(num_entities,)`
@@ -163,7 +158,7 @@ def compute_compressed_adjacency_list(
 
         with
 
-        .. code::
+        .. code-block::
 
             adj_list[i] = compressed_adj_list[offsets[i]:offsets[i+1]]
     """

--- a/src/pykeen/version.py
+++ b/src/pykeen/version.py
@@ -21,9 +21,9 @@ def get_git_hash(terse: bool = True) -> str:
     """Get the PyKEEN git hash.
 
     :param terse: Should the hash be clipped to 8 characters?
-    :return:
-        The git hash, equals 'UNHASHED' if encountered CalledProcessError, signifying that the
-        code is not installed in development mode.
+
+    :returns: The git hash, equals 'UNHASHED' if encountered CalledProcessError, signifying that the code is not
+        installed in development mode.
     """
     rv = _run("git", "rev-parse", "HEAD")
     if rv is None:
@@ -37,8 +37,7 @@ def get_git_hash(terse: bool = True) -> str:
 def get_git_branch() -> str | None:
     """Get the PyKEEN branch, if installed from git in editable mode.
 
-    :return:
-        Returns the name of the current branch, or None if not installed in development mode.
+    :returns: Returns the name of the current branch, or None if not installed in development mode.
     """
     return _run("git", "branch", "--show-current")
 
@@ -60,9 +59,9 @@ def _run(*args: str) -> str | None:
 def get_version(with_git_hash: bool = False) -> str:
     """Get the PyKEEN version string, including a git hash.
 
-    :param with_git_hash:
-        If set to True, the git hash will be appended to the version.
-    :return: The PyKEEN version as well as the git hash, if the parameter with_git_hash was set to true.
+    :param with_git_hash: If set to True, the git hash will be appended to the version.
+
+    :returns: The PyKEEN version as well as the git hash, if the parameter with_git_hash was set to true.
     """
     return f"{VERSION}-{get_git_hash(terse=True)}" if with_git_hash else VERSION
 
@@ -103,6 +102,7 @@ def env(file=None):
     """Print the env or output as HTML if in Jupyter.
 
     :param file: The file to print to if not in a Jupyter setting. Defaults to sys.stdout
+
     :returns: A :class:`IPython.display.HTML` if in a Jupyter notebook setting, otherwise none.
     """
     if _in_jupyter():

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -1360,8 +1360,8 @@ class BaseKG2ETest(ModelTestCase):
     def _check_constraints(self):
         """Check model constraints.
 
-        * Entity and relation embeddings have to have at most unit L2 norm.
-        * Covariances have to have values between c_min and c_max
+        - Entity and relation embeddings have to have at most unit L2 norm.
+        - Covariances have to have values between c_min and c_max
         """
         self.instance: ERModel
         (e_mean, e_cov), (r_mean, r_cov) = self.instance.entity_representations, self.instance.relation_representations
@@ -1623,14 +1623,11 @@ class DecompositionTestCase(GenericTestCase[pykeen.nn.message_passing.Decomposit
             assert y.shape == (self.x.shape[0], self.output_dim)
 
     def prepare_adjacency(self, horizontal: bool) -> torch.Tensor:
-        """
-        Prepare adjacency matrix for the given stacking direction.
+        """Prepare adjacency matrix for the given stacking direction.
 
-        :param horizontal:
-            whether to stack horizontally or vertically
+        :param horizontal: whether to stack horizontally or vertically
 
-        :return:
-            the adjacency matrix
+        :returns: the adjacency matrix
         """
         return adjacency_tensor_to_stacked_matrix(
             num_relations=self.factory.num_relations,
@@ -2435,8 +2432,7 @@ class GraphPairCombinatorTestCase(unittest_templates.GenericTestCase[GraphPairCo
         self._test_combination(labels=False)
 
     def test_manual(self):
-        """
-        Smoke-test on a manual example.
+        """Smoke-test on a manual example.
 
         cf. https://github.com/pykeen/pykeen/pull/893#discussion_r861553903
         """

--- a/tests/test_ablation.py
+++ b/tests/test_ablation.py
@@ -14,7 +14,9 @@ class TestAblation(unittest.TestCase):
     def test_quate(self):
         """Test using a model with no regularizer argument.
 
-        .. seealso:: https://github.com/pykeen/pykeen/issues/451
+        .. seealso::
+
+            https://github.com/pykeen/pykeen/issues/451
         """
         with tempfile.TemporaryDirectory() as directory:
             ablation_pipeline(

--- a/tests/test_datasets/test_loading.py
+++ b/tests/test_datasets/test_loading.py
@@ -118,7 +118,9 @@ class MockZipFileRemoteDataset(PackedZipRemoteDataset):
 class TestSingle(cases.CachedDatasetCase):
     """Test the base classes.
 
-    .. note:: This uses the nations training dataset
+    .. note::
+
+        This uses the nations training dataset
     """
 
     exp_num_entities = 14
@@ -132,7 +134,9 @@ class TestSingle(cases.CachedDatasetCase):
 class TestTarFileSingle(cases.CachedDatasetCase):
     """Test the base classes.
 
-    .. note:: This uses the nations training dataset
+    .. note::
+
+        This uses the nations training dataset
     """
 
     exp_num_entities = 14

--- a/tests/test_hpo.py
+++ b/tests/test_hpo.py
@@ -304,7 +304,9 @@ class TestHPODatasets(unittest.TestCase):
     def test_custom_tf_object(self):
         """Test using a custom triples factories with HPO.
 
-        .. seealso:: https://github.com/pykeen/pykeen/issues/230
+        .. seealso::
+
+            https://github.com/pykeen/pykeen/issues/230
         """
         tf = TriplesFactory.from_path(path=NATIONS_TRAIN_PATH)
         training, testing, validation = tf.split([0.8, 0.1, 0.1], random_state=0)

--- a/tests/test_model_mode.py
+++ b/tests/test_model_mode.py
@@ -85,17 +85,15 @@ class TestBaseModelScoringFunctions(unittest.TestCase):
         self.model = FixedModel(triples_factory=self.triples_factory).to(self.device)
 
     def _test(self, score_func: Callable, dim: Target) -> None:
-        """
-        Check whether the output of optimized function matches the output of a repeated batch.
+        """Check whether the output of optimized function matches the output of a repeated batch.
 
-        .. note ::
+        .. note::
+
             the repeated batch is created via :func:`pykeen.utils.extend_batch` and passed to
             :meth:`pykeen.models.base.Model.score_hrt`.
 
-        :param score_func:
-            the optimized score function, e.g., :meth:`pykeen.models.base.Model.score_t`
-        :param dim:
-            the dimension
+        :param score_func: the optimized score function, e.g., :meth:`pykeen.models.base.Model.score_t`
+        :param dim: the dimension
         """
         batch = torch.tensor([[0, 0], [1, 0]], dtype=torch.long, device=self.device)
         hrt_batch = extend_batch(

--- a/tests/test_nn/test_sim.py
+++ b/tests/test_nn/test_sim.py
@@ -18,16 +18,14 @@ def _torch_kl_similarity(
 ) -> torch.FloatTensor:
     """Compute KL similarity using torch.distributions.
 
-    :param h: shape: (batch_size, num_heads, 1, 1, d)
-        The head entity Gaussian distribution.
-    :param r: shape: (batch_size, 1, num_relations, 1, d)
-        The relation Gaussian distribution.
-    :param t: shape: (batch_size, 1, 1, num_tails, d)
-        The tail entity Gaussian distribution.
-    :return: torch.Tensor, shape: (s_1, ..., s_k)
-        The KL-divergence.
+    :param h: shape: (batch_size, num_heads, 1, 1, d) The head entity Gaussian distribution.
+    :param r: shape: (batch_size, 1, num_relations, 1, d) The relation Gaussian distribution.
+    :param t: shape: (batch_size, 1, 1, num_tails, d) The tail entity Gaussian distribution.
 
-    .. warning ::
+    :returns: torch.Tensor, shape: (s_1, ..., s_k) The KL-divergence.
+
+    .. warning::
+
         Do not use this method in production code.
     """
     e_mean = h.mean - t.mean

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -537,7 +537,9 @@ class TestUtils(unittest.TestCase):
     def test_load_triples_with_nans(self):
         """Test loading triples that have a ``nan`` string.
 
-        .. seealso:: https://github.com/pykeen/pykeen/pull/883
+        .. seealso::
+
+            https://github.com/pykeen/pykeen/pull/883
         """
         path = RESOURCES.joinpath("test_nans.tsv")
         expected_triples = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -177,7 +177,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(set(id_remapping.values()), set(compacted_mapping.values()))
 
     def test_clamp_norm(self):
-        """Test  clamp_norm() ."""
+        """Test clamp_norm() ."""
         max_norm = 1.0
         gen = torch.manual_seed(42)
         eps = 1.0e-06

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,14 +17,11 @@ def rand(*size: int, generator: torch.Generator, device: torch.device) -> torch.
 
 
 def is_installed(name: str) -> bool:
-    """
-    Return whether a package is installed.
+    """Return whether a package is installed.
 
-    :param name:
-        the package's name
+    :param name: the package's name
 
-    :return:
-        whether the package can be imported
+    :returns: whether the package can be imported
     """
     try:
         importlib.import_module(name=name)


### PR DESCRIPTION
This applies _most_ of `uvx docstrfmt src/ tests/ docs/ --no-docstring-trailing-line`. There are still a few weird corner cases to work through before making this as part of CI

I had to make 3-4 creative applications of `noqa` to make darglint happy, and in a few place fix code blocks that started with `::`, but otherwise this is all automatically done. 

In a few places I did not commit the changes since they need more care in a follow-up

In many places (mostly from docdata), docstrfmt failed and did not do any reformatting. This is also for follow-up