### PR TITLE
Loss weights

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -349,7 +349,7 @@ class Loss(_Loss):
             num_classes=num_entities,
         )
 
-        return self(x=predictions, target=labels, weight=weights, reduction=self.reduction)
+        return self(x=predictions, target=labels, weight=weights)
 
     def process_lcwa_scores(
         self,
@@ -382,7 +382,7 @@ class Loss(_Loss):
             epsilon=label_smoothing,
             num_classes=num_entities,
         )
-        return self(x=predictions, target=labels, weight=weights, reduction=self.reduction)
+        return self(x=predictions, target=labels, weight=weights)
 
 
 class PointwiseLoss(Loss):

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -159,7 +159,6 @@ triples $\mathcal{b}$ in the subset $\mathcal{B} \in 2^{2^{\mathcal{T}}}$.
     \mathcal{L}_L(\mathcal{B}) = \frac{1}{|\mathcal{B}|} \sum \limits_{\mathcal{b} \in \mathcal{B}} L(\mathcal{b})
 """  # noqa: E501
 
-import abc
 import logging
 import math
 from abc import abstractmethod

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -307,6 +307,8 @@ class Loss(_Loss):
             The target tensor.
         :param weight:
             The sample weights.
+
+        # noqa: DAR401
         """
         # TODO: Can we pull label smoothing inside?
         raise NotImplementedError

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -539,8 +539,7 @@ class MarginPairwiseLoss(PairwiseLoss):
         weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
         # Sanity check
-        if weights is not None:
-            raise NotImplementedError(f"{self} does not support loss weights.")
+        self._raise_on_weights(weights)
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
 
@@ -564,8 +563,7 @@ class MarginPairwiseLoss(PairwiseLoss):
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
-        if weights is not None:
-            raise NotImplementedError(f"{self} does not support loss weights.")
+        self._raise_on_weights(weights)
 
         # for LCWA scores, we consider all pairs of positive and negative scores for a single batch element.
         # note: this leads to non-uniform memory requirements for different batches, depending on the total number of
