### PR TITLE
🪨🌀 Add weight support to dispersion metrics

### DIFF
--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -681,8 +681,8 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
     @classmethod
     def _iter_default_metrics(cls) -> Iterable[tuple[HintOrType[RankBasedMetric], OptionalKwargs]]:
         for metric, kwargs in super()._iter_default_metrics():
-            cls = rank_based_metric_resolver.lookup(metric)
-            if cls.supports_weights:
+            metric_cls = rank_based_metric_resolver.lookup(metric)
+            if metric_cls.supports_weights:
                 yield metric, kwargs
 
     @staticmethod

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -1400,6 +1400,7 @@ class Variance(RankBasedMetric):
     where $\bar{r} = \frac{\sum_{i=1}^{n} w_i r_i}{\sum_{j=1}^{n} w_j}$ is the weighted mean.
 
     .. note::
+
         This computes the variance of the **observed weighted sample**, not the variance of the weighted mean
         (which is computed by :func:`weighted_mean_variance` and used in metric expected value/variance calculations).
 
@@ -1461,6 +1462,7 @@ class Count(RankBasedMetric):
     Lower numbers may indicate unreliable results.
 
     .. note::
+
         This metric does not support weights. The count is defined as the number of rank observations,
         not a weighted sum. If you need to track weighted sample sizes, consider using the sum of weights
         separately.

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -151,6 +151,7 @@ __all__ = [
     "HITS_METRICS",
     "WEIGHTED_MEDIAN_SCALE",
     "EPSILON",
+    "NoWeightSupportError",
 ]
 
 #: A small value to help avoid dividing by zero
@@ -1587,6 +1588,10 @@ class MedianAbsoluteDeviation(RankBasedMetric):
         return weighted_median(a=abs_diff_from_median, weights=weights).item() / WEIGHTED_MEDIAN_SCALE
 
 
+class NoWeightSupportError(ValueError):
+    """The metric does not support weights."""
+
+
 @parse_docdata
 class Count(RankBasedMetric):
     """The ranks' count.
@@ -1615,7 +1620,7 @@ class Count(RankBasedMetric):
     ) -> float:  # noqa: D102
         # TODO: should we return the sum of weights?
         if weights is not None:
-            raise ValueError(
+            raise NoWeightSupportError(
                 f"{self.__class__.__name__} does not support weights. Count is the number of observations."
             )
         return float(np.asanyarray(ranks).size)

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -156,8 +156,8 @@ __all__ = [
 #: A small value to help avoid dividing by zero
 EPSILON = 1.0e-12
 
-#: note: scale="normal", means that we divide by inverse of the standard normal
-#: quantile function at 0.75, which is approximately 0.67449.
+#: The consistency constant for MAD with scale="normal": the 0.75 quantile of the
+#: standard normal distribution (Φ^(-1)(0.75))
 WEIGHTED_MEDIAN_SCALE = 0.67449
 
 

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -149,9 +149,16 @@ __all__ = [
     "harmonic_variances",
     #
     "HITS_METRICS",
+    "WEIGHTED_MEDIAN_SCALE",
+    "EPSILON",
 ]
 
+#: A small value to help avoid dividing by zero
 EPSILON = 1.0e-12
+
+#: note: scale="normal", means that we divide by inverse of the standard normal
+#: quantile function at 0.75, which is approximately 0.67449.
+WEIGHTED_MEDIAN_SCALE = 0.67449
 
 
 def generate_ranks(
@@ -1556,10 +1563,8 @@ class MedianAbsoluteDeviation(RankBasedMetric):
 
         median = weighted_median(a=ranks, weights=weights)
         abs_diff_from_median = np.abs(ranks - median)
-        # note: scale="normal", means that we divide by inverse of the standard normal
-        # quantile function at 0.75, which is approximately 0.67449.
-        scale = 0.67449
-        return weighted_median(a=abs_diff_from_median, weights=weights).item() / scale
+
+        return weighted_median(a=abs_diff_from_median, weights=weights).item() / WEIGHTED_MEDIAN_SCALE
 
 
 @parse_docdata

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -1463,13 +1463,15 @@ class InverseMedianRank(RankBasedMetric):
 class StandardDeviation(RankBasedMetric):
     r"""The ranks' standard deviation.
 
-    For weighted standard deviation, the calculation uses:
+    For individual ranks $\{r_i\}_{i=1}^n$ with weights $\{w_i\}_{i=1}^n$ (defaulting to
+    $w_i = 1/n$ when not explicitly provided), and letting $W = \sum_{i=1}^n w_i$ denote
+    the sum of weights, the weighted standard deviation is:
 
     .. math::
 
-        \sigma = \sqrt{\frac{\sum_{i=1}^{n} w_i (r_i - \bar{r})^2}{\sum_{j=1}^{n} w_j}}
+        \sigma = \sqrt{\frac{1}{W} \sum_{i=1}^{n} w_i (r_i - \bar{r})^2}
 
