### PR TITLE
🧑‍🔧🪓 Fix inductive split

### DIFF
--- a/src/pykeen/datasets/ea/combination.py
+++ b/src/pykeen/datasets/ea/combination.py
@@ -263,7 +263,7 @@ class ProcessedTuple(NamedTuple):
     translation_kwargs: Mapping[str, Any]
 
 
-FactoryType = TypeVar("FactoryType", bound=CoreTriplesFactory)
+FactoryType = TypeVar("FactoryType", CoreTriplesFactory, TriplesFactory)
 
 
 class GraphPairCombinator(Generic[FactoryType], ABC):
@@ -299,6 +299,7 @@ class GraphPairCombinator(Generic[FactoryType], ABC):
         # process
         # TODO: restrict to only using training alignments?
         mapped_triples, alignment, translation_kwargs = self.process(mapped_triples, alignment, offsets)
+        combined_factory: FactoryType
         if isinstance(left, TriplesFactory) and isinstance(right, TriplesFactory):
             # merge mappings
             entity_to_id, relation_to_id = merge_label_to_id_mappings(
@@ -306,16 +307,16 @@ class GraphPairCombinator(Generic[FactoryType], ABC):
                 right=right,
                 **translation_kwargs,
             )
-            factory = TriplesFactory(
+            combined_factory = TriplesFactory(
                 mapped_triples=mapped_triples,
                 entity_to_id=entity_to_id,
                 relation_to_id=relation_to_id,
                 **kwargs,
             )
         else:
-            factory = CoreTriplesFactory.create(mapped_triples=mapped_triples, **kwargs)
+            combined_factory = CoreTriplesFactory.create(mapped_triples=mapped_triples, **kwargs)
 
-        return factory, alignment
+        return combined_factory, alignment
 
     @abstractmethod
     def process(

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -13,7 +13,7 @@ import torch
 from typing_extensions import Self
 
 from .splitting import split, split_fully_inductive, split_semi_inductive
-from .utils import TRIPLES_DF_COLUMNS, load_triples, tensor_to_df
+from .utils import TRIPLES_DF_COLUMNS, get_num_ids, load_triples, tensor_to_df
 from ..constants import COLUMN_LABELS
 from ..inverse import relation_inverter_resolver
 from ..typing import (
@@ -303,21 +303,6 @@ class KGInfo(ExtraReprMixin):
         yield f"num_entities={self.num_entities}"
         yield f"num_relations={self.num_relations}"
         yield f"create_inverse_triples={self.create_inverse_triples}"
-
-
-def max_value(x: LongTensor) -> int | None:
-    """Return the maximum value, or None if the tensor is empty."""
-    if x.numel():
-        return x.max().item()
-    return None
-
-
-def get_num_ids(x: LongTensor) -> int:
-    """Return the number of ids values."""
-    max_id = max_value(x)
-    if max_id is None:
-        return 0
-    return max_id + 1
 
 
 @dataclasses.dataclass

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -481,8 +481,8 @@ class CoreTriplesFactory(KGInfo):
         # input validation
         if mapped_triples.ndim != 2 or mapped_triples.shape[1] != 3:
             raise ValueError(f"Invalid shape for mapped_triples: {mapped_triples.shape}; must be (n, 3)")
-        if mapped_triples.is_floating_point():
-            raise TypeError(f"Invalid type: {mapped_triples.dtype=}. Must be integer dtype.")
+        if mapped_triples.is_complex() or mapped_triples.is_floating_point():
+            raise TypeError(f"Invalid type: {mapped_triples.dtype}. Must be integer dtype.")
         # always store as torch.long, i.e., torch's default integer dtype
         self.mapped_triples = mapped_triples.to(dtype=torch.long)
         # verify ID ranges

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -664,11 +664,30 @@ class CoreTriplesFactory(KGInfo):
         )
 
     def make_condensator(self, entities: bool = True, relations: bool = False) -> TripleCondensator:
-        """Create a triple condensator."""
+        """Create a triple condensator from the factory's triples without applying it.
+
+        :param entities:
+            Whether to condense entity IDs.
+        :param relations:
+            Whether to condense relations IDs.
+
+        :return:
+            The triple condensator.
+        """
         return TripleCondensator.make(mapped_triples=self.mapped_triples, entities=entities, relations=relations)
 
     def apply_condensator(self, condensator: TripleCondensator) -> Self:
-        """Apply the triple condensator."""
+        """Apply the triple condensator.
+
+        :param condensator:
+            The condensator.
+
+        .. warning::
+            This creates a triples factory that may have a new entity or relation to id mapping.
+
+        :return:
+            A condensed version with potentially smaller num_entities or num_relations.
+        """
         # short-circuit if nothing needs to change
         if not condensator:
             return self

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -17,6 +17,8 @@ __all__ = [
     "get_entities",
     "get_relations",
     "tensor_to_df",
+    "max_value",
+    "get_num_ids",
 ]
 
 TRIPLES_DF_COLUMNS = ("head_id", "head_label", "relation_id", "relation_label", "tail_id", "tail_label")
@@ -176,3 +178,18 @@ def compute_compressed_adjacency_list(
     offset[1:] = torch.cumsum(degrees, dim=0)[:-1]
     compressed_adj_lists = torch.cat([torch.as_tensor(adj_list, dtype=torch.long) for adj_list in adj_lists], dim=0)
     return degrees, offset, compressed_adj_lists
+
+
+def max_value(x: LongTensor) -> int | None:
+    """Return the maximum value, or None if the tensor is empty."""
+    if x.numel():
+        return x.max().item()
+    return None
+
+
+def get_num_ids(x: LongTensor) -> int:
+    """Return the number of ids values."""
+    max_id = max_value(x)
+    if max_id is None:
+        return 0
+    return max_id + 1

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2429,7 +2429,6 @@ class GraphPairCombinatorTestCase(unittest_templates.GenericTestCase[GraphPairCo
 
     def test_combination_id(self):
         """Test combination without labels."""
-        # FIXME this test is failing in tests/test_datasets/test_combination
         self._test_combination(labels=False)
 
     def test_manual(self):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2429,6 +2429,7 @@ class GraphPairCombinatorTestCase(unittest_templates.GenericTestCase[GraphPairCo
 
     def test_combination_id(self):
         """Test combination without labels."""
+        # FIXME this test is failing in tests/test_datasets/test_combination
         self._test_combination(labels=False)
 
     def test_manual(self):

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -297,6 +297,9 @@ class TestSplit(unittest.TestCase):
             self.assertLessEqual(total_num_triples, self.triples_factory.num_triples)
         else:
             self.assertEqual(total_num_triples, self.triples_factory.num_triples)
+        # verify that triple have been compacted
+        self.assertLess(factory.mapped_triples[:, ::2].max(), factory.num_entities)
+        self.assertLess(factory.mapped_triples[:, 1].max(), factory.num_relations)
 
     def _test_invariants_transductive(
         self, training_triples_factory: TriplesFactory, *other_factories: TriplesFactory, lossy: bool = False

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -628,6 +628,7 @@ def test_core_triples_factory_error_handling(dtype: torch.dtype, size: tuple[int
     """Test error handling in init method of CoreTriplesFactory."""
     with expectation:
         CoreTriplesFactory(
+            # FIXME ellipses break code! can we assign real numbers to these?
             mapped_triples=torch.randint(33, size=size).to(dtype=dtype), num_entities=..., num_relations=...
         )
 

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -291,15 +291,15 @@ class TestSplit(unittest.TestCase):
             self.assertEqual(type(factory), type(self.triples_factory))
             # we only support inductive *entity* splits for now
             self.assertEqual(factory.num_relations, self.triples_factory.num_relations)
+            # verify that triple have been compacted
+            self.assertLess(factory.mapped_triples[:, ::2].max(), factory.num_entities)
+            self.assertLess(factory.mapped_triples[:, 1].max(), factory.num_relations)
         # verify that no triple got lost
         total_num_triples = sum(t.num_triples for t in factories)
         if lossy:
             self.assertLessEqual(total_num_triples, self.triples_factory.num_triples)
         else:
             self.assertEqual(total_num_triples, self.triples_factory.num_triples)
-        # verify that triple have been compacted
-        self.assertLess(factory.mapped_triples[:, ::2].max(), factory.num_entities)
-        self.assertLess(factory.mapped_triples[:, 1].max(), factory.num_relations)
 
     def _test_invariants_transductive(
         self, training_triples_factory: TriplesFactory, *other_factories: TriplesFactory, lossy: bool = False

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -20,7 +20,12 @@ from pykeen.training.lcwa import create_lcwa_instances
 from pykeen.training.slcwa import create_slcwa_instances
 from pykeen.triples import CoreTriplesFactory, LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory, generation
 from pykeen.triples.splitting import splitter_resolver
-from pykeen.triples.triples_factory import INVERSE_SUFFIX, _map_triples_elements_to_ids, get_mapped_triples
+from pykeen.triples.triples_factory import (
+    INVERSE_SUFFIX,
+    _map_triples_elements_to_ids,
+    get_mapped_triples,
+    valid_triple_id_range,
+)
 from pykeen.triples.utils import TRIPLES_DF_COLUMNS, load_triples
 from tests.constants import RESOURCES
 from tests.utils import needs_packages
@@ -292,8 +297,11 @@ class TestSplit(unittest.TestCase):
             # we only support inductive *entity* splits for now
             self.assertEqual(factory.num_relations, self.triples_factory.num_relations)
             # verify that triple have been compacted
-            self.assertLess(factory.mapped_triples[:, ::2].max(), factory.num_entities)
-            self.assertLess(factory.mapped_triples[:, 1].max(), factory.num_relations)
+            self.assertTrue(
+                valid_triple_id_range(
+                    factory.mapped_triples, num_entities=factory.num_entities, num_relations=factory.num_relations
+                )
+            )
         # verify that no triple got lost
         total_num_triples = sum(t.num_triples for t in factories)
         if lossy:

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -626,10 +626,12 @@ class TestUtils(unittest.TestCase):
 )
 def test_core_triples_factory_error_handling(dtype: torch.dtype, size: tuple[int, ...], expectation):
     """Test error handling in init method of CoreTriplesFactory."""
+    max_id_upper_bound = 33
     with expectation:
         CoreTriplesFactory(
-            # FIXME ellipses break code! can we assign real numbers to these?
-            mapped_triples=torch.randint(33, size=size).to(dtype=dtype), num_entities=..., num_relations=...
+            mapped_triples=torch.randint(max_id_upper_bound, size=size).to(dtype=dtype),
+            num_entities=max_id_upper_bound,
+            num_relations=max_id_upper_bound,
         )
 
 


### PR DESCRIPTION
The fully inductive split does not properly apply the ID remapping to the triples.

- [x] Verify triple IDs' ranges in the `CoreTriplesFactory` init
- [x] Introduce a `Condensator` / `TripleCondensator` to encapsulate a pre-computed index re-mapping for multiple applications.