### PR TITLE
📐🛡️ Refactor GeometricMeanRank for improved numerical stability

### DIFF
--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -92,6 +92,7 @@ import numpy as np
 from class_resolver import ClassResolver, HintOrType
 from docdata import parse_docdata
 from scipy import stats
+from scipy.special import expm1
 
 from .utils import (
     Metric,
@@ -891,6 +892,101 @@ class InverseArithmeticMeanRank(RankBasedMetric):
         return np.reciprocal(np.average(np.asanyarray(ranks), weights=weights)).item()
 
 
+def _compute_log_expected_power(k_values: np.ndarray, powers: np.ndarray, memory_limit_elements: int = 10**7) -> float:
+    """
+    Compute $sum( ln( E[X_i^p_i] ) )$.
+
+    Does so efficiently by using sorted batching and vectorization.
+
+    :param k_values: shape: (n,)
+        Upper bounds.
+    :param powers: shape: (n,)
+        Exponents.
+    :param memory_limit_elements:
+        Max number of float elements in the temporary matrix buffer.
+        10^7 elements ~ 80MB RAM.
+
+    :return:
+        The scalar log-value.
+    """
+    # 1. Sort inputs by k.
+    # This minimizes the 'masking waste' when we batch variables together.
+    # Small k's are processed with small k's; large with large.
+    sort_idx = np.argsort(k_values)
+    k_sorted = np.asarray(k_values)[sort_idx]
+    p_sorted = np.asarray(powers)[sort_idx]
+
+    n = len(k_sorted)
+    total_log_moment = 0.0
+
+    start_idx = 0
+    while start_idx < n:
+        # 2. Determine Batch Size dynamically based on Memory Limit.
+        # We want to find 'end_idx' such that:
+        # (rows in batch) * (max_k in batch) <= memory_limit
+        # Since k is sorted ascending, max_k_in_batch is simply k_sorted[end_idx-1].
+
+        end_idx = start_idx + 1
+
+        # We peek ahead to see how many rows we can fit.
+        # This is a heuristic: we check if adding the next block of rows
+        # would explode the matrix size required.
+        while end_idx < n:
+            current_max_k = k_sorted[end_idx]  # This would be the new width
+            current_rows = end_idx - start_idx + 1
+
+            # Check budget
+            if current_rows * current_max_k > memory_limit_elements:
+                break
+            end_idx += 1
+
+        # 3. Process the Batch
+        k_batch = k_sorted[start_idx:end_idx]
+        p_batch = p_sorted[start_idx:end_idx]
+
+        # Max k in this specific batch (determines matrix columns)
+        max_k_batch = int(k_batch[-1])
+
+        # TODO: check if we are 0- or 1-based
+        # Create base grid [1, 2, ..., max_k_batch]
+        # Shape: (1, max_k)
+        j_grid = np.arange(1, max_k_batch + 1, dtype=np.float64).reshape(1, -1)
+
+        # Reshape powers for broadcasting
+        # Shape: (batch_rows, 1)
+        p_col = p_batch.reshape(-1, 1)
+
+        # 4. Compute Powers (Broadcasting)
+        # Matrix Result: (batch_rows, max_k)
+        # value[i, j] = (j+1) ^ p_i
+        values = j_grid**p_col
+
+        # 5. Masking
+        # Since k is sorted, we have a "lower triangular" style validity mask
+        # (roughly), but strictly we just need to zero out j > k_i.
+        # Shape: (batch_rows, 1) compared to (1, max_k)
+        mask = j_grid <= k_batch.reshape(-1, 1)
+
+        # Apply mask (zero out values strictly greater than k_i)
+        # We use 'where' or multiplication. Multiplication is faster for floats usually.
+        values *= mask
+
+        # 6. Summation
+        # Sum along columns to get sum(j^p) for each variable
+        row_sums = np.sum(values, axis=1)
+
+        # Compute log terms: log(sum) - log(k)
+        # We use np.log with a safety for the 0 sums (though sums of j^p >= 1 are never 0)
+        batch_log_moments = np.log(row_sums) - np.log(k_batch)
+
+        total_log_moment += np.sum(batch_log_moments)
+
+        # Move to next batch
+        start_idx = end_idx
+
+    return total_log_moment
+
+
 @parse_docdata
 class GeometricMeanRank(RankBasedMetric):
     r"""The (weighted) geometric mean rank.
@@ -958,6 +1054,14 @@ class GeometricMeanRank(RankBasedMetric):
     ) -> float:  # noqa: D102
         return stats.gmean(ranks, weights=weights).item()
 
+    @staticmethod
+    def _normalize_weights(weights: np.ndarray | None, n: int) -> np.ndarray:
+        if weights is None:
+            return np.full(shape=n, fill_value=1 / n)
+        total = np.sum(weights)
+        safe_total = np.clip(total, a_min=np.finfo(weights.dtype).eps, a_max=None)
+        return weights / safe_total
+
     # docstr-coverage: inherited
     def expected_value(
         self,
@@ -966,8 +1070,13 @@ class GeometricMeanRank(RankBasedMetric):
         weights: np.ndarray | None = None,
         **kwargs,
     ) -> float:  # noqa: D102
-        is_log, individual = self._individual_expectation(num_candidates=num_candidates, weights=weights)
-        return stable_product(individual, is_log=is_log).item()
+        alpha = self._normalize_weights(weights, n=len(num_candidates))
+
+        # E[G] = Product( E[ X_i^alpha_i ] )
+        # We calculate this in log space
+        log_expectation = _compute_log_expected_power(num_candidates, powers=alpha)
+
+        return np.exp(log_expectation)
 
     # docstr-coverage: inherited
     def variance(
@@ -977,61 +1086,28 @@ class GeometricMeanRank(RankBasedMetric):
         weights: np.ndarray | None = None,
         **kwargs,
     ) -> float:  # noqa: D102
-        # V (prod x_i) = prod (V[x_i] - E[x_i]^2) - prod(E[x_i])^2
-        is_log, individual_expectation = self._individual_expectation(num_candidates=num_candidates, weights=weights)
-        if is_log:
-            individual_expectation = np.exp(individual_expectation)
-        individual_variance = self._individual_variance(
-            num_candidates=num_candidates, weights=weights, individual_expectation=individual_expectation
-        )
-        return (
-            stable_product(individual_variance + individual_expectation**2)
-            - stable_product(individual_expectation) ** 2
-        )
+        alpha = self._normalize_weights(weights, n=len(num_candidates))
 
-    @classmethod
-    def _individual_variance(
-        cls, num_candidates: np.ndarray, weights: np.ndarray | None, individual_expectation: np.ndarray
-    ) -> np.ndarray:
-        # use V[x] = E[x^2] - E[x]^2
-        x2 = (
-            np.exp(cls._log_individual_expectation_no_weight(num_candidates=num_candidates, factor=2.0))
-            if weights is None
-            else cls._individual_expectation_weighted(num_candidates=num_candidates, weights=weights, factor=2.0)
-        )
-        return x2 - individual_expectation**2
+        # 1. Calculate Log of First Moment E[G]
+        # Power p = alpha
+        log_expectation = _compute_log_expected_power(num_candidates, alpha)
 
-    @classmethod
-    def _individual_expectation(cls, num_candidates: np.ndarray, weights: np.ndarray | None) -> tuple[bool, np.ndarray]:
-        if weights is None:
-            return True, cls._log_individual_expectation_no_weight(num_candidates=num_candidates)
-        return False, cls._individual_expectation_weighted(num_candidates=num_candidates, weights=weights)
+        # 2. Calculate Log of Second Moment E[G^2]
+        # Power p = 2 * alpha
+        log_squared_expectation = _compute_log_expected_power(num_candidates, 2 * alpha)
 
-    @staticmethod
-    def _individual_expectation_weighted(
-        num_candidates: np.ndarray, weights: np.ndarray, factor: float = 1.0
-    ) -> np.ndarray:
-        weights = factor * weights / weights.sum()
-        x = np.empty_like(weights)
-        # group by same weight -> compute H_w(n) for multiple n at once
-        unique_weights, inverse = np.unique(weights, return_inverse=True)
-        for i, w in enumerate(unique_weights):
-            mask = inverse == i
-            nc = num_candidates[mask]
-            h = generalized_harmonic_numbers(nc.max(), p=w)
-            x[mask] = h[nc - 1] / nc
-        return x
+        # 3. Calculate Variance using Expm1 for stability
+        # Var = E[G^2] - (E[G])^2
+        #     = exp(log_E_G2) - exp(2 * log_E_G)
+        #     = exp(2 * log_E_G) * [ exp(log_E_G2 - 2*log_E_G) - 1 ]
 
-    @staticmethod
-    def _log_individual_expectation_no_weight(num_candidates: np.ndarray, factor: float = 1.0) -> np.ndarray:
-        m = num_candidates.size
-        # we compute log E[r_i^(1/m)] for all N_i = 1 ... max_N_i once
-        max_val = num_candidates.max()
-        x = np.arange(1, max_val + 1, dtype=float)
-        x = factor * np.log(x) / m
-        x = logcumsumexp(x)
-        # now select from precomputed cumulative sums and aggregate
-        return x[num_candidates - 1] - np.log(num_candidates)
+        log_diff = log_squared_expectation - (2 * log_expectation)
+
+        # Clamp negative zero errors (floating point noise)
+        if log_diff < 0:
+            log_diff = 0.0
+
+        return np.exp(2 * log_expectation) * expm1(log_diff)
 
 
 @parse_docdata

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -96,14 +96,12 @@ from scipy import stats
 from .utils import (
     Metric,
     ValueRange,
-    stable_product,
     weighted_harmonic_mean,
     weighted_mean_expectation,
     weighted_mean_variance,
     weighted_median,
 )
 from ..typing import RANK_REALISTIC, RANK_TYPES, RankType
-from ..utils import logcumsumexp
 
 __all__ = [
     "rank_based_metric_resolver",
@@ -1349,7 +1347,7 @@ class InverseMedianRank(RankBasedMetric):
     def __call__(
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
-        return np.reciprocal(weighted_median(a=ranks, weights=weights)).item()
+        return np.reciprocal(weighted_median(a=ranks, weights=weights), dtype=float).item()
 
 
 @parse_docdata

--- a/src/pykeen/metrics/utils.py
+++ b/src/pykeen/metrics/utils.py
@@ -13,7 +13,6 @@ from ..utils import ExtraReprMixin, camel_to_snake
 __all__ = [
     "Metric",
     "ValueRange",
-    "stable_product",
     "weighted_mean_expectation",
     "weighted_mean_variance",
     "weighted_harmonic_mean",

--- a/src/pykeen/metrics/utils.py
+++ b/src/pykeen/metrics/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     "weighted_mean_variance",
     "weighted_harmonic_mean",
     "weighted_median",
+    "compute_log_expected_power",
 ]
 
 
@@ -257,3 +258,98 @@ def weighted_median(a: np.ndarray, weights: np.ndarray | None = None) -> np.ndar
     if cdf[idx] == 0.5:
         return s_ranks[idx : idx + 2].mean()
     return s_ranks[idx]
+
+
+def compute_log_expected_power(k_values: np.ndarray, powers: np.ndarray, memory_limit_elements: int = 10**7) -> float:
+    """
+    Compute $sum( ln( E[X_i^p_i] ) )$.
+
+    Does so efficiently by using sorted batching and vectorization.
+
+    :param k_values: shape: (n,)
+        Upper bounds.
+    :param powers: shape: (n,)
+        Exponents.
+    :param memory_limit_elements:
+        Max number of float elements in the temporary matrix buffer.
+        10^7 elements ~ 80MB RAM.
+
+    :return:
+        The scalar log-value.
+    """
+    # 1. Sort inputs by k.
+    # This minimizes the 'masking waste' when we batch variables together.
+    # Small k's are processed with small k's; large with large.
+    sort_idx = np.argsort(k_values)
+    k_sorted = np.asarray(k_values)[sort_idx]
+    p_sorted = np.asarray(powers)[sort_idx]
+
+    n = len(k_sorted)
+    total_log_moment = 0.0
+
+    start_idx = 0
+    while start_idx < n:
+        # 2. Determine Batch Size dynamically based on Memory Limit.
+        # We want to find 'end_idx' such that:
+        # (rows in batch) * (max_k in batch) <= memory_limit
+        # Since k is sorted ascending, max_k_in_batch is simply k_sorted[end_idx-1].
+
+        end_idx = start_idx + 1
+
+        # We peek ahead to see how many rows we can fit.
+        # This is a heuristic: we check if adding the next block of rows
+        # would explode the matrix size required.
+        while end_idx < n:
+            current_max_k = k_sorted[end_idx]  # This would be the new width
+            current_rows = end_idx - start_idx + 1
+
+            # Check budget
+            if current_rows * current_max_k > memory_limit_elements:
+                break
+            end_idx += 1
+
+        # 3. Process the Batch
+        k_batch = k_sorted[start_idx:end_idx]
+        p_batch = p_sorted[start_idx:end_idx]
+
+        # Max k in this specific batch (determines matrix columns)
+        max_k_batch = int(k_batch[-1])
+
+        # TODO: check if we are 0- or 1-based
+        # Create base grid [1, 2, ..., max_k_batch]
+        # Shape: (1, max_k)
+        j_grid = np.arange(1, max_k_batch + 1, dtype=np.float64).reshape(1, -1)
+
+        # Reshape powers for broadcasting
+        # Shape: (batch_rows, 1)
+        p_col = p_batch.reshape(-1, 1)
+
+        # 4. Compute Powers (Broadcasting)
+        # Matrix Result: (batch_rows, max_k)
+        # value[i, j] = (j+1) ^ p_i
+        values = j_grid**p_col
+
+        # 5. Masking
+        # Since k is sorted, we have a "lower triangular" style validity mask
+        # (roughly), but strictly we just need to zero out j > k_i.
+        # Shape: (batch_rows, 1) compared to (1, max_k)
+        mask = j_grid <= k_batch.reshape(-1, 1)
+
+        # Apply mask (zero out values strictly greater than k_i)
+        # We use 'where' or multiplication. Multiplication is faster for floats usually.
+        values *= mask
+
+        # 6. Summation
+        # Sum along columns to get sum(j^p) for each variable
+        row_sums = np.sum(values, axis=1)
+
+        # Compute log terms: log(sum) - log(k)
+        # We use np.log with a safety for the 0 sums (though sums of j^p >= 1 are never 0)
+        batch_log_moments = np.log(row_sums) - np.log(k_batch)
+
+        total_log_moment += np.sum(batch_log_moments)
+
+        # Move to next batch
+        start_idx = end_idx
+
+    return total_log_moment

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2362,8 +2362,7 @@ class RankBasedMetricTestCase(unittest_templates.GenericTestCase[RankBasedMetric
         weights = repeats.astype(float)
         value_weighted = self.instance(ranks=self.ranks, num_candidates=self.num_candidates, weights=weights)
 
-        # TODO: abs=2 recovers the previous value passed to assertAlmostEqual, but is a wild tolerance...
-        assert value_repeat == pytest.approx(value_weighted, abs=2), (value_repeat, value_weighted)
+        assert value_repeat == pytest.approx(value_weighted), (value_repeat, value_weighted)
 
 
 class MetricResultTestCase(unittest_templates.GenericTestCase[MetricResults]):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2365,6 +2365,14 @@ class RankBasedMetricTestCase(unittest_templates.GenericTestCase[RankBasedMetric
         assert value_repeat == pytest.approx(value_weighted), (value_repeat, value_weighted)
 
 
+class ZRankBasedMetricTestCase(RankBasedMetricTestCase):
+    """Test cases for z-normalized metrics."""
+
+    # docstr-coverage: inherited
+    def test_weights_coherence(self):  # noqa: D102
+        raise unittest.SkipTest("Z-normalized metrics do not work well with the sampling weight interpretation.")
+
+
 class MetricResultTestCase(unittest_templates.GenericTestCase[MetricResults]):
     """Test for metric results."""
 

--- a/tests/test_evaluation/test_rank_based_metrics.py
+++ b/tests/test_evaluation/test_rank_based_metrics.py
@@ -12,7 +12,6 @@ from scipy.stats import bootstrap
 import pykeen.metrics.ranking
 from pykeen.metrics.ranking import generalized_harmonic_numbers, harmonic_variances
 from pykeen.metrics.utils import (
-    stable_product,
     weighted_harmonic_mean,
     weighted_mean_expectation,
     weighted_mean_variance,
@@ -249,17 +248,3 @@ class WeightedTests(unittest.TestCase):
     def test_weighted_mean_variance(self):
         """Test weighted mean variance."""
         self._test_weighted_mean_moment(closed_form=weighted_mean_variance, statistic=numpy.var, key="scale")
-
-
-def test_stable_product():
-    """Test stable_product."""
-    generator = numpy.random.default_rng(seed=0)
-    array = generator.random(size=(13,))
-
-    # positive values only
-    numpy.testing.assert_almost_equal(stable_product(array), numpy.prod(array))
-    numpy.testing.assert_almost_equal(stable_product(np.log(array), is_log=True), numpy.prod(array))
-
-    # positive and negative values
-    array = 2 * array - 1
-    numpy.testing.assert_almost_equal(stable_product(array), numpy.prod(array))

--- a/tests/test_evaluation/test_rank_based_metrics.py
+++ b/tests/test_evaluation/test_rank_based_metrics.py
@@ -142,6 +142,9 @@ class MedianAbsoluteDeviationTests(cases.RankBasedMetricTestCase):
 
     cls = pykeen.metrics.ranking.MedianAbsoluteDeviation
 
+    def test_weights_direction(self) -> None:
+        raise unittest.SkipTest("Test does not make sense to dispersion metrics")
+
 
 class MedianRankTests(cases.RankBasedMetricTestCase):
     """Tests for median rank."""

--- a/tests/test_evaluation/test_rank_based_metrics.py
+++ b/tests/test_evaluation/test_rank_based_metrics.py
@@ -33,7 +33,7 @@ class AdjustedArithmeticMeanRankIndexTests(cases.RankBasedMetricTestCase):
     cls = pykeen.metrics.ranking.AdjustedArithmeticMeanRankIndex
 
 
-class ZInverseHarmonicMeanRankTests(cases.RankBasedMetricTestCase):
+class ZInverseHarmonicMeanRankTests(cases.ZRankBasedMetricTestCase):
     """Tests for adjusted MRR."""
 
     cls = pykeen.metrics.ranking.ZInverseHarmonicMeanRank
@@ -57,7 +57,7 @@ class ArithmeticMeanRankTests(cases.RankBasedMetricTestCase):
     cls = pykeen.metrics.ranking.ArithmeticMeanRank
 
 
-class ZArithmeticMeanRankTests(cases.RankBasedMetricTestCase):
+class ZArithmeticMeanRankTests(cases.ZRankBasedMetricTestCase):
     """Tests for z-scored arithmetic mean rank."""
 
     cls = pykeen.metrics.ranking.ZArithmeticMeanRank
@@ -85,14 +85,10 @@ class AdjustedGeometricMeanRankIndexTests(cases.RankBasedMetricTestCase):
         raise unittest.SkipTest("The weights of a geometric mean do not represent sample weights.")
 
 
-class ZGeometricMeanRankTests(cases.RankBasedMetricTestCase):
+class ZGeometricMeanRankTests(cases.ZRankBasedMetricTestCase):
     """Tests for z-geometric mean rank."""
 
     cls = pykeen.metrics.ranking.ZGeometricMeanRank
-
-    def test_weights_coherence(self) -> None:
-        # TODO: do we want this interpretation?
-        raise unittest.SkipTest("The weights of a geometric mean do not represent sample weights.")
 
 
 class HarmonicMeanRankTests(cases.RankBasedMetricTestCase):
@@ -107,7 +103,7 @@ class HitsAtKTests(cases.RankBasedMetricTestCase):
     cls = pykeen.metrics.ranking.HitsAtK
 
 
-class ZHitsAtKTests(cases.RankBasedMetricTestCase):
+class ZHitsAtKTests(cases.ZRankBasedMetricTestCase):
     """Tests for z-scored hits at k."""
 
     cls = pykeen.metrics.ranking.ZHitsAtK

--- a/tests/test_evaluation/test_rank_based_metrics.py
+++ b/tests/test_evaluation/test_rank_based_metrics.py
@@ -139,6 +139,10 @@ class MedianAbsoluteDeviationTests(cases.RankBasedMetricTestCase):
 
     cls = pykeen.metrics.ranking.MedianAbsoluteDeviation
 
+    # docstr-coverage: inherited
+    def test_weights_coherence(self):  # noqa: D102
+        raise unittest.SkipTest("Does not work well with the sampling weight interpretation.")
+
     def test_weights_direction(self) -> None:
         raise unittest.SkipTest("Test does not make sense to dispersion metrics")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,7 +28,6 @@ from pykeen.utils import (
     get_optimal_sequence,
     get_until_first_blank,
     iter_weisfeiler_lehman,
-    logcumsumexp,
     merge_kwargs,
     project_entity,
     set_random_seed,
@@ -336,14 +335,6 @@ class TestUtils(unittest.TestCase):
 
             # compare result to sequential addition
             assert torch.allclose(result, functools.reduce(operator.mul, tensors[1:], tensors[0]))
-
-    def test_logcumsumexp(self):
-        """Verify that our numpy implementation gives the same results as the torch variant."""
-        generator = numpy.random.default_rng(seed=42)
-        a = generator.random(size=(21,))
-        r1 = logcumsumexp(a)
-        r2 = torch.logcumsumexp(torch.as_tensor(a), dim=0).numpy()
-        numpy.testing.assert_allclose(r1, r2)
 
     def test_weisfeiler_lehman(self):
         """Test Weisfeiler Lehman."""


### PR DESCRIPTION
- Refactor log-space computation that can be used for both expected values & variance
- calculate variance completely in logspace
- normalize weights first (which simplifies some code)
- Tighten test tolerance in `test_weights_coherence` (remove abs=2)

Part 3 of https://github.com/pykeen/pykeen/pull/1558