@@ -1196,8 +1194,7 @@ class CrossEntropyLoss(SetwiseLoss):
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
-        if weights is not None:
-            raise NotImplementedError(f"{self} does not support loss weights.")
+        self._raise_on_weights(weights)
         # we need dense negative scores => unfilter if necessary
         negative_scores = prepare_negative_scores_for_softmax(
             batch_filter=batch_filter,
@@ -1232,8 +1229,7 @@ class CrossEntropyLoss(SetwiseLoss):
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
-        if weights is not None:
-            raise NotImplementedError(f"{self} does not support loss weights.")
+        self._raise_on_weights(weights)
         # make sure labels form a proper probability distribution
         labels = functional.normalize(labels, p=1, dim=-1)
         # calculate cross entropy loss
@@ -1319,8 +1315,7 @@ class InfoNCELoss(CrossEntropyLoss):
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
-        if weights is not None:
-            raise NotImplementedError(f"{self} does not support loss weights.")
+        self._raise_on_weights(weights)
         # determine positive; do not check with == since the labels are floats
         pos_mask = labels > 0.5
         # subtract margin from positive scores
@@ -1344,8 +1339,7 @@ class InfoNCELoss(CrossEntropyLoss):
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
-        if weights is not None:
-            raise NotImplementedError(f"{self} does not support loss weights.")
+        self._raise_on_weights(weights)
         # subtract margin from positive scores
         positive_scores = positive_scores - self.margin
         # normalize positive score shape
@@ -1387,8 +1381,7 @@ class AdversarialLoss(SetwiseLoss):
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
-        if weights is not None:
-            raise NotImplementedError(f"{self} does not support loss weights.")
+        self._raise_on_weights(weights)
         # determine positive; do not check with == since the labels are floats
         pos_mask = labels > 0.5
 
@@ -1422,8 +1415,7 @@ class AdversarialLoss(SetwiseLoss):
         weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
         # Sanity check
-        if weights is not None:
-            raise NotImplementedError(f"{self} does not support loss weights.")
+        self._raise_on_weights(weights)
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -164,7 +164,7 @@ import math
 from abc import abstractmethod
 from collections.abc import Mapping
 from textwrap import dedent
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar
 
 import torch
 from class_resolver import ClassResolver, Hint
@@ -268,7 +268,6 @@ class NoSampleWeightSupportError(RuntimeError):
         return f"{self.instance.__class__.__name__} does not support sample weights."
 
 
-TorchReductionMethod = Literal["mean", "sum", "none"]
 _REDUCTION_METHODS = dict(
     mean=torch.mean,
     sum=torch.sum,

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -276,7 +276,7 @@ _REDUCTION_METHODS = dict(
 )
 
 
-class Loss(_Loss):
+class Loss(_Loss, abc.ABC):
     """A loss function."""
 
     #: synonyms of this loss
@@ -295,7 +295,8 @@ class Loss(_Loss):
         super().__init__(reduction=reduction)
         self._reduction_method = _REDUCTION_METHODS[reduction]
 
-    @abc.abstractmethod
+    # TODO: mypy does not seem to like this annotation
+    # @abc.abstractmethod
     def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:
         # TODO: Can we pull label smoothing inside?
         raise NotImplementedError

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -297,7 +297,7 @@ class Loss(_Loss):
 
     # TODO: mypy does not seem to like this annotation
     # @abc.abstractmethod
-    def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: DAR401
+    def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:
         """
         Calculate the loss function.
 
@@ -489,7 +489,7 @@ class BCEWithLogitsLoss(PointwiseLoss):
     # docstr-coverage: inherited
     def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: D102
         return functional.binary_cross_entropy_with_logits(
-          x, target, reduction=self.reduction, weight=weight, pos_weight=self.pos_weight
+            x, target, reduction=self.reduction, weight=weight, pos_weight=self.pos_weight
         )
 
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -298,6 +298,16 @@ class Loss(_Loss):
     # TODO: mypy does not seem to like this annotation
     # @abc.abstractmethod
     def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:
+        """
+        Calculate the loss function.
+
+        :param x:
+            The input tensor.
+        :param target:
+            The target tensor.
+        :param weight:
+            The sample weights.
+        """
         # TODO: Can we pull label smoothing inside?
         raise NotImplementedError
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -276,7 +276,7 @@ _REDUCTION_METHODS = dict(
 )
 
 
-class Loss(_Loss, abc.ABC):
+class Loss(_Loss):
     """A loss function."""
 
     #: synonyms of this loss

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -295,7 +295,7 @@ class Loss(_Loss):
 
     # TODO: mypy does not seem to like this annotation
     # @abc.abstractmethod
-    def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:
+    def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: DAR401
         """
         Calculate the loss function.
 
@@ -919,20 +919,8 @@ class DoubleMarginLoss(PointwiseLoss):
 
         return self(x=predictions, target=labels)
 
-    def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:
-        """
-        Compute the double margin loss.
-
-        The scores have to be in broadcastable shape.
-
-        :param predictions:
-            The predicted scores.
-        :param labels:
-            The labels.
-
-        :return:
-            A scalar loss term.
-        """
+    # docstr-coverage: inherited
+    def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: D102
         return self.positive_weight * self._reduction_method(
             target * self.margin_activation(self.positive_margin - x)
         ) + self.negative_weight * self._reduction_method(

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -290,6 +290,7 @@ class Loss(_Loss):
         label_smoothing: float | None = None,
         batch_filter: BoolTensor | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:
         """
         Process scores from sLCWA training loop.
@@ -306,10 +307,14 @@ class Loss(_Loss):
             pre-filtered.
         :param num_entities:
             The number of entities. Only required if label smoothing is enabled.
+        :param weights: shape: (batch_size, num_neg_per_pos)
+            Sample weights.
 
         :return:
             A scalar loss term.
         """
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         # flatten and stack
         positive_scores = positive_scores.view(-1)
         negative_scores = negative_scores.view(-1)
@@ -495,8 +500,11 @@ class MarginPairwiseLoss(PairwiseLoss):
         label_smoothing: float | None = None,
         batch_filter: BoolTensor | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
         # Sanity check
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
 
@@ -837,10 +845,13 @@ class DoubleMarginLoss(PointwiseLoss):
         label_smoothing: float | None = None,
         batch_filter: BoolTensor | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
 
         # positive term
         if batch_filter is None:
@@ -1135,7 +1146,10 @@ class CrossEntropyLoss(SetwiseLoss):
         label_smoothing: float | None = None,
         batch_filter: BoolTensor | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         # we need dense negative scores => unfilter if necessary
         negative_scores = prepare_negative_scores_for_softmax(
             batch_filter=batch_filter,
@@ -1274,7 +1288,10 @@ class InfoNCELoss(CrossEntropyLoss):
         label_smoothing: float | None = None,
         batch_filter: BoolTensor | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         # subtract margin from positive scores
         positive_scores = positive_scores - self.margin
         # normalize positive score shape
@@ -1345,8 +1362,11 @@ class AdversarialLoss(SetwiseLoss):
         label_smoothing: float | None = None,
         batch_filter: BoolTensor | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
         # Sanity check
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -932,7 +932,7 @@ class DoubleMarginLoss(PointwiseLoss):
                 num_classes=num_entities,
             )
 
-        return self(predictions=predictions, labels=labels)
+        return self(x=predictions, target=labels, reduction=self.reduction)
 
     def forward(
         self,

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -336,22 +336,27 @@ class Loss(_Loss):
         labels: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:
         """
         Process scores from LCWA training loop.
 
-        :param predictions: shape: (batch_size, num_entities)
+        :param predictions: shape: (*shape)
             The scores.
-        :param labels: shape: (batch_size, num_entities)
+        :param labels: shape: (*shape)
             The labels.
         :param label_smoothing:
             An optional label smoothing parameter.
         :param num_entities:
             The number of entities (required for label-smoothing).
+        :param weights: shape: (*shape)
+            Sample weights.
 
         :return:
             A scalar loss value.
         """
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         # TODO: Do label smoothing only once
         labels = apply_label_smoothing(
             labels=labels,
@@ -523,10 +528,13 @@ class MarginPairwiseLoss(PairwiseLoss):
         labels: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
 
         # for LCWA scores, we consider all pairs of positive and negative scores for a single batch element.
         # note: this leads to non-uniform memory requirements for different batches, depending on the total number of
@@ -882,8 +890,11 @@ class DoubleMarginLoss(PointwiseLoss):
         labels: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
         # Sanity check
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         if label_smoothing:
             labels = apply_label_smoothing(
                 labels=labels,
@@ -1182,7 +1193,10 @@ class CrossEntropyLoss(SetwiseLoss):
         labels: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         # make sure labels form a proper probability distribution
         labels = functional.normalize(labels, p=1, dim=-1)
         # calculate cross entropy loss
@@ -1266,7 +1280,10 @@ class InfoNCELoss(CrossEntropyLoss):
         labels: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         # determine positive; do not check with == since the labels are floats
         pos_mask = labels > 0.5
         # subtract margin from positive scores
@@ -1331,7 +1348,10 @@ class AdversarialLoss(SetwiseLoss):
         labels: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
+        weights: FloatTensor | None = None,
     ) -> FloatTensor:  # noqa: D102
+        if weights is not None:
+            raise NotImplementedError(f"{self} does not support loss weights.")
         # determine positive; do not check with == since the labels are floats
         pos_mask = labels > 0.5
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -286,6 +286,7 @@ class Loss(_Loss):
         self,
         positive_scores: FloatTensor,
         negative_scores: FloatTensor,
+        # TODO: why is label smoothing part of the process_*_scores call?!
         label_smoothing: float | None = None,
         batch_filter: BoolTensor | None = None,
         num_entities: int | None = None,

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -51,7 +51,15 @@ from pykeen.datasets.kinships import KINSHIPS_TRAIN_PATH
 from pykeen.datasets.mocks import create_inductive_dataset
 from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH
 from pykeen.evaluation import Evaluator, MetricResults, evaluator_resolver
-from pykeen.losses import Loss, PairwiseLoss, PointwiseLoss, SetwiseLoss, UnsupportedLabelSmoothingError, loss_resolver
+from pykeen.losses import (
+    Loss,
+    NoSampleWeightSupportError,
+    PairwiseLoss,
+    PointwiseLoss,
+    SetwiseLoss,
+    UnsupportedLabelSmoothingError,
+    loss_resolver,
+)
 from pykeen.metrics import rank_based_metric_resolver
 from pykeen.metrics.ranking import (
     DerivedRankBasedMetric,
@@ -84,6 +92,7 @@ from pykeen.typing import (
     RANK_REALISTIC,
     SIDE_BOTH,
     TRAINING,
+    FloatTensor,
     HeadRepresentation,
     InductiveMode,
     Initializer,
@@ -263,7 +272,7 @@ class LossTestCase(GenericTestCase[Loss]):
     #: The number of entities LCWA training loop / label smoothing.
     num_entities: ClassVar[int] = 7
 
-    def _check_loss_value(self, loss_value: torch.FloatTensor) -> None:
+    def _check_loss_value(self, loss_value: FloatTensor) -> None:
         """Check loss value dimensionality, and ability for backward."""
         # test reduction
         self.assertEqual(0, loss_value.ndim)
@@ -279,6 +288,7 @@ class LossTestCase(GenericTestCase[Loss]):
         positive_scores: torch.FloatTensor,
         negative_scores: torch.FloatTensor,
         batch_filter: torch.BoolTensor | None = None,
+        weights: FloatTensor | None = None,
     ):
         """Help test processing scores from SLCWA training loop."""
         loss_value = self.instance.process_slcwa_scores(
@@ -287,19 +297,23 @@ class LossTestCase(GenericTestCase[Loss]):
             label_smoothing=None,
             batch_filter=batch_filter,
             num_entities=self.num_entities,
+            weights=weights,
         )
         self._check_loss_value(loss_value=loss_value)
 
-    def test_process_slcwa_scores(self):
-        """Test processing scores from SLCWA training loop."""
+    def _make_slcwa(self) -> tuple[FloatTensor, FloatTensor]:
         positive_scores = torch.rand(self.batch_size, 1, requires_grad=True)
         negative_scores = torch.rand(self.batch_size, self.num_neg_per_pos, requires_grad=True)
+        return positive_scores, negative_scores
+
+    def test_process_slcwa_scores(self):
+        """Test processing scores from SLCWA training loop."""
+        positive_scores, negative_scores = self._make_slcwa()
         self.help_test_process_slcwa_scores(positive_scores=positive_scores, negative_scores=negative_scores)
 
     def test_process_slcwa_scores_filtered(self):
         """Test processing scores from SLCWA training loop with filtering."""
-        positive_scores = torch.rand(self.batch_size, 1, requires_grad=True)
-        negative_scores = torch.rand(self.batch_size, self.num_neg_per_pos, requires_grad=True)
+        positive_scores, negative_scores = self._make_slcwa()
         batch_filter = torch.rand(self.batch_size, self.num_neg_per_pos) < 0.5
         self.help_test_process_slcwa_scores(
             positive_scores=positive_scores,
@@ -307,26 +321,58 @@ class LossTestCase(GenericTestCase[Loss]):
             batch_filter=batch_filter,
         )
 
+    def test_process_slcwa_scores_weights(self):
+        """Test processing scores from SLCWA training loop with weights."""
+        positive_scores, negative_scores = self._make_slcwa()
+        weights = torch.rand_like(negative_scores)
+        try:
+            self.help_test_process_slcwa_scores(
+                positive_scores=positive_scores, negative_scores=negative_scores, weights=weights
+            )
+        except NoSampleWeightSupportError as e:
+            raise SkipTest(f"{self.cls} does not support sample weights") from e
+
+    def _make_lcwa(self) -> tuple[FloatTensor, FloatTensor]:
+        predictions = torch.rand(self.batch_size, self.num_entities, requires_grad=True)
+        labels = (torch.rand(self.batch_size, self.num_entities, requires_grad=True) > 0.8).float()
+        return predictions, labels
+
     def test_process_lcwa_scores(self):
         """Test processing scores from LCWA training loop without smoothing."""
-        self.help_test_process_lcwa_scores(label_smoothing=None)
+        predictions, labels = self._make_lcwa()
+        self.help_test_process_lcwa_scores(predictions=predictions, labels=labels)
 
     def test_process_lcwa_scores_smooth(self):
         """Test processing scores from LCWA training loop with smoothing."""
+        predictions, labels = self._make_lcwa()
         try:
-            self.help_test_process_lcwa_scores(label_smoothing=0.01)
+            self.help_test_process_lcwa_scores(predictions=predictions, labels=labels, label_smoothing=0.01)
         except UnsupportedLabelSmoothingError as error:
             raise SkipTest from error
 
-    def help_test_process_lcwa_scores(self, label_smoothing):
+    def test_process_lcwa_scores_weights(self):
+        """Test processing scores from LCWA training loop with weights."""
+        predictions, labels = self._make_lcwa()
+        weights = torch.rand_like(predictions)
+        try:
+            self.help_test_process_lcwa_scores(predictions=predictions, labels=labels, weights=weights)
+        except NoSampleWeightSupportError as e:
+            raise SkipTest(f"{self.cls} does not support sample weights") from e
+
+    def help_test_process_lcwa_scores(
+        self,
+        predictions: FloatTensor,
+        labels: FloatTensor,
+        label_smoothing: float | None = None,
+        weights: FloatTensor | None = None,
+    ) -> None:
         """Help test processing scores from LCWA training loop."""
-        predictions = torch.rand(self.batch_size, self.num_entities, requires_grad=True)
-        labels = (torch.rand(self.batch_size, self.num_entities, requires_grad=True) > 0.8).float()
         loss_value = self.instance.process_lcwa_scores(
             predictions=predictions,
             labels=labels,
             label_smoothing=label_smoothing,
             num_entities=self.num_entities,
+            weights=weights,
         )
         self._check_loss_value(loss_value=loss_value)
 

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -288,8 +288,9 @@ class LossTestCase(GenericTestCase[Loss]):
         positive_scores: torch.FloatTensor,
         negative_scores: torch.FloatTensor,
         batch_filter: torch.BoolTensor | None = None,
-        weights: FloatTensor | None = None,
-    ):
+        pos_weights: FloatTensor | None = None,
+        neg_weights: FloatTensor | None = None,
+    ) -> None:
         """Help test processing scores from SLCWA training loop."""
         loss_value = self.instance.process_slcwa_scores(
             positive_scores=positive_scores,
@@ -297,7 +298,8 @@ class LossTestCase(GenericTestCase[Loss]):
             label_smoothing=None,
             batch_filter=batch_filter,
             num_entities=self.num_entities,
-            weights=weights,
+            pos_weights=pos_weights,
+            neg_weights=neg_weights,
         )
         self._check_loss_value(loss_value=loss_value)
 
@@ -324,10 +326,14 @@ class LossTestCase(GenericTestCase[Loss]):
     def test_process_slcwa_scores_weights(self):
         """Test processing scores from SLCWA training loop with weights."""
         positive_scores, negative_scores = self._make_slcwa()
-        weights = torch.rand_like(negative_scores)
+        pos_weights = torch.rand_like(positive_scores)
+        neg_weights = torch.rand_like(negative_scores)
         try:
             self.help_test_process_slcwa_scores(
-                positive_scores=positive_scores, negative_scores=negative_scores, weights=weights
+                positive_scores=positive_scores,
+                negative_scores=negative_scores,
+                pos_weights=pos_weights,
+                neg_weights=neg_weights,
             )
         except NoSampleWeightSupportError as e:
             raise SkipTest(f"{self.cls} does not support sample weights") from e


### PR DESCRIPTION
Add sample weights to loss functions.

For many loss functions, this works by selecting `none` as the aggregation of the underlying loss implementation and calculating a weighted average instead of the uniformly weighted average.

This PR does *not*:

- add support for sample weights to the training loops
- add support for *class* weights
  - some underlying PyTorch loss functions natively support those, e.g., [`torch.nn.BCEWithLogitsLoss`](https://pytorch.org/docs/stable/generated/torch.nn.BCEWithLogitsLoss.html)'s `pos_weight`. It would make sense to expose that, but it is a different feature.
- add support for *edge* weights in message passing. We already have some support for them.

Related to https://github.com/pykeen/pykeen/issues/1523