### PR TITLE
🐛🧪 Fix pytest parametrize deprecation warnings and bump CI actions off Node 20

### DIFF
--- a/.github/actions/setup-tox/action.yml
+++ b/.github/actions/setup-tox/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
         # cache dependencies, cf. https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -22,7 +22,7 @@ jobs:
         # no need to check documentation with multiple python versions
         python-version: [ "3.14" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-tox
         with:
@@ -50,7 +50,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-tox
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.14" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-tox
         with:
@@ -36,7 +36,7 @@ jobs:
       matrix:
         python-version: [ "3.14" ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: ./.github/actions/setup-tox
       with:

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -59,10 +59,10 @@ MODEL_CONFIGURATIONS = {
     models.TuckER: {"embedding_dim": EMBEDDING_DIM},
     models.UM: {"embedding_dim": EMBEDDING_DIM},
 }
-TEST_CONFIGURATIONS = (
+TEST_CONFIGURATIONS = [
     (model, model_config, lit)
     for (model, model_config), lit in itertools.product(MODEL_CONFIGURATIONS.items(), LIT_MODULES)
-)
+]
 
 
 # test combinations of models with training loops

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -168,7 +168,7 @@ def _check_score_pack(pack: pykeen.predict.ScorePack, model: pykeen.models.Model
     assert pack.result[:, 1].max() < model.num_relations
 
 
-@pytest.mark.parametrize(("model", "k", "target", "batch_size"), _iter_predict_all_inputs())
+@pytest.mark.parametrize(("model", "k", "target", "batch_size"), list(_iter_predict_all_inputs()))
 def test_predict_all(model: pykeen.models.Model, k: int | None, target: pykeen.typing.Target, batch_size: int):
     """Test the predict method."""
     pack = pykeen.predict.predict_all(model=model, k=k, target=target, batch_size=batch_size)
@@ -222,7 +222,9 @@ def _iter_predict_triples_inputs() -> Iterable[
     yield model, factory.mapped_triples[:3], None, None
 
 
-@pytest.mark.parametrize(("model", "triples", "triples_factory", "batch_size"), _iter_predict_triples_inputs())
+@pytest.mark.parametrize(
+    ("model", "triples", "triples_factory", "batch_size"), list(_iter_predict_triples_inputs())
+)
 def test_predict_triples(
     model: pykeen.models.Model,
     triples: AnyTriples,
@@ -267,7 +269,9 @@ def _iter_get_input_batch_inputs() -> Iterable[
     yield factory, None, 1, "uk", pykeen.typing.LABEL_HEAD
 
 
-@pytest.mark.parametrize(("factory", "head", "relation", "tail", "exp_target"), _iter_get_input_batch_inputs())
+@pytest.mark.parametrize(
+    ("factory", "head", "relation", "tail", "exp_target"), list(_iter_get_input_batch_inputs())
+)
 def test_get_input_batch(
     factory: CoreTriplesFactory | None,
     head: None | int | str,
@@ -355,7 +359,9 @@ def _iter_predict_target_inputs() -> Iterable[
         yield model, 0, 1, None, factory_, [0, 3, 7]
 
 
-@pytest.mark.parametrize(("model", "head", "relation", "tail", "factory", "targets"), _iter_predict_target_inputs())
+@pytest.mark.parametrize(
+    ("model", "head", "relation", "tail", "factory", "targets"), list(_iter_predict_target_inputs())
+)
 def test_predict_target(
     model: pykeen.models.Model,
     head: None | int | str,

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -222,9 +222,7 @@ def _iter_predict_triples_inputs() -> Iterable[
     yield model, factory.mapped_triples[:3], None, None
 
 
-@pytest.mark.parametrize(
-    ("model", "triples", "triples_factory", "batch_size"), list(_iter_predict_triples_inputs())
-)
+@pytest.mark.parametrize(("model", "triples", "triples_factory", "batch_size"), list(_iter_predict_triples_inputs()))
 def test_predict_triples(
     model: pykeen.models.Model,
     triples: AnyTriples,
@@ -269,9 +267,7 @@ def _iter_get_input_batch_inputs() -> Iterable[
     yield factory, None, 1, "uk", pykeen.typing.LABEL_HEAD
 
 
-@pytest.mark.parametrize(
-    ("factory", "head", "relation", "tail", "exp_target"), list(_iter_get_input_batch_inputs())
-)
+@pytest.mark.parametrize(("factory", "head", "relation", "tail", "exp_target"), list(_iter_get_input_batch_inputs()))
 def test_get_input_batch(
     factory: CoreTriplesFactory | None,
     head: None | int | str,

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -630,7 +630,7 @@ def _iter_get_mapped_triples_inputs() -> Iterable[tuple[Any, Mapping[str, Any]]]
     yield None, {"triples": np.asarray(labeled), "factory": factory}
 
 
-@pytest.mark.parametrize(("x", "inputs"), _iter_get_mapped_triples_inputs())
+@pytest.mark.parametrize(("x", "inputs"), list(_iter_get_mapped_triples_inputs()))
 def test_get_mapped_triples(x, inputs: Mapping[str, Any]):
     """Test get_mapped_triples."""
     mapped_triples = get_mapped_triples(x, **inputs)
@@ -651,7 +651,7 @@ def tf_one_hole() -> CoreTriplesFactory:
     return tf
 
 
-@pytest.mark.parametrize(("entities", "relations"), itt.product((False, True), repeat=2))
+@pytest.mark.parametrize(("entities", "relations"), list(itt.product((False, True), repeat=2)))
 def test_condense(tf_one_hole: CoreTriplesFactory, entities: bool, relations: bool) -> None:
     """Test condensation."""
     tf_new = tf_one_hole.condense(entities=entities, relations=relations)


### PR DESCRIPTION
## Summary
- Wrap generator/iterator arguments (`_iter_predict_all_inputs()`, `_iter_predict_triples_inputs()`, `_iter_get_input_batch_inputs()`, `_iter_predict_target_inputs()`, `_iter_get_mapped_triples_inputs()`, `itertools.product(...)`, and `TEST_CONFIGURATIONS`) passed to `pytest.mark.parametrize` in `list(...)` — `pytest`'s `PytestRemovedIn10Warning` now flags non-`Collection` iterables there.
- Bump `actions/checkout` to `v5` and `actions/setup-python` to `v6` in CI workflows to clear the "Node.js 20 is deprecated" annotation.

## Test plan
- [x] Confirmed the affected files parse (`ast.parse`)
- [ ] CI run passes without the pytest/Node deprecation warnings