### PR TITLE
🩹🌐 Fix flaky Wikidata representation tests by mocking live network calls

### DIFF
--- a/src/pykeen/nn/vision/representation.py
+++ b/src/pykeen/nn/vision/representation.py
@@ -214,7 +214,12 @@ class WikidataVisualRepresentation(BackfillRepresentation):
     """
 
     def __init__(
-        self, wikidata_ids: Sequence[str], max_id: int | None = None, image_kwargs: OptionalKwargs = None, **kwargs
+        self,
+        wikidata_ids: Sequence[str],
+        max_id: int | None = None,
+        image_kwargs: OptionalKwargs = None,
+        cache: WikidataImageCache | None = None,
+        **kwargs,
     ):
         """Initialize the representation.
 
@@ -222,6 +227,7 @@ class WikidataVisualRepresentation(BackfillRepresentation):
         :param max_id: The total number of IDs. If provided, must match the length of ``wikidata_ids``.
         :param image_kwargs: Keyword-based parameters passed to
             :meth:`pykeen.nn.vision.cache.WikidataImageCache.get_image_paths`.
+        :param cache: A pre-instantiated image cache. If None, :class:`WikidataImageCache` is used.
         :param kwargs: Additional keyword-based parameters passed to
             :class:`pykeen.nn.vision.representation.VisualRepresentation`.
 
@@ -230,7 +236,8 @@ class WikidataVisualRepresentation(BackfillRepresentation):
         max_id = max_id or len(wikidata_ids)
         if len(wikidata_ids) != max_id:
             raise ValueError(f"Inconsistent max_id={max_id} vs. len(wikidata_ids)={len(wikidata_ids)}")
-        images = WikidataImageCache().get_image_paths(wikidata_ids, **(image_kwargs or {}))
+        cache = cache or WikidataImageCache()
+        images = cache.get_image_paths(wikidata_ids, **(image_kwargs or {}))
         base_ids = [i for i, path in enumerate(images) if path is not None]
         images = [path for path in images if path is not None]
         super().__init__(

--- a/tests/test_nn/test_representation.py
+++ b/tests/test_nn/test_representation.py
@@ -1,11 +1,15 @@
 """Test embeddings."""
 
+import pathlib
+import tempfile
 from collections import ChainMap
 from collections.abc import MutableMapping
 from typing import Any, ClassVar
+from unittest.mock import MagicMock
 
 import numpy
 import pytest
+from PIL import Image
 import torch
 import unittest_templates
 
@@ -300,6 +304,14 @@ class WikidataVisualRepresentationTestCase(cases.RepresentationTestCase):
         kwargs = super()._pre_instantiation_hook(kwargs)
         kwargs.pop("max_id")
         self.max_id = len(kwargs["wikidata_ids"])
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        fake_image_path = pathlib.Path(self._tmp.name) / "fake.jpg"
+        Image.new("RGB", (256, 256)).save(fake_image_path)
+        wikidata_ids = kwargs["wikidata_ids"]
+        mock_cache = MagicMock()
+        mock_cache.get_image_paths.return_value = [fake_image_path] * (len(wikidata_ids) - 1) + [None]
+        kwargs["cache"] = mock_cache
         return kwargs
 
 
@@ -330,6 +342,9 @@ class WikidataTextRepresentationTests(cases.RepresentationTestCase):
         # the representation module infers the max_id from the provided labels
         kwargs.pop("max_id")
         self.max_id = len(kwargs["identifiers"])
+        mock_cache = MagicMock()
+        mock_cache.get_texts.return_value = list(kwargs["identifiers"])
+        kwargs["cache"] = mock_cache
         return kwargs
 
 
@@ -352,6 +367,9 @@ class BiomedicalCURIERepresentationTests(cases.RepresentationTestCase):
         # the representation module infers the max_id from the provided labels
         kwargs.pop("max_id")
         self.max_id = len(kwargs["identifiers"])
+        mock_cache = MagicMock()
+        mock_cache.get_texts.return_value = list(kwargs["identifiers"])
+        kwargs["cache"] = mock_cache
         return kwargs
 
 


### PR DESCRIPTION
Fix https://github.com/pykeen/pykeen/issues/1585

## Summary

- Add optional `cache` parameter to `WikidataVisualRepresentation.__init__` to allow injecting a pre-built cache, mirroring the existing pattern in `CachedTextRepresentation`
- Mock the cache in `WikidataTextRepresentationTests`, `WikidataVisualRepresentationTestCase`, and `BiomedicalCURIERepresentationTests` so no live network requests are made during the fast test suite