### PR TITLE
⏩#️⃣ Forward max_id to adapted representations

### DIFF
--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1835,7 +1835,7 @@ class TransformedRepresentation(Representation):
         # import here to avoid cyclic import
         from . import representation_resolver
 
-        base = representation_resolver.make(base, base_kwargs)
+        base = representation_resolver.make(base, base_kwargs, max_id=max_id)
 
         # infer shape
         shape = ShapeError.verify(

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -1695,7 +1695,8 @@ def merge_kwargs(kwargs: OneOrManyOptionalKwargs, **extra_kwargs: Any | None) ->
     if isinstance(kwargs, Sequence):
         return [merge_kwargs(kw, **extra_kwargs) for kw in kwargs]
 
-    kwargs = kwargs or {}
+    # create shallow copy to avoid side-effects
+    kwargs = dict(kwargs or {})
     for key, value in extra_kwargs.items():
         if value is None:
             continue

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -1666,10 +1666,12 @@ def circular_correlation(a: FloatTensor, b: FloatTensor) -> FloatTensor:
     return torch.fft.irfft(p_fft, n=a.shape[-1], dim=-1)
 
 
+# docstr-coverage:excused `overload`
 @overload
 def merge_kwargs(kwargs: Sequence[OptionalKwargs], **extra_kwargs: Any | None) -> Sequence[OptionalKwargs]: ...
 
 
+# docstr-coverage:excused `overload`
 @overload
 def merge_kwargs(kwargs: OptionalKwargs, **extra_kwargs: Any | None) -> OptionalKwargs: ...
 

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -1679,8 +1679,10 @@ def merge_kwargs(kwargs: OptionalKwargs, **extra_kwargs: Any | None) -> Optional
 def merge_kwargs(kwargs: OneOrManyOptionalKwargs, **extra_kwargs: Any | None) -> OneOrManyOptionalKwargs:
     """Add extra fields to parameters, skipping None entries.
 
+    If a list is provided, extra parameters are added to each.
+
     :param kwargs:
-        The base parameters.
+        The base parameters, or a list thereof.
     :param extra_kwargs:
         The external parameters to add.
 

--- a/tests/test_nn/test_representation.py
+++ b/tests/test_nn/test_representation.py
@@ -495,7 +495,6 @@ class TransformedRepresentationTest(cases.RepresentationTestCase):
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs)
         kwargs["transformation"] = torch.nn.Linear(5, 7)
-        kwargs["base_kwargs"]["max_id"] = kwargs.pop("max_id")
         return kwargs
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -395,6 +395,7 @@ class TestUtils(unittest.TestCase):
         ({}, {"max_id": 10}, {"max_id": 10}, None),
         ({"max_id": 10}, {"max_id": None}, {"max_id": 10}, None),
         ({"max_id": 10}, {"max_id": 7}, ..., ValueError),
+        ([{'shape': (3,)}, {'shape': (4,)}], {'max_id': 7}, ..., None)
     ],
 )
 def test_merge_kwargs(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 """Tests for the :mod:`pykeen.utils` module."""
 
+import contextlib
 import functools
 import itertools
 import operator
@@ -8,6 +9,7 @@ import string
 import timeit
 import unittest
 from collections.abc import Iterable
+from typing import Any
 
 import numpy
 import pytest
@@ -27,6 +29,7 @@ from pykeen.utils import (
     get_until_first_blank,
     iter_weisfeiler_lehman,
     logcumsumexp,
+    merge_kwargs,
     project_entity,
     set_random_seed,
     split_complex,
@@ -383,3 +386,21 @@ class TestUtils(unittest.TestCase):
         sim_ref = reference[None, :] == reference[:, None]
         sim_approx = approx[None, :] == approx[:, None]
         assert torch.allclose(sim_ref, sim_approx)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "extra", "expected", "error"),
+    [
+        ({"max_id": 10}, {}, {"max_id": 10}, None),
+        ({}, {"max_id": 10}, {"max_id": 10}, None),
+        ({"max_id": 10}, {"max_id": None}, {"max_id": 10}, None),
+        ({"max_id": 10}, {"max_id": 7}, ..., ValueError),
+    ],
+)
+def test_merge_kwargs(
+    kwargs: dict[str, Any], extra: dict[str, Any], expected: dict[str, Any], error: type[BaseException] | None
+) -> None:
+    """Test merging of parameters."""
+    with pytest.raises(error) if error else contextlib.nullcontext():
+        merged_kwargs = merge_kwargs(kwargs=kwargs, **extra)
+        assert merged_kwargs == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -395,7 +395,12 @@ class TestUtils(unittest.TestCase):
         ({}, {"max_id": 10}, {"max_id": 10}, None),
         ({"max_id": 10}, {"max_id": None}, {"max_id": 10}, None),
         ({"max_id": 10}, {"max_id": 7}, ..., ValueError),
-        ([{'shape': (3,)}, {'shape': (4,)}], {'max_id': 7}, ..., None)
+        (
+            [{"shape": (3,)}, {"shape": (4,)}],
+            {"max_id": 7},
+            [{"shape": (3,), "max_id": 7}, {"shape": (4,), "max_id": 7}],
+            None,
+        ),
     ],
 )
 def test_merge_kwargs(


### PR DESCRIPTION
Enable passing `max_id` directly to `representation_resolver` rather than having to move it into `base_kwargs`:

```python
from torch import nn

from pykeen.nn import representation_resolver

representation_resolver.make(
    "transformed",
    transformation=nn.Linear(32, 32),
    base_kwargs=dict(shape=32),
    max_id=10,
)
```

It could make sense to bring those changes upstream to https://github.com/cthoyt/class-resolver