### PR TITLE
✨🍎 Add macOS (arm64, CPU-only) to the Tests CI matrix

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -50,13 +50,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [ "3.10", "3.14" ]
-        # cannot use macos-latest for now, cf.
-        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners
-        # cannot use Python 3.8
-        # cannot use M1 at all, since PyG does not provide M1 packages...
-        # include:
-        #   - os: macos-14
-        #     python-version: "3.11"
+        include:
+          # macos-latest is now an Apple Silicon (arm64) runner; torch and torch_geometric both
+          # ship arm64 wheels, so this now works. Kept to a single combination since macOS
+          # runners are billed at a much higher rate than Linux/Windows.
+          # resolve_device() never selects mps (it only falls back cuda -> cpu), so this only
+          # exercises the CPU path -- it does not cover the still-unresolved MPS support in
+          # torch_max_mem, cf. https://github.com/mberr/torch-max-mem/issues/14
+          - os: macos-latest
+            python-version: "3.14"
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary
- Adds a single `macos-latest` / Python 3.14 combination to the `Tests` matrix in `common.yml`, via `include:` rather than the main `os:` list, so it doesn't cross-product against both Python versions.
- `macos-latest` now points to an Apple Silicon (arm64) runner, and both `torch` and `torch_geometric` ship arm64 wheels, so the old blocker documented in the removed comment no longer applies.
- `resolve_device()` (`src/pykeen/utils.py:134`) only ever falls back `cuda -> cpu`, never selecting `mps`, so this exclusively exercises the CPU path. It intentionally does **not** enable/test the `mps` backend, since MPS support is still broken upstream:
  - [mberr/torch-max-mem#14](https://github.com/mberr/torch-max-mem/issues/14) — AMO/OOM handling doesn't work correctly on `mps` (crashes even at batch_size=1)
  - [pytorch/pytorch#105839](https://github.com/pytorch/pytorch/issues/105839) — `cdist` buffer-size issue on MPS
  - Related: the long-open, unmerged [#975](https://github.com/pykeen/pykeen/pull/975) (actual MPS device support), last updated Feb 2025, blocked on the same upstream issues plus MPS segfaults.
- Kept to one Python version deliberately: since macOS here only tests CPU (same code path as Linux/Windows), a second Python version mostly re-tests the same arm64-packaging question rather than adding new signal, and the merge queue re-runs every check again before merge, so keeping the matrix lean helps overall turnaround time.

This repo is public, so GitHub Actions minutes are free here — the tradeoff is signal-per-job and merge-queue turnaround, not billing.

## Test plan
- [ ] Confirm the new `Tests (macos-latest, 3.14)` job appears and passes on this PR
- [ ] Confirm it's not (yet) a required status check, so it doesn't block merges while we get a feel for its stability/runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)