### PR TITLE
🏴‍☠️❇️ Update inductive NodePiece example

### DIFF
--- a/docs/source/examples/tutorial/inductive_lp/01_model.py
+++ b/docs/source/examples/tutorial/inductive_lp/01_model.py
@@ -1,3 +1,5 @@
+"""Setup an inductive node piece model."""
+
 from pykeen.datasets.inductive.ilp_teru import InductiveFB15k237
 from pykeen.losses import NSSALoss
 from pykeen.models.inductive import InductiveNodePiece

--- a/docs/source/examples/tutorial/inductive_lp/01_model.py
+++ b/docs/source/examples/tutorial/inductive_lp/01_model.py
@@ -1,0 +1,14 @@
+from pykeen.datasets.inductive.ilp_teru import InductiveFB15k237
+from pykeen.losses import NSSALoss
+from pykeen.models.inductive import InductiveNodePiece
+
+dataset = InductiveFB15k237(version="v1", create_inverse_triples=True)
+
+model = InductiveNodePiece(
+    triples_factory=dataset.transductive_training,  # training factory, used to tokenize training nodes
+    inference_factory=dataset.inductive_inference,  # inference factory, used to tokenize inference nodes
+    num_tokens=12,  # length of a node hash - how many unique relations per node will be used
+    aggregation="mlp",  # aggregation function, defaults to an MLP, can be any PyTorch function
+    loss=NSSALoss(margin=15),  # dummy loss
+    random_seed=42,
+)

--- a/docs/source/examples/tutorial/inductive_lp/01_model_gnn.py
+++ b/docs/source/examples/tutorial/inductive_lp/01_model_gnn.py
@@ -1,3 +1,5 @@
+"""Setup an inductive node piece model with GNN encoder."""
+
 from pykeen.datasets.inductive.ilp_teru import InductiveFB15k237
 from pykeen.losses import NSSALoss
 from pykeen.models.inductive import InductiveNodePieceGNN

--- a/docs/source/examples/tutorial/inductive_lp/01_model_gnn.py
+++ b/docs/source/examples/tutorial/inductive_lp/01_model_gnn.py
@@ -1,0 +1,15 @@
+from pykeen.datasets.inductive.ilp_teru import InductiveFB15k237
+from pykeen.losses import NSSALoss
+from pykeen.models.inductive import InductiveNodePieceGNN
+
+dataset = InductiveFB15k237(version="v1", create_inverse_triples=True)
+
+model = InductiveNodePieceGNN(
+    triples_factory=dataset.transductive_training,  # training factory, will be also used for a GNN
+    inference_factory=dataset.inductive_inference,  # inference factory, will be used for a GNN
+    num_tokens=12,  # length of a node hash - how many unique relations per node will be used
+    aggregation="mlp",  # aggregation function, defaults to an MLP, can be any PyTorch function
+    loss=NSSALoss(margin=15),  # dummy loss
+    random_seed=42,
+    gnn_encoder=None,  # defaults to a 2-layer CompGCN with DistMult composition function
+)

--- a/docs/source/examples/tutorial/inductive_lp/02_training.py
+++ b/docs/source/examples/tutorial/inductive_lp/02_training.py
@@ -1,0 +1,27 @@
+from pykeen.datasets.inductive.ilp_teru import InductiveFB15k237
+from pykeen.evaluation.rank_based_evaluator import SampledRankBasedEvaluator
+from pykeen.training import SLCWATrainingLoop
+
+dataset = InductiveFB15k237(version="v1", create_inverse_triples=True)
+
+model = ...  # model init here, one of InductiveNodePiece
+optimizer = ...  # some optimizer
+
+training_loop = SLCWATrainingLoop(
+    triples_factory=dataset.transductive_training,  # training triples
+    model=model,
+    optimizer=optimizer,
+    mode="training",  # necessary to specify for the inductive mode - training has its own set of nodes
+)
+
+valid_evaluator = SampledRankBasedEvaluator(
+    mode="validation",  # necessary to specify for the inductive mode - this will use inference nodes
+    evaluation_factory=dataset.inductive_validation,  # validation triples to predict
+    additional_filter_triples=dataset.inductive_inference.mapped_triples,  # filter out true inference triples
+)
+
+test_evaluator = SampledRankBasedEvaluator(
+    mode="testing",  # necessary to specify for the inductive mode - this will use inference nodes
+    evaluation_factory=dataset.inductive_testing,  # test triples to predict
+    additional_filter_triples=dataset.inductive_inference.mapped_triples,  # filter out true inference triples
+)

--- a/docs/source/examples/tutorial/inductive_lp/02_training.py
+++ b/docs/source/examples/tutorial/inductive_lp/02_training.py
@@ -14,6 +14,7 @@ training_loop = SLCWATrainingLoop(
     mode="training",  # necessary to specify for the inductive mode - training has its own set of nodes
 )
 
