### PR TITLE
Use evaluation loop

### DIFF
--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -152,6 +152,7 @@ class EvaluationLoop(Generic[BatchType]):
         self,
         # batch
         batch_size: int | None = None,
+        slice_size: int | None = None,
         # tqdm
         use_tqdm: bool = True,
         tqdm_kwargs: OptionalKwargs = None,
@@ -177,7 +178,8 @@ class EvaluationLoop(Generic[BatchType]):
         )
         # set upper limit for slice size
         # TODO: if we knew the targets here, we could guess this better
-        slice_size = max(self.model.num_entities, self.model.num_relations)
+        if slice_size is None:
+            slice_size = max(self.model.num_entities, self.model.num_relations)
         # set model to evaluation mode
         self.model.eval()
         # delegate to AMO wrapper

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -70,6 +70,7 @@ def _evaluate(
 
     :param loop: the evaluation loop instance.
     :param batch_size: the batch size
+    :param slice_size: The optional slice size.
     :param use_tqdm: whether to use tqdm progress bar
     :param tqdm_kwargs: additional keyword-based parameters for the progress bar
     :param kwargs: additional keyword-based parameters passed to :meth:`EvaluationLoop.get_loader`
@@ -101,16 +102,21 @@ class EvaluationLoop(Generic[BatchType]):
         model: Model,
         dataset: Dataset[BatchType],
         evaluator: Evaluator,
+        mode: InductiveMode | None = None,
     ) -> None:
         """Initialize the evaluation loop.
 
         :param model: the model to evaluate.
         :param dataset: the evaluation dataset
         :param evaluator: the evaluator instance
+        :param mode: the inductive mode for evaluation. Defaults to None, meaning transductive setting
         """
         self.model = model
         self.evaluator = evaluator
         self.dataset = dataset
+        if mode is not None:
+            raise NotImplementedError(f"non-transductive evaluation mode is not yet implemented: {mode}")
+        self.mode = mode
 
     @abstractmethod
     def process_batch(self, batch: BatchType, slice_size: int | None = None) -> None:

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -109,13 +109,11 @@ class EvaluationLoop(Generic[BatchType]):
         :param model: the model to evaluate.
         :param dataset: the evaluation dataset
         :param evaluator: the evaluator instance
-        :param mode: the inductive mode for evaluation. Defaults to None, meaning transductive setting
+        :param mode: the inductive mode, or None for transductive evaluation
         """
         self.model = model
         self.evaluator = evaluator
         self.dataset = dataset
-        if mode is not None:
-            raise NotImplementedError(f"non-transductive evaluation mode is not yet implemented: {mode}")
         self.mode = mode
 
     @abstractmethod
@@ -388,10 +386,10 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
                 additional_filter_triples=additional_filter_triples,
             ),
             evaluator=evaluator,
+            mode=mode,
             **kwargs,
         )
         self.targets = targets
-        self.mode = mode
 
     # docstr-coverage: inherited
     def get_collator(self):  # noqa: D102

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -166,6 +166,7 @@ class EvaluationLoop(Generic[BatchType]):
             the contained model will be set to evaluation mode.
 
         :param batch_size: the batch size. If None, enable automatic memory optimization to maximize memory utilization.
+        :param slice_size: the slice size. If None, enable automatic slicing.
         :param use_tqdm: whether to use tqdm progress bar
         :param tqdm_kwargs: additional keyword-based parameters passed to tqdm
         :param kwargs: additional keyword-based parameters passed to :meth:`get_loader`

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -393,6 +393,7 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
             # TODO: in theory, we could make a single score calculation for e.g.,
             # {(h, r, t1), (h, r, t1), ..., (h, r, tk)}
             # predict scores for all candidates
+            # TODO: slice_size
             scores = self.model.predict(hrt_batch=hrt_batch, target=target, mode=self.mode)
             true_scores = dense_positive_mask = None
 

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -108,7 +108,6 @@ class EvaluationLoop(Generic[BatchType]):
         :param model: the model to evaluate.
         :param dataset: the evaluation dataset
         :param evaluator: the evaluator instance
-        :param mode: the inductive mode, or None for transductive evaluation
         """
         self.model = model
         self.evaluator = evaluator

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -102,7 +102,6 @@ class EvaluationLoop(Generic[BatchType]):
         model: Model,
         dataset: Dataset[BatchType],
         evaluator: Evaluator,
