### PR TITLE
🤖🔓 GHA: Also run on pull_request_target

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -7,6 +7,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [review_requested, ready_for_review, auto_merge_enabled]
+  pull_request_target:
+    types: [auto_merge_enabled]
 
 jobs:
   docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [auto_merge_enabled]
   pull_request_target:
-    types: [auto_merge_enabled]
+    types: [auto_merge_enabled, opened, synchronize]
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [auto_merge_enabled]
+  pull_request_target:
+    types: [auto_merge_enabled]
 
 jobs:
   lint:


### PR DESCRIPTION
This MR enables actions on [`pull_request_target`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) which should allow triggering for external PRs. I think that from our repo settings, an approval is still necessary for first time contributors, so that seems reasonably safe.