### PR TITLE
🦍🍌 Training with sample weights

### DIFF
--- a/src/pykeen/contrib/lightning.py
+++ b/src/pykeen/contrib/lightning.py
@@ -39,8 +39,8 @@ from pykeen.models.cli import options
 from pykeen.optimizers import optimizer_resolver
 from pykeen.sampling import NegativeSampler
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop
-from pykeen.training.lcwa import create_lcwa_instances
 from pykeen.training.slcwa import create_slcwa_instances
+from pykeen.triples.instances import LCWAInstances
 from pykeen.triples.triples_factory import CoreTriplesFactory
 from pykeen.typing import FloatTensor, InductiveMode, LongTensor, OneOrSequence
 
@@ -243,7 +243,7 @@ class LCWALitModule(LitModule):
     # docstr-coverage: inherited
     def _dataloader(self, triples_factory: CoreTriplesFactory, shuffle: bool = False) -> torch.utils.data.DataLoader:  # noqa: D102
         return torch.utils.data.DataLoader(
-            dataset=create_lcwa_instances(triples_factory),
+            dataset=LCWAInstances.from_triples_factory(triples_factory),
             batch_size=self.batch_size,
             shuffle=shuffle,
         )

--- a/src/pykeen/contrib/lightning.py
+++ b/src/pykeen/contrib/lightning.py
@@ -39,8 +39,7 @@ from pykeen.models.cli import options
 from pykeen.optimizers import optimizer_resolver
 from pykeen.sampling import NegativeSampler
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop
-from pykeen.training.slcwa import create_slcwa_instances
-from pykeen.triples.instances import LCWAInstances
+from pykeen.triples.instances import BatchedSLCWAInstances, LCWAInstances
 from pykeen.triples.triples_factory import CoreTriplesFactory
 from pykeen.typing import FloatTensor, InductiveMode, LongTensor, OneOrSequence
 
@@ -197,7 +196,7 @@ class SLCWALitModule(LitModule):
     # docstr-coverage: inherited
     def _dataloader(self, triples_factory: CoreTriplesFactory, shuffle: bool = False) -> torch.utils.data.DataLoader:  # noqa: D102
         return torch.utils.data.DataLoader(
-            dataset=create_slcwa_instances(
+            dataset=BatchedSLCWAInstances.from_triples_factory(
                 triples_factory,
                 batch_size=self.batch_size,
                 # TODO:

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -117,6 +117,7 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch, LCWABatch]):
         # Split batch components
         batch_pairs = batch.pairs
         batch_labels_full = batch.target
+        batch_weights = batch.weights
 
         # Send batch to device
         batch_pairs = batch_pairs[start:stop].to(device=model.device)
@@ -130,6 +131,7 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch, LCWABatch]):
                 labels=batch_labels_full,
                 label_smoothing=label_smoothing,
                 num_entities=num_targets,
+                weights=batch_weights,
             )
             + model.collect_regularization_term()
         )

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -122,6 +122,8 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch, LCWABatch]):
         # Send batch to device
         batch_pairs = batch_pairs[start:stop].to(device=model.device)
         batch_labels_full = batch_labels_full[start:stop].to(device=model.device)
+        if batch_weights is not None:
+            batch_weights = batch_weights[start:stop].to(device=model.device)
 
         predictions = score_method(batch_pairs, slice_size=slice_size, mode=mode)
 

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 name_to_index = {name: index for index, name in enumerate("hrt")}
 
 
-class LCWATrainingLoop(TrainingLoop[LCWABatch, LCWABatch]):
+class LCWATrainingLoop(TrainingLoop[LCWABatch]):
     r"""A training loop that is based upon the local closed world assumption (LCWA).
 
     Under the LCWA, for a given true training triple $(h, r, t) \in \mathcal{T}_{train}$, all triples
@@ -232,7 +232,7 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch, LCWABatch]):
 
 
 # note: we use Tuple[Tensor] here, so we can re-use TensorDataset instead of having to create a custom one
-class SymmetricLCWATrainingLoop(TrainingLoop[tuple[MappedTriples], tuple[MappedTriples]]):
+class SymmetricLCWATrainingLoop(TrainingLoop[tuple[MappedTriples]]):
     r"""A "symmetric" LCWA scoring heads *and* tails at once.
 
     This objective was introduced by [lacroix2018]_ as

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -94,12 +94,12 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch, LCWABatch]):
             )
 
         dataset = create_lcwa_instances(triples_factory, target=self.target)
-        return DataLoader(dataset=dataset, collate_fn=dataset.get_collator(), **kwargs)
+        return DataLoader(dataset=dataset, **kwargs)
 
     @staticmethod
     # docstr-coverage: inherited
     def _get_batch_size(batch: LCWABatch) -> int:  # noqa: D102
-        return batch.pairs.shape[0]
+        return batch["pairs"].shape[0]
 
     @staticmethod
     def _process_batch_static(
@@ -115,9 +115,9 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch, LCWABatch]):
         slice_size: int | None = None,
     ) -> FloatTensor:
         # Split batch components
-        batch_pairs = batch.pairs
-        batch_labels_full = batch.target
-        batch_weights = batch.weights
+        batch_pairs = batch["pairs"]
+        batch_labels_full = batch["target"]
+        batch_weights = batch.get("weights")
 
         # Send batch to device
         batch_pairs = batch_pairs[start:stop].to(device=model.device)

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -6,7 +6,7 @@ from math import ceil
 from typing import ClassVar
 
 from torch.nn import functional