-        mode: InductiveMode | None = None,
     ) -> None:
         """Initialize the evaluation loop.
 
@@ -114,7 +113,10 @@ class EvaluationLoop(Generic[BatchType]):
         self.model = model
         self.evaluator = evaluator
         self.dataset = dataset
-        self.mode = mode
+
+    def mode(self) -> InductiveMode | None:
+        """Get the mode from the evaluator."""
+        return self.evaluator.mode
 
     @abstractmethod
     def process_batch(self, batch: BatchType, slice_size: int | None = None) -> None:
@@ -361,7 +363,6 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
         evaluator: HintOrType[Evaluator] = None,
         evaluator_kwargs: OptionalKwargs = None,
         targets: Collection[Target] = (LABEL_HEAD, LABEL_TAIL),
-        mode: InductiveMode | None = None,
         additional_filter_triples: AdditionalFilterTriplesHint = None,
         **kwargs,
     ) -> None:
@@ -371,7 +372,6 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
         :param evaluator: the evaluator, or a hint thereof
         :param evaluator_kwargs: additional keyword-based parameters for instantiating the evaluator
         :param targets: the prediction targets.
-        :param mode: the inductive mode, or None for transductive evaluation
         :param additional_filter_triples: additional filter triples to use for creating the filter
         :param kwargs: additional keyword-based parameters passed to :meth:`EvaluationLoop.__init__`. Should not contain
             the keys `dataset` or `evaluator`.
@@ -389,7 +389,6 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
                 additional_filter_triples=additional_filter_triples,
             ),
             evaluator=evaluator,
-            mode=mode,
             **kwargs,
         )
         self.targets = targets

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1287,6 +1287,7 @@ def _handle_evaluation(
     evaluate_start_time = time.time()
     # TODO: what about SampledEvaluator?
     evaluation_loop = LCWAEvaluationLoop(
+        model=model_instance,
         triples_factory=evaluation_factory,
         evaluator=evaluator_instance,
         # TODO: mode support?

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1281,8 +1281,10 @@ def _handle_evaluation(
         )
     )
     evaluation_loop_kwargs = {}
-    if "targets" in evaluation_kwargs:
-        evaluation_loop_kwargs["targets"] = evaluation_kwargs.pop("targets")
+    # patch dictionary
+    for key in ("targets", "additional_filter_triples"):
+        if key in evaluation_kwargs:
+            evaluation_loop_kwargs[key] = evaluation_kwargs.pop(key)
     evaluate_start_time = time.time()
     # TODO: what about SampledEvaluator?
     evaluation_loop = LCWAEvaluationLoop(
@@ -1290,7 +1292,6 @@ def _handle_evaluation(
         triples_factory=evaluation_factory,
         evaluator=evaluator_instance,
         # TODO: mode support?
-        additional_filter_triples=additional_filter_triples,
         **evaluation_loop_kwargs,
     )
     metric_results = evaluation_loop.evaluate(**evaluation_kwargs)

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1209,7 +1209,6 @@ def _handle_evaluation(
     filter_validation_when_testing: bool = True,
     use_tqdm: bool | None = None,
 ) -> tuple[MetricResults, float]:
-    # TODO: use LCWAEvaluationLoop
     if use_testing_data:
         evaluation_factory = testing
     elif validation is None:

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1208,6 +1208,7 @@ def _handle_evaluation(
     filter_validation_when_testing: bool = True,
     use_tqdm: bool | None = None,
 ) -> tuple[MetricResults, float]:
+    # TODO: use LCWAEvaluationLoop
     if use_testing_data:
         evaluation_factory = testing
     elif validation is None:

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1287,11 +1287,12 @@ def _handle_evaluation(
             evaluation_loop_kwargs[key] = evaluation_kwargs.pop(key)
     evaluate_start_time = time.time()
     # TODO: what about SampledEvaluator?
+    # Note: if you want to set the inductive mode during evaluation,
+    # then it is done via the construction of the evaluator instance.
     evaluation_loop = LCWAEvaluationLoop(
         model=model_instance,
         triples_factory=evaluation_factory,
         evaluator=evaluator_instance,
-        # TODO: mode support?
         **evaluation_loop_kwargs,
     )
     metric_results = evaluation_loop.evaluate(**evaluation_kwargs)

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1285,6 +1285,7 @@ def _handle_evaluation(
     if "targets" in evaluation_kwargs:
         evaluation_loop_kwargs["targets"] = evaluation_kwargs.pop("targets")
     evaluate_start_time = time.time()
+    # TODO: what about SampledEvaluator?
     evaluation_loop = LCWAEvaluationLoop(
         triples_factory=evaluation_factory,
         evaluator=evaluator_instance,

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -18,6 +18,7 @@ from ..evaluation.evaluation_loop import LCWAEvaluationLoop
 from ..models import Model
 from ..trackers import ResultTracker
 from ..triples import CoreTriplesFactory
+from ..typing import InductiveMode
 from ..utils import fix_dataclass_init_docs
 
 __all__ = [
@@ -166,6 +167,8 @@ class EarlyStopper(Stopper):
     use_tqdm: bool = False
     #: Keyword arguments for the tqdm progress bar
     tqdm_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+    #: The inductive mode
+    mode: InductiveMode | None = None
 
     _stopper: EarlyStoppingLogic = dataclasses.field(init=False, repr=False)
 
@@ -190,7 +193,8 @@ class EarlyStopper(Stopper):
             model=self.model,
             triples_factory=self.evaluation_triples_factory,
             evaluator=self.evaluator,
-            # TODO: targets, mode?
+            mode=self.mode,
+            # TODO: targets?
             additional_filter_triples=[self.training_triples_factory.mapped_triples],
         )
 

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -121,7 +121,13 @@ class EarlyStoppingLogic:
 @fix_dataclass_init_docs
 @dataclass
 class EarlyStopper(Stopper):
-    """A harness for early stopping."""
+    """A harness for early stopping.
+
+    .. note::
+
+        If you want to use inductive modes, then they need to be
+        set during the construction of the ``evaluator``
+    """
 
     #: The model
     model: Model = dataclasses.field(repr=False)
@@ -167,8 +173,6 @@ class EarlyStopper(Stopper):
     use_tqdm: bool = False
     #: Keyword arguments for the tqdm progress bar
     tqdm_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
-    #: The inductive mode
-    mode: InductiveMode | None = None
 
     _stopper: EarlyStoppingLogic = dataclasses.field(init=False, repr=False)
 
@@ -193,7 +197,6 @@ class EarlyStopper(Stopper):
             model=self.model,
             triples_factory=self.evaluation_triples_factory,
             evaluator=self.evaluator,
-            mode=self.mode,
             # TODO: targets?
             additional_filter_triples=[self.training_triples_factory.mapped_triples],
         )

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -214,6 +214,7 @@ class EarlyStopper(Stopper):
         """Evaluate on a metric and compare to past evaluations to decide if training should stop."""
         # for mypy
         assert self.best_model_path is not None
+        # TODO: re-use LCWAEvaluationLoop instantiated once
         # Evaluate
         metric_results = self.evaluator.evaluate(
             model=self.model,

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -18,7 +18,6 @@ from ..evaluation.evaluation_loop import LCWAEvaluationLoop
 from ..models import Model
 from ..trackers import ResultTracker
 from ..triples import CoreTriplesFactory
-from ..typing import InductiveMode
 from ..utils import fix_dataclass_init_docs
 
 __all__ = [

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2170,6 +2170,12 @@ class EvaluationLoopTestCase(GenericTestCase[pykeen.evaluation.evaluation_loop.E
         batch = next(iter(self.instance.get_loader(batch_size=self.batch_size)))
         self.instance.process_batch(batch=batch)
 
+    def test_equivalence(self) -> None:
+        """Test equivalence between Evaluator.evaluate and evaluation loop."""
+        result = self.instance.evaluator.evaluate(model=self.instance.model, mapped_triples=self.factory.mapped_triples)
+        result2 = self.instance.evaluate()
+        self.assertEqual(result.to_flat_dict(), result2.to_flat_dict())
+
 
 class EvaluationOnlyModelTestCase(unittest_templates.GenericTestCase[pykeen.models.EvaluationOnlyModel]):
     """Test case for evaluation only models."""


### PR DESCRIPTION
Update the code to use `EvaluationLoop` instead of the `Evaluator.evaluate`.

`EvaluationLoop` uses a PyTorch dataset and dataloader to improve communication and computation overlap. In the filtered setting, `EvaluationLoop` precomputes the filter positions once and re-uses them next time.

Also implement support for slicing.