### PR TITLE
⬆️📌 Bump pystow version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "tabulate",
     "more_click",
     "more_itertools",
-    "pystow>=0.4.3,<0.8",
+    "pystow>=0.8.4",
     "docdata>=0.0.5",
     "class_resolver>=0.6.0",
     "pyyaml",


### PR DESCRIPTION
[v0.8.4](https://github.com/cthoyt/pystow/releases/tag/v0.8.4) fixes the issue that necessitated the `<0.8` upper pin.