### PR TITLE
🪢🪛 Fix type annotations for entity/relation to ID mapping

### DIFF
--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -798,10 +798,6 @@ class CoreTriplesFactory(KGInfo):
         :param entities: A sequence of either integer identifiers for entities or
             string labels for entities (that will get auto-converted)
         :returns: Integer identifiers for entities, in the same order.
-
-        :raises ValueError: If the ``entities`` passed are string labels
-            and this triples factory does not have an entity label to identifier mapping
-            (e.g., it's just a base :class:`CoreTriplesFactory` instance)
         """
         return [self._raise_on_string(e, label="entity") for e in entities]
 
@@ -811,9 +807,6 @@ class CoreTriplesFactory(KGInfo):
         :param relations: A sequence of either integer identifiers for relations or
             string labels for relations (that will get auto-converted)
         :returns: Integer identifiers for relations, in the same order.
-        :raises ValueError: If the ``relations`` passed are string labels
-            and this triples factory does not have a relation label to identifier mapping
-            (e.g., it's just a base :class:`CoreTriplesFactory` instance)
         """
         return [self._raise_on_string(r, label="relation") for r in relations]
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import re
 from collections.abc import Callable, Collection, Iterable, Mapping, MutableMapping, Sequence
-from typing import Any, ClassVar, TextIO, cast
+from typing import Any, ClassVar, TextIO
 
 import numpy as np
 import pandas as pd

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1474,9 +1474,9 @@ class TriplesFactory(CoreTriplesFactory):
         if entities is None and relations is None:
             return self
         if entities is not None:
-            entities = self.entities_to_ids(entities=list(entities))
+            entities = self.entities_to_ids(entities=entities)
         if relations is not None:
-            relations = self.relations_to_ids(relations=list(relations))
+            relations = self.relations_to_ids(relations=relations)
         tf = super().new_with_restriction(
             entities=entities,
             relations=relations,

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -795,6 +795,9 @@ class CoreTriplesFactory(KGInfo):
     def entities_to_ids(self, entities: Iterable[int] | Iterable[str]) -> Sequence[int]:
         """Normalize entities to IDs.
 
+        It raises a :class:`TypeError` if the factory does not support the given data type,
+        e.g. you cannot use `str` with :class:`~pykeen.triples.CoreTriplesFactory`.
+
         :param entities: A sequence of either integer identifiers for entities or
             string labels for entities (that will get auto-converted)
         :returns: Integer identifiers for entities, in the same order.
@@ -803,6 +806,9 @@ class CoreTriplesFactory(KGInfo):
 
     def relations_to_ids(self, relations: Iterable[int] | Iterable[str]) -> Sequence[int]:
         """Normalize relations to IDs.
+
+        It raises a :class:`TypeError` if the factory does not support the given data type,
+        e.g. you cannot use `str` with :class:`~pykeen.triples.CoreTriplesFactory`.
 
         :param relations: A sequence of either integer identifiers for relations or
             string labels for relations (that will get auto-converted)


### PR DESCRIPTION
Previously, it was annotated as `Collection`. However, it is important the order of the result is the same order as the input, because in many use cases we want to lookup ids for multiple entities and then use the ids to e.g. lookup embeddings.

The implementation did already do that, so I just updated the type annotations.

At the same time, I also allowed to pass `Iterable` to push the lazy/stream-able interface further down.