### PR TITLE
All batch pairs training loop

### DIFF
--- a/docs/source/examples/training/bcwa.py
+++ b/docs/source/examples/training/bcwa.py
@@ -1,0 +1,32 @@
+"""Training with batch-local closed world assumption."""
+
+# %%
+from pykeen.datasets.utils import get_dataset
+from pykeen.models import ConvE
+from pykeen.training.cwa import BatchCWATrainingLoop
+
+# %%
+dataset = get_dataset(dataset="CodexSmall")
+model = ConvE(embedding_dim=256, triples_factory=dataset.training, loss="BCEWithLogits").to(device="cuda")
+# %%
+loop = BatchCWATrainingLoop(
+    model=model,
+    triples_factory=dataset.training,
+    result_tracker="console",
+    result_tracker_kwargs=dict(metric_filter=r".*both\.realistic\.hits_at_.*"),
+    optimizer_kwargs=dict(lr=0.001),
+)
+# %%
+loop.train(
+    triples_factory=dataset.training,
+    num_epochs=400,
+    batch_size=64,
+    callbacks="evaluation",
+    callbacks_kwargs=dict(
+        evaluation_triples=dataset.validation.mapped_triples,
+        prefix="validation",
+        additional_filter_triples=[dataset.training.mapped_triples],
+    ),
+)
+
+# %%

--- a/docs/source/examples/training/bcwa.py
+++ b/docs/source/examples/training/bcwa.py
@@ -1,32 +1,47 @@
 """Training with batch-local closed world assumption."""
 
 # %%
+import torch
+
 from pykeen.datasets.utils import get_dataset
-from pykeen.models import ConvE
-from pykeen.training.cwa import BatchCWATrainingLoop
+from pykeen.models import DistMult
+from pykeen.training.bcwa import BatchCWATrainingLoop
 
 # %%
-dataset = get_dataset(dataset="CodexSmall")
-model = ConvE(embedding_dim=256, triples_factory=dataset.training, loss="BCEWithLogits").to(device="cuda")
+dataset = get_dataset(dataset="CodexSmall", dataset_kwargs=dict(create_inverse_triples=True))
+model = DistMult(embedding_dim=32, triples_factory=dataset.training, loss="BCEWithLogits").to(device="cuda")
 # %%
 loop = BatchCWATrainingLoop(
     model=model,
     triples_factory=dataset.training,
     result_tracker="console",
-    result_tracker_kwargs=dict(metric_filter=r".*both\.realistic\.hits_at_.*"),
-    optimizer_kwargs=dict(lr=0.001),
+    result_tracker_kwargs=dict(metric_filter=r".*both\.realistic\.adjusted.*"),
 )
 # %%
+validation = dataset.validation
+training_triples = dataset.training.mapped_triples
+partial_training_triples = training_triples[torch.randperm(dataset.training.num_triples)[:1000]]
+assert validation is not None
 loop.train(
     triples_factory=dataset.training,
-    num_epochs=400,
-    batch_size=64,
-    callbacks="evaluation",
-    callbacks_kwargs=dict(
-        evaluation_triples=dataset.validation.mapped_triples,
-        prefix="validation",
-        additional_filter_triples=[dataset.training.mapped_triples],
-    ),
+    num_epochs=10,
+    batch_size=256,
+    callbacks=["evaluation"] * 2,
+    callbacks_kwargs=[
+        dict(
+            evaluation_triples=validation.mapped_triples,
+            prefix="validation",
+            additional_filter_triples=[dataset.training.mapped_triples],
+        ),
+        dict(
+            evaluation_triples=partial_training_triples,
+            prefix="training",
+            additional_filter_triples=[dataset.training.mapped_triples],
+        ),
+    ],
 )
+
+# TODO: Loss seems to decrease, but metrics *decrease* (to negative adjusted indices)
+#  That looks like something is wrong somewhere
 
 # %%

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -386,7 +386,11 @@ class Loss(_Loss):
         raise NotImplementedError
 
     def process_bcwa_scores(
-        self, predictions: FloatTensor, targets: LongTensor, label_smoothing: float | None = None
+        self,
+        predictions: FloatTensor,
+        targets: LongTensor,
+        label_smoothing: float | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:
         """
         Process scores for BCWA training loop.
@@ -401,6 +405,7 @@ class Loss(_Loss):
         :return:
             A scalar loss value.
         """
+        self._raise_on_weights(weights)  # TODO use weights
         labels = torch.zeros_like(predictions)
         hs, rs, ts = targets.unbind(dim=-1)
         labels[hs, rs, ts] = 1.0

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -354,6 +354,26 @@ class Loss(_Loss):
         )
         return self(predictions, labels)
 