+assert dataset.inductive_validation is not None
 valid_evaluator = SampledRankBasedEvaluator(
     mode="validation",  # necessary to specify for the inductive mode - this will use inference nodes
     evaluation_factory=dataset.inductive_validation,  # validation triples to predict

--- a/docs/source/examples/tutorial/inductive_lp/02_training.py
+++ b/docs/source/examples/tutorial/inductive_lp/02_training.py
@@ -1,3 +1,5 @@
+"""Train the inductive model."""
+
 from pykeen.datasets.inductive.ilp_teru import InductiveFB15k237
 from pykeen.evaluation.rank_based_evaluator import SampledRankBasedEvaluator
 from pykeen.training import SLCWATrainingLoop

--- a/docs/source/examples/tutorial/inductive_lp/03_full.py
+++ b/docs/source/examples/tutorial/inductive_lp/03_full.py
@@ -34,6 +34,7 @@ training_loop = SLCWATrainingLoop(
 )
 
 # Validation and Test evaluators use a restricted protocol ranking against 50 random negatives
+assert dataset.inductive_validation is not None
 valid_evaluator = SampledRankBasedEvaluator(
     mode="validation",  # necessary to specify for the inductive mode - this will use inference nodes
     evaluation_factory=dataset.inductive_validation,  # validation triples to predict

--- a/docs/source/examples/tutorial/inductive_lp/03_full.py
+++ b/docs/source/examples/tutorial/inductive_lp/03_full.py
@@ -1,0 +1,81 @@
+"""Full example for inductive link prediction."""
+
+from torch.optim import Adam
+
+from pykeen.datasets.inductive.ilp_teru import InductiveFB15k237
+from pykeen.evaluation.rank_based_evaluator import SampledRankBasedEvaluator
+from pykeen.losses import NSSALoss
+from pykeen.models.inductive import InductiveNodePieceGNN
+from pykeen.stoppers import EarlyStopper
+from pykeen.training import SLCWATrainingLoop
+
+dataset = InductiveFB15k237(version="v1", create_inverse_triples=True)
+
+model = InductiveNodePieceGNN(
+    triples_factory=dataset.transductive_training,  # training factory, will be also used for a GNN
+    inference_factory=dataset.inductive_inference,  # inference factory, will be used for a GNN
+    num_tokens=12,  # length of a node hash - how many unique relations per node will be used
+    aggregation="mlp",  # aggregation function, defaults to an MLP, can be any PyTorch function
+    loss=NSSALoss(margin=15),  # dummy loss
+    random_seed=42,
+    gnn_encoder=None,  # defaults to a 2-layer CompGCN with DistMult composition function
+)
+# ensure that the model is on the right device
+model = model.to(model.device)
+
+optimizer = Adam(params=model.parameters(), lr=0.0005)
+
+training_loop = SLCWATrainingLoop(
+    triples_factory=dataset.transductive_training,  # training triples
+    model=model,
+    optimizer=optimizer,
+    negative_sampler_kwargs=dict(num_negs_per_pos=32),
+    mode="training",  # necessary to specify for the inductive mode - training has its own set of nodes
+)
+
+# Validation and Test evaluators use a restricted protocol ranking against 50 random negatives
+valid_evaluator = SampledRankBasedEvaluator(
+    mode="validation",  # necessary to specify for the inductive mode - this will use inference nodes
+    evaluation_factory=dataset.inductive_validation,  # validation triples to predict
+    additional_filter_triples=dataset.inductive_inference.mapped_triples,  # filter out true inference triples
+)
+
+# According to the original code
+# https://github.com/kkteru/grail/blob/2a3dffa719518e7e6250e355a2fb37cd932de91e/test_ranking.py#L526-L529
+# test filtering uses only the inductive_inference split and does not include inductive_validation triples
+# If you use the full RankBasedEvaluator, both inductive_inference and inductive_validation triples
+# must be added to the additional_filter_triples
+test_evaluator = SampledRankBasedEvaluator(
+    mode="testing",  # necessary to specify for the inductive mode - this will use inference nodes
+    evaluation_factory=dataset.inductive_testing,  # test triples to predict
+    additional_filter_triples=dataset.inductive_inference.mapped_triples,  # filter out true inference triples
+)
+
+early_stopper = EarlyStopper(
+    model=model,
+    training_triples_factory=dataset.inductive_inference,
+    evaluation_triples_factory=dataset.inductive_validation,
+    frequency=1,
+    patience=100000,  # for test reasons, turn it off
+    result_tracker=None,
+    evaluation_batch_size=256,
+    evaluator=valid_evaluator,
+)
+
+# Training starts here
+training_loop.train(
+    triples_factory=dataset.transductive_training,
+    stopper=early_stopper,
+    num_epochs=100,
+)
+
+# Test evaluation
+result = test_evaluator.evaluate(
+    model=model,
+    mapped_triples=dataset.inductive_testing.mapped_triples,
+    additional_filter_triples=dataset.inductive_inference.mapped_triples,
+    batch_size=256,
+)
+
+# print final results
+print(result.to_flat_dict())

--- a/docs/source/examples/tutorial/inductive_lp/replace_triples_factory.py
+++ b/docs/source/examples/tutorial/inductive_lp/replace_triples_factory.py
@@ -1,0 +1,55 @@
+"""An example for exchanging the triples factory after training."""
+
+import logging
+
+from pykeen.datasets import get_dataset
+from pykeen.models import InductiveNodePiece
+from pykeen.pipeline import pipeline
+from pykeen.predict import predict_triples
+from pykeen.triples.generation import generate_triples_factory
+
+logging.basicConfig(level=logging.INFO)
+
+# we use all of CodexSmall's data as source graph
+dataset = get_dataset(dataset="CodexSmall")
+dataset.summarize()
+tf_all = dataset.merged()
+
+# create a fully inductive split with two evaluation parts (validation & test)
+tf_training, tf_inference, tf_validation, tf_testing = tf_all.split_fully_inductive(
+    entity_split_train_ratio=0.5, evaluation_triples_ratios=(0.8, 0.1), random_state=42
+)
+
+# train an inductive node piece model
+tf_training.create_inverse_triples = True
+result = pipeline(
+    training=tf_training,
+    testing=tf_testing,
+    dataset_kwargs=dict(create_inverse_triples=True),
+    model="InductiveNodePiece",
+    model_kwargs=dict(inference_factory=tf_inference),
+    training_kwargs=dict(num_epochs=0),
+    training_loop_kwargs=dict(mode="training"),
+    evaluator_kwargs=dict(mode="validation"),
+)
+
+# inference some validation triples
+df = predict_triples(model=result.model, triples_factory=tf_validation, mode="validation").process()
+print(df)
+
+# we replace the validation factory by a faked triples factory (which we mock here with random triples)
+# note: we need to keep the relations fixed (because of NodePiece's parametrization)!
+tf_new = generate_triples_factory(
+    num_entities=13,
+    num_relations=tf_training.real_num_relations,
+    random_state=42,
+    create_inverse_triples=False,
+)
+model: InductiveNodePiece = result.model
+model.replace_entity_representations_(
+    mode="validation", representation=model.create_entity_representation_for_new_triples(tf_new)
+)
+
+# inference new validation triples
+df = predict_triples(model=result.model, triples_factory=tf_new, mode="validation").process()
+print(df)

--- a/docs/source/tutorial/inductive_lp.rst
+++ b/docs/source/tutorial/inductive_lp.rst
@@ -2,10 +2,8 @@
 
 Inductive Link Prediction
 =========================
-
 .. image:: ../img/ilp_1.png
   :alt: Transductive vs Inductive setup
-
 
 For years, a standard training setup in PyKEEN and other KGE libraries
 was implying that a training graph includes all entities on which we will
@@ -21,13 +19,16 @@ the inductive setup is that at inference time we have a new graph
 (called *inductive inference* graph), and link prediction is executed
 against that new inference graph of unseen entities.
 
-In fact, there exist several variations of the inductive setup according to the taxonomy by [ali2021]_ :
+In fact, there exist several variations of the inductive setup according
+to the taxonomy by [ali2021]_ :
 
-- An inference graph is totally disconnected from the training graph (disjoint), aka *fully-inductive* setup.
-  Link prediction pattern between entities is therefore *unseen-to-unseen*.
-- An inference graph extends the training graph connecting new nodes to the seen graph aka *semi-inductive* setup.
-  Link prediction patterns can be *unseen-to-unseen* when we predict links among newly added nodes
-  or *unseen-to-seen* / *seen-to-unseen* when we predict links between known nodes and newly arrived.
+- An inference graph is totally disconnected from the training graph (disjoint),
+  aka *fully-inductive* setup.Link prediction pattern between entities is therefore
+  *unseen-to-unseen*.
+- An inference graph extends the training graph connecting new nodes to the seen
+  graph aka *semi-inductive* setup. Link prediction patterns can be *unseen-to-unseen*
+  when we predict links among newly added nodes or *unseen-to-seen* / *seen-to-unseen*
+  when we predict links between known nodes and newly arrived.
 
 PyKEEN supports inductive link prediction providing interfaces to
 organize the datasets, build representations of unseen entities, and
@@ -39,28 +40,30 @@ because we will learn representations of those relations to transfer to unseen g
 Organizing the Dataset
 ----------------------
 The basic class to build inductive datasets is :class:`~pykeen.datasets.inductive.InductiveDataset`.
-It is supposed to contain more than 3 triple factories, i.e., in the *fully-inductive* setup it is expected to have
-at least 4 triple factories (`transductive_training`, `inductive_inference`, `inductive_validation`, `inductive_test`).
-`transductive_training` is the graph with entities index `(0..N)` on which we will train a model,
-`inductive_inference` is the new graph appearing at inference time with new entities (indexing `(0..K)`).
-Note that the number of entities in the `transductive_training` and `inductive_inference` is different.
-`inductive_validation` and `inductive_test` share the entities with `inductive_inference`
-but not with `transductive_training`. This way, we inform a model that we are predicting links against the
-inductive inference graph, not against the training graph.
+It is supposed to contain more than 3 triple factories, i.e., in the *fully-inductive* setup it is
+expected to have at least 4 triple factories (`transductive_training`, `inductive_inference`,
+`inductive_validation`, `inductive_test`). `transductive_training` is the graph with entities index
+`(0..N)` on which we will train a model, `inductive_inference` is the new graph appearing at inference
+time with new entities (indexing `(0..K)`). Note that the number of entities in the `transductive_training`
+and `inductive_inference` is different. `inductive_validation` and `inductive_test` share the entities
+with `inductive_inference` but not with `transductive_training`. This way, we inform a model that we
+are predicting links against the inductive inference graph, not against the training graph.
 
-PyKEEN supports 12 fully-inductive datasets introduced by [teru2020]_ where training and inductive inference graphs
-are disjoint. Each of 3 KG families, :class:`~pykeen.datasets.inductive.InductiveFB15k237`, :class:`~pykeen.datasets.inductive.InductiveWN18RR`, and :class:`~pykeen.datasets.inductive.InductiveNELL`, have 4 versions
-varying by the size of training and inference graphs as well as the total number of entities and relations.
-It is ensured that the relations sets of all inference graphs are subsets of their training graphs.
+PyKEEN supports 12 fully-inductive datasets introduced by [teru2020]_ where training and inductive
+inference graphs are disjoint. Each of 3 KG families, :class:`~pykeen.datasets.inductive.InductiveFB15k237`,
+:class:`~pykeen.datasets.inductive.InductiveWN18RR`, and :class:`~pykeen.datasets.inductive.InductiveNELL`,
+have 4 versions varying by the size of training and inference graphs as well as the total number of entities
+and relations. It is ensured that the relations sets of all inference graphs are subsets of their training
+graphs.
 
 
 Featurizing Unseen Entities
 ---------------------------
 Training entity embeddings on the training graph is meaningless as those embeddings cannot be
-used at inference time.
-Instead, we need some universal featurizing mechanism which would build representations of both seen
-and unseen entities.
-We can distinguish between cases where we have additional features available, such as entity labels or descriptions, chemical fingerprints, ... and cases where we only have access to relational features, i.e. the multi-relational graph structure.
+used at inference time. Instead, we need some universal featurizing mechanism which would build
+representations of both seen and unseen entities. We can distinguish between cases where we have
+additional features available, such as entity labels or descriptions, chemical fingerprints, ...
+and cases where we only have access to relational features, i.e. the multi-relational graph structure.
 
 .. seealso::
 
@@ -71,33 +74,48 @@ The following are examples of suitable representations for inductive link predic
 
 Features
 ~~~~~~~~
-In cases where you have access to features and can get them for unseen entities at inference time, you can use a non-trainable / frozen :class:`~pykeen.nn.representation.Embedding` to store those. This featurization method generally is domain-specific.
+In cases where you have access to features and can get them for unseen entities at inference time,
+you can use a non-trainable / frozen :class:`~pykeen.nn.representation.Embedding` to store those.
+This featurization method generally is domain-specific.
 
 A special case of featurization are text-based features, e.g., from entity names or descriptions.
-You can use :class:`~pykeen.nn.representation.TextRepresentation` to utilize a (usually pre-trained) text embedding or language model to obtain features. At both training and inference time, fixed-size entity vectors are obtained after passing their textual descriptions through a pre-trained language model.
+You can use :class:`~pykeen.nn.representation.TextRepresentation` to utilize a (usually pre-trained
+text embedding or language model to obtain features. At both training and inference time, fixed-size
+entity vectors are obtained after passing their textual descriptions through a pre-trained language
+model.
 
 NodePiece
 ~~~~~~~~~
-The :class:`~pykeen.nn.NodePieceRepresentation` can be used in the most basic cases where unseen entities arrive without any feature or descriptions. Since the set of relations at training and inference time is the same, it will *tokenize* each entity through a subset of incident relation types. 
+The :class:`~pykeen.nn.NodePieceRepresentation` can be used in the most basic cases where unseen
+entities arrive without any feature or descriptions. Since the set of relations at training and
+inference time is the same, it will *tokenize* each entity through a subset of incident relation types.
 
 Combination
 ~~~~~~~~~~~
-Once you have basic inductive representations, you can also combine or transform them to form more complex features. For example, you could add message passing or a learnable transformation to the features.
+Once you have basic inductive representations, you can also combine or transform them to form more
+complex features. For example, you could add message passing or a learnable transformation to the
+features.
 
 
 Composing the Model
 -------------------
-In order to compose a link prediction model for inductive link prediction, PyKEEN offers the :class:`~pykeen.models.InductiveERModel` base class.
-In comprises a mapping from *inductive modes* to the respective entity representations.
-For computational reasons, these are pre-defined for inference / validation / test and not constructed on-the-fly.
-However, the model exposes a utility method to enable exchanging representations for a new inference graph, cf. :meth:`~pykeen.models.InductiveERModel.replace_entity_representations_`.
+In order to compose a link prediction model for inductive link prediction, PyKEEN offers the
+:class:`~pykeen.models.InductiveERModel` base class. In comprises a mapping from *inductive modes*
+to the respective entity representations. For computational reasons, these are pre-defined for
+inference / validation / test and not constructed on-the-fly. However, the model exposes a utility
+method to enable exchanging representations for a new inference graph, cf.
+:meth:`~pykeen.models.InductiveERModel.replace_entity_representations_`.
 
 At the moment, PyKEEN also provides two fully-configured inductive NodePiece implementations:
 :class:`~pykeen.models.InductiveNodePiece` and :class:`~pykeen.models.InductiveNodePieceGNN`.
-Both inductive versions of NodePiece train an encoder on top of the vocabulary of relational *tokens* that can be easily re-used at inference time.
-:class:`~pykeen.models.InductiveNodePieceGNN` additionally performs message passing over the *inductive_inference* graph after building node representations from the vocabulary. By default, message passing is performed with a 2-layer CompGCN.
-:class:`~pykeen.models.InductiveNodePiece` and :class:`~pykeen.models.InductiveNodePieceGNN` can be paired with any interaction function from PyKEEN where the dimension of relation vectors is the same as dimension of final node vectors.
-Alternative interactions can be integrated with custom initialization of the relation representation module.
+Both inductive versions of NodePiece train an encoder on top of the vocabulary of relational
+*tokens* that can be easily re-used at inference time. :class:`~pykeen.models.InductiveNodePieceGNN`
+additionally performs message passing over the *inductive_inference* graph after building node
+representations from the vocabulary. By default, message passing is performed with a 2-layer CompGCN.
+:class:`~pykeen.models.InductiveNodePiece` and :class:`~pykeen.models.InductiveNodePieceGNN` can be
+paired with any interaction function from PyKEEN where the dimension of relation vectors is the same
+as dimension of final node vectors. Alternative interactions can be integrated with custom
+initialization of the relation representation module.
 
 Example
 ~~~~~~~
@@ -109,10 +127,10 @@ Creating a message-passing version of NodePiece is pretty much the same:
 
 .. literalinclude:: ../examples/tutorial/inductive_lp/01_model_gnn.py
 
-Note this version has the ``gnn_encoder`` argument - keeping it ``None`` would invoke a default 2-layer CompGCN.
-You can pass here any relational GNN that returns updated matrices of entities and relations as
-the scoring function will use them for ranking triples. See :class:`~pykeen.models.InductiveNodePieceGNN`
-for more details.
+Note this version has the ``gnn_encoder`` argument - keeping it ``None`` would invoke a default
+2-layer CompGCN. You can pass here any relational GNN that returns updated matrices of entities
+and relations as the scoring function will use them for ranking triples. See
+:class:`~pykeen.models.InductiveNodePieceGNN` for more details.
 
 
 Training & Evaluation
@@ -143,6 +161,7 @@ Full Inductive LP Example
 -------------------------
 
 A minimally working example for training an `InductiveNodePieceGNN` on the `InductiveFB15k237` (v1)
-in the sLCWA mode with 32 negative samples per positive, with NSSALoss, and SampledEvaluator would look like this:
+in the sLCWA mode with 32 negative samples per positive, with NSSALoss, and SampledEvaluator would
+look like this:
 
 .. literalinclude:: ../examples/tutorial/inductive_lp/03_full.py

--- a/docs/source/tutorial/inductive_lp.rst
+++ b/docs/source/tutorial/inductive_lp.rst
@@ -87,11 +87,11 @@ Alternative interactions can be integrated with custom initialization of the rel
 
 Let's create a basic `InductiveNodePiece` using one of the `InductiveFB15k237` datasets:
 
-.. literalinclude:: ../examples/tutoria/inductive_lp/01_model.py
+.. literalinclude:: ../examples/tutorial/inductive_lp/01_model.py
 
 Creating a message-passing version of NodePiece is pretty much the same:
 
-.. literalinclude:: ../examples/tutoria/inductive_lp/01_model_gnn.py
+.. literalinclude:: ../examples/tutorial/inductive_lp/01_model_gnn.py
 
 Note this version has the ``gnn_encoder`` argument - keeping it ``None`` would invoke a default 2-layer CompGCN.
 You can pass here any relational GNN that returns updated matrices of entities and relations as
@@ -130,7 +130,7 @@ validation / test triple only against 50 random negatives. PyKEEN implements thi
 
 Let's create a training loop and validation / test evaluators:
 
-.. literalinclude:: ../examples/tutoria/inductive_lp/02_training.py
+.. literalinclude:: ../examples/tutorial/inductive_lp/02_training.py
 
 
 Full Inductive LP Example
@@ -139,4 +139,4 @@ Full Inductive LP Example
 A minimally working example for training an `InductiveNodePieceGNN` on the `InductiveFB15k237` (v1)
 in the sLCWA mode with 32 negative samples per positive, with NSSALoss, and SampledEvaluator would look like this:
 
-.. literalinclude:: ../examples/tutoria/inductive_lp/03_full.py
+.. literalinclude:: ../examples/tutorial/inductive_lp/03_full.py

--- a/docs/source/tutorial/inductive_lp.rst
+++ b/docs/source/tutorial/inductive_lp.rst
@@ -38,7 +38,7 @@ because we will learn representations of those relations to transfer to unseen g
 
 Organizing the Dataset
 ----------------------
-The basic class to build inductive datasets is :class:`pykeen.datasets.inductive.InductiveDataset`.
+The basic class to build inductive datasets is :class:`~pykeen.datasets.inductive.InductiveDataset`.
 It is supposed to contain more than 3 triple factories, i.e., in the *fully-inductive* setup it is expected to have
 at least 4 triple factories (`transductive_training`, `inductive_inference`, `inductive_validation`, `inductive_test`).
 `transductive_training` is the graph with entities index `(0..N)` on which we will train a model,
@@ -49,7 +49,7 @@ but not with `transductive_training`. This way, we inform a model that we are pr
 inductive inference graph, not against the training graph.
 
 PyKEEN supports 12 fully-inductive datasets introduced by [teru2020]_ where training and inductive inference graphs
-are disjoint. Each of 3 KG families, `InductiveFB15k237`, `InductiveWN18RR`, and `InductiveNELL`, have 4 versions
+are disjoint. Each of 3 KG families, :class:`~pykeen.datasets.inductive.InductiveFB15k237`, :class:`~pykeen.datasets.inductive.InductiveWN18RR`, and :class:`~pykeen.datasets.inductive.InductiveNELL`, have 4 versions
 varying by the size of training and inference graphs as well as the total number of entities and relations.
 It is ensured that the relations sets of all inference graphs are subsets of their training graphs.
 
@@ -60,31 +60,47 @@ Training entity embeddings on the training graph is meaningless as those embeddi
 used at inference time.
 Instead, we need some universal featurizing mechanism which would build representations of both seen
 and unseen entities.
-In PyKEEN, there exist at least 2 such mechanisms depending on the availability of node descriptions.
+We can distinguish between cases where we have additional features available, such as entity labels or descriptions, chemical fingerprints, ... and cases where we only have access to relational features, i.e. the multi-relational graph structure.
 
+.. seealso::
+
+  The :ref:`representations` tutorial gives a general overview about different representation components.
+  Some of those can be used to form inductive representations.
+
+The following are examples of suitable representations for inductive link prediction:
+
+Features
+~~~~~~~~
+In cases where you have access to features and can get them for unseen entities at inference time, you can use a non-trainable / frozen :class:`~pykeen.nn.representation.Embedding` to store those. This featurization method generally is domain-specific.
+
+A special case of featurization are text-based features, e.g., from entity names or descriptions.
+You can use :class:`~pykeen.nn.representation.TextRepresentation` to utilize a (usually pre-trained) text embedding or language model to obtain features. At both training and inference time, fixed-size entity vectors are obtained after passing their textual descriptions through a pre-trained language model.
 
 NodePiece
 ~~~~~~~~~
-In the most basic case, unseen entities arrive without any features nor descriptions.
-We cater for this case using :class:`pykeen.nn.representation.NodePieceRepresentation` -
-since the set of relations at training and inference time is the same, NodePiece Representation
-will *tokenize* each entity through a subset of incident relation types.
-Out of computational reasons, NodePiece representations of `inductive_inference` entities
-(to be seen at inference time) can be pre-computed as well.
+The :class:`~pykeen.nn.NodePieceRepresentation` can be used in the most basic cases where unseen entities arrive without any feature or descriptions. Since the set of relations at training and inference time is the same, it will *tokenize* each entity through a subset of incident relation types. 
 
-At the moment, PyKEEN provides two inductive NodePiece implementations:
-* :class:`pykeen.models.inductive.InductiveNodePiece` - basic version;
-* :class:`pykeen.models.inductive.InductiveNodePieceGNN` - in addition to tokenization and learnable hash
-encoder, this version also performs message passing over the *inductive_inference* graph after building
-node representations from the vocabulary. By default, message passing is performed with a 2-layer CompGCN
+Combination
+~~~~~~~~~~~
+Once you have basic inductive representations, you can also combine or transform them to form more complex features. For example, you could add message passing or a learnable transformation to the features.
 
-Both inductive versions of NodePiece train an encoder
-on top of the vocabulary of relational *tokens* that can be easily re-used at inference time.
-This way, we can obtain representations of unseen entities.
-`InductiveNodePiece` and `InductiveNodePieceGNN` can be paired with any interaction function from PyKEEN
-where the dimension of relation vectors is the same as dimension of final node vectors.
+
+Composing the Model
+-------------------
+In order to compose a link prediction model for inductive link prediction, PyKEEN offers the :class:`~pykeen.models.InductiveERModel` base class.
+In comprises a mapping from *inductive modes* to the respective entity representations.
+For computational reasons, these are pre-defined for inference / validation / test and not constructed on-the-fly.
+However, the model exposes a utility method to enable exchanging representations for a new inference graph, cf. :meth:`~pykeen.models.InductiveERModel.replace_entity_representations_`.
+
+At the moment, PyKEEN also provides two fully-configured inductive NodePiece implementations:
+:class:`~pykeen.models.InductiveNodePiece` and :class:`~pykeen.models.InductiveNodePieceGNN`.
+Both inductive versions of NodePiece train an encoder on top of the vocabulary of relational *tokens* that can be easily re-used at inference time.
+:class:`~pykeen.models.InductiveNodePieceGNN` additionally performs message passing over the *inductive_inference* graph after building node representations from the vocabulary. By default, message passing is performed with a 2-layer CompGCN.
+:class:`~pykeen.models.InductiveNodePiece` and :class:`~pykeen.models.InductiveNodePieceGNN` can be paired with any interaction function from PyKEEN where the dimension of relation vectors is the same as dimension of final node vectors.
 Alternative interactions can be integrated with custom initialization of the relation representation module.
 
+Example
+~~~~~~~
 Let's create a basic `InductiveNodePiece` using one of the `InductiveFB15k237` datasets:
 
 .. literalinclude:: ../examples/tutorial/inductive_lp/01_model.py
@@ -95,18 +111,8 @@ Creating a message-passing version of NodePiece is pretty much the same:
 
 Note this version has the ``gnn_encoder`` argument - keeping it ``None`` would invoke a default 2-layer CompGCN.
 You can pass here any relational GNN that returns updated matrices of entities and relations as
-the scoring function will use them for ranking triples. See :class:`pykeen.models.inductive.InductiveNodePieceGNN`
+the scoring function will use them for ranking triples. See :class:`~pykeen.models.InductiveNodePieceGNN`
 for more details.
-
-
-Label-based Transformer Representation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If entity descriptions are available, the universal featurizing mechanism can
-be a language model accessible via :class:`pykeen.nn.representation.LabelBasedTransformerRepresentation`.
-At both training and inference time, fixed-size entity vectors are obtained after passing
-their textual descriptions through a pre-trained language model.
-
-This is work in progress and not yet available.
 
 
 Training & Evaluation
@@ -119,14 +125,14 @@ or `mode=testing`, the model has to invoke representations of inference graphs.
 In the case of fully-inductive (disjoint) datasets from [teru2020]_ the inference graph at
 validation and test is the same.
 
-By default, you can use standard PyKEEN training loops :class:`pykeen.training.SLCWATrainingLoop` and
-:class:`pykeen.training.LCWATrainingLoop` with the new `mode` parameter. Similarly, you can use a
-standard evaluator :class:`pykeen.evaluation.rank_based_evaluator.RankBasedEvaluator` with the `mode`
+By default, you can use standard PyKEEN training loops :class:`~pykeen.training.SLCWATrainingLoop` and
+:class:`~pykeen.training.LCWATrainingLoop` with the new `mode` parameter. Similarly, you can use a
+standard evaluator :class:`~pykeen.evaluation.rank_based_evaluator.RankBasedEvaluator` with the `mode`
 parameter to evaluate validation / test triples over the whole inference graph.
 
 Moreover, original work of [teru2020]_ used a restricted evaluation protocol ranking each
 validation / test triple only against 50 random negatives. PyKEEN implements this protocol with
-:class:`pykeen.evaluation.rank_based_evaluator.SampledRankBasedEvaluator`
+:class:`~pykeen.evaluation.rank_based_evaluator.SampledRankBasedEvaluator`
 
 Let's create a training loop and validation / test evaluators:
 

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -102,7 +102,7 @@ class InductiveERModel(ERModel):
             representation = [representation]
         old = self._get_entity_representations_from_inductive_mode(mode=mode)
         key = self._key_for_mode(mode)
-        self._mode_to_representations[key] = nn.ModuleList(representation)
+        self._mode_to_representations[key] = nn.ModuleList(representation).to(self.device)
         return old
 
     # docstr-coverage: inherited

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -1,7 +1,7 @@
 """Base classes for inductive models."""
 
 from collections import ChainMap
-from collections.abc import Mapping, Sequence
+from collections.abc import MutableMapping, Sequence
 
 from class_resolver import OneOrManyHintOrType, OneOrManyOptionalKwargs
 from torch import nn
@@ -22,7 +22,7 @@ class InductiveERModel(ERModel):
 
     #: a mapping from inductive mode to corresponding entity representations
     #: note: there may be duplicate values, if entity representations are shared between validation and testing
-    _mode_to_representations: Mapping[str, Sequence[Representation]]
+    _mode_to_representations: MutableMapping[str, Sequence[Representation]]
 
     def __init__(
         self,
@@ -85,7 +85,25 @@ class InductiveERModel(ERModel):
             )
         _mode_to_representations[TESTING] = testing_entity_representations
         # note: "training" is an attribute of nn.Module -> need to rename to avoid name collision
-        self._mode_to_representations = nn.ModuleDict({f"{k}_factory": v for k, v in _mode_to_representations.items()})
+        self._mode_to_representations = nn.ModuleDict(
+            {self._key_for_mode(mode): v for mode, v in _mode_to_representations.items()}
+        )
+
+    @staticmethod
+    def _key_for_mode(mode: InductiveMode) -> str:
+        # note: "training" is an attribute of nn.Module -> need to rename to avoid name collision
+        return f"{mode}_representations"
+
+    def replace_entity_representations_(
+        self, mode: InductiveMode, representation: Sequence[Representation] | Representation
+    ) -> Sequence[Representation]:
+        """Replace the entity representations for the given inductive mode."""
+        if isinstance(representation, Representation):
+            representation = [representation]
+        old = self._get_entity_representations_from_inductive_mode(mode=mode)
+        key = self._key_for_mode(mode)
+        self._mode_to_representations[key] = nn.ModuleList(representation)
+        return old
 
     # docstr-coverage: inherited
     def _get_entity_representations_from_inductive_mode(
@@ -95,7 +113,7 @@ class InductiveERModel(ERModel):
             raise ValueError(
                 f"{self.__class__.__name__} does not support the transductive setting (i.e., when mode is None)"
             )
-        key = f"{mode}_factory"
+        key = self._key_for_mode(mode)
         if key in self._mode_to_representations:
             return self._mode_to_representations[key]
         raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")

--- a/src/pykeen/models/inductive/inductive_nodepiece.py
+++ b/src/pykeen/models/inductive/inductive_nodepiece.py
@@ -162,8 +162,6 @@ class InductiveNodePiece(InductiveERModel):
         :raises ValueError:
             if the triples factory does not request inverse triples, or the number of relations differs.
         """
-        if not triples_factory.create_inverse_triples:
-            raise ValueError("Must create a triples factory with inverse triples")
         if triples_factory.num_relations != self.num_relations:
             raise ValueError(f"{self.num_relations=} != {triples_factory.num_relations=} !")
         # note: we cannot ensure the mapping also matches...

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -1109,7 +1109,7 @@ def predict_target(
 def predict_triples(
     model: Model,
     *,
-    triples: None | MappedTriples | LabeledTriples | tuple[str, str, str] | Sequence[tuple[str, str, str]],
+    triples: None | MappedTriples | LabeledTriples | tuple[str, str, str] | Sequence[tuple[str, str, str]] = None,
     triples_factory: CoreTriplesFactory | None = None,
     batch_size: int | None = None,
     mode: InductiveMode | None = None,


### PR DESCRIPTION
- [x] extract examples into Python files
- [x] fix device issue when an accelerator is available
- [x] add `replace_entity_representations_` to replace entity representations for an inductive mode
- [x] add example for how to perform inference with a completely new triples factory
- [x] Fix issue with missing default value for `triples` in `predict_triples`

Fix #1501