### PR TITLE
🩹🧹 Make ruff rule selection explicit and fix the 2 rules it actually enforces

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ training approach and evaluates with [rank-based evaluation](https://pykeen.read
 from pykeen.pipeline import pipeline
 
 result = pipeline(
-    model='TransE',
-    dataset='nations',
+    model="TransE",
+    dataset="nations",
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ extend-include = ["*.ipynb"]
 
 [tool.ruff.lint]
 # See https://docs.astral.sh/ruff/rules
-extend-select = [
+select = [
     # Airflow (AIR)
     # "AIR",   # (framework-specific, not used in this project)
     # eradicate (ERA)

--- a/src/pykeen/nn/vision/cache.py
+++ b/src/pykeen/nn/vision/cache.py
@@ -109,7 +109,7 @@ class WikidataImageCache(WikidataTextCache):
                 if relation not in url_dict:
                     continue
                 # now there is an image available -> select reproducible by URL sorting
-                image_url = sorted(url_dict[relation])[0]
+                image_url = min(url_dict[relation])
                 ext = image_url.rsplit(".", maxsplit=1)[-1].lower()
                 if ext not in extensions:
                     logger.warning(f"Unknown extension: {ext} for {image_url}")

--- a/src/pykeen/templates/README.md
+++ b/src/pykeen/templates/README.md
@@ -86,8 +86,8 @@ training approach and evaluates with [rank-based evaluation](https://pykeen.read
 from pykeen.pipeline import pipeline
 
 result = pipeline(
-    model='TransE',
-    dataset='nations',
+    model="TransE",
+    dataset="nations",
 )
 ```
 

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -428,11 +428,13 @@ class TestLiterals(unittest.TestCase):
 
         assert result.shape[0] == 1, "only the fully known triple should pass through"
         assert log.output == [
-            "WARNING:pykeen.triples.triples_factory:"
-            "You're trying to map 3 triples with 2 entities "
-            "(2 as head, 1 as tail) and 0 relations"
-            " that are not in the training set. 3 of 4 triples"
-            " will be excluded from the mapping."
+            (
+                "WARNING:pykeen.triples.triples_factory:"
+                "You're trying to map 3 triples with 2 entities "
+                "(2 as head, 1 as tail) and 0 relations"
+                " that are not in the training set. 3 of 4 triples"
+                " will be excluded from the mapping."
+            )
         ]
 
     def test_inverse_triples(self):


### PR DESCRIPTION
## Summary

`master`'s `Lint` check is currently broken: `ruff check` reports **788 errors**. This is not code debt — it's a config/tooling mismatch that surfaced with a recent `ruff` upgrade (CI resolves `ruff==0.16.1`, unpinned in `tox.ini`).

`pyproject.toml` deliberately leaves many rule categories unselected (`RUF`, `PYI`, `TRY`, `PL`, `DTZ`, `BLE`, `YTT`, ... are commented out in `[tool.ruff.lint] extend-select`, e.g. `# "RUF",`). But `extend-select` only *adds* rules on top of ruff's own default selection — it never restricts it. And ruff's bare default (no config at all) now enables **~413 rules**, way beyond the historical minimal `E4`/`E7`/`E9`/`F` default. So every category the project explicitly opted out of started firing anyway, purely because ruff's own defaults grew.

This is currently blocking the merge queue for unrelated PRs (e.g. #1588) via the required `Lint (3.10)`/`Lint (3.14)` checks.

## Changes

- `pyproject.toml`: `extend-select` → `select`. This makes the enabled rule set fully explicit and immune to future drift in ruff's own default selection. This alone takes `ruff check` from 788 errors down to 2.
- `src/pykeen/nn/vision/cache.py`: `sorted(...)[0]` → `min(...)` (`FURB192`) — one of the 2 genuine violations that remain once the config bug is fixed (the project does select `FURB`).
- `tests/test_triples_factory.py`: parenthesize the implicitly-concatenated multi-line log message inside the list literal, per `ISC004` (the project does select `ISC`) — purely a readability disambiguation, no behavior change.
- `README.md` / `src/pykeen/templates/README.md`: same pre-existing `ruff format` quote-style fix as in #1594 (this branch was cut from `master` before that PR merged, so it picked up the same drift independently — no conflict either way).

## Verification

- `ruff check`: 788 errors → 0.
- `ruff format --check`: clean.
- `tox -e pyroma,docstr-coverage,doc8`: all green (unrelated `manifest` check fails locally only due to a missing `python3-venv` package on this machine, not a code issue).

## Note

This is independent of #1594 (the `mypy` fix) — different files, no real overlap. Both need to land on `master` before #1588's merge queue attempt will pass, since that job runs `mypy` and `ruff check` sequentially and currently fails at whichever step is broken first.