### PR TITLE
Use the model's loss_default in pipeline() instead of the loss resolver's default

### DIFF
--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1041,6 +1041,15 @@ def _build_model_helper(
             logger.warning(
                 f"Cannot specify loss in kwargs ({loss}) and model_kwargs ({_loss}). removing from model_kwargs.",
             )
+    if loss is None and not isinstance(model, Model):
+        # When no loss is requested, fall back to the *model's* default loss rather than the loss
+        # resolver's default (:class:`~pykeen.losses.MarginRankingLoss`). This is what
+        # :meth:`pykeen.models.Model.__init__` does when it receives ``loss=None``, and what
+        # :func:`pykeen.hpo.hpo_pipeline` already does when it builds its search space.
+        model_cls = model_resolver.lookup(model)
+        loss = model_cls.loss_default
+        # the model's defaults act as defaults, i.e., explicitly given kwargs take precedence
+        loss_kwargs = {**(model_cls.loss_default_kwargs or {}), **(loss_kwargs or {})}
     model_kwargs["loss"] = loss_resolver.make(loss, loss_kwargs)
 
     if not isinstance(model, Model):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,6 +12,7 @@ import torch
 import pykeen.regularizers
 from pykeen.datasets import EagerDataset, Nations
 from pykeen.evaluation import Evaluator
+from pykeen.losses import BCEAfterSigmoidLoss, Loss, MarginRankingLoss, NSSALoss
 from pykeen.models import ERModel, FixedModel, Model
 from pykeen.models.resolve import DimensionError, make_model, make_model_cls
 from pykeen.nn.modules import TransEInteraction
@@ -495,6 +496,51 @@ def test_deferred_evaluate():
     assert isinstance(result_b, PipelineResult)
     # results should differ because the evaluation sets differ
     assert result_a.metric_results.to_dict() != result_b.metric_results.to_dict()
+
+
+def _resolve_loss(**kwargs) -> Loss:
+    """Resolve a pipeline on Nations and return the loss instance the model was built with."""
+    kwargs.setdefault("model_kwargs", {}).setdefault("embedding_dim", 8)
+    return resolve_pipeline(dataset="nations", random_seed=0, **kwargs).model.loss
+
+
+def test_pipeline_uses_model_loss_default():
+    """Test that a model without an explicitly requested loss is built with its own ``loss_default``."""
+    # ConvE declares BCEAfterSigmoidLoss; before, the loss resolver's default silently won instead
+    assert isinstance(_resolve_loss(model="ConvE"), BCEAfterSigmoidLoss)
+
+
+def test_pipeline_uses_model_loss_default_kwargs():
+    """Test that ``loss_default_kwargs`` are used along with ``loss_default``."""
+    loss = _resolve_loss(model="PairRE")
+    assert isinstance(loss, NSSALoss)
+    # PairRE.loss_default_kwargs, not NSSALoss's own default margin
+    assert loss.margin == pytest.approx(12.0)
+
+
+def test_pipeline_loss_default_is_noop_for_margin_ranking_models():
+    """Test that models inheriting the base ``loss_default`` are unaffected."""
+    # TransE names no loss of its own, so it inherits Model.loss_default -- exactly what the loss
+    # resolver produced before, i.e., previously reported results for such models do not change
+    loss = _resolve_loss(model="TransE")
+    assert isinstance(loss, MarginRankingLoss)
+    assert loss.margin == pytest.approx(1.0)
+
+
+def test_pipeline_explicit_loss_wins():
+    """Test that an explicitly requested loss is not overridden by the model's default."""
+    assert isinstance(_resolve_loss(model="ConvE", loss="MarginRanking"), MarginRankingLoss)
+    # ... also when it is passed inside model_kwargs
+    assert isinstance(_resolve_loss(model="ConvE", model_kwargs={"loss": "MarginRanking"}), MarginRankingLoss)
+
+
+def test_pipeline_loss_kwargs_without_loss():
+    """Test that ``loss_kwargs`` given without a ``loss`` are applied to the model's default loss."""
+    loss = _resolve_loss(model="PairRE", loss_kwargs={"margin": 2.0})
+    assert isinstance(loss, NSSALoss)
+    assert loss.margin == pytest.approx(2.0)
+    # the remaining defaults of the model are kept
+    assert loss.inverse_softmax_temperature == pytest.approx(1.0)
 
 
 @pytest.mark.parametrize("tf_cls", [CoreTriplesFactory, TriplesFactory])


### PR DESCRIPTION

### Link to the relevant Bug(s)

Fixes #1612

### Description of the Change

`_build_model_helper` unconditionally ran

```python
model_kwargs["loss"] = loss_resolver.make(loss, loss_kwargs)
```

so a `loss=None` was resolved to the loss resolver's default, `MarginRankingLoss(margin=1.0)`, and
handed to the model as a concrete instance. `Model.__init__` therefore never reached its
`loss is None` branch and a model's declared `loss_default` / `loss_default_kwargs` were silently
discarded — for 12 of the 40 registered models (ConvE, ComplEx, TuckER, QuatE, ProjE, PairRE, BoxE,
SimplE, ERMLPE, and the literal models).

The fix resolves the loss class from the model itself when the caller named none:

```python
if loss is None and not isinstance(model, Model):
    model_cls = model_resolver.lookup(model)
    loss = model_cls.loss_default
    loss_kwargs = {**(model_cls.loss_default_kwargs or {}), **(loss_kwargs or {})}
model_kwargs["loss"] = loss_resolver.make(loss, loss_kwargs)
```

Three deliberate details:

- It mirrors what `hpo_pipeline` already does (`model_cls.loss_default if loss is None else
  loss_resolver.lookup(loss)`), so `pipeline()` and HPO now agree on which loss a model is trained
  with.
- `loss_kwargs` passed *without* a `loss` are no longer dropped or applied to the wrong loss class:
  they now override the model's `loss_default_kwargs` entry by entry, in the same
  defaults-then-overrides spirit as the `model_kwargs.setdefault(...)` loop a few lines below.
- `model_kwargs["loss"]` is still always populated with an instantiated loss, so the result tracker's
  parameter logging (`# the loss was already logged as part of the model kwargs`) and the saved
  configuration keep working unchanged. Nothing outside this one block needed to move.

Precedence is unchanged where a loss *is* named, whether via the `loss` argument or via
`model_kwargs["loss"]`.

### Possible Drawbacks

**Results change for the 12 affected models.** Anyone who ran `pipeline(model="ConvE", ...)` without
naming a loss was training with `MarginRankingLoss` and will now train with `BCEAfterSigmoidLoss`.
That is the point of the fix, but it does mean previously recorded numbers for those models are not
reproducible on the new version without explicitly passing `loss="MarginRanking"`. It may be worth a
line in the changelog. Models inheriting `Model.loss_default` — TransE and most others — are bit-for-bit
unaffected, which `test_pipeline_loss_default_is_noop_for_margin_ranking_models` pins down.

A second, smaller change: `pipeline(loss_kwargs=..., loss=None)` used to configure a
`MarginRankingLoss` and now configures the model's own default loss. Passing a kwarg that the model's
default loss does not accept will now raise instead of quietly working. That seems strictly better than
the old behaviour, but it is a visible difference.

### Verification Process

Against `master` @ a1accf11 on Python 3.12 / PyTorch 2.13:

- Confirmed the bug first: the reproduction script in the linked issue prints `BCEAfterSigmoidLoss`
  for direct construction and `MarginRankingLoss` via the pipeline.
- Added five tests to `tests/test_pipeline.py` covering the default loss, the default kwargs, an
  explicit loss (both as `loss=` and inside `model_kwargs`), `loss_kwargs` without a `loss`, and the
  no-regression case for `MarginRankingLoss` models. They use `resolve_pipeline`, so they instantiate
  without training and run in under three seconds.
- Reverted the `api.py` change and re-ran: three of the five fail, the two that assert unchanged
  behaviour pass. So the tests do pin the fix rather than pass vacuously.
- `pytest tests/test_pipeline.py` → 26 passed, 1 skipped.
- `pytest tests -m 'not slow' -n 4` → 2274 passed, 182 skipped, 391 subtests passed. (One unrelated
  collection error in `tests/test_nn/test_representation.py`, `ModuleNotFoundError: No module named
  'PIL'`, from an optional extra missing in my environment; it reproduces on unmodified master.)
- `ruff format --check` and `ruff check` clean; `mypy --ignore-missing-imports src/pykeen/pipeline/`
  clean.
- `xdoctest -m src/pykeen/pipeline/api.py` and the four `python -m doctest` RST targets from
  `tox -e doctests` all pass.

### Release Notes

- Fixed an issue where `pipeline()` ignored a model's default loss function and always used
  `MarginRankingLoss` when no loss was explicitly given.
