### PR TITLE
⚡🧪 Speed up test suite with pytest-xdist and reduced Lightning fixture overhead

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ lightning = [
     "pytorch_lightning>=1.7.2",
 ]
 biomedicine = ["bioregistry", "pyobo>=0.8.7"]
-tests = ["unittest-templates>=0.0.5", "coverage", "pytest"]
+tests = ["unittest-templates>=0.0.5", "coverage", "pytest", "pytest-xdist"]
 docs = [
     "sphinx>=8.0",
     "sphinx-rtd-theme>=3.0",

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -2572,6 +2572,9 @@ class EarlyStopperTestCase(unittest_templates.GenericTestCase[EarlyStopper]):
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
         kwargs = super()._pre_instantiation_hook(kwargs)
         nations = Nations()
+        # use a per-test directory rather than a fixed shared path, since a fixed path can collide
+        # across tests running concurrently (e.g., under pytest-xdist)
+        self.directory = tempfile.TemporaryDirectory()
         kwargs.update(
             {
                 "evaluator": MockEvaluator(key=("hits_at_10", SIDE_BOTH, RANK_REALISTIC), values=self.mock_losses),
@@ -2581,10 +2584,14 @@ class EarlyStopperTestCase(unittest_templates.GenericTestCase[EarlyStopper]):
                 "patience": self.patience,
                 "relative_delta": self.delta,
                 "larger_is_better": False,
-                "best_model_path": pathlib.Path(tempfile.gettempdir(), "test-best-model-weights.pt"),
+                "best_model_path": pathlib.Path(self.directory.name, "test-best-model-weights.pt"),
             }
         )
         return kwargs
+
+    def tearDown(self) -> None:
+        """Tear down the test case by cleaning up the temporary directory."""
+        self.directory.cleanup()
 
     def test_initialization(self):
         """Test warm-up phase."""

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -12,7 +12,9 @@ from tests.utils import needs_packages
 try:
     from pykeen.contrib.lightning import lit_module_resolver, lit_pipeline
 
-    LIT_MODULES = lit_module_resolver.lookup_dict.keys()
+    # sorted since lookup_dict's order is not deterministic across processes,
+    # which would break pytest-xdist's collection consistency check
+    LIT_MODULES = sorted(lit_module_resolver.lookup_dict.keys())
 except ImportError:
     LIT_MODULES = []
     lit_pipeline = None
@@ -104,6 +106,10 @@ def test_lit_training(model, model_kwargs, training_loop):
             "enable_checkpointing": False,
             # fast run
             "max_epochs": 2,
+            # reduce fixed per-test overhead; validation itself still runs each epoch
+            "enable_progress_bar": False,
+            "enable_model_summary": False,
+            "num_sanity_val_steps": 0,
         },
     )
 
@@ -128,5 +134,9 @@ def test_lit_pipeline_with_dataset_without_validation():
             "enable_checkpointing": False,
             # fast run
             "max_epochs": 2,
+            # reduce fixed per-test overhead; validation itself still runs each epoch
+            "enable_progress_bar": False,
+            "enable_model_summary": False,
+            "num_sanity_val_steps": 0,
         },
     )

--- a/tox.ini
+++ b/tox.ini
@@ -53,13 +53,22 @@ allowlist_externals =
     /usr/local/bin/git
 
 [testenv:py]
-commands = coverage run -p -m pytest --durations=20 {posargs:tests} -m 'not slow'
+setenv =
+    {[testenv]setenv}
+    # avoid each xdist worker oversubscribing all cores for BLAS/torch ops
+    OMP_NUM_THREADS = 1
+    MKL_NUM_THREADS = 1
+commands = coverage run -p -m pytest --durations=20 {posargs:tests} -m 'not slow' -n {env:PYTEST_XDIST_N:4}
 extras =
     mlflow
     tests
 
 [testenv:integration]
-commands = coverage run -p -m pytest --durations=20 {posargs:tests} -m slow
+setenv =
+    {[testenv]setenv}
+    OMP_NUM_THREADS = 1
+    MKL_NUM_THREADS = 1
+commands = coverage run -p -m pytest --durations=20 {posargs:tests} -m slow -n {env:PYTEST_XDIST_N:4}
 extras =
     mlflow
     tests


### PR DESCRIPTION
## Summary
- Add `pytest-xdist` to the `tests` extra and enable `-n {env:PYTEST_XDIST_N:4}` for both the `py` (fast) and `integration` (slow) tox envs, plus `OMP_NUM_THREADS=1`/`MKL_NUM_THREADS=1` so workers don't oversubscribe cores for BLAS/torch ops. Defaults to 4 workers rather than `auto` since `auto` OOM-killed on a memory-constrained dev box; 4 matches typical GitHub-hosted runner core counts and is overridable via `PYTEST_XDIST_N`.
- Trim fixed per-test PyTorch Lightning `Trainer` overhead in `tests/test_lightning.py` (`enable_progress_bar=False`, `enable_model_summary=False`, `num_sanity_val_steps=0`) — real validation still runs every epoch, only the redundant pre-training sanity-check pass is skipped. `accelerator="auto"` is left untouched so MPS auto-selection on macOS CI (#1599, #1600) stays covered. This file was the single slowest in the fast suite (some parametrizations up to 51s); locally this + xdist brought it from 7m13s serial to 2m44s.
- Fix two issues found while validating this under xdist:
  - `LIT_MODULES` in `test_lightning.py` came from `class_resolver`'s set-based subclass registry, whose iteration order is not stable across processes — this broke pytest-xdist's cross-worker collection consistency check. Now sorted.
  - `EarlyStopperTestCase` in `tests/cases.py` wrote to a hardcoded shared path (`<tmp>/test-best-model-weights.pt`) instead of a per-test temp file, which could race under concurrent workers.

## Test plan
- [x] `tests/test_lightning.py` passes locally under `-n 4` (69 passed, 164.7s vs 433.6s serial)
- [x] Verified test collection is now deterministic across repeated invocations (previously varied due to the `class_resolver` set ordering)
- [x] Full fast + slow suite passes on CI under the new `-n 4` xdist config across the OS/Python matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)