-from torch.utils.data import DataLoader, Dataset, TensorDataset
+from torch.utils.data import DataLoader, TensorDataset
 from torch_max_mem.api import is_oom_error
 
 from .training_loop import TrainingLoop
@@ -93,7 +93,7 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch]):
                 f"sampler='{sampler}'.",
             )
 
-        dataset = create_lcwa_instances(triples_factory, target=self.target)
+        dataset = LCWAInstances.from_triples_factory(triples_factory, target=self.target)
         return DataLoader(dataset=dataset, **kwargs)
 
     @staticmethod
@@ -306,13 +306,3 @@ class SymmetricLCWATrainingLoop(TrainingLoop[tuple[MappedTriples]]):
     def _slice_size_search(self, **kwargs) -> int:
         # TODO?
         raise MemoryError("The current model can't be trained on this hardware with these parameters.")
-
-
-def create_lcwa_instances(tf: CoreTriplesFactory, target: int | None = None) -> Dataset:
-    """Create LCWA instances for this factory's triples."""
-    return LCWAInstances.from_triples(
-        mapped_triples=tf._add_inverse_triples_if_necessary(mapped_triples=tf.mapped_triples),
-        num_entities=tf.num_entities,
-        num_relations=tf.num_relations,
-        target=target,
-    )

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -22,7 +22,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-class SLCWATrainingLoop(TrainingLoop[SLCWABatch, SLCWABatch]):
+class SLCWATrainingLoop(TrainingLoop[SLCWABatch]):
     """A training loop that uses the stochastic local closed world assumption training approach.
 
     [ruffinelli2020]_ call the sLCWA ``NegSamp`` in their work.

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -1,6 +1,7 @@
 """Training KGE models based on the sLCWA."""
 
 import logging
+from typing import Literal
 
 from class_resolver import HintOrType, OptionalKwargs
 from torch.utils.data import DataLoader
@@ -46,7 +47,13 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch]):
 
     # docstr-coverage: inherited
     def _create_training_data_loader(
-        self, triples_factory: CoreTriplesFactory, sampler: str | None, batch_size: int, drop_last: bool, **kwargs
+        self,
+        triples_factory: CoreTriplesFactory,
+        *,
+        sampler: Literal["schlichtkrull"] | None,
+        batch_size: int,
+        drop_last: bool,
+        **kwargs,
     ) -> DataLoader[SLCWABatch]:  # noqa: D102
         assert "batch_sampler" not in kwargs
         cls = BatchedSLCWAInstances if sampler is None else SubGraphSLCWAInstances

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -55,8 +55,14 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch]):
         drop_last: bool,
         **kwargs,
     ) -> DataLoader[SLCWABatch]:  # noqa: D102
-        assert "batch_sampler" not in kwargs
-        cls = BatchedSLCWAInstances if sampler is None else SubGraphSLCWAInstances
+        cls: type[BatchedSLCWAInstances] | type[SubGraphSLCWAInstances]
+        match sampler:
+            case None:
+                cls = BatchedSLCWAInstances
+            case "schlichtkrull":
+                cls = SubGraphSLCWAInstances
+            case _:
+                raise ValueError(f"Invalid {sampler=}")
         return DataLoader(
             dataset=cls.from_triples_factory(
                 triples_factory,

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -65,7 +65,6 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch]):
                 drop_last=drop_last,
                 negative_sampler=self.negative_sampler,
                 negative_sampler_kwargs=self.negative_sampler_kwargs,
-                sampler=sampler,
             ),
             # disable automatic batching
             batch_size=None,

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -70,7 +70,7 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch, SLCWABatch]):
     @staticmethod
     # docstr-coverage: inherited
     def _get_batch_size(batch: SLCWABatch) -> int:  # noqa: D102
-        return batch.positives.shape[0]
+        return batch["positives"].shape[0]
 
     @staticmethod
     def _process_batch_static(
@@ -88,11 +88,11 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch, SLCWABatch]):
             raise AttributeError("Slicing is not possible for sLCWA training loops.")
 
         # split batch
-        positive_batch = batch.positives
-        negative_batch = batch.negatives
-        positive_filter = batch.masks
-        pos_weights = batch.pos_weights
-        neg_weights = batch.neg_weights
+        positive_batch = batch["positives"]
+        negative_batch = batch["negatives"]
+        positive_filter = batch.get("masks")
+        pos_weights = batch.get("pos_weights")
+        neg_weights = batch.get("neg_weights")
 
         # send to device
         positive_batch = positive_batch[start:stop].to(device=model.device)

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -101,6 +101,10 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch, SLCWABatch]):
             positive_filter = positive_filter[start:stop]
             negative_batch = negative_batch[positive_filter]
             positive_filter = positive_filter.to(model.device)
+        if pos_weights is not None:
+            pos_weights = pos_weights[start:stop].to(device=model.device)
+        if neg_weights is not None:
+            neg_weights = neg_weights[start:stop].to(device=model.device)
         # Make it negative batch broadcastable (required for num_negs_per_pos > 1).
         negative_score_shape = negative_batch.shape[:-1]
         negative_batch = negative_batch.view(-1, 3)

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -175,6 +175,7 @@ def create_slcwa_instances(
     **kwargs: Any,
 ) -> Dataset:
     """Create sLCWA instances for this factory's triples."""