-    where $\bar{r} = \frac{\sum_{i=1}^{n} w_i r_i}{\sum_{j=1}^{n} w_j}$ is the weighted mean.
+    where $\bar{r} = \frac{1}{W} \sum_{i=1}^{n} w_i r_i$ is the weighted mean.
 
     ---
     link: https://pykeen.readthedocs.io/en/stable/tutorial/understanding_evaluation.html
@@ -1498,13 +1500,15 @@ class StandardDeviation(RankBasedMetric):
 class Variance(RankBasedMetric):
     r"""The ranks' variance.
 
-    For weighted variance, the calculation uses:
+    For individual ranks $\{r_i\}_{i=1}^n$ with weights $\{w_i\}_{i=1}^n$ (defaulting to
+    $w_i = 1/n$ when not explicitly provided), and letting $W = \sum_{i=1}^n w_i$ denote
+    the sum of weights, the weighted variance is:
 
     .. math::
 
-        \sigma^2 = \frac{\sum_{i=1}^{n} w_i (r_i - \bar{r})^2}{\sum_{j=1}^{n} w_j}
+        \sigma^2 = \frac{1}{W} \sum_{i=1}^{n} w_i (r_i - \bar{r})^2
 
-    where $\bar{r} = \frac{\sum_{i=1}^{n} w_i r_i}{\sum_{j=1}^{n} w_j}$ is the weighted mean.
+    where $\bar{r} = \frac{1}{W} \sum_{i=1}^{n} w_i r_i$ is the weighted mean.
 
     .. note::
 
@@ -1535,7 +1539,23 @@ class Variance(RankBasedMetric):
 
 @parse_docdata
 class MedianAbsoluteDeviation(RankBasedMetric):
-    """The ranks' median absolute deviation (MAD).
+    r"""The ranks' median absolute deviation (MAD).
+
+    For individual ranks $\{r_i\}_{i=1}^n$ with optional weights $\{w_i\}_{i=1}^n$, the
+    median absolute deviation is defined as:
+
+    .. math::
+
+        MAD = \frac{\text{median}_w(|r_i - \text{median}_w(r)|)}{c}
+
+    where $\text{median}_w$ denotes the weighted median and $c \approx 0.67449$ is a
+    consistency constant equal to the 0.75 quantile of the standard normal distribution
+    (i.e., $\Phi^{-1}(0.75)$), ensuring that MAD estimates the standard deviation for
+    normally distributed data.
+
+    When weights are not provided, this reduces to the standard (unweighted) median
+    absolute deviation computed via :func:`scipy.stats.median_abs_deviation` with
+    ``scale='normal'``.
 
     ---
     link: https://pykeen.readthedocs.io/en/stable/tutorial/understanding_evaluation.html

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2242,6 +2242,7 @@ class RankBasedMetricTestCase(unittest_templates.GenericTestCase[RankBasedMetric
 
     def test_increasing(self):
         """Test correct increasing annotation."""
+        # TODO: this does not necessarily hold for dispersion metrics (std, var)
         x, y = (
             self.instance(ranks=ranks, num_candidates=self.num_candidates)
             for ranks in [
@@ -2330,6 +2331,7 @@ class RankBasedMetricTestCase(unittest_templates.GenericTestCase[RankBasedMetric
 
     def test_weights_direction(self):
         """Test monotonicity of weighting."""
+        # TODO: this does not necessarily hold for dispersion metrics (std, var)
         if not self.instance.supports_weights:
             raise SkipTest(f"{self.instance} does not support weights")
 

--- a/tests/test_evaluation/test_rank_based_metrics.py
+++ b/tests/test_evaluation/test_rank_based_metrics.py
@@ -146,11 +146,17 @@ class StandardDeviationTests(cases.RankBasedMetricTestCase):
 
     cls = pykeen.metrics.ranking.StandardDeviation
 
+    def test_weights_direction(self) -> None:
+        raise unittest.SkipTest("Test does not make sense to dispersion metrics")
+
 
 class VarianceTests(cases.RankBasedMetricTestCase):
     """Tests for rank variance."""
 
     cls = pykeen.metrics.ranking.Variance
+
+    def test_weights_direction(self) -> None:
+        raise unittest.SkipTest("Test does not make sense to dispersion metrics")
 
 
 class RankBasedMetricsTest(unittest_templates.MetaTestCase[pykeen.metrics.ranking.RankBasedMetric]):


### PR DESCRIPTION
- Add weighted standard deviation support with proper formula
- Add weighted variance support with clear documentation distinguishing from weighted_mean_variance
- Fix `MedianAbsoluteDeviation` weighted case to apply correct scale factor (0.67449)
- (Make `Count` explicitly reject weights with clear error message)
- Skip `test_weights_direction` for `StandardDeviation` and `Variance` (dispersion metrics don't follow monotonicity)

Part 2 of https://github.com/pykeen/pykeen/pull/1558