### PR TITLE
🔓⚖️ Expose pos_weight for BCEWithLogitsLoss

### DIFF
--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -419,7 +419,7 @@ class BCEWithLogitsLoss(PointwiseLoss):
 
         :param reduction:
             The reduction, cf. :mod:`pykeen.nn.modules._Loss`
-        :param pos_weigt:
+        :param pos_weight:
             A weight for the positive class.
         """
         super().__init__(reduction=reduction)

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -208,6 +208,8 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 DEFAULT_MARGIN_HPO_STRATEGY = dict(type=float, low=0, high=3)
+DEFAULT_HPO_STRATEGY_REDUCTION = {"type": "categorical", "choices": ["mean", "sum"]}
+DEFAULT_HPO_STRATEGY_POS_WEIGHT = {"type": float, "low": 2**-2, "high": 2**10, "log": True}
 
 
 def apply_label_smoothing(
@@ -411,6 +413,11 @@ class BCEWithLogitsLoss(PointwiseLoss):
     """
 
     synonyms = {"Negative Log Likelihood Loss"}
+
+    hpo_default: ClassVar[Mapping[str, Any]] = {
+        "reduction": DEFAULT_HPO_STRATEGY_REDUCTION,
+        "pos_weight": DEFAULT_HPO_STRATEGY_POS_WEIGHT,
+    }
 
     pos_weight: FloatTensor | None
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -412,13 +412,31 @@ class BCEWithLogitsLoss(PointwiseLoss):
 
     synonyms = {"Negative Log Likelihood Loss"}
 
+    pos_weight: FloatTensor | None
+
+    def __init__(self, reduction: str = "mean", pos_weight: None | float = None):
+        """Initialize the loss criterion.
+
+        :param reduction:
+            The reduction, cf. :mod:`pykeen.nn.modules._Loss`
+        :param pos_weigt:
+            A weight for the positive class.
+        """
+        super().__init__(reduction=reduction)
+        if pos_weight:
+            self.register_buffer("pos_weight", tensor=torch.as_tensor(pos_weight))
+        else:
+            self.pos_weight = None
+
     # docstr-coverage: inherited
     def forward(
         self,
         scores: FloatTensor,
         labels: FloatTensor,
     ) -> FloatTensor:  # noqa: D102
-        return functional.binary_cross_entropy_with_logits(scores, labels, reduction=self.reduction)
+        return functional.binary_cross_entropy_with_logits(
+            scores, labels, reduction=self.reduction, pos_weight=self.pos_weight
+        )
 
 
 @parse_docdata


### PR DESCRIPTION
Expose the `pos_weight` parameter of [`BCEWithLogitsLoss`](https://pytorch.org/docs/stable/generated/torch.nn.BCEWithLogitsLoss.html) as configuration option.

This can be useful in cases where there is a class imbalance (as frequently observed in KG with more "negative" triples than positive ones).