### PR TITLE
🩹🎯 Forward evaluation_kwargs to early stopper (#1587)

### DIFF
--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1154,6 +1154,11 @@ def _handle_training(
     _evaluation_batch_size = evaluation_kwargs.get("batch_size")
     if _evaluation_batch_size is not None:
         stopper_kwargs.setdefault("evaluation_batch_size", _evaluation_batch_size)
+    # Forward remaining evaluation_kwargs (e.g., targets) to the stopper so that
+    # validation runs during early stopping use the same settings as the final evaluation.
+    _stopper_evaluation_kwargs = {k: v for k, v in evaluation_kwargs.items() if k not in ("batch_size", "slice_size")}
+    if _stopper_evaluation_kwargs:
+        stopper_kwargs.setdefault("evaluation_kwargs", _stopper_evaluation_kwargs)
 
     stopper_instance: Stopper = stopper_resolver.make(
         stopper,

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -165,6 +165,9 @@ class EarlyStopper(Stopper):
     use_tqdm: bool = False
     #: Keyword arguments for the tqdm progress bar
     tqdm_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+    #: Additional keyword arguments passed to :meth:`pykeen.evaluation.Evaluator.evaluate`.
+    #: Do not include ``batch_size`` or ``slice_size`` here; use the dedicated fields instead.
+    evaluation_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
 
     _stopper: EarlyStoppingLogic = dataclasses.field(init=False, repr=False)
 
@@ -225,6 +228,7 @@ class EarlyStopper(Stopper):
             slice_size=self.evaluation_slice_size,
             # Only perform time-consuming checks for the first call.
             do_time_consuming_checks=self.evaluation_batch_size is None,
+            **self.evaluation_kwargs,
         )
         # After the first evaluation pass the optimal batch and slice size is obtained and saved for re-use
         self.evaluation_batch_size = self.evaluator.batch_size

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -167,10 +167,10 @@ def test_pipeline_forwards_evaluation_kwargs_to_stopper():
         pipeline(
             dataset="nations",
             model="TransE",
-            training_kwargs=dict(num_epochs=2),
-            evaluation_kwargs=dict(targets=targets),
+            training_kwargs={"num_epochs": 2},
+            evaluation_kwargs={"targets": targets},
             stopper="early",
-            stopper_kwargs=dict(frequency=1, patience=100),
+            stopper_kwargs={"frequency": 1, "patience": 100},
             use_testing_data=False,
         )
 

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -1,6 +1,7 @@
 """Tests of early stopping."""
 
 import unittest
+from unittest.mock import patch
 
 import numpy
 import pytest
@@ -10,7 +11,9 @@ from torch.optim import Adam
 
 from pykeen.datasets import Nations
 from pykeen.evaluation import RankBasedEvaluator
+from pykeen.evaluation.evaluator import Evaluator
 from pykeen.models import Model, TransE
+from pykeen.pipeline import pipeline
 from pykeen.stoppers.early_stopping import EarlyStopper, EarlyStoppingLogic, is_improvement
 from pykeen.training import SLCWATrainingLoop
 from tests import cases
@@ -144,3 +147,33 @@ class TestEarlyStopperRealWorld(unittest.TestCase):
         assert stopper.number_results == len(losses) // stopper.frequency
         assert stopper.best_epoch == self.stop_epoch - self.patience * stopper.frequency
         assert self.stop_epoch == len(losses), "Did not stop early like it should have"
+
+
+def test_pipeline_forwards_evaluation_kwargs_to_stopper():
+    """Verify that evaluation_kwargs passed to pipeline() reach every evaluator.evaluate() call.
+
+    Regression test for https://github.com/pykeen/pykeen/issues/1587.
+    """
+    targets = ("tail",)
+    observed_targets: list = []
+    _original_evaluate = Evaluator.evaluate
+
+    def spy_evaluate(self, *args, **kwargs):
+        observed_targets.append(kwargs.get("targets"))
+        return _original_evaluate(self, *args, **kwargs)
+
+    with patch.object(Evaluator, "evaluate", spy_evaluate):
+        pipeline(
+            dataset="nations",
+            model="TransE",
+            training_kwargs=dict(num_epochs=2),
+            evaluation_kwargs=dict(targets=targets),
+            stopper="early",
+            stopper_kwargs=dict(frequency=1, patience=100),
+            use_testing_data=False,
+        )
+
+    assert observed_targets, "evaluator.evaluate() was never called"
+    assert all(t == targets for t in observed_targets), (
+        f"Expected all evaluate() calls to use targets={targets!r}, got {observed_targets!r}"
+    )

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -149,6 +149,7 @@ class TestEarlyStopperRealWorld(unittest.TestCase):
         assert self.stop_epoch == len(losses), "Did not stop early like it should have"
 
 
+@pytest.mark.slow
 def test_pipeline_forwards_evaluation_kwargs_to_stopper():
     """Verify that evaluation_kwargs passed to pipeline() reach every evaluator.evaluate() call.
 


### PR DESCRIPTION
Fix #1587 

## Summary

`evaluation_kwargs` passed to `pipeline()` (e.g. `targets=("tail",)`) was silently dropped for early stopper validation runs. Only `batch_size` was forwarded; all other parameters were ignored, so the stopper always evaluated both head and tail regardless of user intent.

## Changes

- `EarlyStopper`: add `evaluation_kwargs: dict[str, Any]` field (defaults to `{}`) and unpack it into the `evaluator.evaluate()` call inside `should_stop()`.
- `pipeline._handle_training()`: forward `evaluation_kwargs` (excluding `batch_size` and `slice_size`, which already have dedicated stopper fields) into `stopper_kwargs["evaluation_kwargs"]` via `setdefault`, so the stopper inherits the pipeline-level evaluation settings by default.
- Add a `@pytest.mark.slow` regression test that spies on `Evaluator.evaluate` via `patch.object` and asserts every call receives the expected `targets`.

## Behaviour after fix

```python
# targets=("tail",) now applies to both final evaluation AND early stopper validation
pipeline(
    dataset="nations",
    model="TransE",
    evaluation_kwargs=dict(targets=("tail",)),
    stopper="early",
    stopper_kwargs=dict(frequency=5, patience=3),
)
