### PR TITLE
🩹🚂 Fix merge-queue check cancellations and general CI cleanup

### DIFF
--- a/.github/actions/setup-tox/action.yml
+++ b/.github/actions/setup-tox/action.yml
@@ -1,5 +1,5 @@
 name: Set up Python and tox
-description: Checks out the repository, sets up Python with pip caching, and installs tox and tox-uv.
+description: Sets up Python with pip caching and installs tox and tox-uv. Requires the repository to already be checked out.
 
 inputs:
   python-version:
@@ -9,8 +9,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
-
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/actions/setup-tox/action.yml
+++ b/.github/actions/setup-tox/action.yml
@@ -1,0 +1,26 @@
+name: Set up Python and tox
+description: Checks out the repository, sets up Python with pip caching, and installs tox and tox-uv.
+
+inputs:
+  python-version:
+    description: The Python version to set up
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+        cache: 'pip'
+        cache-dependency-path: |
+          ./pyproject.toml
+          ./tox.ini
+
+    - name: Install dependencies
+      run: pip install tox tox-uv
+      shell: bash

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -27,7 +27,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
           cache: 'pip'
-          cache-dependency-path: './pyproject.toml'
+          cache-dependency-path: |
+            ./pyproject.toml
+            ./tox.ini
       
       - name: Install dependencies
         run: pip install tox tox-uv
@@ -68,7 +70,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
           cache: 'pip'
-          cache-dependency-path: './pyproject.toml'
+          cache-dependency-path: |
+            ./pyproject.toml
+            ./tox.ini
       
       - name: Install dependencies
         run: pip install tox tox-uv

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -87,4 +87,4 @@ jobs:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.event_name != 'merge_group' }}

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     name: Documentation

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -19,21 +19,10 @@ jobs:
         # no need to check documentation with multiple python versions
         python-version: [ "3.14" ]
     steps:
-      - uses: actions/checkout@v4
-      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-tox
         with:
           python-version: ${{ matrix.python-version }}
-          # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-          cache: 'pip'
-          cache-dependency-path: |
-            ./pyproject.toml
-            ./tox.ini
-      
-      - name: Install dependencies
-        run: pip install tox tox-uv
-      
+
       # - name: Check RST format
       #   run: tox -e doclint
 
@@ -62,21 +51,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-tox
         with:
           python-version: ${{ matrix.python-version }}
-          # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-          cache: 'pip'
-          cache-dependency-path: |
-            ./pyproject.toml
-            ./tox.ini
-      
-      - name: Install dependencies
-        run: pip install tox tox-uv
-      
+
       - name: Run fast tests
         run: tox -e py
       

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -22,6 +22,8 @@ jobs:
         # no need to check documentation with multiple python versions
         python-version: [ "3.14" ]
     steps:
+      - uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup-tox
         with:
           python-version: ${{ matrix.python-version }}
@@ -51,6 +53,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup-tox
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -26,9 +26,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # - name: Check RST format
-      #   run: tox -e doclint
-
       - name: Check README.rst
         run: tox -e readme
 
@@ -66,9 +63,6 @@ jobs:
       
       - name: Run doctests
         run: tox -e doctests
-      
-      # - name: Test notebooks
-      #   run: tox -e treon
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
           cache: 'pip'
-          cache-dependency-path: './pyproject.toml'
-      
+          cache-dependency-path: |
+            ./pyproject.toml
+            ./tox.ini
+
       - name: Install dependencies
         run: pip install tox tox-uv
 
@@ -48,8 +50,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
         # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
         cache: 'pip'
-        cache-dependency-path: './pyproject.toml'
-    
+        cache-dependency-path: |
+          ./pyproject.toml
+          ./tox.ini
+
     - name: Install dependencies
       run: pip install tox tox-uv
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,20 +17,9 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.14" ]
     steps:
-      - uses: actions/checkout@v4
-      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-tox
         with:
           python-version: ${{ matrix.python-version }}
-          # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-          cache: 'pip'
-          cache-dependency-path: |
-            ./pyproject.toml
-            ./tox.ini
-
-      - name: Install dependencies
-        run: pip install tox tox-uv
 
       - name: Check static typing with MyPy
         run: tox -e mypy
@@ -42,20 +31,9 @@ jobs:
       matrix:
         python-version: [ "3.14" ]
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - uses: ./.github/actions/setup-tox
       with:
         python-version: ${{ matrix.python-version }}
-        # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
-        cache: 'pip'
-        cache-dependency-path: |
-          ./pyproject.toml
-          ./tox.ini
-
-    - name: Install dependencies
-      run: pip install tox tox-uv
 
     - name: Check code quality
       run: tox -e lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 
 on:
   push:
+    branches:
+      - master
   merge_group:
   workflow_dispatch:
   pull_request:
@@ -69,4 +71,4 @@ jobs:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.event_name != 'merge_group' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,8 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.14" ]
     steps:
+      - uses: actions/checkout@v4
+
       - uses: ./.github/actions/setup-tox
         with:
           python-version: ${{ matrix.python-version }}
@@ -34,6 +36,8 @@ jobs:
       matrix:
         python-version: [ "3.14" ]
     steps:
+    - uses: actions/checkout@v4
+
     - uses: ./.github/actions/setup-tox
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Check static typing with MyPy
         run: tox -e mypy
 
-      - name: Check code quality
-        run: tox -e lint
-  
   lint-single-version:
     name: Lint Single Version
     runs-on: ubuntu-latest
@@ -55,6 +52,9 @@ jobs:
     
     - name: Install dependencies
       run: pip install tox tox-uv
+
+    - name: Check code quality
+      run: tox -e lint
 
     - name: Check package metadata with Pyroma
       run: tox -e pyroma


### PR DESCRIPTION
## Summary
- Fixes the root cause of Lint checks being cancelled mid merge-train (see https://github.com/pykeen/pykeen/actions/runs/31267271668): `lint.yml`'s unscoped `push` trigger duplicated the `merge_group`-triggered run on the queue's temporary `gh-readonly-queue/*` ref, and the two runs cancelled each other in the same concurrency group. Also excludes `merge_group` from `cancel-in-progress` in both workflows as defense in depth, since a cancelled required check ejects a PR from the queue.
- Moves the ruff check (`tox -e lint`) out of the Python-version matrix in the `Lint` job — ruff's output doesn't depend on the interpreter, so it was running redundantly on both 3.10 and 3.14. It now runs once in `Lint Single Version`.
- Fixes the pip cache key to also watch `tox.ini`, where mypy/ruff/sphinx/doc8 tool versions are pinned (previously only `pyproject.toml` was watched, so bumping a tool version there wouldn't bust the cache).
- Extracts the repeated checkout/setup-python/install-tox steps (duplicated across all four jobs in `lint.yml` and `common.yml`) into a composite action, `.github/actions/setup-tox`.
- Adds explicit `permissions: contents: read` to `lint.yml` and `common.yml`, since neither needs a writable token.
- Removes dead commented-out `doclint`/`treon` steps.

Each change is its own commit for easy review.

## Test plan
- [ ] YAML validated locally (`yaml.safe_load` on all changed workflow/action files)
- [ ] Confirm this PR's own CI runs (Lint, Lint Single Version, Documentation, Tests) pass under the refactored workflows
- [ ] Watch the next merge-queue entry to confirm Lint no longer gets cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)