+    def process_cwa_scores(
+        self,
+        predictions: FloatTensor,
+        targets: LongTensor,
+        label_smoothing: float | None = None,
+    ) -> FloatTensor:
+        """
+        Process scores for CWA training loop.
+
+        :param scores: shape: (num_heads, num_relations, num_tails)
+            The scores.
+        :param targets: shape: (nnz, 3)
+            The (batch-local) indices of positive triples.
+        """
+        labels = torch.zeros_like(predictions)
+        h, r, t = targets.unbind(dim=-1)
+        labels[h, r, t] = 1.0
+        labels = apply_label_smoothing(labels=labels, epsilon=label_smoothing, num_classes=2)
+        return self(predictions, labels)
+
 
 class PointwiseLoss(Loss):
     """Pointwise loss functions compute an independent loss term for each triple-label pair."""

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -360,7 +360,7 @@ class Loss(_Loss):
         """
         Process scores for BCWA training loop.
 
-        :param scores: shape: (num_heads, num_relations, num_tails)
+        :param predictions: shape: (num_heads, num_relations, num_tails)
             The scores.
         :param targets: shape: (nnz,)
             The positive triples in batch-local indices.

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -357,7 +357,9 @@ class Loss(_Loss):
     def process_cwa_scores(
         self,
         predictions: FloatTensor,
-        targets: LongTensor,
+        hs: LongTensor,
+        rs: LongTensor,
+        ts: LongTensor,
         label_smoothing: float | None = None,
     ) -> FloatTensor:
         """
@@ -365,12 +367,15 @@ class Loss(_Loss):
 
         :param scores: shape: (num_heads, num_relations, num_tails)
             The scores.
-        :param targets: shape: (nnz, 3)
-            The (batch-local) indices of positive triples.
+        :param hs: shape: (nnz,)
+            The (batch-local) head indices of positive triples.
+        :param rs: shape: (nnz,)
+            The (batch-local) head indices of positive triples.
+        :param ts: shape: (nnz,)
+            The (batch-local) head indices of positive triples.
         """
         labels = torch.zeros_like(predictions)
-        h, r, t = targets.unbind(dim=-1)
-        labels[h, r, t] = 1.0
+        labels[hs, rs, ts] = 1.0
         labels = apply_label_smoothing(labels=labels, epsilon=label_smoothing, num_classes=2)
         return self(predictions, labels)
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -354,27 +354,24 @@ class Loss(_Loss):
         )
         return self(predictions, labels)
 
-    def process_cwa_scores(
-        self,
-        predictions: FloatTensor,
-        hs: LongTensor,
-        rs: LongTensor,
-        ts: LongTensor,
-        label_smoothing: float | None = None,
+    def process_bcwa_scores(
+        self, predictions: FloatTensor, targets: LongTensor, label_smoothing: float | None = None
     ) -> FloatTensor:
         """
-        Process scores for CWA training loop.
+        Process scores for BCWA training loop.
 
         :param scores: shape: (num_heads, num_relations, num_tails)
             The scores.
