### PR TITLE
🩹🧹 Fix master's broken Lint check (mypy scalar types + ruff rule selection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ training approach and evaluates with [rank-based evaluation](https://pykeen.read
 from pykeen.pipeline import pipeline
 
 result = pipeline(
-    model='TransE',
-    dataset='nations',
+    model="TransE",
+    dataset="nations",
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ extend-include = ["*.ipynb"]
 
 [tool.ruff.lint]
 # See https://docs.astral.sh/ruff/rules
-extend-select = [
+select = [
     # Airflow (AIR)
     # "AIR",   # (framework-specific, not used in this project)
     # eradicate (ERA)

--- a/src/pykeen/metrics/utils.py
+++ b/src/pykeen/metrics/utils.py
@@ -265,7 +265,7 @@ def weighted_harmonic_mean(a: np.ndarray, weights: np.ndarray | None = None) -> 
     return np.reciprocal(np.average(np.reciprocal(a.astype(float)), weights=weights))
 
 
-def weighted_median(a: np.ndarray, weights: np.ndarray | None = None) -> np.ndarray:
+def weighted_median(a: np.ndarray, weights: np.ndarray | None = None) -> np.floating:
     """Calculate weighted median."""
     if weights is None:
         return np.median(a)

--- a/src/pykeen/nn/node_piece/tokenization.py
+++ b/src/pykeen/nn/node_piece/tokenization.py
@@ -138,7 +138,7 @@ class AnchorTokenizer(Tokenizer):
         num_empty = (tokens < 0).all(axis=1).sum()
         if num_empty > 0:
             logger.warning(
-                f"{format_relative_comparison(part=num_empty, total=num_entities)} do not have any anchor.",
+                f"{format_relative_comparison(part=num_empty.item(), total=num_entities)} do not have any anchor.",
             )
         # convert to torch
         return len(anchors) + 1, torch.as_tensor(tokens, dtype=torch.long)

--- a/src/pykeen/nn/vision/cache.py
+++ b/src/pykeen/nn/vision/cache.py
@@ -109,7 +109,7 @@ class WikidataImageCache(WikidataTextCache):
                 if relation not in url_dict:
                     continue
                 # now there is an image available -> select reproducible by URL sorting
-                image_url = sorted(url_dict[relation])[0]
+                image_url = min(url_dict[relation])
                 ext = image_url.rsplit(".", maxsplit=1)[-1].lower()
                 if ext not in extensions:
                     logger.warning(f"Unknown extension: {ext} for {image_url}")

--- a/src/pykeen/templates/README.md
+++ b/src/pykeen/templates/README.md
@@ -86,8 +86,8 @@ training approach and evaluates with [rank-based evaluation](https://pykeen.read
 from pykeen.pipeline import pipeline
 
 result = pipeline(
-    model='TransE',
-    dataset='nations',
+    model="TransE",
+    dataset="nations",
 )
 ```
 

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -428,11 +428,13 @@ class TestLiterals(unittest.TestCase):
 
         assert result.shape[0] == 1, "only the fully known triple should pass through"
         assert log.output == [
-            "WARNING:pykeen.triples.triples_factory:"
-            "You're trying to map 3 triples with 2 entities "
-            "(2 as head, 1 as tail) and 0 relations"
-            " that are not in the training set. 3 of 4 triples"
-            " will be excluded from the mapping."
+            (
+                "WARNING:pykeen.triples.triples_factory:"
+                "You're trying to map 3 triples with 2 entities "
+                "(2 as head, 1 as tail) and 0 relations"
+                " that are not in the training set. 3 of 4 triples"
+                " will be excluded from the mapping."
+            )
         ]
 
     def test_inverse_triples(self):


### PR DESCRIPTION
## Summary

`master`'s required `Lint` check is currently broken, blocking the merge queue for unrelated PRs (e.g. #1588). This combines two independent fixes (previously split across #1594 and #1595, superseded by this PR) into one, since both need to land before the `Lint` job passes end-to-end.

### mypy — stricter numpy stubs (2 errors)

- `weighted_median()` in `src/pykeen/metrics/utils.py` is annotated as returning `np.ndarray`, but every code path actually returns a numpy scalar. Fixed the annotation to `np.floating`.
- `AnchorTokenizer._call()` in `src/pykeen/nn/node_piece/tokenization.py` passes a numpy integer scalar to `format_relative_comparison(part: int, ...)`. Unwrapped it with `.item()`, consistent with how numpy scalars are handled elsewhere in the codebase (e.g. `weighted_median`'s callers in `metrics/ranking.py`).

### ruff — 788 errors from an unpinned version bump

`ruff`'s own default enabled rule set has grown to ~413 rules, up from the historical minimal `E4`/`E7`/`E9`/`F` default. `pyproject.toml` used `extend-select`, which only *adds* to whatever ruff's default is and never restricts it, so every category the project deliberately left unselected (`RUF`, `PYI`, `TRY`, `PL*`, `DTZ`, `BLE`, `YTT`, ...) started firing.

- `pyproject.toml`: `extend-select` → `select`, so the enabled rule set is fully explicit and no longer drifts with ruff's own defaults. This alone takes `ruff check` from 788 errors down to 2. **Not** adopting the newly-defaulted categories in this PR — that's a separate policy decision for the maintainers, not a CI-unblocking fix.
- `src/pykeen/nn/vision/cache.py`: `sorted(...)[0]` → `min(...)` (`FURB192`), one of the 2 genuine violations that remain (the project does select `FURB`).
- `tests/test_triples_factory.py`: parenthesize the implicitly-concatenated log message inside the list literal (`ISC004`; the project does select `ISC`) for unambiguous readability, no behavior change.

Also fixes a pre-existing `ruff format` quote-style issue in `README.md` / `src/pykeen/templates/README.md`, previously masked because the `mypy` step failed first in the same CI job.

## Verification

- `tox -e mypy`: clean (245 source files).
- `tox -e lint` (`ruff format --check` + `ruff check`): clean.