### PR TITLE
🪫🔈 Generalize low-rank representation

### DIFF
--- a/docs/source/examples/nn/representation/low_rank_mixture.py
+++ b/docs/source/examples/nn/representation/low_rank_mixture.py
@@ -1,0 +1,41 @@
+"""Use the (generalized) low-rank approximation to create a mixture model representation."""
+
+# %%
+from pykeen.datasets import get_dataset
+from pykeen.models import ERModel
+from pykeen.nn import LowRankRepresentation
+from pykeen.pipeline import pipeline
+
+dataset = get_dataset(dataset="CoDExSmall")
+
+# set up relation representations as a mixture (~soft clustering) with 5 components
+embedding_dim = 32
+num_components = 5
+r = LowRankRepresentation(
+    max_id=dataset.num_relations,
+    shape=embedding_dim,
+    num_bases=num_components,
+    weight_kwargs=dict(normalizer="softmax"),
+)
+# use DistMult interaction, and a simple embedding matrix for relations
+model = ERModel(
+    triples_factory=dataset.training,
+    interaction="distmult",
+    entity_representations_kwargs=dict(shape=embedding_dim),
+    relation_representations=r,
+)
+result = pipeline(dataset=dataset, model=model, training_kwargs=dict(num_epochs=20))
+
+# %%
+# TODO: get labels for relations
+# e.g. https://www.wikidata.org/wiki/Property:P3373
+# WikidataTextCache
+
+# %%
+# use the mixture weights
+weights = r.weight()
+component_index = weights.argmax(dim=1).tolist()
+components = [[] for _ in range(num_components)]
+for label, relation_index in dataset.relation_to_id.items():
+    components[component_index[relation_index]].append(label)
+print(components)

--- a/docs/source/examples/nn/representation/low_rank_mixture.py
+++ b/docs/source/examples/nn/representation/low_rank_mixture.py
@@ -5,6 +5,7 @@ from pykeen.datasets import get_dataset
 from pykeen.models import ERModel
 from pykeen.nn import LowRankRepresentation
 from pykeen.pipeline import pipeline
+from pykeen.typing import FloatTensor
 
 dataset = get_dataset(dataset="CoDExSmall")
 
@@ -18,7 +19,7 @@ r = LowRankRepresentation(
     weight_kwargs=dict(normalizer="softmax"),
 )
 # use DistMult interaction, and a simple embedding matrix for relations