+    # TODO: move into classmethods?
     cls = BatchedSLCWAInstances if sampler is None else SubGraphSLCWAInstances
     if "shuffle" in kwargs:
         if kwargs.pop("shuffle"):

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -14,7 +14,7 @@ from contextlib import ExitStack
 from datetime import datetime
 from hashlib import md5
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from typing import IO, Any, ClassVar, Generic, TypeVar
+from typing import IO, Any, ClassVar, Generic, Literal, TypeVar
 
 import numpy as np
 import torch
@@ -207,7 +207,7 @@ class TrainingLoop(Generic[BatchType], ABC):
         batch_size: int | None = None,
         slice_size: int | None = None,
         label_smoothing: float = 0.0,
-        sampler: str | None = None,
+        sampler: Literal["schlichtkrull"] | None = None,
         continue_training: bool = False,
         only_size_probing: bool = False,
         use_tqdm: bool = True,
@@ -488,7 +488,7 @@ class TrainingLoop(Generic[BatchType], ABC):
         batch_size: int | None = None,
         slice_size: int | None = None,
         label_smoothing: float = 0.0,
-        sampler: str | None = None,
+        sampler: Literal["schlichtkrull"] | None = None,
         continue_training: bool = False,
         only_size_probing: bool = False,
         use_tqdm: bool = True,
@@ -791,7 +791,13 @@ class TrainingLoop(Generic[BatchType], ABC):
 
     @abstractmethod
     def _create_training_data_loader(
-        self, triples_factory: CoreTriplesFactory, *, sampler: str | None, batch_size: int, drop_last: bool, **kwargs
+        self,
+        triples_factory: CoreTriplesFactory,
+        *,
+        sampler: Literal["schlichtkrull"] | None,
+        batch_size: int,
+        drop_last: bool,
+        **kwargs,
     ) -> DataLoader[BatchType]:
         """Create a data loader over training instances.
 
@@ -934,7 +940,7 @@ class TrainingLoop(Generic[BatchType], ABC):
         self,
         *,
         batch_size: int,
-        sampler: str | None,
+        sampler: Literal["schlichtkrull"] | None,
         triples_factory: CoreTriplesFactory,
     ) -> tuple[int, int | None]:
         """Check if sub-batching and/or slicing is necessary to train the model on the hardware at hand."""
@@ -986,7 +992,7 @@ class TrainingLoop(Generic[BatchType], ABC):
         self,
         *,
         batch_size: int,
-        sampler: str | None,
+        sampler: Literal["schlichtkrull"] | None,
         triples_factory: CoreTriplesFactory,
     ) -> tuple[int, bool, bool]:
         """Find the allowable sub batch size for training with the current setting.

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -54,7 +54,6 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-SampleType = TypeVar("SampleType")
 BatchType = TypeVar("BatchType")
 
 
@@ -116,7 +115,7 @@ def _get_lr_scheduler_kwargs(lr_scheduler: LRScheduler) -> Mapping[str, Any]:
     }
 
 
-class TrainingLoop(Generic[SampleType, BatchType], ABC):
+class TrainingLoop(Generic[BatchType], ABC):
     """A training loop."""
 
     lr_scheduler: LRScheduler | None

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -24,8 +24,6 @@ __all__ = [
     "LCWAInstances",
 ]
 
-# TODO: the same
-SampleType = TypeVar("SampleType")
 BatchType = TypeVar("BatchType")
 
 

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -187,6 +187,9 @@ class BaseBatchedSLCWAInstances(data.IterableDataset[SLCWABatch]):
                 warnings.warn("Training instances are always shuffled.", DeprecationWarning, stacklevel=2)
             else:
                 raise AssertionError("If shuffle is provided, it must be True.")
