### PR TITLE
✂️🏋️ Add `resolve_pipeline`, `ResolutionResult`, and `TrainResult` for composable training workflows

### DIFF
--- a/src/pykeen/pipeline/__init__.py
+++ b/src/pykeen/pipeline/__init__.py
@@ -2,21 +2,25 @@
 
 from .api import (
     PipelineResult,
+    TrainResult,
     pipeline,
     pipeline_from_config,
     pipeline_from_path,
     replicate_pipeline_from_config,
     replicate_pipeline_from_path,
+    train_pipeline,
 )
 from .plot_utils import plot, plot_early_stopping, plot_er, plot_losses
 
 __all__ = [
     "PipelineResult",
+    "TrainResult",
     "pipeline_from_path",
     "pipeline_from_config",
     "replicate_pipeline_from_config",
     "replicate_pipeline_from_path",
     "pipeline",
+    "train_pipeline",
     "plot_losses",
     "plot_early_stopping",
     "plot_er",

--- a/src/pykeen/pipeline/__init__.py
+++ b/src/pykeen/pipeline/__init__.py
@@ -10,7 +10,6 @@ from .api import (
     replicate_pipeline_from_config,
     replicate_pipeline_from_path,
     resolve_pipeline,
-    train_pipeline,
 )
 from .plot_utils import plot, plot_early_stopping, plot_er, plot_losses
 
@@ -24,7 +23,6 @@ __all__ = [
     "replicate_pipeline_from_path",
     "pipeline",
     "resolve_pipeline",
-    "train_pipeline",
     "plot_losses",
     "plot_early_stopping",
     "plot_er",

--- a/src/pykeen/pipeline/__init__.py
+++ b/src/pykeen/pipeline/__init__.py
@@ -2,24 +2,28 @@
 
 from .api import (
     PipelineResult,
+    ResolutionResult,
     TrainResult,
     pipeline,
     pipeline_from_config,
     pipeline_from_path,
     replicate_pipeline_from_config,
     replicate_pipeline_from_path,
+    resolve_pipeline,
     train_pipeline,
 )
 from .plot_utils import plot, plot_early_stopping, plot_er, plot_losses
 
 __all__ = [
     "PipelineResult",
+    "ResolutionResult",
     "TrainResult",
     "pipeline_from_path",
     "pipeline_from_config",
     "replicate_pipeline_from_config",
     "replicate_pipeline_from_path",
     "pipeline",
+    "resolve_pipeline",
     "train_pipeline",
     "plot_losses",
     "plot_early_stopping",

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -238,12 +238,14 @@ from ..version import get_git_hash, get_version
 
 __all__ = [
     "PipelineResult",
+    "ResolutionResult",
     "TrainResult",
     "pipeline_from_path",
     "pipeline_from_config",
     "replicate_pipeline_from_config",
     "replicate_pipeline_from_path",
     "pipeline",
+    "resolve_pipeline",
     "train_pipeline",
 ]
 
@@ -659,6 +661,92 @@ class TrainResult:
             metadata=self.metadata,
             train_seconds=self.train_seconds,
             evaluate_seconds=evaluate_seconds,
+        )
+
+
+@fix_dataclass_init_docs
+@dataclass
+class ResolutionResult:
+    """Result of :func:`resolve_pipeline`, containing all resolved pipeline components before training.
+
+    Call :meth:`train` to run training and obtain a :class:`TrainResult`.
+    """
+
+    #: The random seed used at the beginning of the pipeline
+    random_seed: int
+
+    #: The model to train
+    model: Model
+
+    #: The training triples
+    training: CoreTriplesFactory
+
+    #: The testing triples (if any)
+    testing: CoreTriplesFactory | None
+
+    #: The validation triples (if any)
+    validation: CoreTriplesFactory | None
+
+    #: The training loop
+    training_loop: TrainingLoop
+
+    #: The evaluator (used by stopper during training, and for post-training evaluation)
+    evaluator: Evaluator
+
+    #: Keyword arguments forwarded to the evaluator's evaluate function
+    evaluation_kwargs: dict[str, Any]
+
+    #: The stopper (NopStopper when no early stopping was configured)
+    stopper: Stopper
+
+    #: The result tracker
+    result_tracker: MultiResultTracker
+
+    #: Keyword arguments used during training
+    training_kwargs: dict[str, Any]
+
+    #: Whether to clear the optimizer after training
+    clear_optimizer: bool
+
+    #: The resolved configuration, logged before training
+    configuration: Mapping[str, Any]
+
+    #: Any additional metadata as a dictionary
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def train(self) -> TrainResult:
+        """Run training and return a :class:`TrainResult`.
+
+        :returns: A :class:`TrainResult` holding the trained model, losses, and all state
+            needed to call :meth:`TrainResult.evaluate` later.
+        """
+        training_start_time = time.time()
+        losses = self.training_loop.train(
+            triples_factory=self.training,
+            stopper=self.stopper,
+            clear_optimizer=self.clear_optimizer,
+            **self.training_kwargs,
+        )
+        assert losses is not None
+        train_seconds = time.time() - training_start_time
+        step = self.training_kwargs.get("num_epochs")
+        self.result_tracker.log_metrics(metrics={"total_training": train_seconds}, step=step, prefix="times")
+        return TrainResult(
+            random_seed=self.random_seed,
+            model=self.model,
+            training=self.training,
+            testing=self.testing,
+            validation=self.validation,
+            training_loop=self.training_loop,
+            losses=losses,
+            train_seconds=train_seconds,
+            stopper=self.stopper,
+            configuration=self.configuration,
+            metadata=self.metadata,
+            evaluator=self.evaluator,
+            evaluation_kwargs=self.evaluation_kwargs,
+            result_tracker=self.result_tracker,
+            training_kwargs=self.training_kwargs,
         )
 
 
@@ -1275,77 +1363,6 @@ def _handle_evaluator(
     return evaluator_instance, evaluation_kwargs
 
 
-def _handle_training(
-    *,
-    _result_tracker: MultiResultTracker,
-    training: CoreTriplesFactory,
-    validation: CoreTriplesFactory | None,
-    model_instance: Model,
-    evaluator_instance: Evaluator,
-    training_loop_instance: TrainingLoop,
-    clear_optimizer: bool,
-    evaluation_kwargs: Mapping[str, Any],
-    # 7. Training (ronaldo style)
-    epochs: int | None = None,
-    training_kwargs: dict[str, Any],
-    stopper: HintType[Stopper] = None,
-    stopper_kwargs: Mapping[str, Any] | None = None,
-    # Misc
-    use_tqdm: bool | None = None,
-) -> tuple[Stopper, Mapping[str, Any], list[float], float]:
-    # Stopping
-    if "stopper" in training_kwargs and stopper is not None:
-        raise ValueError("Specified stopper in training_kwargs and as stopper")
-    if "stopper" in training_kwargs:
-        stopper = training_kwargs.pop("stopper")
-    if stopper_kwargs is None:
-        stopper_kwargs = {}
-    stopper_kwargs = dict(stopper_kwargs)
-
-    # Load the evaluation batch size for the stopper, if it has been set
-    _evaluation_batch_size = evaluation_kwargs.get("batch_size")
-    if _evaluation_batch_size is not None:
-        stopper_kwargs.setdefault("evaluation_batch_size", _evaluation_batch_size)
-
-    stopper_instance: Stopper = stopper_resolver.make(
-        stopper,
-        model=model_instance,
-        evaluator=evaluator_instance,
-        training_triples_factory=training,
-        evaluation_triples_factory=validation,
-        result_tracker=_result_tracker,
-        **stopper_kwargs,
-    )
-
-    if epochs is not None:
-        training_kwargs["num_epochs"] = epochs
-    if use_tqdm is not None:
-        training_kwargs["use_tqdm"] = use_tqdm
-    training_kwargs.setdefault("num_epochs", 5)
-    training_kwargs.setdefault("batch_size", 256)
-    _result_tracker.log_params(params=training_kwargs)
-
-    # Add logging for debugging
-    configuration = _result_tracker.get_configuration()
-    logger.debug("Run Pipeline based on following config:")
-    for key, value in configuration.items():
-        logger.debug(f"{key}: {value}")
-
-    # Train like Cristiano Ronaldo
-    training_start_time = time.time()
-    losses = training_loop_instance.train(
-        triples_factory=training,
-        stopper=stopper_instance,
-        clear_optimizer=clear_optimizer,
-        **training_kwargs,
-    )
-    assert losses is not None  # losses is only none if it's doing search mode
-    training_end_time = time.time() - training_start_time
-    step = training_kwargs.get("num_epochs")
-    _result_tracker.log_metrics(metrics={"total_training": training_end_time}, step=step, prefix="times")
-    return stopper_instance, configuration, losses, training_end_time
-
-
 def _handle_evaluation(
     *,
     _result_tracker: ResultTracker,
@@ -1453,7 +1470,7 @@ def _handle_evaluation(
     return metric_results, evaluate_end_time
 
 
-def train_pipeline(
+def resolve_pipeline(
     *,
     # 1. Dataset
     dataset: None | str | Dataset | type[Dataset] = None,
@@ -1487,7 +1504,7 @@ def train_pipeline(
     training_loop_kwargs: Mapping[str, Any] | None = None,
     negative_sampler: HintType[NegativeSampler] = None,
     negative_sampler_kwargs: Mapping[str, Any] | None = None,
-    # 7. Training (ronaldo style)
+    # 7. Training
     epochs: int | None = None,
     training_kwargs: Mapping[str, Any] | None = None,
     stopper: HintType[Stopper] = None,
@@ -1504,18 +1521,14 @@ def train_pipeline(
     device: Hint[torch.device] = None,
     random_seed: int | None = None,
     use_tqdm: bool | None = None,
-) -> TrainResult:
-    """Train a model and return a :class:`TrainResult` without running post-training evaluation.
+) -> ResolutionResult:
+    """Resolve all pipeline components into a :class:`ResolutionResult` without running training.
 
-    All parameters match :func:`pipeline`. Evaluation-specific parameters
-    (``use_testing_data``, ``evaluation_fallback``, ``filter_validation_when_testing``) are
-    moved to :meth:`TrainResult.evaluate`.
+    All parameters match :func:`train_pipeline`. Use :meth:`ResolutionResult.train` to run
+    training and :meth:`TrainResult.evaluate` to run evaluation, or use the higher-level
+    :func:`train_pipeline` or :func:`pipeline` convenience functions.
 
-    Pass ``testing=None`` together with an explicit ``training`` factory to run in
-    training-only mode (no evaluation triples required).
-
-    :returns: A :class:`TrainResult` holding the trained model, losses, and all state
-        needed to call :meth:`TrainResult.evaluate` later.
+    :returns: A :class:`ResolutionResult` holding all resolved components ready for training.
     """
     if training_kwargs is None:
         training_kwargs = {}
@@ -1582,39 +1595,164 @@ def train_pipeline(
         evaluation_kwargs=evaluation_kwargs,
     )
 
-    stopper_instance, configuration, losses, train_seconds = _handle_training(
-        _result_tracker=_result_tracker,
-        training=training_tf,
-        validation=validation_tf,
-        model_instance=model_instance,
-        evaluator_instance=evaluator_instance,
-        training_loop_instance=training_loop_instance,
-        clear_optimizer=clear_optimizer,
-        evaluation_kwargs=evaluation_kwargs,
-        epochs=epochs,
-        training_kwargs=training_kwargs,
-        stopper=stopper,
-        stopper_kwargs=stopper_kwargs,
-        use_tqdm=use_tqdm,
+    # Resolve stopper
+    if "stopper" in training_kwargs and stopper is not None:
+        raise ValueError("Specified stopper in training_kwargs and as stopper")
+    if "stopper" in training_kwargs:
+        stopper = training_kwargs.pop("stopper")
+    if stopper_kwargs is None:
+        stopper_kwargs = {}
+    stopper_kwargs = dict(stopper_kwargs)
+    _evaluation_batch_size = evaluation_kwargs.get("batch_size")
+    if _evaluation_batch_size is not None:
+        stopper_kwargs.setdefault("evaluation_batch_size", _evaluation_batch_size)
+    stopper_instance: Stopper = stopper_resolver.make(
+        stopper,
+        model=model_instance,
+        evaluator=evaluator_instance,
+        training_triples_factory=training_tf,
+        evaluation_triples_factory=validation_tf,
+        result_tracker=_result_tracker,
+        **stopper_kwargs,
     )
 
-    return TrainResult(
+    # Finalize training kwargs and log
+    if epochs is not None:
+        training_kwargs["num_epochs"] = epochs
+    if use_tqdm is not None:
+        training_kwargs["use_tqdm"] = use_tqdm
+    training_kwargs.setdefault("num_epochs", 5)
+    training_kwargs.setdefault("batch_size", 256)
+    _result_tracker.log_params(params=training_kwargs)
+
+    # Configuration snapshot (all params logged at this point)
+    configuration = _result_tracker.get_configuration()
+    logger.debug("Run Pipeline based on following config:")
+    for key, value in configuration.items():
+        logger.debug(f"{key}: {value}")
+
+    return ResolutionResult(
         random_seed=_random_seed,
         model=model_instance,
         training=training_tf,
         testing=testing_tf,
         validation=validation_tf,
         training_loop=training_loop_instance,
-        losses=losses,
-        train_seconds=train_seconds,
-        stopper=stopper_instance,
-        configuration=configuration,
-        metadata=metadata,
         evaluator=evaluator_instance,
         evaluation_kwargs=evaluation_kwargs,
+        stopper=stopper_instance,
         result_tracker=_result_tracker,
         training_kwargs=training_kwargs,
+        clear_optimizer=clear_optimizer,
+        configuration=configuration,
+        metadata=metadata,
     )
+
+
+def train_pipeline(
+    *,
+    # 1. Dataset
+    dataset: None | str | Dataset | type[Dataset] = None,
+    dataset_kwargs: Mapping[str, Any] | None = None,
+    training: Hint[CoreTriplesFactory] = None,
+    testing: Hint[CoreTriplesFactory] = None,
+    validation: Hint[CoreTriplesFactory] = None,
+    evaluation_entity_whitelist: Collection[str] | None = None,
+    evaluation_relation_whitelist: Collection[str] | None = None,
+    # 2. Model
+    model: None | str | Model | type[Model] = None,
+    model_kwargs: Mapping[str, Any] | None = None,
+    interaction: None | str | Interaction | type[Interaction] = None,
+    interaction_kwargs: Mapping[str, Any] | None = None,
+    dimensions: None | int | Mapping[str, int] = None,
+    # 3. Loss
+    loss: HintType[Loss] = None,
+    loss_kwargs: Mapping[str, Any] | None = None,
+    # 4. Regularizer
+    regularizer: HintType[Regularizer] = None,
+    regularizer_kwargs: Mapping[str, Any] | None = None,
+    # 5. Optimizer
+    optimizer: HintType[Optimizer] = None,
+    optimizer_kwargs: Mapping[str, Any] | None = None,
+    clear_optimizer: bool = True,
+    # 5.1 Learning Rate Scheduler
+    lr_scheduler: HintType[LRScheduler] = None,
+    lr_scheduler_kwargs: Mapping[str, Any] | None = None,
+    # 6. Training Loop
+    training_loop: HintType[TrainingLoop] = None,
+    training_loop_kwargs: Mapping[str, Any] | None = None,
+    negative_sampler: HintType[NegativeSampler] = None,
+    negative_sampler_kwargs: Mapping[str, Any] | None = None,
+    # 7. Training (ronaldo style)
+    epochs: int | None = None,
+    training_kwargs: Mapping[str, Any] | None = None,
+    stopper: HintType[Stopper] = None,
+    stopper_kwargs: Mapping[str, Any] | None = None,
+    # 8. Evaluator (still needed: stopper calls it during training)
+    evaluator: HintType[Evaluator] = None,
+    evaluator_kwargs: Mapping[str, Any] | None = None,
+    evaluation_kwargs: Mapping[str, Any] | None = None,
+    # 9. Tracking
+    result_tracker: OneOrManyHintOrType[ResultTracker] = None,
+    result_tracker_kwargs: OneOrManyOptionalKwargs = None,
+    # Misc
+    metadata: dict[str, Any] | None = None,
+    device: Hint[torch.device] = None,
+    random_seed: int | None = None,
+    use_tqdm: bool | None = None,
+) -> TrainResult:
+    """Train a model and return a :class:`TrainResult` without running post-training evaluation.
+
+    All parameters match :func:`pipeline`. Evaluation-specific parameters
+    (``use_testing_data``, ``evaluation_fallback``, ``filter_validation_when_testing``) are
+    moved to :meth:`TrainResult.evaluate`.
+
+    Pass ``testing=None`` together with an explicit ``training`` factory to run in
+    training-only mode (no evaluation triples required).
+
+    :returns: A :class:`TrainResult` holding the trained model, losses, and all state
+        needed to call :meth:`TrainResult.evaluate` later.
+    """
+    return resolve_pipeline(
+        dataset=dataset,
+        dataset_kwargs=dataset_kwargs,
+        training=training,
+        testing=testing,
+        validation=validation,
+        evaluation_entity_whitelist=evaluation_entity_whitelist,
+        evaluation_relation_whitelist=evaluation_relation_whitelist,
+        model=model,
+        model_kwargs=model_kwargs,
+        interaction=interaction,
+        interaction_kwargs=interaction_kwargs,
+        dimensions=dimensions,
+        loss=loss,
+        loss_kwargs=loss_kwargs,
+        regularizer=regularizer,
+        regularizer_kwargs=regularizer_kwargs,
+        optimizer=optimizer,
+        optimizer_kwargs=optimizer_kwargs,
+        clear_optimizer=clear_optimizer,
+        lr_scheduler=lr_scheduler,
+        lr_scheduler_kwargs=lr_scheduler_kwargs,
+        training_loop=training_loop,
+        training_loop_kwargs=training_loop_kwargs,
+        negative_sampler=negative_sampler,
+        negative_sampler_kwargs=negative_sampler_kwargs,
+        epochs=epochs,
+        training_kwargs=training_kwargs,
+        stopper=stopper,
+        stopper_kwargs=stopper_kwargs,
+        evaluator=evaluator,
+        evaluator_kwargs=evaluator_kwargs,
+        evaluation_kwargs=evaluation_kwargs,
+        result_tracker=result_tracker,
+        result_tracker_kwargs=result_tracker_kwargs,
+        metadata=metadata,
+        device=device,
+        random_seed=random_seed,
+        use_tqdm=use_tqdm,
+    ).train()
 
 
 def pipeline(  # noqa: C901

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1046,7 +1046,11 @@ def _handle_dataset(
         dataset_instance = get_dataset(
             dataset=dataset, dataset_kwargs=dataset_kwargs, training=training, testing=testing, validation=validation
         )
-        training_tf, testing_tf, validation_tf = dataset_instance.training, dataset_instance.testing, dataset_instance.validation
+        training_tf, testing_tf, validation_tf = (
+            dataset_instance.training,
+            dataset_instance.testing,
+            dataset_instance.validation,
+        )
 
     if dataset is None:
         _result_tracker.log_params(
@@ -1059,8 +1063,9 @@ def _handle_dataset(
         )
     else:
         assert dataset_instance is not None
-        _result_tracker.log_params({"dataset": dataset_instance.get_normalized_name(), "dataset_kwargs": dataset_kwargs})
-
+        _result_tracker.log_params(
+            {"dataset": dataset_instance.get_normalized_name(), "dataset_kwargs": dataset_kwargs}
+        )
 
     if any(f is not None for f in (evaluation_entity_whitelist, evaluation_relation_whitelist)):
         if testing_tf is not None:

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1024,9 +1024,17 @@ def _handle_dataset(
 ) -> tuple[CoreTriplesFactory, CoreTriplesFactory | None, CoreTriplesFactory | None]:
     """Resolve training, testing, and validation factories.
 
-    When ``dataset=None`` and ``testing=None``, both ``training`` and ``validation``
-    must be pre-built :class:`CoreTriplesFactory` instances; testing stays ``None``
-    and the caller is responsible for failing at evaluation time if needed.
+    Behaviour depends on which of ``dataset`` and ``testing`` are provided:
+
+    - ``dataset=None, testing=None``: training-only mode. ``training`` (and ``validation``
+      if given) must be pre-built :class:`CoreTriplesFactory` instances. Returns
+      ``testing=None``; evaluation will fail unless a testing factory is supplied at
+      evaluation time.
+    - ``dataset=None, testing=provided``: explicit factories. Passed directly to
+      :func:`get_dataset`, which accepts pre-built factories or path strings (but not mixed).
+    - ``dataset=provided, testing=None``: named dataset. Testing comes from the dataset;
+      passing ``training``/``testing`` alongside raises :exc:`ValueError`.
+    - ``dataset=provided, testing=provided``: raises :exc:`ValueError` (ambiguous).
     """
     if dataset is None and testing is None:
         if not isinstance(training, CoreTriplesFactory):

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -238,11 +238,13 @@ from ..version import get_git_hash, get_version
 
 __all__ = [
     "PipelineResult",
+    "TrainResult",
     "pipeline_from_path",
     "pipeline_from_config",
     "replicate_pipeline_from_config",
     "replicate_pipeline_from_path",
     "pipeline",
+    "train_pipeline",
 ]
 
 logger = logging.getLogger(__name__)
@@ -536,6 +538,128 @@ class PipelineResult(Result):
 
         model_path = directory_p / "trained_model.pkl"
         s3.upload_fileobj(get_model_io(self.model), bucket, model_path)
+
+
+@fix_dataclass_init_docs
+@dataclass
+class TrainResult:
+    """Result of :func:`train_pipeline`, containing a trained model without post-training evaluation.
+
+    Call :meth:`evaluate` to run evaluation and obtain a full :class:`PipelineResult`.
+    """
+
+    #: The random seed used at the beginning of the pipeline
+    random_seed: int
+
+    #: The model trained by the pipeline
+    model: Model
+
+    #: The training triples
+    training: CoreTriplesFactory
+
+    #: The testing triples (if any)
+    testing: CoreTriplesFactory | None
+
+    #: The validation triples (if any)
+    validation: CoreTriplesFactory | None
+
+    #: The training loop used by the pipeline
+    training_loop: TrainingLoop
+
+    #: The losses during training
+    losses: list[float]
+
+    #: How long in seconds did training take?
+    train_seconds: float
+
+    #: The evaluator (also used by the stopper during training)
+    evaluator: Evaluator
+
+    #: Keyword arguments forwarded to the evaluator's evaluate function
+    evaluation_kwargs: dict[str, Any]
+
+    #: The result tracker
+    result_tracker: MultiResultTracker
+
+    #: Keyword arguments used during training (kept for evaluation logging)
+    training_kwargs: dict[str, Any]
+
+    #: The stopper used during training (NopStopper when no early stopping was configured)
+    stopper: Stopper
+
+    #: The configuration
+    configuration: Mapping[str, Any] = field(default_factory=dict)
+
+    #: Any additional metadata as a dictionary
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def save_model(self, path: str | pathlib.Path) -> None:
+        """Save the trained model to the given path using :func:`torch.save`.
+
+        :param path: The path to which the model is saved.
+        """
+        torch.save(self.model, path, pickle_protocol=pickle.HIGHEST_PROTOCOL)
+
+    def evaluate(
+        self,
+        testing: CoreTriplesFactory | None = None,
+        *,
+        use_testing_data: bool = True,
+        evaluation_fallback: bool = False,
+        filter_validation_when_testing: bool = True,
+        use_tqdm: bool | None = None,
+    ) -> PipelineResult:
+        """Run post-training evaluation and return a full :class:`PipelineResult`.
+
+        :param testing:
+            Override the testing triples factory. Falls back to the one stored in this result.
+        :param use_testing_data:
+            If true, use the testing triples for evaluation; otherwise use validation triples.
+        :param evaluation_fallback:
+            If true, fall back to smaller batch sizes / CPU when GPU evaluation fails.
+        :param filter_validation_when_testing:
+            If true, add validation triples to the filtered-evaluation negative set when testing.
+        :param use_tqdm:
+            Globally override tqdm progress bar usage.
+
+        :returns: A full pipeline result including metric results.
+
+        :raises ValueError: if no testing triples are available and ``use_testing_data=True``.
+        """
+        resolved_testing = testing if testing is not None else self.testing
+        if resolved_testing is None and use_testing_data:
+            raise ValueError(
+                "No testing triples available. Pass testing= or set use_testing_data=False to evaluate on validation."
+            )
+        metric_results, evaluate_seconds = _handle_evaluation(
+            _result_tracker=self.result_tracker,
+            model_instance=self.model,
+            evaluator_instance=self.evaluator,
+            stopper_instance=self.stopper,
+            training=self.training,
+            testing=resolved_testing,
+            validation=self.validation,
+            training_kwargs=self.training_kwargs,
+            evaluation_kwargs=dict(self.evaluation_kwargs),
+            use_testing_data=use_testing_data,
+            evaluation_fallback=evaluation_fallback,
+            filter_validation_when_testing=filter_validation_when_testing,
+            use_tqdm=use_tqdm,
+        )
+        self.result_tracker.end_run()
+        return PipelineResult(
+            random_seed=self.random_seed,
+            model=self.model,
+            training=self.training,
+            training_loop=self.training_loop,
+            losses=self.losses,
+            stopper=self.stopper,
+            configuration=self.configuration,
+            metric_results=metric_results,
+            metadata=self.metadata,
+            train_seconds=self.train_seconds,
+            evaluate_seconds=evaluate_seconds,
+        )
 
 
 def replicate_pipeline_from_path(
@@ -888,8 +1012,24 @@ def _handle_dataset(
     validation: Hint[CoreTriplesFactory] = None,
     evaluation_entity_whitelist: Collection[str] | None = None,
     evaluation_relation_whitelist: Collection[str] | None = None,
-) -> tuple[CoreTriplesFactory, CoreTriplesFactory, CoreTriplesFactory | None]:
-    # TODO: allow empty validation / testing
+) -> tuple[CoreTriplesFactory, CoreTriplesFactory | None, CoreTriplesFactory | None]:
+    # Training-only path: explicit factory provided, no testing requested
+    if dataset is None and testing is None:
+        if not isinstance(training, CoreTriplesFactory):
+            raise ValueError(
+                "When testing=None, training must be a pre-built CoreTriplesFactory (not a path/string)."
+            )
+        if validation is not None and not isinstance(validation, CoreTriplesFactory):
+            raise ValueError("validation must be a pre-built CoreTriplesFactory when testing=None.")
+        _result_tracker.log_params({"dataset": USER_DEFINED_CODE})
+        if any(f is not None for f in (evaluation_entity_whitelist, evaluation_relation_whitelist)):
+            if validation is not None:
+                validation = validation.new_with_restriction(
+                    entities=evaluation_entity_whitelist,
+                    relations=evaluation_relation_whitelist,
+                )
+        return training, None, validation
+
     dataset_instance: Dataset = get_dataset(
         dataset=dataset,
         dataset_kwargs=dataset_kwargs,
@@ -904,13 +1044,13 @@ def _handle_dataset(
                 "dataset_kwargs": dataset_kwargs,
             }
         )
-    else:  # means that dataset was defined by triples factories
+    else:
         _result_tracker.log_params(
             {
                 "dataset": USER_DEFINED_CODE,
                 "training": training if isinstance(training, str) else USER_DEFINED_CODE,
-                "testing": testing if isinstance(training, str) else USER_DEFINED_CODE,
-                "validation": validation if isinstance(training, str) else USER_DEFINED_CODE,
+                "testing": testing if isinstance(testing, str) else USER_DEFINED_CODE,
+                "validation": validation if isinstance(validation, str) else USER_DEFINED_CODE,
             }
         )
 
@@ -1299,6 +1439,170 @@ def _handle_evaluation(
     return metric_results, evaluate_end_time
 
 
+def train_pipeline(
+    *,
+    # 1. Dataset
+    dataset: None | str | Dataset | type[Dataset] = None,
+    dataset_kwargs: Mapping[str, Any] | None = None,
+    training: Hint[CoreTriplesFactory] = None,
+    testing: Hint[CoreTriplesFactory] = None,
+    validation: Hint[CoreTriplesFactory] = None,
+    evaluation_entity_whitelist: Collection[str] | None = None,
+    evaluation_relation_whitelist: Collection[str] | None = None,
+    # 2. Model
+    model: None | str | Model | type[Model] = None,
+    model_kwargs: Mapping[str, Any] | None = None,
+    interaction: None | str | Interaction | type[Interaction] = None,
+    interaction_kwargs: Mapping[str, Any] | None = None,
+    dimensions: None | int | Mapping[str, int] = None,
+    # 3. Loss
+    loss: HintType[Loss] = None,
+    loss_kwargs: Mapping[str, Any] | None = None,
+    # 4. Regularizer
+    regularizer: HintType[Regularizer] = None,
+    regularizer_kwargs: Mapping[str, Any] | None = None,
+    # 5. Optimizer
+    optimizer: HintType[Optimizer] = None,
+    optimizer_kwargs: Mapping[str, Any] | None = None,
+    clear_optimizer: bool = True,
+    # 5.1 Learning Rate Scheduler
+    lr_scheduler: HintType[LRScheduler] = None,
+    lr_scheduler_kwargs: Mapping[str, Any] | None = None,
+    # 6. Training Loop
+    training_loop: HintType[TrainingLoop] = None,
+    training_loop_kwargs: Mapping[str, Any] | None = None,
+    negative_sampler: HintType[NegativeSampler] = None,
+    negative_sampler_kwargs: Mapping[str, Any] | None = None,
+    # 7. Training (ronaldo style)
+    epochs: int | None = None,
+    training_kwargs: Mapping[str, Any] | None = None,
+    stopper: HintType[Stopper] = None,
+    stopper_kwargs: Mapping[str, Any] | None = None,
+    # 8. Evaluator (still needed: stopper calls it during training)
+    evaluator: HintType[Evaluator] = None,
+    evaluator_kwargs: Mapping[str, Any] | None = None,
+    evaluation_kwargs: Mapping[str, Any] | None = None,
+    # 9. Tracking
+    result_tracker: OneOrManyHintOrType[ResultTracker] = None,
+    result_tracker_kwargs: OneOrManyOptionalKwargs = None,
+    # Misc
+    metadata: dict[str, Any] | None = None,
+    device: Hint[torch.device] = None,
+    random_seed: int | None = None,
+    use_tqdm: bool | None = None,
+) -> TrainResult:
+    """Train a model and return a :class:`TrainResult` without running post-training evaluation.
+
+    All parameters match :func:`pipeline`. Evaluation-specific parameters
+    (``use_testing_data``, ``evaluation_fallback``, ``filter_validation_when_testing``) are
+    moved to :meth:`TrainResult.evaluate`.
+
+    Pass ``testing=None`` together with an explicit ``training`` factory to run in
+    training-only mode (no evaluation triples required).
+
+    :returns: A :class:`TrainResult` holding the trained model, losses, and all state
+        needed to call :meth:`TrainResult.evaluate` later.
+    """
+    if training_kwargs is None:
+        training_kwargs = {}
+    training_kwargs = dict(training_kwargs)
+
+    _random_seed, clear_optimizer = _handle_random_seed(
+        training_kwargs=training_kwargs, random_seed=random_seed, clear_optimizer=clear_optimizer
+    )
+    set_random_seed(_random_seed)
+
+    _result_tracker = resolve_result_trackers(result_tracker, result_tracker_kwargs)
+
+    if not metadata:
+        metadata = {}
+    title = metadata.get("title")
+
+    _result_tracker.start_run(run_name=title)
+
+    training_tf, testing_tf, validation_tf = _handle_dataset(
+        _result_tracker=_result_tracker,
+        dataset=dataset,
+        dataset_kwargs=dataset_kwargs,
+        training=training,
+        testing=testing,
+        validation=validation,
+        evaluation_entity_whitelist=evaluation_entity_whitelist,
+        evaluation_relation_whitelist=evaluation_relation_whitelist,
+    )
+
+    model_instance = _handle_model(
+        device=device,
+        _result_tracker=_result_tracker,
+        _random_seed=_random_seed,
+        training=training_tf,
+        model=model,
+        model_kwargs=model_kwargs,
+        interaction=interaction,
+        interaction_kwargs=interaction_kwargs,
+        dimensions=dimensions,
+        loss=loss,
+        loss_kwargs=loss_kwargs,
+        regularizer=regularizer,
+        regularizer_kwargs=regularizer_kwargs,
+    )
+
+    training_loop_instance = _handle_training_loop(
+        _result_tracker=_result_tracker,
+        model_instance=model_instance,
+        training=training_tf,
+        optimizer=optimizer,
+        optimizer_kwargs=optimizer_kwargs,
+        lr_scheduler=lr_scheduler,
+        lr_scheduler_kwargs=lr_scheduler_kwargs,
+        training_loop=training_loop,
+        training_loop_kwargs=training_loop_kwargs,
+        negative_sampler=negative_sampler,
+        negative_sampler_kwargs=negative_sampler_kwargs,
+    )
+
+    evaluator_instance, evaluation_kwargs = _handle_evaluator(
+        _result_tracker=_result_tracker,
+        evaluator=evaluator,
+        evaluator_kwargs=evaluator_kwargs,
+        evaluation_kwargs=evaluation_kwargs,
+    )
+
+    stopper_instance, configuration, losses, train_seconds = _handle_training(
+        _result_tracker=_result_tracker,
+        training=training_tf,
+        validation=validation_tf,
+        model_instance=model_instance,
+        evaluator_instance=evaluator_instance,
+        training_loop_instance=training_loop_instance,
+        clear_optimizer=clear_optimizer,
+        evaluation_kwargs=evaluation_kwargs,
+        epochs=epochs,
+        training_kwargs=training_kwargs,
+        stopper=stopper,
+        stopper_kwargs=stopper_kwargs,
+        use_tqdm=use_tqdm,
+    )
+
+    return TrainResult(
+        random_seed=_random_seed,
+        model=model_instance,
+        training=training_tf,
+        testing=testing_tf,
+        validation=validation_tf,
+        training_loop=training_loop_instance,
+        losses=losses,
+        train_seconds=train_seconds,
+        stopper=stopper_instance,
+        configuration=configuration,
+        metadata=metadata,
+        evaluator=evaluator_instance,
+        evaluation_kwargs=evaluation_kwargs,
+        result_tracker=_result_tracker,
+        training_kwargs=training_kwargs,
+    )
+
+
 def pipeline(  # noqa: C901
     *,
     # 1. Dataset
@@ -1474,26 +1778,7 @@ def pipeline(  # noqa: C901
 
     :returns: A pipeline result package.
     """
-    if training_kwargs is None:
-        training_kwargs = {}
-    training_kwargs = dict(training_kwargs)
-
-    _random_seed, clear_optimizer = _handle_random_seed(
-        training_kwargs=training_kwargs, random_seed=random_seed, clear_optimizer=clear_optimizer
-    )
-    set_random_seed(_random_seed)
-
-    _result_tracker = resolve_result_trackers(result_tracker, result_tracker_kwargs)
-
-    if not metadata:
-        metadata = {}
-    title = metadata.get("title")
-
-    # Start tracking
-    _result_tracker.start_run(run_name=title)
-
-    training, testing, validation = _handle_dataset(
-        _result_tracker=_result_tracker,
+    return train_pipeline(
         dataset=dataset,
         dataset_kwargs=dataset_kwargs,
         training=training,
@@ -1501,13 +1786,6 @@ def pipeline(  # noqa: C901
         validation=validation,
         evaluation_entity_whitelist=evaluation_entity_whitelist,
         evaluation_relation_whitelist=evaluation_relation_whitelist,
-    )
-
-    model_instance = _handle_model(
-        device=device,
-        _result_tracker=_result_tracker,
-        _random_seed=_random_seed,
-        training=training,
         model=model,
         model_kwargs=model_kwargs,
         interaction=interaction,
@@ -1517,72 +1795,31 @@ def pipeline(  # noqa: C901
         loss_kwargs=loss_kwargs,
         regularizer=regularizer,
         regularizer_kwargs=regularizer_kwargs,
-    )
-
-    training_loop_instance = _handle_training_loop(
-        _result_tracker=_result_tracker,
-        model_instance=model_instance,
-        training=training,
         optimizer=optimizer,
         optimizer_kwargs=optimizer_kwargs,
+        clear_optimizer=clear_optimizer,
         lr_scheduler=lr_scheduler,
         lr_scheduler_kwargs=lr_scheduler_kwargs,
         training_loop=training_loop,
         training_loop_kwargs=training_loop_kwargs,
         negative_sampler=negative_sampler,
         negative_sampler_kwargs=negative_sampler_kwargs,
-    )
-
-    evaluator_instance, evaluation_kwargs = _handle_evaluator(
-        _result_tracker=_result_tracker,
-        evaluator=evaluator,
-        evaluator_kwargs=evaluator_kwargs,
-        evaluation_kwargs=evaluation_kwargs,
-    )
-
-    stopper_instance, configuration, losses, train_seconds = _handle_training(
-        _result_tracker=_result_tracker,
-        training=training,
-        validation=validation,
-        model_instance=model_instance,
-        evaluator_instance=evaluator_instance,
-        training_loop_instance=training_loop_instance,
-        clear_optimizer=clear_optimizer,
-        evaluation_kwargs=evaluation_kwargs,
         epochs=epochs,
         training_kwargs=training_kwargs,
         stopper=stopper,
         stopper_kwargs=stopper_kwargs,
-        use_tqdm=use_tqdm,
-    )
-
-    metric_results, evaluate_seconds = _handle_evaluation(
-        _result_tracker=_result_tracker,
-        model_instance=model_instance,
-        evaluator_instance=evaluator_instance,
-        stopper_instance=stopper_instance,
-        training=training,
-        testing=testing,
-        validation=validation,
-        training_kwargs=training_kwargs,
+        evaluator=evaluator,
+        evaluator_kwargs=evaluator_kwargs,
         evaluation_kwargs=evaluation_kwargs,
+        result_tracker=result_tracker,
+        result_tracker_kwargs=result_tracker_kwargs,
+        metadata=metadata,
+        device=device,
+        random_seed=random_seed,
+        use_tqdm=use_tqdm,
+    ).evaluate(
         use_testing_data=use_testing_data,
         evaluation_fallback=evaluation_fallback,
         filter_validation_when_testing=filter_validation_when_testing,
         use_tqdm=use_tqdm,
-    )
-    _result_tracker.end_run()
-
-    return PipelineResult(
-        random_seed=_random_seed,
-        model=model_instance,
-        training=training,
-        training_loop=training_loop_instance,
-        losses=losses,
-        stopper=stopper_instance,
-        configuration=configuration,
-        metric_results=metric_results,
-        metadata=metadata,
-        train_seconds=train_seconds,
-        evaluate_seconds=evaluate_seconds,
     )

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1013,21 +1013,25 @@ def _handle_dataset(
     evaluation_entity_whitelist: Collection[str] | None = None,
     evaluation_relation_whitelist: Collection[str] | None = None,
 ) -> tuple[CoreTriplesFactory, CoreTriplesFactory | None, CoreTriplesFactory | None]:
-    # Training-only path: explicit factory provided, no testing requested
+    """Resolve training, testing, and validation factories.
+
+    When ``dataset=None`` and ``testing=None``, both ``training`` and ``validation``
+    must be pre-built :class:`CoreTriplesFactory` instances; testing stays ``None``
+    and the caller is responsible for failing at evaluation time if needed.
+    """
     if dataset is None and testing is None:
         if not isinstance(training, CoreTriplesFactory):
-            raise ValueError(
-                "When testing=None, training must be a pre-built CoreTriplesFactory (not a path/string)."
-            )
+            raise ValueError("When testing=None, training must be a pre-built CoreTriplesFactory (not a path/string).")
         if validation is not None and not isinstance(validation, CoreTriplesFactory):
             raise ValueError("validation must be a pre-built CoreTriplesFactory when testing=None.")
         _result_tracker.log_params({"dataset": USER_DEFINED_CODE})
-        if any(f is not None for f in (evaluation_entity_whitelist, evaluation_relation_whitelist)):
-            if validation is not None:
-                validation = validation.new_with_restriction(
-                    entities=evaluation_entity_whitelist,
-                    relations=evaluation_relation_whitelist,
-                )
+        if validation is not None and any(
+            f is not None for f in (evaluation_entity_whitelist, evaluation_relation_whitelist)
+        ):
+            validation = validation.new_with_restriction(
+                entities=evaluation_entity_whitelist,
+                relations=evaluation_relation_whitelist,
+            )
         return training, None, validation
 
     dataset_instance: Dataset = get_dataset(
@@ -1054,19 +1058,22 @@ def _handle_dataset(
             }
         )
 
-    training, testing, validation = dataset_instance.training, dataset_instance.testing, dataset_instance.validation
-    # evaluation restriction to a subset of entities/relations
+    training_tf, testing_tf, validation_tf = (
+        dataset_instance.training,
+        dataset_instance.testing,
+        dataset_instance.validation,
+    )
     if any(f is not None for f in (evaluation_entity_whitelist, evaluation_relation_whitelist)):
-        testing = testing.new_with_restriction(
+        testing_tf = testing_tf.new_with_restriction(
             entities=evaluation_entity_whitelist,
             relations=evaluation_relation_whitelist,
         )
-        if validation is not None:
-            validation = validation.new_with_restriction(
+        if validation_tf is not None:
+            validation_tf = validation_tf.new_with_restriction(
                 entities=evaluation_entity_whitelist,
                 relations=evaluation_relation_whitelist,
             )
-    return training, testing, validation
+    return training_tf, testing_tf, validation_tf
 
 
 def _handle_model(

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -246,7 +246,6 @@ __all__ = [
     "replicate_pipeline_from_path",
     "pipeline",
     "resolve_pipeline",
-    "train_pipeline",
 ]
 
 logger = logging.getLogger(__name__)
@@ -1649,112 +1648,6 @@ def resolve_pipeline(
     )
 
 
-def train_pipeline(
-    *,
-    # 1. Dataset
-    dataset: None | str | Dataset | type[Dataset] = None,
-    dataset_kwargs: Mapping[str, Any] | None = None,
-    training: Hint[CoreTriplesFactory] = None,
-    testing: Hint[CoreTriplesFactory] = None,
-    validation: Hint[CoreTriplesFactory] = None,
-    evaluation_entity_whitelist: Collection[str] | None = None,
-    evaluation_relation_whitelist: Collection[str] | None = None,
-    # 2. Model
-    model: None | str | Model | type[Model] = None,
-    model_kwargs: Mapping[str, Any] | None = None,
-    interaction: None | str | Interaction | type[Interaction] = None,
-    interaction_kwargs: Mapping[str, Any] | None = None,
-    dimensions: None | int | Mapping[str, int] = None,
-    # 3. Loss
-    loss: HintType[Loss] = None,
-    loss_kwargs: Mapping[str, Any] | None = None,
-    # 4. Regularizer
-    regularizer: HintType[Regularizer] = None,
-    regularizer_kwargs: Mapping[str, Any] | None = None,
-    # 5. Optimizer
-    optimizer: HintType[Optimizer] = None,
-    optimizer_kwargs: Mapping[str, Any] | None = None,
-    clear_optimizer: bool = True,
-    # 5.1 Learning Rate Scheduler
-    lr_scheduler: HintType[LRScheduler] = None,
-    lr_scheduler_kwargs: Mapping[str, Any] | None = None,
-    # 6. Training Loop
-    training_loop: HintType[TrainingLoop] = None,
-    training_loop_kwargs: Mapping[str, Any] | None = None,
-    negative_sampler: HintType[NegativeSampler] = None,
-    negative_sampler_kwargs: Mapping[str, Any] | None = None,
-    # 7. Training (ronaldo style)
-    epochs: int | None = None,
-    training_kwargs: Mapping[str, Any] | None = None,
-    stopper: HintType[Stopper] = None,
-    stopper_kwargs: Mapping[str, Any] | None = None,
-    # 8. Evaluator (still needed: stopper calls it during training)
-    evaluator: HintType[Evaluator] = None,
-    evaluator_kwargs: Mapping[str, Any] | None = None,
-    evaluation_kwargs: Mapping[str, Any] | None = None,
-    # 9. Tracking
-    result_tracker: OneOrManyHintOrType[ResultTracker] = None,
-    result_tracker_kwargs: OneOrManyOptionalKwargs = None,
-    # Misc
-    metadata: dict[str, Any] | None = None,
-    device: Hint[torch.device] = None,
-    random_seed: int | None = None,
-    use_tqdm: bool | None = None,
-) -> TrainResult:
-    """Train a model and return a :class:`TrainResult` without running post-training evaluation.
-
-    All parameters match :func:`pipeline`. Evaluation-specific parameters
-    (``use_testing_data``, ``evaluation_fallback``, ``filter_validation_when_testing``) are
-    moved to :meth:`TrainResult.evaluate`.
-
-    Pass ``testing=None`` together with an explicit ``training`` factory to run in
-    training-only mode (no evaluation triples required).
-
-    :returns: A :class:`TrainResult` holding the trained model, losses, and all state
-        needed to call :meth:`TrainResult.evaluate` later.
-    """
-    return resolve_pipeline(
-        dataset=dataset,
-        dataset_kwargs=dataset_kwargs,
-        training=training,
-        testing=testing,
-        validation=validation,
-        evaluation_entity_whitelist=evaluation_entity_whitelist,
-        evaluation_relation_whitelist=evaluation_relation_whitelist,
-        model=model,
-        model_kwargs=model_kwargs,
-        interaction=interaction,
-        interaction_kwargs=interaction_kwargs,
-        dimensions=dimensions,
-        loss=loss,
-        loss_kwargs=loss_kwargs,
-        regularizer=regularizer,
-        regularizer_kwargs=regularizer_kwargs,
-        optimizer=optimizer,
-        optimizer_kwargs=optimizer_kwargs,
-        clear_optimizer=clear_optimizer,
-        lr_scheduler=lr_scheduler,
-        lr_scheduler_kwargs=lr_scheduler_kwargs,
-        training_loop=training_loop,
-        training_loop_kwargs=training_loop_kwargs,
-        negative_sampler=negative_sampler,
-        negative_sampler_kwargs=negative_sampler_kwargs,
-        epochs=epochs,
-        training_kwargs=training_kwargs,
-        stopper=stopper,
-        stopper_kwargs=stopper_kwargs,
-        evaluator=evaluator,
-        evaluator_kwargs=evaluator_kwargs,
-        evaluation_kwargs=evaluation_kwargs,
-        result_tracker=result_tracker,
-        result_tracker_kwargs=result_tracker_kwargs,
-        metadata=metadata,
-        device=device,
-        random_seed=random_seed,
-        use_tqdm=use_tqdm,
-    ).train()
-
-
 def pipeline(  # noqa: C901
     *,
     # 1. Dataset
@@ -1930,48 +1823,52 @@ def pipeline(  # noqa: C901
 
     :returns: A pipeline result package.
     """
-    return train_pipeline(
-        dataset=dataset,
-        dataset_kwargs=dataset_kwargs,
-        training=training,
-        testing=testing,
-        validation=validation,
-        evaluation_entity_whitelist=evaluation_entity_whitelist,
-        evaluation_relation_whitelist=evaluation_relation_whitelist,
-        model=model,
-        model_kwargs=model_kwargs,
-        interaction=interaction,
-        interaction_kwargs=interaction_kwargs,
-        dimensions=dimensions,
-        loss=loss,
-        loss_kwargs=loss_kwargs,
-        regularizer=regularizer,
-        regularizer_kwargs=regularizer_kwargs,
-        optimizer=optimizer,
-        optimizer_kwargs=optimizer_kwargs,
-        clear_optimizer=clear_optimizer,
-        lr_scheduler=lr_scheduler,
-        lr_scheduler_kwargs=lr_scheduler_kwargs,
-        training_loop=training_loop,
-        training_loop_kwargs=training_loop_kwargs,
-        negative_sampler=negative_sampler,
-        negative_sampler_kwargs=negative_sampler_kwargs,
-        epochs=epochs,
-        training_kwargs=training_kwargs,
-        stopper=stopper,
-        stopper_kwargs=stopper_kwargs,
-        evaluator=evaluator,
-        evaluator_kwargs=evaluator_kwargs,
-        evaluation_kwargs=evaluation_kwargs,
-        result_tracker=result_tracker,
-        result_tracker_kwargs=result_tracker_kwargs,
-        metadata=metadata,
-        device=device,
-        random_seed=random_seed,
-        use_tqdm=use_tqdm,
-    ).evaluate(
-        use_testing_data=use_testing_data,
-        evaluation_fallback=evaluation_fallback,
-        filter_validation_when_testing=filter_validation_when_testing,
-        use_tqdm=use_tqdm,
+    return (
+        resolve_pipeline(
+            dataset=dataset,
+            dataset_kwargs=dataset_kwargs,
+            training=training,
+            testing=testing,
+            validation=validation,
+            evaluation_entity_whitelist=evaluation_entity_whitelist,
+            evaluation_relation_whitelist=evaluation_relation_whitelist,
+            model=model,
+            model_kwargs=model_kwargs,
+            interaction=interaction,
+            interaction_kwargs=interaction_kwargs,
+            dimensions=dimensions,
+            loss=loss,
+            loss_kwargs=loss_kwargs,
+            regularizer=regularizer,
+            regularizer_kwargs=regularizer_kwargs,
+            optimizer=optimizer,
+            optimizer_kwargs=optimizer_kwargs,
+            clear_optimizer=clear_optimizer,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_kwargs=lr_scheduler_kwargs,
+            training_loop=training_loop,
+            training_loop_kwargs=training_loop_kwargs,
+            negative_sampler=negative_sampler,
+            negative_sampler_kwargs=negative_sampler_kwargs,
+            epochs=epochs,
+            training_kwargs=training_kwargs,
+            stopper=stopper,
+            stopper_kwargs=stopper_kwargs,
+            evaluator=evaluator,
+            evaluator_kwargs=evaluator_kwargs,
+            evaluation_kwargs=evaluation_kwargs,
+            result_tracker=result_tracker,
+            result_tracker_kwargs=result_tracker_kwargs,
+            metadata=metadata,
+            device=device,
+            random_seed=random_seed,
+            use_tqdm=use_tqdm,
+        )
+        .train()
+        .evaluate(
+            use_testing_data=use_testing_data,
+            evaluation_fallback=evaluation_fallback,
+            filter_validation_when_testing=filter_validation_when_testing,
+            use_tqdm=use_tqdm,
+        )
     )

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1341,7 +1341,7 @@ def _handle_evaluation(
     evaluator_instance: Evaluator,
     stopper_instance: Stopper,
     training: CoreTriplesFactory,
-    testing: CoreTriplesFactory,
+    testing: CoreTriplesFactory | None,
     validation: CoreTriplesFactory | None,
     training_kwargs: dict[str, Any],
     evaluation_kwargs: dict[str, Any],
@@ -1352,6 +1352,8 @@ def _handle_evaluation(
     use_tqdm: bool | None = None,
 ) -> tuple[MetricResults, float]:
     if use_testing_data:
+        if testing is None:
+            raise ValueError("no testing triples available")
         evaluation_factory = testing
     elif validation is None:
         raise ValueError("no validation triples available")

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1002,6 +1002,15 @@ def _handle_random_seed(
     return _random_seed, clear_optimizer
 
 
+def _log_hint(hint: Hint[CoreTriplesFactory]) -> str | None:
+    """Convert a factory hint to a loggable value: path string, None, or USER_DEFINED_CODE."""
+    if hint is None:
+        return None
+    if isinstance(hint, str):
+        return hint
+    return USER_DEFINED_CODE
+
+
 def _handle_dataset(
     *,
     _result_tracker: ResultTracker,
@@ -1024,50 +1033,33 @@ def _handle_dataset(
             raise ValueError("When testing=None, training must be a pre-built CoreTriplesFactory (not a path/string).")
         if validation is not None and not isinstance(validation, CoreTriplesFactory):
             raise ValueError("validation must be a pre-built CoreTriplesFactory when testing=None.")
-        _result_tracker.log_params({"dataset": USER_DEFINED_CODE})
-        if validation is not None and any(
-            f is not None for f in (evaluation_entity_whitelist, evaluation_relation_whitelist)
-        ):
-            validation = validation.new_with_restriction(
-                entities=evaluation_entity_whitelist,
-                relations=evaluation_relation_whitelist,
-            )
-        return training, None, validation
-
-    dataset_instance: Dataset = get_dataset(
-        dataset=dataset,
-        dataset_kwargs=dataset_kwargs,
-        training=training,
-        testing=testing,
-        validation=validation,
-    )
-    if dataset is not None:
-        _result_tracker.log_params(
-            {
-                "dataset": dataset_instance.get_normalized_name(),
-                "dataset_kwargs": dataset_kwargs,
-            }
-        )
+        training_tf, testing_tf, validation_tf = training, None, validation
     else:
+        dataset_instance = get_dataset(
+            dataset=dataset, dataset_kwargs=dataset_kwargs, training=training, testing=testing, validation=validation
+        )
+        training_tf, testing_tf, validation_tf = dataset_instance.training, dataset_instance.testing, dataset_instance.validation
+
+    if dataset is None:
         _result_tracker.log_params(
             {
                 "dataset": USER_DEFINED_CODE,
-                "training": training if isinstance(training, str) else USER_DEFINED_CODE,
-                "testing": testing if isinstance(testing, str) else USER_DEFINED_CODE,
-                "validation": validation if isinstance(validation, str) else USER_DEFINED_CODE,
+                "training": _log_hint(training),
+                "testing": _log_hint(testing),
+                "validation": _log_hint(validation),
             }
         )
+    else:
+        assert dataset_instance is not None
+        _result_tracker.log_params({"dataset": dataset_instance.get_normalized_name(), "dataset_kwargs": dataset_kwargs})
 
-    training_tf, testing_tf, validation_tf = (
-        dataset_instance.training,
-        dataset_instance.testing,
-        dataset_instance.validation,
-    )
+
     if any(f is not None for f in (evaluation_entity_whitelist, evaluation_relation_whitelist)):
-        testing_tf = testing_tf.new_with_restriction(
-            entities=evaluation_entity_whitelist,
-            relations=evaluation_relation_whitelist,
-        )
+        if testing_tf is not None:
+            testing_tf = testing_tf.new_with_restriction(
+                entities=evaluation_entity_whitelist,
+                relations=evaluation_relation_whitelist,
+            )
         if validation_tf is not None:
             validation_tf = validation_tf.new_with_restriction(
                 entities=evaluation_entity_whitelist,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -420,6 +420,7 @@ def test_resolve_pipeline():
         model="TransE",
         model_kwargs={"embedding_dim": 8},
         training_kwargs={"num_epochs": 1, "use_tqdm": False},
+        random_seed=42,
     )
     assert isinstance(resolution, ResolutionResult)
     # factories are the exact objects passed in — no copies
@@ -449,6 +450,7 @@ def test_training_only():
         model="TransE",
         model_kwargs={"embedding_dim": 8},
         training_kwargs={"num_epochs": 1, "use_tqdm": False},
+        random_seed=42,
     ).train()
     assert isinstance(result, TrainResult)
     assert result.testing is None
@@ -475,6 +477,7 @@ def test_deferred_evaluate():
         model="TransE",
         model_kwargs={"embedding_dim": 8},
         training_kwargs={"num_epochs": 1, "use_tqdm": False},
+        random_seed=42,
     ).train()
 
     # default: evaluates on testing_a

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,6 +11,7 @@ import torch
 
 import pykeen.regularizers
 from pykeen.datasets import EagerDataset, Nations
+from pykeen.evaluation import Evaluator
 from pykeen.models import ERModel, FixedModel, Model
 from pykeen.models.resolve import DimensionError, make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
@@ -19,7 +20,8 @@ from pykeen.pipeline import PipelineResult, ResolutionResult, TrainResult, pipel
 from pykeen.pipeline.api import replicate_pipeline_from_config
 from pykeen.regularizers import NoRegularizer
 from pykeen.sampling.negative_sampler import NegativeSampler
-from pykeen.training import SLCWATrainingLoop
+from pykeen.stoppers import Stopper
+from pykeen.training import SLCWATrainingLoop, TrainingLoop
 from pykeen.triples.generation import generate_triples_factory
 from pykeen.triples.triples_factory import CoreTriplesFactory, TriplesFactory
 from pykeen.utils import resolve_device
@@ -407,33 +409,39 @@ def test_negative_sampler_kwargs():
 
 
 def test_resolve_pipeline():
-    """Test that resolve_pipeline returns a ResolutionResult and training runs correctly from it."""
+    """Test that resolve_pipeline instantiates all components correctly before training."""
     tf = generate_triples_factory(num_entities=20, num_relations=5, num_triples=100)
-    training, testing, _ = tf.split([0.8, 0.1, 0.1])
+    training, testing, validation = tf.split([0.8, 0.1, 0.1])
 
     resolution = resolve_pipeline(
         training=training,
         testing=testing,
+        validation=validation,
         model="TransE",
         model_kwargs={"embedding_dim": 8},
         training_kwargs={"num_epochs": 1, "use_tqdm": False},
     )
     assert isinstance(resolution, ResolutionResult)
+    # factories are the exact objects passed in — no copies
+    assert resolution.training is training
     assert resolution.testing is testing
-
-    train_result = resolution.train()
-    assert isinstance(train_result, TrainResult)
-    assert len(train_result.losses) == 1
-
-    pipeline_result = train_result.evaluate()
-    assert isinstance(pipeline_result, PipelineResult)
-    assert pipeline_result.metric_results is not None
+    assert resolution.validation is validation
+    # all components are fully instantiated before any training
+    assert isinstance(resolution.model, Model)
+    assert isinstance(resolution.training_loop, TrainingLoop)
+    assert isinstance(resolution.evaluator, Evaluator)
+    assert isinstance(resolution.stopper, Stopper)
+    # training_kwargs have been finalized with defaults applied
+    assert resolution.training_kwargs["num_epochs"] == 1
+    assert "batch_size" in resolution.training_kwargs
+    # configuration snapshot is non-empty
+    assert resolution.configuration
 
 
 def test_training_only():
     """Test training without testing triples (training-only mode, issue #1579)."""
     tf = generate_triples_factory(num_entities=20, num_relations=5, num_triples=100)
-    training, _, validation = tf.split([0.8, 0.1, 0.1])
+    training, testing, validation = tf.split([0.8, 0.1, 0.1])
 
     result = resolve_pipeline(
         training=training,
@@ -446,25 +454,39 @@ def test_training_only():
     assert result.testing is None
     assert len(result.losses) == 1
 
+    # evaluate() raises without testing triples ...
+    with pytest.raises(ValueError, match="No testing triples"):
+        result.evaluate()
+    # ... but succeeds when testing is supplied at evaluation time
+    pipeline_result = result.evaluate(testing=testing)
+    assert isinstance(pipeline_result, PipelineResult)
+    assert pipeline_result.metric_results is not None
+
 
 def test_deferred_evaluate():
-    """Test that a TrainResult can be evaluated later with an explicit testing factory."""
+    """Test that .evaluate() can use a different testing factory than the one resolved at pipeline setup."""
     tf = generate_triples_factory(num_entities=20, num_relations=5, num_triples=100)
-    training, testing, validation = tf.split([0.8, 0.1, 0.1])
+    training, testing_a, testing_b, validation = tf.split([0.7, 0.1, 0.1, 0.1])
 
     train_result = resolve_pipeline(
         training=training,
-        testing=testing,
+        testing=testing_a,
         validation=validation,
         model="TransE",
         model_kwargs={"embedding_dim": 8},
         training_kwargs={"num_epochs": 1, "use_tqdm": False},
     ).train()
-    assert isinstance(train_result, TrainResult)
 
-    pipeline_result = train_result.evaluate()
-    assert isinstance(pipeline_result, PipelineResult)
-    assert pipeline_result.metric_results is not None
+    # default: evaluates on testing_a
+    result_a = train_result.evaluate()
+    # override: evaluates on testing_b
+    result_b = train_result.evaluate(testing=testing_b)
+
+    assert isinstance(result_a, PipelineResult)
+    assert isinstance(result_b, PipelineResult)
+    # results differ because the evaluation sets differ
+    assert result_a.metric_results is not None
+    assert result_b.metric_results is not None
 
 
 @pytest.mark.parametrize("tf_cls", [CoreTriplesFactory, TriplesFactory])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -484,9 +484,8 @@ def test_deferred_evaluate():
 
     assert isinstance(result_a, PipelineResult)
     assert isinstance(result_b, PipelineResult)
-    # results differ because the evaluation sets differ
-    assert result_a.metric_results is not None
-    assert result_b.metric_results is not None
+    # results should differ because the evaluation sets differ
+    assert result_a.metric_results.to_dict() != result_b.metric_results.to_dict()
 
 
 @pytest.mark.parametrize("tf_cls", [CoreTriplesFactory, TriplesFactory])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,7 +15,7 @@ from pykeen.models import ERModel, FixedModel, Model
 from pykeen.models.resolve import DimensionError, make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
 from pykeen.nn.representation import Embedding
-from pykeen.pipeline import PipelineResult, pipeline
+from pykeen.pipeline import PipelineResult, TrainResult, pipeline, train_pipeline
 from pykeen.pipeline.api import replicate_pipeline_from_config
 from pykeen.regularizers import NoRegularizer
 from pykeen.sampling.negative_sampler import NegativeSampler
@@ -404,6 +404,43 @@ def test_negative_sampler_kwargs():
             model="distmult",
             epochs=0,
         )
+
+
+def test_train_pipeline_training_only():
+    """Test train_pipeline without testing triples (training-only mode, issue #1579)."""
+    tf = generate_triples_factory(num_entities=20, num_relations=5, num_triples=100)
+    training, _, validation = tf.split([0.8, 0.1, 0.1])
+
+    result = train_pipeline(
+        training=training,
+        validation=validation,
+        model="TransE",
+        model_kwargs={"embedding_dim": 8},
+        training_kwargs={"num_epochs": 1, "use_tqdm": False},
+    )
+    assert isinstance(result, TrainResult)
+    assert result.testing is None
+    assert len(result.losses) == 1
+
+
+def test_train_pipeline_deferred_evaluate():
+    """Test that train_pipeline result can be evaluated later with an explicit testing factory."""
+    tf = generate_triples_factory(num_entities=20, num_relations=5, num_triples=100)
+    training, testing, validation = tf.split([0.8, 0.1, 0.1])
+
+    train_result = train_pipeline(
+        training=training,
+        testing=testing,
+        validation=validation,
+        model="TransE",
+        model_kwargs={"embedding_dim": 8},
+        training_kwargs={"num_epochs": 1, "use_tqdm": False},
+    )
+    assert isinstance(train_result, TrainResult)
+
+    pipeline_result = train_result.evaluate()
+    assert isinstance(pipeline_result, PipelineResult)
+    assert pipeline_result.metric_results is not None
 
 
 @pytest.mark.parametrize("tf_cls", [CoreTriplesFactory, TriplesFactory])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,7 +15,7 @@ from pykeen.models import ERModel, FixedModel, Model
 from pykeen.models.resolve import DimensionError, make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
 from pykeen.nn.representation import Embedding
-from pykeen.pipeline import PipelineResult, ResolutionResult, TrainResult, pipeline, resolve_pipeline, train_pipeline
+from pykeen.pipeline import PipelineResult, ResolutionResult, TrainResult, pipeline, resolve_pipeline
 from pykeen.pipeline.api import replicate_pipeline_from_config
 from pykeen.regularizers import NoRegularizer
 from pykeen.sampling.negative_sampler import NegativeSampler
@@ -430,36 +430,36 @@ def test_resolve_pipeline():
     assert pipeline_result.metric_results is not None
 
 
-def test_train_pipeline_training_only():
-    """Test train_pipeline without testing triples (training-only mode, issue #1579)."""
+def test_training_only():
+    """Test training without testing triples (training-only mode, issue #1579)."""
     tf = generate_triples_factory(num_entities=20, num_relations=5, num_triples=100)
     training, _, validation = tf.split([0.8, 0.1, 0.1])
 
-    result = train_pipeline(
+    result = resolve_pipeline(
         training=training,
         validation=validation,
         model="TransE",
         model_kwargs={"embedding_dim": 8},
         training_kwargs={"num_epochs": 1, "use_tqdm": False},
-    )
+    ).train()
     assert isinstance(result, TrainResult)
     assert result.testing is None
     assert len(result.losses) == 1
 
 
-def test_train_pipeline_deferred_evaluate():
-    """Test that train_pipeline result can be evaluated later with an explicit testing factory."""
+def test_deferred_evaluate():
+    """Test that a TrainResult can be evaluated later with an explicit testing factory."""
     tf = generate_triples_factory(num_entities=20, num_relations=5, num_triples=100)
     training, testing, validation = tf.split([0.8, 0.1, 0.1])
 
-    train_result = train_pipeline(
+    train_result = resolve_pipeline(
         training=training,
         testing=testing,
         validation=validation,
         model="TransE",
         model_kwargs={"embedding_dim": 8},
         training_kwargs={"num_epochs": 1, "use_tqdm": False},
-    )
+    ).train()
     assert isinstance(train_result, TrainResult)
 
     pipeline_result = train_result.evaluate()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,7 +15,7 @@ from pykeen.models import ERModel, FixedModel, Model
 from pykeen.models.resolve import DimensionError, make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
 from pykeen.nn.representation import Embedding
-from pykeen.pipeline import PipelineResult, TrainResult, pipeline, train_pipeline
+from pykeen.pipeline import PipelineResult, ResolutionResult, TrainResult, pipeline, resolve_pipeline, train_pipeline
 from pykeen.pipeline.api import replicate_pipeline_from_config
 from pykeen.regularizers import NoRegularizer
 from pykeen.sampling.negative_sampler import NegativeSampler
@@ -404,6 +404,30 @@ def test_negative_sampler_kwargs():
             model="distmult",
             epochs=0,
         )
+
+
+def test_resolve_pipeline():
+    """Test that resolve_pipeline returns a ResolutionResult and training runs correctly from it."""
+    tf = generate_triples_factory(num_entities=20, num_relations=5, num_triples=100)
+    training, testing, _ = tf.split([0.8, 0.1, 0.1])
+
+    resolution = resolve_pipeline(
+        training=training,
+        testing=testing,
+        model="TransE",
+        model_kwargs={"embedding_dim": 8},
+        training_kwargs={"num_epochs": 1, "use_tqdm": False},
+    )
+    assert isinstance(resolution, ResolutionResult)
+    assert resolution.testing is testing
+
+    train_result = resolution.train()
+    assert isinstance(train_result, TrainResult)
+    assert len(train_result.losses) == 1
+
+    pipeline_result = train_result.evaluate()
+    assert isinstance(pipeline_result, PipelineResult)
+    assert pipeline_result.metric_results is not None
 
 
 def test_train_pipeline_training_only():


### PR DESCRIPTION
## Summary

- Introduces a three-stage pipeline that can be used in full or stepped through:
  - `resolve_pipeline()` → `ResolutionResult`: instantiates all components (model, training loop, evaluator, stopper, factories) and logs all params — no computation yet.
  - `ResolutionResult.train()` → `TrainResult`: runs the training loop.
  - `TrainResult.evaluate()` → `PipelineResult`: runs evaluation on demand.
- `pipeline()` is now `resolve_pipeline(...).train().evaluate(...)`. Existing behaviour is unchanged.
- Passing `testing=None` with an explicit `training` factory skips evaluation entirely — no dummy triples factory required — addressing #1579.
- `TrainResult.evaluate()` accepts an optional `testing` factory to override the one resolved at pipeline setup time.

## Motivation

Users who only need embeddings (downstream tasks, large CPU-only graphs) were forced to supply a dummy `testing=tf` just to satisfy the API, and evaluation still ran anyway. This was reported in #1579 and is the original goal of the long-open PR #919.

Exposing the three stages also makes the pipeline composable: resolve once, train, then evaluate multiple times (e.g. on different test splits), or hand the `TrainResult` off to a custom evaluation routine. `resolve_pipeline()` also lets users inspect the fully-instantiated configuration before committing to a training run.

## Usage

```python
from pykeen.pipeline import resolve_pipeline, pipeline

# Training only — no evaluation triples needed
result = resolve_pipeline(
    training=my_triples_factory,
    model="RotatE",
    training_kwargs={"num_epochs": 100},
).train()
embeddings = result.model.entity_representations[0]()

# Evaluate later (on a different split if needed)
pipeline_result = result.evaluate(testing=test_factory)
print(pipeline_result.get_metric("hits@10"))

# Inspect resolved components before training
resolution = resolve_pipeline(dataset="nations", model="TransE")
print(resolution.model)           # fully instantiated model
print(resolution.training_kwargs) # finalized training kwargs
train_result = resolution.train()
pipeline_result = train_result.evaluate()

# Full pipeline — identical to the old pipeline() call
pipeline_result = pipeline(dataset="nations", model="TransE")
```

## Notes

- `testing=None` training-only mode currently requires `training` to be a pre-built `CoreTriplesFactory` (not a file path). Path-based loading can be added in a follow-up.
- The evaluator and stopper kwargs are accepted by `resolve_pipeline` because the stopper calls the evaluator during training for early stopping.
- Closes #1579.
- Supersedes #919.