-model = ERModel(
+model = ERModel[FloatTensor, FloatTensor, FloatTensor](
     triples_factory=dataset.training,
     interaction="distmult",
     entity_representations_kwargs=dict(shape=embedding_dim),
@@ -35,7 +36,7 @@ result = pipeline(dataset=dataset, model=model, training_kwargs=dict(num_epochs=
 # use the mixture weights
 weights = r.weight()
 component_index = weights.argmax(dim=1).tolist()
-components = [[] for _ in range(num_components)]
+components: list[list[str]] = [[] for _ in range(num_components)]
 for label, relation_index in dataset.relation_to_id.items():
     components[component_index[relation_index]].append(label)
 print(components)

--- a/docs/source/examples/nn/representation/low_rank_mixture.py
+++ b/docs/source/examples/nn/representation/low_rank_mixture.py
@@ -1,6 +1,9 @@
 """Use the (generalized) low-rank approximation to create a mixture model representation."""
 
 # %%
+
+from tabulate import tabulate
+
 from pykeen.datasets import get_dataset
 from pykeen.models import ERModel
 from pykeen.nn import LowRankRepresentation
@@ -34,13 +37,13 @@ result = pipeline(dataset=dataset, model=model, training_kwargs=dict(num_epochs=
 
 # keys are Wikidata IDs, which are the "labels" in CoDEx, and values
 # are the concatenation of the Wikidata label + description
-relation_to_text: dict[str, str | None] = WikidataTextCache().get_texts_dict(dataset.relation_to_id)
+relation_to_text: dict[str, str | None] = WikidataTextCache().get_labels_dict(dataset.relation_to_id)
 
 # %%
 # use the mixture weights
 weights = r.weight()
 component_index = weights.argmax(dim=1).tolist()
-components: list[list[str]] = [[] for _ in range(num_components)]
+components: list[list[str]] = [[f"Component {i}"] for i in range(num_components)]
 for label, relation_index in dataset.relation_to_id.items():
-    components[component_index[relation_index]].append(label)
-print(components)
+    components[component_index[relation_index]].append(f"{label} {relation_to_text[label]}")
+print(tabulate(components))

--- a/docs/source/examples/nn/representation/low_rank_mixture.py
+++ b/docs/source/examples/nn/representation/low_rank_mixture.py
@@ -4,6 +4,7 @@
 from pykeen.datasets import get_dataset
 from pykeen.models import ERModel
 from pykeen.nn import LowRankRepresentation
+from pykeen.nn.text.cache import WikidataTextCache
 from pykeen.pipeline import pipeline
 from pykeen.typing import FloatTensor
 
@@ -28,9 +29,12 @@ model = ERModel[FloatTensor, FloatTensor, FloatTensor](
 result = pipeline(dataset=dataset, model=model, training_kwargs=dict(num_epochs=20))
 
 # %%
-# TODO: get labels for relations
+# TODO: use this relation to label/description dict
 # e.g. https://www.wikidata.org/wiki/Property:P3373
-# WikidataTextCache
+
+# keys are Wikidata IDs, which are the "labels" in CoDEx, and values
+# are the concatenation of the Wikidata label + description
+relation_to_text: dict[str, str | None] = WikidataTextCache().get_texts_dict(dataset.relation_to_id)
 
 # %%
 # use the mixture weights

--- a/docs/source/examples/nn/representation/low_rank_mixture.py
+++ b/docs/source/examples/nn/representation/low_rank_mixture.py
@@ -1,6 +1,7 @@
 """Use the (generalized) low-rank approximation to create a mixture model representation."""
 
-# %%
+import pandas
+
 from pykeen.datasets import get_dataset
 from pykeen.models import ERModel
 from pykeen.nn import LowRankRepresentation
@@ -8,7 +9,7 @@ from pykeen.nn.text.cache import WikidataTextCache
 from pykeen.pipeline import pipeline
 from pykeen.typing import FloatTensor
 
-dataset = get_dataset(dataset="CoDExSmall")
+dataset = get_dataset(dataset="CoDExSmall", dataset_kwargs=dict(create_inverse_triples=True))
 
 # set up relation representations as a mixture (~soft clustering) with 5 components
 embedding_dim = 32
@@ -28,19 +29,21 @@ model = ERModel[FloatTensor, FloatTensor, FloatTensor](
 )
 result = pipeline(dataset=dataset, model=model, training_kwargs=dict(num_epochs=20))
 
-# %%
-# TODO: use this relation to label/description dict
-# e.g. https://www.wikidata.org/wiki/Property:P3373
-
 # keys are Wikidata IDs, which are the "labels" in CoDEx, and values
 # are the concatenation of the Wikidata label + description
-relation_to_text: dict[str, str | None] = WikidataTextCache().get_texts_dict(dataset.relation_to_id)
+relation_to_text = WikidataTextCache().get_texts_dict(dataset.relation_to_id)
 
-# %%
 # use the mixture weights
-weights = r.weight()
-component_index = weights.argmax(dim=1).tolist()
-components: list[list[str]] = [[] for _ in range(num_components)]
+weights = r.weight().detach().cpu().numpy()
+_data = []
 for label, relation_index in dataset.relation_to_id.items():
-    components[component_index[relation_index]].append(label)
-print(components)
+    text = relation_to_text[label]
+    for c, w in enumerate(weights[relation_index]):
+        _data.append((relation_index, label, text, c, w))
+df = pandas.DataFrame(data=_data, columns=["relation_index", "wikidata-id", "text", "component_index", "weight"])
+
+
+# For each component, look at the relations that are most assigned to it
+print(
+    df.groupby(by="component_index").apply(lambda g: g.nlargest(3, columns="weight"))[["wikidata-id", "text", "weight"]]
+)

--- a/docs/source/examples/nn/representation/low_rank_mixture.py
+++ b/docs/source/examples/nn/representation/low_rank_mixture.py
@@ -14,7 +14,7 @@ dataset = get_dataset(dataset="CoDExSmall", dataset_kwargs=dict(create_inverse_t
 # set up relation representations as a mixture (~soft clustering) with 5 components
 embedding_dim = 32
 num_components = 5
-r = LowRankRepresentation(
+relation_representation = LowRankRepresentation(
     max_id=dataset.num_relations,
     shape=embedding_dim,
     num_bases=num_components,
@@ -25,25 +25,27 @@ model = ERModel[FloatTensor, FloatTensor, FloatTensor](
     triples_factory=dataset.training,
     interaction="distmult",
     entity_representations_kwargs=dict(shape=embedding_dim),
-    relation_representations=r,
+    relation_representations=relation_representation,
 )
 result = pipeline(dataset=dataset, model=model, training_kwargs=dict(num_epochs=20))
 
 # keys are Wikidata IDs, which are the "labels" in CoDEx, and values
 # are the concatenation of the Wikidata label + description
-relation_to_text = WikidataTextCache().get_texts_dict(dataset.relation_to_id)
+wikidata_id_to_label = WikidataTextCache().get_texts_dict(dataset.relation_to_id)
 
 # use the mixture weights
-weights = r.weight().detach().cpu().numpy()
-_data = []
-for label, relation_index in dataset.relation_to_id.items():
-    text = relation_to_text[label]
-    for c, w in enumerate(weights[relation_index]):
-        _data.append((relation_index, label, text, c, w))
-df = pandas.DataFrame(data=_data, columns=["relation_index", "wikidata-id", "text", "component_index", "weight"])
+relation_weights = relation_representation.weight().detach().cpu().numpy()
+rows = [
+    (relation_index, wikidata_id, wikidata_id_to_label[wikidata_id], component, weight)
+    for wikidata_id, relation_index in dataset.relation_to_id.items()
+    for component, weight in enumerate(relation_weights[relation_index])
+]
+df = pandas.DataFrame(data=rows, columns=["relation_index", "wikidata-id", "text", "component_index", "weight"])
 
 
 # For each component, look at the relations that are most assigned to it
 print(
-    df.groupby(by="component_index").apply(lambda g: g.nlargest(3, columns="weight"))[["wikidata-id", "text", "weight"]]
+    df.groupby(by="component_index").apply(lambda g: g.nlargest(3, columns="weight"), include_groups=False)[
+        ["wikidata-id", "text", "weight"]
+    ]
 )

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -241,7 +241,7 @@ class BasesDecomposition(Decomposition):
 
     # docstr-coverage: inherited
     def forward_horizontally_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
-        x = einsum("ni, rb, bio -> rno", x, self.base_weights, self.base)
+        x = einsum("ni, rb, bio -> rno", x, self.base_weights, self.bases)
         # TODO: can we change the dimension order to make this contiguous?
         return torch.spmm(adj, x.reshape(-1, self.output_dim))
 
@@ -249,7 +249,7 @@ class BasesDecomposition(Decomposition):
     def forward_vertically_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
         x = torch.spmm(adj, x)
         x = x.view(self.num_relations, -1, self.input_dim)
-        return einsum("rb, bio, rni -> no", self.base_weights, self.base, x)
+        return einsum("rb, bio, rni -> no", self.base_weights, self.bases, x)
 
 
 def _make_dim_divisible(dim: int, divisor: int, name: str) -> int:

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -241,7 +241,8 @@ class BasesDecomposition(Decomposition):
 
     # docstr-coverage: inherited
     def forward_horizontally_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
-        x = einsum("ni, rb, bio -> rno", x, self.base_weights, self.bases)
+        # FIXME upstream this into low ranked representation?
+        x = einsum("ni, rb, bio -> rno", x, self.base_weights, self.base)
         # TODO: can we change the dimension order to make this contiguous?
         return torch.spmm(adj, x.reshape(-1, self.output_dim))
 
@@ -249,7 +250,7 @@ class BasesDecomposition(Decomposition):
     def forward_vertically_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
         x = torch.spmm(adj, x)
         x = x.view(self.num_relations, -1, self.input_dim)
-        return einsum("rb, bio, rni -> no", self.base_weights, self.bases, x)
+        return einsum("rb, bio, rni -> no", self.base_weights, self.base, x)
 
 
 def _make_dim_divisible(dim: int, divisor: int, name: str) -> int:

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -215,9 +215,8 @@ class BasesDecomposition(Decomposition):
             max_id=self.num_relations,
             shape=(self.input_dim, self.output_dim),
             num_bases=num_bases,
-            # FIXME check this
-            # weight_initializer=uniform_norm_p1_,
-            initializer=nn.init.xavier_normal_,
+            weight_kwargs=dict(initializer=uniform_norm_p1_),
+            base_kwargs=dict(initializer=nn.init.xavier_normal_),
         )
 
     # docstr-coverage: inherited

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -215,7 +215,8 @@ class BasesDecomposition(Decomposition):
             max_id=self.num_relations,
             shape=(self.input_dim, self.output_dim),
             num_bases=num_bases,
-            weight_initializer=uniform_norm_p1_,
+            # FIXME check this
+            # weight_initializer=uniform_norm_p1_,
             initializer=nn.init.xavier_normal_,
         )
 

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -241,7 +241,6 @@ class BasesDecomposition(Decomposition):
 
     # docstr-coverage: inherited
     def forward_horizontally_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
-        # FIXME upstream this into low ranked representation?
         x = einsum("ni, rb, bio -> rno", x, self.base_weights, self.base)
         # TODO: can we change the dimension order to make this contiguous?
         return torch.spmm(adj, x.reshape(-1, self.output_dim))

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -227,12 +227,12 @@ class BasesDecomposition(Decomposition):
     @property
     def bases(self) -> torch.Tensor:
         """Return the base representations."""
-        return self.relation_representations.bases(indices=None)
+        return self.relation_representations.base(indices=None)
 
     @property
     def base_weights(self) -> torch.Tensor:
         """Return the base weights."""
-        return self.relation_representations.weight
+        return self.relation_representations.weight(indices=None)
 
     # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -33,7 +33,7 @@ from typing_extensions import Self
 
 from .combination import Combination, combination_resolver
 from .compositions import CompositionModule, composition_resolver
-from .init import initializer_resolver
+from .init import PretrainedInitializer, initializer_resolver
 from .text.cache import PyOBOTextCache, TextCache, WikidataTextCache
 from .text.encoder import TextEncoder, text_encoder_resolver
 from .utils import ShapeError
@@ -582,9 +582,6 @@ class LowRankRepresentation(Representation):
         :return:
             A low-rank approximation obtained via (truncated) SVD, cf. :func:`torch.svd_lowrank`.
         """
-        # TODO: is this a safe non-local import?
-        from .init import PretrainedInitializer
-
         # get base representations, shape: (n, *ds)
         x = other(indices=None)
         # calculate SVD, U.shape: (n, k), s.shape: (k,), u.shape: (k, prod(ds))

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -582,14 +582,7 @@ class LowRankRepresentation(Representation):
             logger.warning(
                 f"The explicitly provided {num_bases=:_} does not match {base.max_id=:_} and has been ignored."
             )
-        if shape is None:
-            shape = base.shape
-        else:
-            shape = tuple(upgrade_to_sequence(shape))
-            if shape != base.shape:
-                raise ShapeError(shape=base.shape, reference=shape)
-
-        super().__init__(max_id=max_id, shape=shape, **kwargs)
+        super().__init__(max_id=max_id, shape=ShapeError.verify(base.shape, shape), **kwargs)
 
         # assign *after* super init
         self.base = base

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -502,10 +502,12 @@ class LowRankRepresentation(Representation):
     def __init__(
         self,
         *,
-        max_id: int,  # TODO: allow None
+        # TODO: allow None
+        max_id: int,
         # TODO: remove
         shape: OneOrSequence[int],
-        num_bases: int = 3,  # TODO: allow None
+        # TODO: allow None
+        num_bases: int = 3,
         # base representation
         # base representation
         base: HintOrType[Representation] = None,

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -29,6 +29,7 @@ from class_resolver.contrib.torch import activation_resolver
 from docdata import parse_docdata
 from torch import nn
 from torch.nn import functional
+from typing_extensions import Self
 
 from .combination import Combination, combination_resolver
 from .compositions import CompositionModule, composition_resolver
@@ -557,7 +558,7 @@ class LowRankRepresentation(Representation):
         self.weight = weight
 
     @classmethod
-    def approximate(cls, other: Representation, num_bases: int = 3, **kwargs) -> LowRankRepresentation:
+    def approximate(cls, other: Representation, num_bases: int = 3, **kwargs) -> Self:
         """
         Construct a low-rank approximation of another representation.
 

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -496,6 +496,10 @@ class LowRankRepresentation(Representation):
     This representation implements the generalized form, where both, $B$ and $W$ are arbitrary representations
     themselves.
 
+    Example usage:
+
+    .. literalinclude:: ../examples/nn/representation/low_rank_mixture.py
+
     ---
     name: Low Rank Embedding
     """

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -530,13 +530,16 @@ class LowRankRepresentation(Representation):
 
         :param max_id:
             The maximum ID (exclusively). Valid Ids reach from ``0`` to ``max_id-1``.
+        :param shape:
+            The shape of an individual representation.
+        :param num_bases:
+            The number of bases. More bases increase expressivity, but also increase the number of trainable parameters.
+
         :param weight:
             The weight representation, or a hint thereof.
         :param weight_kwargs:
             Additional keyword based arguments used to instantiate the weight representation.
 
-        :param num_bases:
-            The number of bases. More bases increase expressivity, but also increase the number of trainable parameters.
         :param base:
             The base representation, or a hint thereof.
         :param base_kwargs:
@@ -553,7 +556,7 @@ class LowRankRepresentation(Representation):
 
         # TODO: verification
 
-        super().__init__(max_id=weight.max_id, shape=base.shape, **kwargs)
+        super().__init__(max_id=max_id, shape=shape, **kwargs)
 
         # assign *after* super init
         self.base = base

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -566,6 +566,10 @@ class LowRankRepresentation(Representation):
 
         :param kwargs:
             Additional keyword based arguments passed to :class:`~pykeen.nn.representation.Representation`.
+
+        :raises MaxIDMismatchError:
+            if the ``max_id`` was given explicitly and does not match the ``max_id`` of the weight
+            representation
         """
         # has to be imported here to avoid cyclic import
         from . import representation_resolver

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -509,19 +509,16 @@ class LowRankRepresentation(Representation):
         *,
         # TODO: allow None
         max_id: int,
-        # TODO: remove
+        # TODO: allow None
         shape: OneOrSequence[int],
         # TODO: allow None
         num_bases: int = 3,
-        # base representation
         # base representation
         base: HintOrType[Representation] = None,
         base_kwargs: OptionalKwargs = None,
         # weight representation
         weight: HintOrType[Representation] = None,
         weight_kwargs: OptionalKwargs = None,
-        # TODO: remove
-        weight_initializer: Initializer = uniform_norm_p1_,
         **kwargs,
     ):
         """
@@ -547,8 +544,8 @@ class LowRankRepresentation(Representation):
         # has to be imported here to avoid cyclic import
         from . import representation_resolver
 
-        base = representation_resolver.make(base, pos_kwargs=base_kwargs, max_id=num_bases)
-        weight = representation_resolver.make(weight, pos_kwargs=weight_kwargs, max_id=max_id)
+        base = representation_resolver.make(base, pos_kwargs=base_kwargs, max_id=num_bases, shape=shape)
+        weight = representation_resolver.make(weight, pos_kwargs=weight_kwargs, max_id=max_id, shape=num_bases)
 
         # TODO: verification
 

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -493,7 +493,8 @@ class LowRankRepresentation(Representation):
     .. math ::
         E[i] = \sum_k B[i, k] \cdot W[k]
 
-    This representation implements the generalized form, where both, $B$ and $W$ are arbitrary representations themselves.
+    This representation implements the generalized form, where both, $B$ and $W$ are arbitrary representations
+    themselves.
 
     ---
     name: Low Rank Embedding
@@ -543,7 +544,6 @@ class LowRankRepresentation(Representation):
         :param kwargs:
             Additional keyword based arguments passed to :class:`~pykeen.nn.representation.Representation`.
         """
-
         # has to be imported here to avoid cyclic import
         from . import representation_resolver
 

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -584,8 +584,10 @@ class LowRankRepresentation(Representation):
             )
         if shape is None:
             shape = base.shape
-        elif tuple(upgrade_to_sequence(shape)) != base.shape:
-            raise ShapeError(shape=base.shape, reference=shape)
+        else:
+            shape = tuple(upgrade_to_sequence(shape))
+            if shape != base.shape:
+                raise ShapeError(shape=base.shape, reference=shape)
 
         super().__init__(max_id=max_id, shape=shape, **kwargs)
 

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -578,7 +578,7 @@ class LowRankRepresentation(Representation):
         # get base representations, shape: (n, *ds)
         x = other(indices=None)
         # calculate SVD, U.shape: (n, k), s.shape: (k,), u.shape: (k, prod(ds))
-        u, s, vh = torch.svd_lowrank(x.view(x.shape[0], -1), q=r.num_bases)
+        u, s, vh = torch.svd_lowrank(x.view(x.shape[0], -1), q=num_bases)
         # setup weight & base representation
         weight = Embedding(
             max_id=num_bases,

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -575,6 +575,8 @@ class LowRankRepresentation(Representation):
 
         :param other:
             The representation to approximate.
+        :param num_bases:
+            The number of bases. More bases increase expressivity, but also increase the number of trainable parameters.
         :param kwargs:
             Additional keyword-based parameters passed to :meth:`__init__`. Must not contain
             ``max_id`` nor ``shape``, which are determined by ``other``.

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -497,8 +497,10 @@ class LowRankRepresentation(Representation):
     name: Low Rank Embedding
     """
 
-    # TODO: implement this
-    # @update_docstring_with_resolver_keys(ResolverKey("bases", resolver="pykeen.nn.representation_resolver"))
+    @update_docstring_with_resolver_keys(
+        ResolverKey("base", resolver="pykeen.nn.representation_resolver"),
+        ResolverKey("weight", resolver="pykeen.nn.representation_resolver"),
+    )
     def __init__(
         self,
         *,

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -33,7 +33,7 @@ from typing_extensions import Self
 
 from .combination import Combination, combination_resolver
 from .compositions import CompositionModule, composition_resolver
-from .init import initializer_resolver, uniform_norm_p1_
+from .init import initializer_resolver
 from .text.cache import PyOBOTextCache, TextCache, WikidataTextCache
 from .text.encoder import TextEncoder, text_encoder_resolver
 from .utils import ShapeError

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -103,8 +103,9 @@ constrainer_resolver = FunctionResolver(
 #: A resolver for normalizers.
 #:
 #: - :func:`torch.nn.functional.normalize`
+#: - :func:`torch.nn.functional.softmax`
 normalizer_resolver = FunctionResolver(
-    [functional.normalize],
+    [functional.normalize, functional.softmax],
     location="pykeen.nn.representation.normalizer_resolver",
 )
 

--- a/src/pykeen/nn/text/cache.py
+++ b/src/pykeen/nn/text/cache.py
@@ -137,7 +137,7 @@ class WikidataTextCache(TextCache):
 
         :raises ValueError: if any invalid ID is encountered
         """
-        pattern = re.compile(r"Q(\d+)")
+        pattern = re.compile(r"[QP](\d+)")
         invalid_ids = [one_id for one_id in ids if not pattern.match(one_id)]
         if invalid_ids:
             raise ValueError(f"Invalid IDs encountered: {invalid_ids}")
@@ -160,7 +160,6 @@ class WikidataTextCache(TextCache):
         :returns: an iterable over JSON results, where the keys correspond to query variables, and the values to the
             corresponding binding
         """
-        # TODO: support relations
         if not wikidata_ids:
             return {}
 
@@ -203,11 +202,11 @@ class WikidataTextCache(TextCache):
         res_json = cls.query(
             sparql=functools.partial(
                 dedent(
-                    """
-                        SELECT ?item ?itemLabel ?itemDescription WHERE {{{{
-                            VALUES ?item {{ {ids} }}
-                            SERVICE wikibase:label {{ bd:serviceParam wikibase:language "{language}". }}
-                        }}}}
+                    """\
+                    SELECT ?item ?itemLabel ?itemDescription WHERE {{{{
+                        VALUES ?item {{ {ids} }}
+                        SERVICE wikibase:label {{ bd:serviceParam wikibase:language "{language},[AUTO_LANGUAGE],mul". }}
+                    }}}}
                     """
                 ).format,
                 language=language,

--- a/src/pykeen/nn/text/cache.py
+++ b/src/pykeen/nn/text/cache.py
@@ -40,6 +40,10 @@ class TextCache(ABC):
     def get_texts(self, identifiers: Sequence[str]) -> Sequence[str | None]:
         """Get text for the given identifiers for the cache."""
 
+    def get_texts_dict(self, identifiers: Sequence[str]) -> dict[str, str | None]:
+        """Get a dictionary from identifiers to their associated text."""
+        return dict(zip(identifiers, self.get_texts(identifiers), strict=False))
+
 
 class IdentityCache(TextCache):
     """A cache without functionality.

--- a/src/pykeen/nn/text/cache.py
+++ b/src/pykeen/nn/text/cache.py
@@ -160,6 +160,7 @@ class WikidataTextCache(TextCache):
         :returns: an iterable over JSON results, where the keys correspond to query variables, and the values to the
             corresponding binding
         """
+        # TODO: support relations
         if not wikidata_ids:
             return {}
 

--- a/src/pykeen/nn/text/cache.py
+++ b/src/pykeen/nn/text/cache.py
@@ -298,6 +298,10 @@ class WikidataTextCache(TextCache):
         """
         return self._get(ids=wikidata_identifiers, component="label")
 
+    def get_labels_dict(self, wikidata_identifiers: Sequence[str]) -> dict[str, str | None]:
+        """Get a dictionary from identifiers to their associated labels."""
+        return dict(zip(wikidata_identifiers, self.get_labels(wikidata_identifiers), strict=False))
+
     def get_descriptions(self, wikidata_identifiers: Sequence[str]) -> Sequence[str]:
         """Get entity descriptions for the given IDs.
 


### PR DESCRIPTION
Implement the generalized low-rank representation, where both, the base and weight are arbitrary representations themselves.

This adds some nice features such as allowing to impose constraints or regularizes on the weight matrix. An interesting instantiation could be to use a softmax normalizer on the weight matrix, which gives the representation the interpretation of a mixture model.


- Extend `LowRankRepresentation` to accept configurable base and weight representations
- Register `softmax` as normalizer
- Extend `WikidataTextCache` to support retrieving relation information.
- Add example for using the generalized low-rank representation for a mixture