+        if kwargs.pop("sampler", None):
+            raise AssertionError("sampler is not handled in sLCWA instances")
+
         return cls(
             mapped_triples=tf._add_inverse_triples_if_necessary(mapped_triples=tf.mapped_triples),
             num_entities=tf.num_entities,

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -110,7 +110,7 @@ T = TypeVar("T", bound=torch.Tensor)
 
 
 def _cat_or_none(xs: Iterable[T | None]) -> T | None:
-    ys = _list_or_none(xs)
+    ys: list[T] | None = _list_or_none(xs)
     if ys is None:
         return None
     return torch.cat(ys, dim=0)

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -100,14 +100,13 @@ class SLCWAInstances(Instances[SLCWABatch]):
         return self.mapped_triples.shape[0]
 
     def __getitem__(self, item: int) -> SLCWABatch:  # noqa: D105
-        positive = self.mapped_triples[item].unsqueeze(dim=0)
+        positive = self.mapped_triples[item]
         # TODO: some negative samplers require batches
         negative, mask = self.sampler.sample(positive_batch=positive)
-        # shape: (1, 3), (1, k, 3), (1, k, 3)?
-        # TODO: default collate adds a batch dimension
-        result = SLCWABatch(positives=positive[0], negatives=negative[0])
+        # shape: (3,), (k, 3), (k, 3)?
+        result = SLCWABatch(positives=positive, negatives=negative)
         if mask is not None:
-            result["masks"] = mask[0]
+            result["masks"] = mask
         # TODO: weights
         return result
 

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -107,7 +107,7 @@ class SLCWAInstances(Instances[SLCWABatch]):
         result = SLCWABatch(positives=positive, negatives=negative)
         if mask is not None:
             result["masks"] = mask
-        # TODO: weights
+        # TODO: weights (see https://github.com/pykeen/pykeen/issues/1533)
         return result
 
 
@@ -158,7 +158,7 @@ class BaseBatchedSLCWAInstances(data.IterableDataset[SLCWABatch]):
         result = SLCWABatch(positives=positive_batch, negatives=negative_batch)
         if masks is not None:
             result["masks"] = masks
-        # TODO: weights
+        # TODO: weights (see https://github.com/pykeen/pykeen/issues/1533)
         return result
 
     @abstractmethod

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -41,6 +41,8 @@ class LCWABatch(TypedDict):
 class SLCWABatch(TypedDict):
     """A batch for sLCWA training."""
 
+    # TODO: separately storing head/relation/tail corruptions would enable faster scoring (and thus training)
+
     #: the positive triples, shape: (batch_size, 3)
     positives: LongTensor
 

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -34,6 +34,7 @@ class LCWABatch(NamedTuple):
 
     pairs: LongTensor
     target: FloatTensor
+    weights: FloatTensor | None
 
 
 class SLCWABatch(NamedTuple):
@@ -388,6 +389,9 @@ class LCWAInstances(Instances[LCWABatch, LCWABatch]):
         return self.pairs.shape[0]
 
     def __getitem__(self, item: int) -> LCWABatch:  # noqa: D105
+        # TODO: weights
         return LCWABatch(
-            pairs=self.pairs[item], target=torch.from_numpy(np.asarray(self.compressed[item, :].todense())[0, :])
+            pairs=self.pairs[item],
+            target=torch.from_numpy(np.asarray(self.compressed[item, :].todense())[0, :]),
+            weights=None,
         )

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -59,7 +59,7 @@ class Instances(data.Dataset[BatchType], Generic[BatchType], ABC):
     """Base class for training instances."""
 
     @abstractmethod
-    def __len__(self):  # noqa:D401
+    def __len__(self):
         """Get the number of instances."""
         raise NotImplementedError
 

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
 from typing import Generic, TypedDict, TypeVar
@@ -177,6 +178,22 @@ class BaseBatchedSLCWAInstances(data.IterableDataset[SLCWABatch]):
         if remainder and not self.drop_last:
             num_batches += 1
         return num_batches
+
+    @classmethod
+    def from_triples_factory(cls, tf: CoreTriplesFactory, **kwargs) -> Self:
+        """Create sLCWA instances for triples factory."""
+        # TODO: can we better type `kwargs`?
+        if "shuffle" in kwargs:
+            if kwargs.pop("shuffle"):
+                warnings.warn("Training instances are always shuffled.", DeprecationWarning, stacklevel=2)
+            else:
+                raise AssertionError("If shuffle is provided, it must be True.")
+        return cls(
+            mapped_triples=tf._add_inverse_triples_if_necessary(mapped_triples=tf.mapped_triples),
+            num_entities=tf.num_entities,
+            num_relations=tf.num_relations,
+            **kwargs,
+        )
 
 
 class BatchedSLCWAInstances(BaseBatchedSLCWAInstances):

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -55,7 +55,7 @@ class SLCWABatch(TypedDict):
     neg_weights: NotRequired[FloatTensor]
 
 
-class Instances(data.Dataset[BatchType], Generic[BatchType], ABC):  # noqa: F821
+class Instances(data.Dataset[BatchType], Generic[BatchType], ABC):
     """Base class for training instances."""
 
     @abstractmethod

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import abc
+from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
 from typing import Generic, TypedDict, TypeVar
 
@@ -54,16 +54,16 @@ class SLCWABatch(TypedDict):
     neg_weights: NotRequired[FloatTensor]
 
 
-class Instances(data.Dataset[BatchType], Generic[BatchType], abc.ABC):
+class Instances(data.Dataset[BatchType], Generic[BatchType], ABC):  # noqa: F821
     """Base class for training instances."""
 
-    @abc.abstractmethod
+    @abstractmethod
     def __len__(self):  # noqa:D401
         """Get the number of instances."""
         raise NotImplementedError
 
     @classmethod
-    @abc.abstractmethod
+    @abstractmethod
     def from_triples(
         cls,
         mapped_triples: MappedTriples,
@@ -196,7 +196,7 @@ class BaseBatchedSLCWAInstances(data.IterableDataset[SLCWABatch]):
         # TODO: weights
         return result
 
-    @abc.abstractmethod
+    @abstractmethod
     def iter_triple_ids(self) -> Iterable[list[int]]:
         """Iterate over batches of IDs of positive triples."""
         raise NotImplementedError

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -165,7 +165,7 @@ class SLCWAInstances(Instances[SLCWABatch, SLCWABatch]):
         negatives = torch.cat([s.negatives for s in samples], dim=0)
         masks = _cat_or_none(s.masks for s in samples)
         pos_weights = _cat_or_none(s.pos_weights for s in samples)
-        neg_weights = _cat_or_none(s.pos_weights for s in samples)
+        neg_weights = _cat_or_none(s.neg_weights for s in samples)
         return SLCWABatch(
             positives=positives, negatives=negatives, masks=masks, pos_weights=pos_weights, neg_weights=neg_weights
         )

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import abc
-import typing
 from collections.abc import Iterable, Iterator
 from typing import Generic, TypedDict, TypeVar
 
@@ -90,32 +89,6 @@ class Instances(data.Dataset[BatchType], Generic[BatchType], abc.ABC):
         """
         # TODO: get rid of this method
         raise NotImplementedError
-
-
-X = TypeVar("X")
-
-
-def _list_or_none(xs: Iterable[X | None]) -> list[X] | None:
-    xs = list(xs)
-    if not xs:
-        return None
-    if xs[0] is None:
-        if any(x is not None for x in xs):
-            raise ValueError(f"{xs=} contains None and not None")
-        return None
-    if any(x is None for x in xs):
-        raise ValueError(f"{xs=} contains None and not None")
-    return typing.cast(list[X], xs)
-
-
-T = TypeVar("T", bound=torch.Tensor)
-
-
-def _cat_or_none(xs: Iterable[T | None]) -> T | None:
-    ys: list[T] | None = _list_or_none(xs)
-    if ys is None:
-        return None
-    return torch.cat(ys, dim=0)
 
 
 class SLCWAInstances(Instances[SLCWABatch]):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -81,7 +81,7 @@ from pykeen.stoppers.early_stopping import EarlyStopper
 from pykeen.trackers import ResultTracker
 from pykeen.training import LCWATrainingLoop, SLCWATrainingLoop, TrainingCallback, TrainingLoop
 from pykeen.triples import Instances, TriplesFactory, generation
-from pykeen.triples.instances import BaseBatchedSLCWAInstances, SLCWABatch
+from pykeen.triples.instances import BaseBatchedSLCWAInstances
 from pykeen.triples.splitting import Cleaner, Splitter
 from pykeen.triples.triples_factory import CoreTriplesFactory
 from pykeen.triples.utils import get_entities

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -20,6 +20,7 @@ from typing import (
 from unittest.case import SkipTest
 from unittest.mock import Mock, patch
 
+import more_itertools
 import numpy
 import numpy.random
 import pandas
@@ -2360,26 +2361,11 @@ class TrainingInstancesTestCase(unittest_templates.GenericTestCase[Instances]):
 
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         self.factory = Nations().training
-        return {}
-
-    @abstractmethod
-    def _get_expected_length(self) -> int:
-        raise NotImplementedError
-
-    def test_getitem(self):
-        """Test __getitem__."""
-        self.instance: Instances
-        assert self.instance[0] is not None
-
-    def test_len(self):
-        """Test __len__."""
-        self.assertEqual(len(self.instance), self._get_expected_length())
+        return kwargs
 
     def test_data_loader(self):
         """Test usage with data loader."""
-        for batch in torch.utils.data.DataLoader(
-            dataset=self.instance, batch_size=2, shuffle=True, collate_fn=self.instance.get_collator()
-        ):
+        for batch in torch.utils.data.DataLoader(dataset=self.instance, batch_size=2, shuffle=True):
             assert batch is not None
 
 
@@ -2403,20 +2389,19 @@ class BatchSLCWATrainingInstancesTestCase(unittest_templates.GenericTestCase[Bas
     def test_data_loader(self):
         """Test data loader."""
         for batch in torch.utils.data.DataLoader(dataset=self.instance, batch_size=None):
-            assert isinstance(batch, SLCWABatch)
-            assert batch.positives.shape == (self.batch_size, 3)
-            assert batch.negatives.shape == (self.batch_size, self.num_negatives_per_positive, 3)
-            assert batch.masks is None
+            assert batch["positives"].shape == (self.batch_size, 3)
+            assert batch["negatives"].shape == (self.batch_size, self.num_negatives_per_positive, 3)
+            assert "masks" not in batch
 
     def test_length(self):
         """Test length."""
-        assert len(self.instance) == len(list(iter(self.instance)))
+        assert len(self.instance) == more_itertools.ilen(self.instance)
 
     def test_data_loader_multiprocessing(self):
         """Test data loader with multiple workers."""
         self.assertEqual(
             sum(
-                batch.positives.shape[0]
+                batch["positives"].shape[0]
                 for batch in torch.utils.data.DataLoader(dataset=self.instance, batch_size=None, num_workers=2)
             ),
             self.factory.num_triples,

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -16,7 +16,7 @@ class LCWAInstancesTestCase(cases.TrainingInstancesTestCase):
 
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
-        other_instance = create_lcwa_instances(
+        other_instance = LCWAInstances.from_triples(
             mapped_triples=self.factory.mapped_triples,
             num_entities=self.factory.num_entities,
             num_relations=self.factory.num_relations,

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -3,7 +3,6 @@
 from collections.abc import MutableMapping
 from typing import Any
 
-from pykeen.training.lcwa import create_lcwa_instances
 from pykeen.triples import LCWAInstances, SLCWAInstances
 from pykeen.triples.instances import BatchedSLCWAInstances, SubGraphSLCWAInstances
 from tests import cases

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -42,7 +42,7 @@ class LCWAInstancesTestCase(cases.TrainingInstancesTestCase):
 
         # check compressed triples
         # reconstruct triples from compressed form
-        reconstructed_triples = set()
+        reconstructed_triples: set[tuple[int, int, int]] = set()
         for hr, row_id in zip(instances.pairs, range(instances.compressed.shape[0]), strict=False):
             h, r = hr.tolist()
             _, tails = instances.compressed[row_id].nonzero()

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -3,8 +3,9 @@
 from collections.abc import MutableMapping
 from typing import Any
 
-import numpy
+import torch
 
+from pykeen.datasets.nations import Nations
 from pykeen.triples import LCWAInstances, SLCWAInstances
 from pykeen.triples.instances import BatchedSLCWAInstances, SubGraphSLCWAInstances
 from tests import cases
@@ -33,10 +34,33 @@ class LCWAInstancesTestCase(cases.TrainingInstancesTestCase):
 
     def test_construction(self) -> None:
         """Test proper construction."""
-        self.instance: LCWAInstances
-        # unique pairs
-        assert len(self.instance.pairs) == len(numpy.unique(self.instance.pairs, axis=0))
-        # TODO: we could check whether can recover all mapped_triples from pairs + targets
+        factory = Nations().training
+        instances = LCWAInstances.from_triples_factory(factory)
+        assert isinstance(instances, LCWAInstances)
+
+        # check compressed triples
+        # reconstruct triples from compressed form
+        reconstructed_triples = set()
+        for hr, row_id in zip(instances.pairs, range(instances.compressed.shape[0]), strict=False):
+            h, r = hr.tolist()
+            _, tails = instances.compressed[row_id].nonzero()
+            reconstructed_triples.update((h, r, t) for t in tails.tolist())
+        original_triples = {tuple(hrt) for hrt in factory.mapped_triples.tolist()}
+        assert original_triples == reconstructed_triples
+
+        # check data loader
+        for batch in torch.utils.data.DataLoader(instances, batch_size=2):
+            self.assertIsInstance(batch, dict)  # i.e., a  LCWABatch
+            self.assertEqual({"pairs", "target"}, batch.keys())
+            self.assertTrue(torch.is_tensor(batch["pairs"]))
+            self.assertTrue(torch.is_tensor(batch["target"]))
+
+            x, y = batch["pairs"], batch["target"]
+            batch_size = x.shape[0]
+            assert x.shape == (batch_size, 2)
+            assert x.dtype == torch.long
+            assert y.shape == (batch_size, factory.num_entities)
+            assert y.dtype == torch.get_default_dtype()
 
 
 class SLCWAInstancesTestCase(cases.TrainingInstancesTestCase):

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -3,8 +3,10 @@
 from collections.abc import MutableMapping
 from typing import Any
 
+import numpy
+
 from pykeen.triples import LCWAInstances, SLCWAInstances
-from pykeen.triples.instances import BatchedSLCWAInstances, SubGraphSLCWAInstances
+from pykeen.triples.instances import BatchedSLCWAInstances, LCWABatch, SLCWABatch, SubGraphSLCWAInstances
 from tests import cases
 
 
@@ -20,8 +22,21 @@ class LCWAInstancesTestCase(cases.TrainingInstancesTestCase):
         kwargs["compressed"] = other_instance.compressed
         return kwargs
 
-    def _get_expected_length(self) -> int:
-        return self.factory.mapped_triples[:, :2].unique(dim=0).shape[0]
+    def test_getitem(self) -> None:
+        """Test item access."""
+        self.instance: LCWAInstances
+        item = self.instance[0]
+        assert isinstance(item, dict)
+        assert {"pairs", "target"}.issubset(item.keys())
+        assert item["pairs"].shape == (2,)
+        assert item["target"].shape == (self.factory.num_entities,)
+
+    def test_construction(self) -> None:
+        """Test proper construction."""
+        self.instance: LCWAInstances
+        # unique pairs
+        assert len(self.instance.pairs) == len(numpy.unique(self.instance.pairs, axis=0))
+        # TODO: we could check whether can recover all mapped_triples from pairs + targets
 
 
 class SLCWAInstancesTestCase(cases.TrainingInstancesTestCase):
@@ -34,8 +49,17 @@ class SLCWAInstancesTestCase(cases.TrainingInstancesTestCase):
         kwargs["mapped_triples"] = self.factory.mapped_triples
         return kwargs
 
-    def _get_expected_length(self) -> int:
-        return self.factory.mapped_triples.shape[0]
+    def test_getitem(self) -> None:
+        """Test item access."""
+        self.instance: SLCWAInstances
+        item = self.instance[0]
+        assert {"positives", "negatives"}.issubset(item.keys())
+        assert item["positives"].shape == (3,)
+        assert item["negatives"].shape == (self.instance.sampler.num_negs_per_pos, 3)
+        if "pos_weights" in item:
+            assert item["pos_weights"].shape == item["positives"].shape
+        if "neg_weights" in item:
+            assert item["neg_weights"].shape == item["negatives"].shape
 
 
 class BatchedSLCWAInstancesTestCase(cases.BatchSLCWATrainingInstancesTestCase):

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -6,7 +6,7 @@ from typing import Any
 import numpy
 
 from pykeen.triples import LCWAInstances, SLCWAInstances
-from pykeen.triples.instances import BatchedSLCWAInstances, LCWABatch, SLCWABatch, SubGraphSLCWAInstances
+from pykeen.triples.instances import BatchedSLCWAInstances, SubGraphSLCWAInstances
 from tests import cases
 
 

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -15,11 +15,7 @@ class LCWAInstancesTestCase(cases.TrainingInstancesTestCase):
 
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
-        other_instance = LCWAInstances.from_triples(
-            mapped_triples=self.factory.mapped_triples,
-            num_entities=self.factory.num_entities,
-            num_relations=self.factory.num_relations,
-        )
+        other_instance = LCWAInstances.from_triples_factory(tf=self.factory)
         kwargs["pairs"] = other_instance.pairs
         kwargs["compressed"] = other_instance.compressed
         return kwargs

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -6,7 +6,7 @@ from typing import Any
 import numpy
 import torch
 
-from pykeen.datasets.nations import Nations
+from pykeen.datasets.nations import NATIONS_TRAIN_PATH
 from pykeen.triples import LCWAInstances, SLCWAInstances
 from pykeen.triples.instances import BatchedSLCWAInstances, SubGraphSLCWAInstances
 from pykeen.triples.triples_factory import TriplesFactory
@@ -36,7 +36,7 @@ class LCWAInstancesTestCase(cases.TrainingInstancesTestCase):
 
     def test_construction(self) -> None:
         """Test proper construction."""
-        factory = Nations().training
+        factory = TriplesFactory.from_path(NATIONS_TRAIN_PATH)
         instances = LCWAInstances.from_triples_factory(factory)
         assert isinstance(instances, LCWAInstances)
 

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -3,6 +3,7 @@
 from collections.abc import MutableMapping
 from typing import Any
 
+from pykeen.training.lcwa import create_lcwa_instances
 from pykeen.triples import LCWAInstances, SLCWAInstances
 from pykeen.triples.instances import BatchedSLCWAInstances, SubGraphSLCWAInstances
 from tests import cases
@@ -15,7 +16,7 @@ class LCWAInstancesTestCase(cases.TrainingInstancesTestCase):
 
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs=kwargs)
-        other_instance = self.cls.from_triples(
+        other_instance = create_lcwa_instances(
             mapped_triples=self.factory.mapped_triples,
             num_entities=self.factory.num_entities,
             num_relations=self.factory.num_relations,

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -3,11 +3,13 @@
 from collections.abc import MutableMapping
 from typing import Any
 
+import numpy
 import torch
 
 from pykeen.datasets.nations import Nations
 from pykeen.triples import LCWAInstances, SLCWAInstances
 from pykeen.triples.instances import BatchedSLCWAInstances, SubGraphSLCWAInstances
+from pykeen.triples.triples_factory import TriplesFactory
 from tests import cases
 
 
@@ -84,6 +86,17 @@ class SLCWAInstancesTestCase(cases.TrainingInstancesTestCase):
             assert item["pos_weights"].shape == item["positives"].shape
         if "neg_weights" in item:
             assert item["neg_weights"].shape == item["negatives"].shape
+
+    def test_correct_inverse_creation(self):
+        """Test if the triples and the corresponding inverses are created."""
+        t = [
+            ["e1", "a.", "e5"],
+            ["e1", "a", "e2"],
+        ]
+        t = numpy.array(t, dtype=str)
+        factory = TriplesFactory.from_labeled_triples(triples=t, create_inverse_triples=True)
+        instances = BatchedSLCWAInstances.from_triples_factory(factory)
+        assert len(instances) == 4
 
 
 class BatchedSLCWAInstancesTestCase(cases.BatchSLCWATrainingInstancesTestCase):

--- a/tests/test_sampling/cases.py
+++ b/tests/test_sampling/cases.py
@@ -10,8 +10,8 @@ import unittest_templates
 from pykeen.datasets import Nations
 from pykeen.sampling import NegativeSampler
 from pykeen.sampling.filtering import BloomFilterer, PythonSetFilterer
-from pykeen.training.slcwa import create_slcwa_instances
 from pykeen.triples import Instances, TriplesFactory
+from pykeen.triples.instances import BatchedSLCWAInstances
 
 __all__ = [
     "NegativeSamplerGenericTestCase",
@@ -48,7 +48,7 @@ class NegativeSamplerGenericTestCase(unittest_templates.GenericTestCase[Negative
     def pre_setup_hook(self) -> None:
         """Set up the test case with a triples factory, training instances, and a default positive batch."""
         self.triples_factory = Nations().training
-        self.training_instances = create_slcwa_instances(self.triples_factory)
+        self.training_instances = BatchedSLCWAInstances.from_triples_factory(self.triples_factory)
         random_state = numpy.random.RandomState(seed=self.seed)
         batch_indices = random_state.randint(low=0, high=len(self.training_instances), size=(self.batch_size,))
         self.positive_batch = self.training_instances.mapped_triples[batch_indices]

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -16,7 +16,6 @@ import torch
 
 from pykeen.datasets import Hetionet, Nations, SingleTabbedDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
-from pykeen.training.lcwa import create_lcwa_instances
 from pykeen.training.slcwa import create_slcwa_instances
 from pykeen.triples import CoreTriplesFactory, LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory, generation
 from pykeen.triples.splitting import splitter_resolver
@@ -231,7 +230,7 @@ class TestTriplesFactory(unittest.TestCase):
     def test_create_lcwa_instances(self):
         """Test create_lcwa_instances."""
         factory = Nations().training
-        instances = create_lcwa_instances(factory)
+        instances = LCWAInstances.from_triples_factory(factory)
         assert isinstance(instances, LCWAInstances)
 
         # check compressed triples

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -16,7 +16,7 @@ import torch
 
 from pykeen.datasets import Hetionet, Nations, SingleTabbedDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
-from pykeen.triples import CoreTriplesFactory, LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory, generation
+from pykeen.triples import CoreTriplesFactory, TriplesFactory, TriplesNumericLiteralsFactory, generation
 from pykeen.triples.instances import BatchedSLCWAInstances
 from pykeen.triples.splitting import splitter_resolver
 from pykeen.triples.triples_factory import (
@@ -226,36 +226,6 @@ class TestTriplesFactory(unittest.TestCase):
                         relation_restriction=relation_restriction,
                         invert_relation_selection=invert_relation_selection,
                     )
-
-    def test_create_lcwa_instances(self):
-        """Test create_lcwa_instances."""
-        factory = Nations().training
-        instances = LCWAInstances.from_triples_factory(factory)
-        assert isinstance(instances, LCWAInstances)
-
-        # check compressed triples
-        # reconstruct triples from compressed form
-        reconstructed_triples = set()
-        for hr, row_id in zip(instances.pairs, range(instances.compressed.shape[0]), strict=False):
-            h, r = hr.tolist()
-            _, tails = instances.compressed[row_id].nonzero()
-            reconstructed_triples.update((h, r, t) for t in tails.tolist())
-        original_triples = {tuple(hrt) for hrt in factory.mapped_triples.tolist()}
-        assert original_triples == reconstructed_triples
-
-        # check data loader
-        for batch in torch.utils.data.DataLoader(instances, batch_size=2):
-            self.assertIsInstance(batch, dict)  # i.e., a  LCWABatch
-            self.assertEqual({"pairs", "target"}, batch.keys())
-            self.assertTrue(torch.is_tensor(batch["pairs"]))
-            self.assertTrue(torch.is_tensor(batch["target"]))
-
-            x, y = batch["pairs"], batch["target"]
-            batch_size = x.shape[0]
-            assert x.shape == (batch_size, 2)
-            assert x.dtype == torch.long
-            assert y.shape == (batch_size, factory.num_entities)
-            assert y.dtype == torch.get_default_dtype()
 
     def test_split_inverse_triples(self):
         """Test whether inverse triples are only created in the training factory."""

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -16,8 +16,8 @@ import torch
 
 from pykeen.datasets import Hetionet, Nations, SingleTabbedDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
-from pykeen.training.slcwa import create_slcwa_instances
 from pykeen.triples import CoreTriplesFactory, LCWAInstances, TriplesFactory, TriplesNumericLiteralsFactory, generation
+from pykeen.triples.instances import BatchedSLCWAInstances
 from pykeen.triples.splitting import splitter_resolver
 from pykeen.triples.triples_factory import (
     INVERSE_SUFFIX,
@@ -90,7 +90,7 @@ class TestTriplesFactory(unittest.TestCase):
         ]
         t = np.array(t, dtype=str)
         factory = TriplesFactory.from_labeled_triples(triples=t, create_inverse_triples=True)
-        instances = create_slcwa_instances(factory)
+        instances = BatchedSLCWAInstances.from_triples_factory(factory)
         assert len(instances) == 4
 
     def test_automatic_incomplete_inverse_detection(self):

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -245,9 +245,12 @@ class TestTriplesFactory(unittest.TestCase):
 
         # check data loader
         for batch in torch.utils.data.DataLoader(instances, batch_size=2):
-            assert len(batch) == 2
-            assert all(torch.is_tensor(x) for x in batch)
-            x, y = batch
+            self.assertIsInstance(batch, dict)  # i.e., a  LCWABatch
+            self.assertEqual({"pairs", "target"}, batch.keys())
+            self.assertTrue(torch.is_tensor(batch["pairs"]))
+            self.assertTrue(torch.is_tensor(batch["target"]))
+
+            x, y = batch["pairs"], batch["target"]
             batch_size = x.shape[0]
             assert x.shape == (batch_size, 2)
             assert x.dtype == torch.long

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -17,7 +17,6 @@ import torch
 from pykeen.datasets import Hetionet, Nations, SingleTabbedDataset
 from pykeen.datasets.nations import NATIONS_TRAIN_PATH
 from pykeen.triples import CoreTriplesFactory, TriplesFactory, TriplesNumericLiteralsFactory, generation
-from pykeen.triples.instances import BatchedSLCWAInstances
 from pykeen.triples.splitting import splitter_resolver
 from pykeen.triples.triples_factory import (
     INVERSE_SUFFIX,
@@ -81,17 +80,6 @@ class TestTriplesFactory(unittest.TestCase):
     def setUp(self) -> None:
         """Instantiate test instance."""
         self.factory = Nations().training
-
-    def test_correct_inverse_creation(self):
-        """Test if the triples and the corresponding inverses are created."""
-        t = [
-            ["e1", "a.", "e5"],
-            ["e1", "a", "e2"],
-        ]
-        t = np.array(t, dtype=str)
-        factory = TriplesFactory.from_labeled_triples(triples=t, create_inverse_triples=True)
-        instances = BatchedSLCWAInstances.from_triples_factory(factory)
-        assert len(instances) == 4
 
     def test_automatic_incomplete_inverse_detection(self):
         """Test detecting that the triples contain inverses, warns about them, and filters them out."""


### PR DESCRIPTION
Add support for sample weights in all training loops.

Also 
- switch from `NamedTuple` to `TypedDict` since the latter is supported by `torch`'s [default collate](https://pytorch.org/docs/stable/data.html#torch.utils.data.default_collate) method.
- get rid of explicit typing of `SampleType` vs. `BatchType` - this was only used for typing the custom collation.
- convert `create_slcwa_instances` and `create_lcwa_instances` to factory `classmethod`s.
- Update typing for sampler from `str | None` to `Literal["schlichtkrull"] | None` to make it more clear what this argument is for

Do not implement determining these weights yet, cf. https://github.com/pykeen/pykeen/issues/1533