### PR TITLE
Specify both generic parameters on FunctionResolver in utils (#1539)

### DIFF
--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -18,7 +18,7 @@ from torch.nn import functional
 from .text import TextEncoder, text_encoder_resolver
 from .utils import iter_matrix_power, safe_diagonal
 from ..triples import CoreTriplesFactory, TriplesFactory
-from ..typing import FloatTensor, Initializer, LongTensor, MappedTriples, OneOrSequence
+from ..typing import FloatTensor, Initializer, LabeledTriples, LongTensor, MappedTriples, OneOrSequence
 from ..utils import compose, get_edge_index, iter_weisfeiler_lehman, upgrade_to_sequence
 
 __all__ = [
@@ -494,7 +494,7 @@ class RandomWalkPositionalEncodingInitializer(PretrainedInitializer):
 #: - :func:`pykeen.nn.init.xavier_normal_norm_`
 #:
 #: as well as initializers from :mod:`torch.nn.init`.
-initializer_resolver: FunctionResolver[Initializer] = FunctionResolver(
+initializer_resolver: FunctionResolver[str, LabeledTriples] = FunctionResolver(
     [
         getattr(torch.nn.init, func)
         for func in dir(torch.nn.init)

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -494,7 +494,7 @@ class RandomWalkPositionalEncodingInitializer(PretrainedInitializer):
 #: - :func:`pykeen.nn.init.xavier_normal_norm_`
 #:
 #: as well as initializers from :mod:`torch.nn.init`.
-initializer_resolver: FunctionResolver[str, LabeledTriples] = FunctionResolver(
+initializer_resolver: FunctionResolver[[str], LabeledTriples] = FunctionResolver(
     [
         getattr(torch.nn.init, func)
         for func in dir(torch.nn.init)

--- a/src/pykeen/triples/utils.py
+++ b/src/pykeen/triples/utils.py
@@ -26,12 +26,12 @@ TRIPLES_DF_COLUMNS = ("head_id", "head_label", "relation_id", "relation_label", 
 Importer = Callable[[str], LabeledTriples]
 
 #: Functions for specifying exotic resources with a given prefix
-PREFIX_IMPORTER_RESOLVER: FunctionResolver[Importer] = FunctionResolver.from_entrypoint(
+PREFIX_IMPORTER_RESOLVER: FunctionResolver[str, LabeledTriples] = FunctionResolver.from_entrypoint(
     "pykeen.triples.prefix_importer"
 )
 
 #: Functions for specifying exotic resources based on their file extension
-EXTENSION_IMPORTER_RESOLVER: FunctionResolver[Importer] = FunctionResolver.from_entrypoint(
+EXTENSION_IMPORTER_RESOLVER: FunctionResolver[str, LabeledTriples] = FunctionResolver.from_entrypoint(
     "pykeen.triples.extension_importer"
 )
 


### PR DESCRIPTION
### Description of the Change

FunctionResolver is a two‑parameter generic (input, output), but was only subscripted with the Importer alias. This patch changes

  `FunctionResolver[Importer]`

to

  `FunctionResolver[str, LabeledTriples]`

for both PREFIX_IMPORTER_RESOLVER and EXTENSION_IMPORTER_RESOLVER, fixing the Python 3.12 “Too few arguments” TypeError raised in #1539
