### PR TITLE
🩹🔒 Switch Lint workflow from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
   merge_group:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
## Summary

The `Lint` workflow's `pull_request_target` trigger checks out the base branch (`master`) by default, not the PR's actual commit, since the checkout step never overrides `ref`. Every `pull_request_target`-triggered `Lint` run has therefore been silently testing `master` instead of the PR — so this check could never actually reflect a PR's own changes, and stays red whenever `master` itself has an issue (as currently seen on #1596, and indirectly blocking #1588's mergeability via `mergeStateStatus: BLOCKED`).

## Why not just fix the checkout ref?

`pull_request_target` runs with the base repo's `GITHUB_TOKEN`/secrets regardless of which fork opened the PR, specifically so workflows *don't* need to build/execute the PR's own code. Pinning `ref: github.event.pull_request.head.sha` would fix the reporting bug, but would also mean this workflow starts actually building a fork's code under that trigger — `pyroma` and `check-manifest` both invoke the PEP 517 build backend to get package metadata, which can execute code from a PR-controlled `setup.py`/`pyproject.toml`. Combined with `actions/checkout`'s default `persist-credentials: true` (a live token-backed git credential sitting in `.git/config`, readable by any process in the job), that's the classic "pwn request" pattern — not something worth introducing just to fix a status-reporting bug.

## History

- `pull_request: types: [auto_merge_enabled]` existed here since 2022, deliberately narrow: external (fork) PRs got no automatic `Lint` run until a maintainer engaged with the PR by enabling auto-merge.
- #1522 (Mar 2025) wanted earlier feedback for external PRs (`opened`/`synchronize`, not just after auto-merge). It added `pull_request_target` to get that, rather than simply widening the existing `pull_request` trigger's own `types:` — which would have achieved the same goal without the trigger/checkout mismatch.
- #1577 (Dec 2025, "Remove duplicate pipelines") removed the now-redundant `pull_request` trigger and trimmed `pull_request_target`'s types, collapsing to a single trigger — but kept the one with the checkout bug.

This workflow has never had a `permissions:` block and never references `secrets.*` — it needs no elevated token permissions at all, so there's no reason to use `pull_request_target` over `pull_request` here in the first place. `lint.yml` is also the only workflow in the repo using `pull_request_target`.

## Change

```diff
   push:
   merge_group:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
```

`pull_request` checks out the PR head correctly by default (no `ref:` override needed), forked-repo runs get a token with no write access and no secrets, and it still triggers automatically for external PRs (same first-time-contributor approval gate as before) — one trigger, no duplicate runs, no checkout/security tradeoff.

## Note

Independent of #1596 — this fixes PR-level status reporting/mergeability, not the merge queue itself (the `merge_group` trigger already builds the correct speculative-merge commit regardless of this bug, which is why #1588's queue failures were never caused by this).