### PR TITLE
🔁🧼 Refactor typing in `repeat_if_necessary()` and `Model._get_entity_len()`

### DIFF
--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -168,7 +168,7 @@ class Model(nn.Module, ABC):
         """Reset all parameters of the model in-place."""
 
     @abstractmethod
-    def _get_entity_len(self, *, mode: InductiveMode | None) -> int | None:
+    def _get_entity_len(self, *, mode: InductiveMode | None) -> int:
         """Get the number of entities depending on the mode parameters."""
 
     def post_parameter_update(self) -> None:

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -101,5 +101,5 @@ class InductiveERModel(ERModel):
         raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")
 
     # docstr-coverage: inherited
-    def _get_entity_len(self, *, mode: InductiveMode | None) -> int | None:  # noqa: D102
+    def _get_entity_len(self, *, mode: InductiveMode | None) -> int:  # noqa: D102
         return self._get_entity_representations_from_inductive_mode(mode=mode)[0].max_id

--- a/src/pykeen/models/meta/filtered.py
+++ b/src/pykeen/models/meta/filtered.py
@@ -155,7 +155,7 @@ class CooccurrenceFilteredModel(Model):
         return new_scores
 
     # docstr-coverage: inherited
-    def _get_entity_len(self, *, mode: InductiveMode | None) -> int | None:
+    def _get_entity_len(self, *, mode: InductiveMode | None) -> int:
         return self.base._get_entity_len(mode=mode)
 
     # docstr-coverage: inherited

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -634,7 +634,7 @@ class ERModel(
             raise ValueError(f"{self.__class__.__name__} does not support inductive mode: {mode}")
         return self.entity_representations
 
-    def _get_entity_len(self, *, mode: InductiveMode | None) -> int | None:  # noqa:D105
+    def _get_entity_len(self, *, mode: InductiveMode | None) -> int:  # noqa:D105
         """
         Return the number of entities for the given inductive mode.
 

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -222,7 +222,7 @@ def _prepare_representation_module_list(
 def repeat_if_necessary(
     scores: FloatTensor,
     representations: Sequence[Representation],
-    num: int | None,
+    num: int,
 ) -> FloatTensor:
     """
     Repeat score tensor if necessary.
@@ -236,7 +236,7 @@ def repeat_if_necessary(
     :param representations:
         the representations. If empty (i.e. no representations for this 1:n scoring), repetition needs to be applied
     :param num:
-        the number of times to repeat, if necessary.
+        the number of times to repeat.
 
     :return:
         the score tensor, which has been repeated, if necessary

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -231,6 +231,10 @@ def _repeat_when_missing_representations(
     `score_{h,t}` / `score_r` are always the same. For efficiency, they are thus
     only computed once, but to meet the API, they have to be brought into the correct shape afterwards.
 
+    For example, this is the case for :class:`pykeen.models.UM`, which does not have any relation
+    representation. Therefore, the scores for all ``(h, *, t)`` will be the same. We calculate
+    them only once, but need to repeat them for downstream use of the scores.
+
     :param scores: shape: (batch_size, ?)
         the score tensor
     :param representations:

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -219,7 +219,7 @@ def _prepare_representation_module_list(
     return rs
 
 
-def repeat_if_necessary(
+def _repeat_when_missing_representations(
     scores: FloatTensor,
     representations: Sequence[Representation],
     num: int,
@@ -236,7 +236,7 @@ def repeat_if_necessary(
     :param representations:
         the representations. If empty (i.e. no representations for this 1:n scoring), repetition needs to be applied
     :param num:
-        the number of times to repeat.
+        the number of times to repeat, if necessary.
 
     :return:
         the score tensor, which has been repeated, if necessary
@@ -532,7 +532,7 @@ class ERModel(
         # unsqueeze if necessary
         if tails is None or tails.ndimension() == 1:
             t = parallel_unsqueeze(t, dim=0)
-        return repeat_if_necessary(
+        return _repeat_when_missing_representations(
             scores=self.interaction(h=h, r=r, t=t),
             representations=self.entity_representations,
             num=self._get_entity_len(mode=mode) if tails is None else tails.shape[-1],
@@ -570,7 +570,7 @@ class ERModel(
         # unsqueeze if necessary
         if heads is None or heads.ndimension() == 1:
             h = parallel_unsqueeze(h, dim=0)
-        return repeat_if_necessary(
+        return _repeat_when_missing_representations(
             scores=self.interaction(h=h, r=r, t=t),
             representations=self.entity_representations,
             num=self._get_entity_len(mode=mode) if heads is None else heads.shape[-1],
@@ -608,7 +608,7 @@ class ERModel(
         # unsqueeze if necessary
         if relations is None or relations.ndimension() == 1:
             r = parallel_unsqueeze(r, dim=0)
-        return repeat_if_necessary(
+        return _repeat_when_missing_representations(
             scores=self.interaction(h=h, r=r, t=t),
             representations=self.relation_representations,
             num=self.num_relations if relations is None else relations.shape[-1],

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -42,6 +42,7 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch]):
     """
 
     supports_slicing: ClassVar[bool] = True
+    num_targets: int
 
     def __init__(
         self,
@@ -106,7 +107,7 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch]):
         model: Model,
         score_method: Callable,
         loss: Loss,
-        num_targets: int | None,
+        num_targets: int,
         mode: InductiveMode | None,
         batch: LCWABatch,
         start: int | None,


### PR DESCRIPTION
This function is type annotated to take an optional `num`, but in practice, it's always given, and in the torch implementation, it doesn't even accept a None. This PR updates the implementation, the docs, and makes this function private.

This also led me to identify that `num_entities` within the LCWA training loop was type annotated as being possible to be none, but in practice it never is.