-        :param hs: shape: (nnz,)
-            The (batch-local) head indices of positive triples.
-        :param rs: shape: (nnz,)
-            The (batch-local) head indices of positive triples.
-        :param ts: shape: (nnz,)
-            The (batch-local) head indices of positive triples.
+        :param targets: shape: (nnz,)
+            The positive triples in batch-local indices.
+        :param label_smoothing:
+            An optional label smoothing parameter.
+
+        :return:
+            A scalar loss value.
         """
         labels = torch.zeros_like(predictions)
+        hs, rs, ts = targets.unbind(dim=-1)
         labels[hs, rs, ts] = 1.0
         labels = apply_label_smoothing(labels=labels, epsilon=label_smoothing, num_classes=2)
         return self(predictions, labels)

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -362,7 +362,7 @@ class Loss(_Loss):
 
         :param predictions: shape: (num_heads, num_relations, num_tails)
             The scores.
-        :param targets: shape: (nnz,)
+        :param targets: shape: (num_positive_triples, 3)
             The positive triples in batch-local indices.
         :param label_smoothing:
             An optional label smoothing parameter.

--- a/src/pykeen/training/bcwa.py
+++ b/src/pykeen/training/bcwa.py
@@ -113,6 +113,8 @@ class BatchCWATrainingLoop(TrainingLoop[LongTensor, BatchCWABatch]):
     ) -> FloatTensor:
         if stop - start < self._get_batch_size(batch):
             raise NotImplementedError("No support for default sub-batching.")
+        if batch.targets is None:
+            raise AssertionError(f"{self} requires a custom collator to fill batch.targets")
 
         # indices: shape: (num_heads, num_relations, num_tails)
         h_indices = batch.hs.view(-1, 1, 1)

--- a/src/pykeen/training/bcwa.py
+++ b/src/pykeen/training/bcwa.py
@@ -33,6 +33,7 @@ class BatchCWABatch(NamedTuple):
     weights: FloatTensor | None = None
     """Sample weights."""
 
+
 class BatchCWADataset(Dataset[BatchCWABatch]):
     """A map-style dataset for BCWA training."""
 

--- a/src/pykeen/training/cwa.py
+++ b/src/pykeen/training/cwa.py
@@ -2,42 +2,97 @@
 
 from typing import NamedTuple
 
-from torch.utils.data import DataLoader
+import torch
+from torch.utils.data import DataLoader, Dataset
 
 from pykeen.models.nbase import ERModel
 from pykeen.training.training_loop import TrainingLoop
 from pykeen.triples import CoreTriplesFactory
-from pykeen.typing import FloatTensor, LongTensor
+from pykeen.typing import COLUMN_TAIL, FloatTensor, LongTensor
 
 
-class CWABatch(NamedTuple):
-    # shape: (batch_size, 3)
-    hrt_batch: LongTensor
-    # shape: (nnz, 3), in batch-local indices
-    hrt_target: LongTensor
+class BatchCWABatch(NamedTuple):
+    # shape: (batch_size,)
+    hs: LongTensor
+    # shape: (batch_size,)
+    rs: LongTensor
+    # shape: (batch_size,)
+    ts: LongTensor
+    # shape: (nnz,), in batch-local indices
+    # should contain all triples whose h, r, t indices occur within the batch
+    h_target: LongTensor
+    r_target: LongTensor
+    t_target: LongTensor
 
 
-class CWATrainingLoop(TrainingLoop[CWABatch, CWABatch]):
+class BatchCWADataset(Dataset[BatchCWABatch]):
+    def __init__(self, mapped_triples: LongTensor):
+        super().__init__()
+        self.mapped_triples = mapped_triples
+
+    def __getitem__(self, item: int) -> BatchCWABatch:
+        h, r, t = self.mapped_triples[item]
+        x = torch.zeros(1, dtype=torch.long)
+        return BatchCWABatch(hs=h, rs=r, ts=t, h_target=x, r_target=x, t_target=x)
+
+    def __len__(self) -> int:
+        return self.mapped_triples.shape[0]
+
+
+class BatchCWACollator:
+    # note: the implement is relatively memory demanding
+    def __init__(self, mapped_triples: LongTensor):
+        self.mapped_triples = mapped_triples
+
+    def __call__(self, batch: list[BatchCWABatch]) -> BatchCWABatch:
+        # collect
+        hs = torch.stack([b.hs for b in batch]).unique()
+        rs = torch.stack([b.rs for b in batch]).unique()
+        ts = torch.stack([b.ts for b in batch]).unique()
+
+        # collect all triples that solely contain the current batch entities/relations
+        other_triples = self.mapped_triples
+        for i, indices in enumerate([hs, rs, ts]):
+            mask = torch.isin(elements=other_triples[:, i], test_elements=indices)
+            other_triples = other_triples[mask]
+
+        # convert to batch local indices
+        targets = []
+        for dim, indices in enumerate([hs, rs, ts]):
+            uniq, inv = other_triples[:, dim].unique(return_inverse=True)
+            assert torch.equal(uniq, indices)
+            targets.append(inv)
+
+        return BatchCWABatch(hs=hs, rs=rs, ts=ts, h_target=targets[0], r_target=targets[1], t_target=targets[2])
+
+
+class BatchCWATrainingLoop(TrainingLoop[BatchCWABatch, BatchCWABatch]):
     def _create_training_data_loader(
         self, triples_factory: CoreTriplesFactory, *, sampler: str | None, batch_size: int, drop_last: bool, **kwargs
-    ) -> DataLoader[CWABatch]:
-        raise NotImplementedError
+    ) -> DataLoader[BatchCWABatch]:
+        mapped_triples = triples_factory.mapped_triples
+        return DataLoader(
+            dataset=BatchCWADataset(mapped_triples=mapped_triples),
+            batch_size=batch_size,
+            drop_last=drop_last,
+            **kwargs,
+            collate_fn=BatchCWACollator(mapped_triples=mapped_triples),
+        )
 
     @staticmethod
-    def _get_batch_size(batch: CWABatch) -> int:
-        return batch.hrt_batch.shape[0]
+    def _get_batch_size(batch: BatchCWABatch) -> int:
+        return batch.hs.shape[0]
 
     def _process_batch(
-        self, batch: CWABatch, start: int, stop: int, label_smoothing: float = 0, slice_size: int | None = None
+        self, batch: BatchCWABatch, start: int, stop: int, label_smoothing: float = 0, slice_size: int | None = None
     ) -> FloatTensor:
         if stop - start < self._get_batch_size(batch):
             raise NotImplementedError("No support for default sub-batching.")
 
         # indices: shape: (num_heads, num_relations, num_tails)
-        h_indices, r_indices, t_indices = batch.hrt_batch.unbind(dim=-1)
-        h_indices = h_indices.view(-1, 1, 1)
-        r_indices = h_indices.view(1, -1, 1)
-        t_indices = h_indices.view(1, 1, -1)
+        h_indices = batch.hs.view(-1, 1, 1)
+        r_indices = batch.rs.view(1, -1, 1)
+        t_indices = batch.ts.view(1, 1, -1)
 
         # calculate scores
         model = self.model
@@ -47,14 +102,16 @@ class CWATrainingLoop(TrainingLoop[CWABatch, CWABatch]):
             r_indices=r_indices,
             t_indices=t_indices,
             slice_size=slice_size,
-            slice_dim=9999,  # TODO
+            slice_dim=COLUMN_TAIL,
             mode=None,
         )
 
         # calculate loss
         return (
             # loss
-            self.loss.process_cwa_scores(scores, non_zero_indices=batch.hrt_target, label_smoothing=label_smoothing)
+            self.loss.process_cwa_scores(
+                scores, hs=batch.h_target, rs=batch.r_target, ts=batch.t_target, label_smoothing=label_smoothing
+            )
             # regularization
             + self.model.collect_regularization_term()
         )

--- a/src/pykeen/training/cwa.py
+++ b/src/pykeen/training/cwa.py
@@ -1,0 +1,65 @@
+"""(Batch) Closed World Assumption."""
+
+from typing import NamedTuple
+
+from torch.utils.data import DataLoader
+
+from pykeen.models.nbase import ERModel
+from pykeen.training.training_loop import TrainingLoop
+from pykeen.triples import CoreTriplesFactory
+from pykeen.typing import FloatTensor, LongTensor
+
+
+class CWABatch(NamedTuple):
+    # shape: (batch_size, 3)
+    hrt_batch: LongTensor
+    # shape: (nnz, 3), in batch-local indices
+    hrt_target: LongTensor
+
+
+class CWATrainingLoop(TrainingLoop[CWABatch, CWABatch]):
+    def _create_training_data_loader(
+        self, triples_factory: CoreTriplesFactory, *, sampler: str | None, batch_size: int, drop_last: bool, **kwargs
+    ) -> DataLoader[CWABatch]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _get_batch_size(batch: CWABatch) -> int:
+        return batch.hrt_batch.shape[0]
+
+    def _process_batch(
+        self, batch: CWABatch, start: int, stop: int, label_smoothing: float = 0, slice_size: int | None = None
+    ) -> FloatTensor:
+        if stop - start < self._get_batch_size(batch):
+            raise NotImplementedError("No support for default sub-batching.")
+
+        # indices: shape: (num_heads, num_relations, num_tails)
+        h_indices, r_indices, t_indices = batch.hrt_batch.unbind(dim=-1)
+        h_indices = h_indices.view(-1, 1, 1)
+        r_indices = h_indices.view(1, -1, 1)
+        t_indices = h_indices.view(1, 1, -1)
+
+        # calculate scores
+        model = self.model
+        assert isinstance(model, ERModel)
+        scores: FloatTensor = self.model(
+            h_indices=h_indices,
+            r_indices=r_indices,
+            t_indices=t_indices,
+            slice_size=slice_size,
+            slice_dim=9999,  # TODO
+            mode=None,
+        )
+
+        # calculate loss
+        return (
+            # loss
+            self.loss.process_cwa_scores(scores, non_zero_indices=batch.hrt_target, label_smoothing=label_smoothing)
+            # regularization
+            + self.model.collect_regularization_term()
+        )
+
+    def _slice_size_search(
+        self, *, triples_factory: CoreTriplesFactory, batch_size: int, sub_batch_size: int, supports_sub_batching: bool
+    ) -> int:
+        raise NotImplementedError("No support for slicing.")

--- a/tests/test_training/test_bcwa.py
+++ b/tests/test_training/test_bcwa.py
@@ -1,0 +1,56 @@
+"""Tests for training with batch-local closed world assumption."""
+
+import pytest
+import torch
+
+from pykeen.training import bcwa
+from pykeen.typing import LongTensor
+
+
+@pytest.fixture()
+def generator() -> torch.Generator:
+    """Build a generator with fixed seed for reproducible tests."""
+    return torch.manual_seed(seed=42)
+
+
+def _make_unique(max_id: int, num: int, generator: torch.Generator) -> LongTensor:
+    ind = torch.randperm(max_id, generator=generator)[:num]
+    ind = ind.unique()
+    assert len(ind) == num
+    return ind
+
+
+@pytest.mark.parametrize(
+    ("num_unique_heads", "num_unique_relations", "num_unique_tails", "num_triples", "num_entities", "num_relations"),
+    [(1, 1, 1, 1, 13, 7), (3, 2, 2, 3, 13, 7)],
+)
+def test_convert_to_batch_local(
+    num_unique_heads: int,
+    num_unique_relations: int,
+    num_unique_tails: int,
+    num_triples: int,
+    num_entities: int,
+    num_relations: int,
+    generator: torch.Generator,
+) -> None:
+    """Test conversion of batch to local indices."""
+    # verify valid test input
+    assert num_unique_heads <= num_entities
+    assert num_unique_relations <= num_relations
+    assert num_unique_tails <= num_entities
+    assert num_triples >= max(num_unique_heads, num_unique_relations, num_unique_tails)
+    hs = _make_unique(max_id=num_entities, num=num_unique_heads, generator=generator)
+    rs = _make_unique(max_id=num_relations, num=num_unique_relations, generator=generator)
+    ts = _make_unique(max_id=num_entities, num=num_unique_tails, generator=generator)
+    indices_l = []
+    for num_unique in (num_unique_heads, num_unique_relations, num_unique_tails):
+        index = torch.randint(0, num_unique, size=(num_triples,), generator=generator)
+        # ensure that each index occurs at least once
+        index[torch.randperm(num_triples)[:num_unique]] = torch.arange(num_unique)
+        indices_l.append(index)
+    indices_t = torch.stack(indices_l, dim=-1)
+    mapped_triples = torch.stack([source[index] for source, index in zip((hs, rs, ts), indices_l, strict=True)], dim=-1)
+    (hs_u, rs_u, ts_u), local_triples = bcwa._convert_to_batch_local(mapped_triples)
+    assert torch.equal(indices_t, local_triples)
+    for i, i_unique in zip((hs, rs, ts), (hs_u, rs_u, ts_u), strict=True):
+        assert torch.equal(i.unique(), i_unique)


### PR DESCRIPTION
A new training loop which aims to make better use of calculated representations, by calculating scores for all 3-combinations of heads, relations and tails within a batch. Such methods are pretty popular in other areas of contrastive learning e.g. https://arxiv.org/abs/2303.15343