### PR TITLE
docs: prefer short-form (~) rendering for cross-references

### DIFF
--- a/docs/source/explanation/models.rst
+++ b/docs/source/explanation/models.rst
@@ -78,7 +78,7 @@ Its core method is :meth:`~pykeen.nn.modules.Interaction.forward`, which receive
 representations and calculates the corresponding triple scores.
 
 As with the representations, interactions passed to :class:`~pykeen.models.ERModel` are resolved, this time using
-:meth:`pykeen.nn.interaction_resolver.make`. Hence, we can provide, e.g., strings corresponding to the interaction
+:meth:`~pykeen.nn.interaction_resolver.make`. Hence, we can provide, e.g., strings corresponding to the interaction
 function instead of an instantiated class. Further information can be found at :ref:`using_resolvers`.
 
 .. note::

--- a/docs/source/explanation/normalizer_constrainer_regularizer.rst
+++ b/docs/source/explanation/normalizer_constrainer_regularizer.rst
@@ -24,7 +24,7 @@ gradient, but rather re-scale its length.
 Normalizers are strict, i.e. the normalized variable is guaranteed to satisfy the constraint.
 
 Since normalizers are part of the computational graph, they are usually implemented directly as part of a module, e.g.,
-in :class:`pykeen.nn.representation.Embedding`.
+in :class:`~pykeen.nn.representation.Embedding`.
 
 Constrainer
 -----------
@@ -39,12 +39,12 @@ constraint set.
 
 Constrainers guarantee the constraint *after each gradient step*, but may violate the constaints in between.
 
-Constrainers are applied in :meth:`pykeen.nn.representation.Representation.post_parameter_update`.
+Constrainers are applied in :meth:`~pykeen.nn.representation.Representation.post_parameter_update`.
 
 .. warning::
 
     If you use PyKEEN modules outside of PyKEEN's training methods, you need to make sure to call
-    :meth:`pykeen.nn.representation.Representation.post_parameter_update` yourself after each parameter update.
+    :meth:`~pykeen.nn.representation.Representation.post_parameter_update` yourself after each parameter update.
 
 .. seealso::
 
@@ -59,7 +59,7 @@ when the original loss term is still high and thus the relative contribution of 
 However, once the optimization has found a sufficiently good solution for the original loss term, it can only further
 improve the total loss by also respecting the regularization term.
 
-You can find implementations of regularizers by looking at subclasses of :class:`pykeen.regularizers.Regularizer`.
+You can find implementations of regularizers by looking at subclasses of :class:`~pykeen.regularizers.Regularizer`.
 
 .. seealso::
 

--- a/docs/source/explanation/performance.rst
+++ b/docs/source/explanation/performance.rst
@@ -15,7 +15,7 @@ need a mapping from the string representations to vectors. Moreover, for computa
 store all entity/relation embeddings in matrices. Thus, the mapping process comprises two parts: Mapping strings to IDs,
 and using the IDs to access the embeddings (=row indices).
 
-In PyKEEN, the mapping process takes place in :class:`pykeen.triples.TriplesFactory`. The triples factory maintains the
+In PyKEEN, the mapping process takes place in :class:`~pykeen.triples.TriplesFactory`. The triples factory maintains the
 sets of unique entity and relation labels and ensures that they are mapped to unique integer IDs on
 $[0,\text{num_unique_entities})$ for entities and $[0, \text{num_unique_relations})$. The mappings are respectively
 accessible via the attributes :data:``pykeen.triples.TriplesFactory.entity_label_to_id`` and
@@ -36,14 +36,14 @@ assumption (LCWA), evaluating a model, and performing the link prediction task, 
 entities/relations for a given tuple, i.e. $(h, r)$, $(r, t)$ or $(h, t)$. In these cases a single tuple is used many
 times for different entities/relations.
 
-For example, we want to rank all entities for a single tuple $(h, r)$ with :class:`pykeen.models.DistMult` for the
-:class:`pykeen.datasets.FB15k237`. This dataset contains 14,505 entities, which means that there are 14,505 $(h, r, t)$
-combinations, whereas $h$ and $r$ are constant. Looking at the interaction function of :class:`pykeen.models.DistMult`,
+For example, we want to rank all entities for a single tuple $(h, r)$ with :class:`~pykeen.models.DistMult` for the
+:class:`~pykeen.datasets.FB15k237`. This dataset contains 14,505 entities, which means that there are 14,505 $(h, r, t)$
+combinations, whereas $h$ and $r$ are constant. Looking at the interaction function of :class:`~pykeen.models.DistMult`,
 we can observe that the :math:`h \odot r` part causes half of the mathematical operations to calculate :math:`h \odot r
 \odot t`. Therefore, calculating the :math:`h \odot r` part only once and reusing it spares us half of the mathematical
 operations for the other 14,504 remaining entities, making the calculations roughly twice as fast in total. The speed-up
 might be significantly higher in cases where the broadcasted part has a high relative complexity compared to the overall
-interaction function, e.g. :class:`pykeen.models.ConvE`.
+interaction function, e.g. :class:`~pykeen.models.ConvE`.
 
 To make this technique possible, PyKEEN models have to provide an explicit broadcasting function via following methods
 in the model class:
@@ -85,7 +85,7 @@ train dataset. Therefore, their definitions could be amended like:
 While this easily defined theoretically, it poses several practical challenges. For example, it leads to the
 computational challenge that all new possible triples $(h, r, t') \in T_{h,r}$ and $(h', r, t) \in H_{r,t}$ must be
 enumerated and then checked for existence in $\mathcal{K}_{train}$. Considering a dataset like
-:class:`pykeen.datasets.FB15k237` that has almost 15,000 entities, each test triple $(h,r,t) \in \mathcal{K}_{test}$
+:class:`~pykeen.datasets.FB15k237` that has almost 15,000 entities, each test triple $(h,r,t) \in \mathcal{K}_{test}$
 leads to $2 * | \mathcal{E} | = 30,000$ possible new triples, which have to be checked against the train dataset and
 then removed.
 

--- a/docs/source/explanation/understanding_evaluation.rst
+++ b/docs/source/explanation/understanding_evaluation.rst
@@ -3,7 +3,7 @@
 Understanding the Evaluation
 ============================
 This part of the tutorial is aimed to help you understand the evaluation of knowledge graph embeddings.
-In particular it explains rank-based evaluation metrics reported in :class:`pykeen.evaluation.RankBasedMetricResults`.
+In particular it explains rank-based evaluation metrics reported in :class:`~pykeen.evaluation.RankBasedMetricResults`.
 
 Knowledge graph embedding are usually evaluated on the task of link prediction. To this end, an evaluation set of
 triples :math:`\mathcal{T}_{eval} \subset \mathcal{E} \times \mathcal{R} \times \mathcal{E}` is provided, and for each
@@ -129,7 +129,7 @@ while the majority of nodes has only a few neighbors. This also impacts the eval
 occur in a large number of triples, they are also more likely to be part of evaluation triples.
 Thus, performing well on triples containing hub entities contributes strongly to the overall performance.
 
-As an example, we can inspect the :class:`pykeen.datasets.WD50KT` dataset, where a single (relation, tail)-combination,
+As an example, we can inspect the :class:`~pykeen.datasets.WD50KT` dataset, where a single (relation, tail)-combination,
 (`"instance of" <https://www.wikidata.org/wiki/Property:P31>`_, `"human" <https://www.wikidata.org/wiki/Q5>`_),
 is present in 699 evaluation triples.
 
@@ -151,7 +151,7 @@ are seemingly important, and thus evaluation should reflect that. However, somet
 this effect, but rather measure the performance evenly across nodes. A similar phenomenon also exists in multi-class
 classification with imbalanced classes, where frequent classes can dominate performance measures.
 In similar vein to the macro :math:`F_1`-score (cf. :func:`sklearn.metrics.f1_score`) known from this area, PyKEEN
-implements a :class:`pykeen.evaluation.MacroRankBasedEvaluator`, which ensure that triples are weighted such that each
+implements a :class:`~pykeen.evaluation.MacroRankBasedEvaluator`, which ensure that triples are weighted such that each
 unique ranking task, e.g., a (head, relation)-pair for tail prediction, contributes evenly.
 
 Technically, we solve the task by implemented variants of existing rank-based metrics which support weighting
@@ -172,7 +172,7 @@ Below, we present the philosophy from [bordes2013]_ and how it is implemented in
 
 HPO Scenario
 ************
-During training/optimization with :func:`pykeen.hpo.hpo_pipeline`, the set of known positive triples comprises the
+During training/optimization with :func:`~pykeen.hpo.hpo_pipeline`, the set of known positive triples comprises the
 training and validation sets. After optimization is finished and the final evaluation is done, the set of known
 positive triples comprises the training, validation, and testing set. PyKEEN explicitly does not use test triples
 for filtering during HPO to avoid any test leakage.
@@ -187,7 +187,7 @@ is being used to avoid any test leakage.
 
 Pipeline Scenario
 *****************
-During vanilla training with the :func:`pykeen.pipeline.pipeline` that has no optimization, no early stopping, nor
+During vanilla training with the :func:`~pykeen.pipeline.pipeline` that has no optimization, no early stopping, nor
 any *post-hoc* choices using the validation set, the set of known positive triples comprises the training and
 testing sets. This scenario is very atypical, and regardless, should be augmented with the validation triples
 to make it more comparable to other published results that do not consider this scenario.
@@ -195,13 +195,13 @@ to make it more comparable to other published results that do not consider this 
 Custom Training Loops
 *********************
 In case the validation triples should *not* be filtered when evaluating the test dataset, the argument
-``filter_validation_when_testing=False`` can be passed to either the :func:`pykeen.hpo.hpo_pipeline` or
-:func:`pykeen.pipeline.pipeline`.
+``filter_validation_when_testing=False`` can be passed to either the :func:`~pykeen.hpo.hpo_pipeline` or
+:func:`~pykeen.pipeline.pipeline`.
 
-If you're rolling your own pipeline, you should keep the following in mind: the :class:`pykeen.evaluation.Evaluator`
+If you're rolling your own pipeline, you should keep the following in mind: the :class:`~pykeen.evaluation.Evaluator`
 when in the filtered setting with ``filtered=True`` will always use the evaluation set (regardless of whether it is the
 testing set or validation set) for filtering. Any other triples that should be filtered should be passed to
-``additional_filter_triples`` in :func:`pykeen.evaluation.Evaluator.evaluate`. Typically, this minimally includes
+``additional_filter_triples`` in :func:`~pykeen.evaluation.Evaluator.evaluate`. Typically, this minimally includes
 the training triples. With the [bordes2013]_ technique where the testing set is used for evaluation, the
 ``additional_filter_triples`` should include both the training triples and validation triples as in the following
 example:
@@ -260,7 +260,7 @@ In order to restrict the evaluation, we proceed as follows:
 
 Example
 *******
-The :class:`pykeen.datasets.Hetionet` is a biomedical knowledge graph containing drugs, genes, diseases, other
+The :class:`~pykeen.datasets.Hetionet` is a biomedical knowledge graph containing drugs, genes, diseases, other
 biological entities, and their interrelations. It was described by Himmelstein *et al.* in `Systematic integration
 of biomedical knowledge prioritizes drugs for repurposing <https://doi.org/10.7554/eLife.26726>`_ to support
 drug repositioning, which translates to the link prediction task between drug and disease nodes.

--- a/docs/source/howto/bring_your_own_data.rst
+++ b/docs/source/howto/bring_your_own_data.rst
@@ -3,9 +3,9 @@
 Bring Your Own Data
 ===================
 As an alternative to using a pre-packaged dataset, the training and testing can be set explicitly
-by file path or with instances of :class:`pykeen.triples.TriplesFactory`. Throughout this
+by file path or with instances of :class:`~pykeen.triples.TriplesFactory`. Throughout this
 tutorial, the paths to the training, testing, and validation sets for built-in
-:class:`pykeen.datasets.Nations` will be used as examples.
+:class:`~pykeen.datasets.Nations` will be used as examples.
 
 Pre-stratified Dataset
 ----------------------
@@ -28,8 +28,8 @@ PyKEEN will take care of making sure that the entities are mapped from their lab
 (technically, 0-dimensional :class:`torch.LongTensor`) indexes and that the different sets of triples
 share the same mapping.
 
-This is equally applicable for the :func:`pykeen.hpo.hpo_pipeline`, which has a similar interface to
-the :func:`pykeen.pipeline.pipeline` as in:
+This is equally applicable for the :func:`~pykeen.hpo.hpo_pipeline`, which has a similar interface to
+the :func:`~pykeen.pipeline.pipeline` as in:
 
 >>> from pykeen.hpo import hpo_pipeline
 >>> from pykeen.datasets.nations import NATIONS_TRAIN_PATH, NATIONS_TEST_PATH, NATIONS_VALIDATE_PATH
@@ -43,11 +43,11 @@ the :func:`pykeen.pipeline.pipeline` as in:
 ... )
 >>> result.save_to_directory('doctests/test_hpo_pre_stratified_transe')
 
-The remainder of the examples will be for :func:`pykeen.pipeline.pipeline`, but all work exactly the same
-for :func:`pykeen.hpo.hpo_pipeline`.
+The remainder of the examples will be for :func:`~pykeen.pipeline.pipeline`, but all work exactly the same
+for :func:`~pykeen.hpo.hpo_pipeline`.
 
 If you want to add dataset-wide arguments, you can use the ``dataset_kwargs`` argument
-to the :class:`pykeen.pipeline.pipeline` to enable options like ``create_inverse_triples=True``.
+to the :class:`~pykeen.pipeline.pipeline` to enable options like ``create_inverse_triples=True``.
 
 >>> from pykeen.pipeline import pipeline
 >>> from pykeen.datasets.nations import NATIONS_TRAIN_PATH, NATIONS_TEST_PATH
@@ -61,7 +61,7 @@ to the :class:`pykeen.pipeline.pipeline` to enable options like ``create_inverse
 >>> result.save_to_directory('doctests/test_pre_stratified_transe')
 
 If you want finer control over how the triples are created, for example, if they are not all coming from
-TSV files, you can use the :class:`pykeen.triples.TriplesFactory` interface.
+TSV files, you can use the :class:`~pykeen.triples.TriplesFactory` interface.
 
 >>> from pykeen.triples import TriplesFactory
 >>> from pykeen.pipeline import pipeline
@@ -88,7 +88,7 @@ TSV files, you can use the :class:`pykeen.triples.TriplesFactory` interface.
     set, so we just reuse it. If we didn't have the same identifiers, then the testing set would get mixed up with
     the wrong identifiers in the training set during evaluation, and we'd get nonsense results.
 
-The ``dataset_kwargs`` argument is ignored when passing your own :class:`pykeen.triples.TriplesFactory`, so be
+The ``dataset_kwargs`` argument is ignored when passing your own :class:`~pykeen.triples.TriplesFactory`, so be
 sure to include the ``create_inverse_triples=True`` in the instantiation of those classes if that's your
 desired behavior as in:
 

--- a/docs/source/howto/bring_your_own_interaction.rst
+++ b/docs/source/howto/bring_your_own_interaction.rst
@@ -2,7 +2,7 @@ Bring Your Own Interaction
 ==========================
 
 This is a tutorial about how to implement your own interaction modules (also known as scoring functions) as subclasses
-of :class:`pykeen.nn.modules.Interaction` for use in PyKEEN.
+of :class:`~pykeen.nn.modules.Interaction` for use in PyKEEN.
 
 Implementing your first Interaction Module
 ------------------------------------------
@@ -16,7 +16,7 @@ Imagine you've taken a time machine back to 2013 and you have just invented Tran
 where $\mathbf{e}_i$ is the $d$-dimensional representation for entity $i$, $\mathbf{r}_j$ is the $d$-dimensional
 representation for relation $j$, and $\|...\|_2$ is the $L_2$ norm.
 
-To implement TransE in PyKEEN, you need to subclass the :class:`pykeen.nn.modules.Interaction`. This class it itself a
+To implement TransE in PyKEEN, you need to subclass the :class:`~pykeen.nn.modules.Interaction`. This class it itself a
 subclass of :class:`torch.nn.Module`, which means that you need to provide an implementation of
 :meth:`torch.nn.Module.forward`. However, the arguments are predefined as ``h``, ``r``, and ``t``, which correspond to
 the representations of the head, relation, and tail, respectively.
@@ -35,7 +35,7 @@ representations.
 
 .. seealso::
 
-    A reference implementation is provided in :class:`pykeen.nn.modules.TransEInteraction`
+    A reference implementation is provided in :class:`~pykeen.nn.modules.TransEInteraction`
 
 As a researcher who just invented TransE, you might wonder what would happen if you replaced the addition ``+`` with
 multiplication ``*``. You might then end up with a new interaction like this (which just happens to be DistMult, which
@@ -59,7 +59,7 @@ representation for relation $j$.
 
 .. seealso::
 
-    A reference implementation is provided in :class:`pykeen.nn.modules.DistMultInteraction`
+    A reference implementation is provided in :class:`~pykeen.nn.modules.DistMultInteraction`
 
 Interactions with Hyper-Parameters
 ----------------------------------
@@ -105,7 +105,7 @@ with hidden dimension $y$, $W_1 \in \mathcal{R}^{3d \times y}$, $W_2\in \mathcal
 $W_1$, $W_1$, $b_1$, and $b_2$ are *global* parameters, meaning that they are trainable, but are neither attached to the
 entities nor relations. Unlike the $p$ in TransE, these global trainable parameters are not considered hyper-parameters.
 However, like hyper-parameters, they can also be defined in the `__init__` function of your
-:class:`pykeen.nn.modules.Interaction` class. They are trained jointly with the entity and relation embeddings during
+:class:`~pykeen.nn.modules.Interaction` class. They are trained jointly with the entity and relation embeddings during
 training.
 
 .. code-block:: python
@@ -134,7 +134,7 @@ standardization of shapes of head, relation, and tail vectors.
 
 .. seealso::
 
-    A reference implementation is provided in :class:`pykeen.nn.modules.ERMLPInteraction`
+    A reference implementation is provided in :class:`~pykeen.nn.modules.ERMLPInteraction`
 
 Interactions with Different Shaped Vectors
 ------------------------------------------
@@ -248,13 +248,13 @@ functions to instantiate a model, make a model class, or run the pipeline using 
 
 .. note::
 
-    The :func:`pykeen.utils.project_entity` function was used in this implementation to reduce the complexity. So far,
+    The :func:`~pykeen.utils.project_entity` function was used in this implementation to reduce the complexity. So far,
     it's the case that all of the models using multiple different representation dimensions are quite complicated and
     don't fall into the paradigm of presenting simple examples.
 
 .. seealso::
 
-    A reference implementation is provided in :class:`pykeen.nn.modules.TransDInteraction`
+    A reference implementation is provided in :class:`~pykeen.nn.modules.TransDInteraction`
 
 Differences between :class:`pykeen.nn.modules.Interaction` and :class:`pykeen.models.Model`
 -------------------------------------------------------------------------------------------
@@ -282,7 +282,7 @@ the "Extending the Models" tutorial.
 Interaction Pipeline
 --------------------
 
-The :func:`pykeen.pipeline.pipeline` also allows passing of an interaction such that the following code block can be
+The :func:`~pykeen.pipeline.pipeline` also allows passing of an interaction such that the following code block can be
 compressed:
 
 .. code-block:: python
@@ -308,5 +308,5 @@ into:
         dataset="Nations", interaction=TransEInteraction, interaction_kwargs={"p": 2}, dimensions={"d": 100}, ...
     )
 
-This can be used with any subclass of the :class:`pykeen.nn.modules.Interaction`, not only ones that are implemented in
+This can be used with any subclass of the :class:`~pykeen.nn.modules.Interaction`, not only ones that are implemented in
 the PyKEEN package.

--- a/docs/source/howto/checkpoints.rst
+++ b/docs/source/howto/checkpoints.rst
@@ -295,7 +295,7 @@ The reason for this behavior is three-fold:
 Checkpoints beyond the Pipeline and Technicalities
 --------------------------------------------------
 Currently, PyKEEN only supports checkpoints for training loops, implemented in the class
-:class:`pykeen.training.TrainingLoop`. When using the :func:`pykeen.pipeline.pipeline` function as defined above, the
+:class:`~pykeen.training.TrainingLoop`. When using the :func:`~pykeen.pipeline.pipeline` function as defined above, the
 pipeline actually uses the training loop functionality. Accordingly, those checkpoints save the states of the
 training loop and not the pipeline itself. Therefore, the checkpoints won't contain evaluation results that reside in
 the pipeline. However, PyKEEN makes sure the final results of the pipeline using training loop checkpoints are exactly
@@ -316,7 +316,7 @@ To show how to use the checkpoint functionality without the pipeline, we define 
 >>> training_loop = SLCWATrainingLoop(model=model, optimizer=optimizer)
 
 At this point we have a model, dataset and optimizer all setup in a training loop and are ready to train the model with
-the ``training_loop``'s method :func:`pykeen.training.TrainingLoop.train`. To enable checkpoints all you have to do is
+the ``training_loop``'s method :func:`~pykeen.training.TrainingLoop.train`. To enable checkpoints all you have to do is
 setting the function argument ``checkpoint_name`` to the name you would like it to have.
 Furthermore, you can set the checkpoint frequency, i.e. how often checkpoints should be saved given in minutes, by
 setting the argument ``checkpoint_frequency`` with an integer. The default frequency is 30 minutes and setting it to

--- a/docs/source/howto/extending_datasets.rst
+++ b/docs/source/howto/extending_datasets.rst
@@ -15,7 +15,7 @@ Unpacked Remote Dataset
 
 Use this tutorial if you have three separate URLs for the respective training, testing, and validation sets that are
 each 3 column TSV files. A good example can be found at https://github.com/ZhenfengLei/KGDatasets/tree/master/DBpedia50.
-There's a base class called :class:`pykeen.datasets.base.UnpackedRemoteDataset` that can be used to wrap it like the
+There's a base class called :class:`~pykeen.datasets.base.UnpackedRemoteDataset` that can be used to wrap it like the
 following:
 
 .. code-block:: python
@@ -41,7 +41,7 @@ Unsplit Datasets
 
 Use this tutorial if you have a single URL for a TSV dataset that needs to be automatically split into training,
 testing, and validation. A good example can be found at https://github.com/hetio/hetionet/raw/master/hetnet/tsv. There's
-a base class called :class:`pykeen.datasets.base.SingleTabbedDataset` that can be used to wrap it like the following:
+a base class called :class:`~pykeen.datasets.base.SingleTabbedDataset` that can be used to wrap it like the following:
 
 .. code-block:: python
 
@@ -65,7 +65,7 @@ Updating the ``setup.cfg``
 
 Whether you're making a pull request against PyKEEN or implementing a dataset in your own package, you can use Python
 entrypoints to register your dataset with PyKEEN. Below is an example of the entrypoints that register
-:class:`pykeen.datasets.Hetionet`, :class:`pykeen.datasets.DRKG`, and others that appear in the PyKEEN `setup.cfg
+:class:`~pykeen.datasets.Hetionet`, :class:`~pykeen.datasets.DRKG`, and others that appear in the PyKEEN `setup.cfg
 <https://github.com/pykeen/pykeen/blob/master/setup.cfg>`_. Under the ``pykeen.datasets`` header, you can pick whatever
 name you want for the dataset as the key (appearing on the left side of the equals, e.g. ``hetionet``) and the path to
 the class (appearing on the right side of the equals, e.g., ``pykeen.datasets.hetionet:Hetionet``). The right side is

--- a/docs/source/howto/extending_models.rst
+++ b/docs/source/howto/extending_models.rst
@@ -8,7 +8,7 @@ Implementing a model by subclassing :class:`pykeen.models.ERModel`
 ------------------------------------------------------------------
 
 The following code block demonstrates how an interaction model can be used to define a full KGEM using the
-:class:`pykeen.models.ERModel` base class.
+:class:`~pykeen.models.ERModel` base class.
 
 .. code-block:: python
 
@@ -58,7 +58,7 @@ The following code block demonstrates how an interaction model can be used to de
                 **kwargs,
             )
 
-The actual implementation of DistMult can be found in :class:`pykeen.models.DistMult`. Note that it additionally
+The actual implementation of DistMult can be found in :class:`~pykeen.models.DistMult`. Note that it additionally
 contains configuration for the initializers, constrainers, and regularizers for each of the embeddings as well as
 class-level defaults for hyper-parameters and hyper-parameter optimization. Modifying these is covered in other
 tutorials.
@@ -81,13 +81,13 @@ the loss class.
         loss_default: ClassVar[Type[Loss]] = NSSALoss
         ...
 
-Now, when using the pipeline, the :class:`pykeen.losses.NSSALoss`. loss is used by default if none is given. The same
+Now, when using the pipeline, the :class:`~pykeen.losses.NSSALoss`. loss is used by default if none is given. The same
 kind of modifications can be made to set a default regularizer with ``regularizer_default``.
 
 Specifying Hyper-parameter Optimization Default Ranges
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-All subclasses of :class:`pykeen.models.Model` can specify the default ranges or values used during hyper-parameter
+All subclasses of :class:`~pykeen.models.Model` can specify the default ranges or values used during hyper-parameter
 optimization (HPO). PyKEEN implements a simple dictionary-based configuration that is interpreted by
 :func:`pykeen.hpo.hpo.suggest_kwargs` in the HPO pipeline.
 
@@ -159,7 +159,7 @@ With ``bool``, you can simply use ``dict(type=bool)`` or ``dict(type='bool')``.
 Implementing a model by instantiating :class:`pykeen.models.ERModel`
 --------------------------------------------------------------------
 
-Instead of creating a new class, you can also directly use the :class:`pykeen.models.ERModel`, e.g.
+Instead of creating a new class, you can also directly use the :class:`~pykeen.models.ERModel`, e.g.
 
 .. code-block:: python
 
@@ -178,7 +178,7 @@ Using a Custom Model with the Pipeline
 --------------------------------------
 
 We can use this new model with all available losses, evaluators, training pipelines, inverse triple modeling, via the
-:func:`pykeen.pipeline.pipeline`, since in addition to the names of models (given as strings), it can also take model
+:func:`~pykeen.pipeline.pipeline`, since in addition to the names of models (given as strings), it can also take model
 classes in the ``model`` argument.
 
 .. code-block:: python

--- a/docs/source/howto/node_piece.rst
+++ b/docs/source/howto/node_piece.rst
@@ -8,7 +8,7 @@ This page gives more practical examples on using and configuring NodePiece.
 Basic Usage
 -----------
 
-We'll use :class:`pykeen.datasets.FB15k237` for illustrating purposes throughout the following examples.
+We'll use :class:`~pykeen.datasets.FB15k237` for illustrating purposes throughout the following examples.
 
 .. code-block:: python
 
@@ -18,7 +18,7 @@ We'll use :class:`pykeen.datasets.FB15k237` for illustrating purposes throughout
     # inverses are necessary for the current version of NodePiece
     dataset = FB15k237(create_inverse_triples=True)
 
-In the simplest usage of :class:`pykeen.models.NodePiece`, we'll only use relations for tokenization. We can do this by
+In the simplest usage of :class:`~pykeen.models.NodePiece`, we'll only use relations for tokenization. We can do this by
 with the following arguments:
 
 1. Set the ``tokenizers="RelationTokenizer"`` to :class:`pykeen.nn.node_piece.RelationTokenizer`. We can simply refer to
@@ -38,8 +38,8 @@ Here's how the code looks:
         embedding_dim=64,
     )
 
-Next, we'll use a combination of tokenizers (:class:`pykeen.nn.node_piece.AnchorTokenizer` and
-:class:`pykeen.nn.node_piece.RelationTokenizer`) to replicate the full NodePiece tokenization with $k$ anchors and $m$
+Next, we'll use a combination of tokenizers (:class:`~pykeen.nn.node_piece.AnchorTokenizer` and
+:class:`~pykeen.nn.node_piece.RelationTokenizer`) to replicate the full NodePiece tokenization with $k$ anchors and $m$
 relational context. It's as easy as sending a list of tokenizers to ``tokenizers`` and sending a list of arguments to
 ``num_tokens``:
 
@@ -59,25 +59,25 @@ and ``num_tokens`` matters here.
 Anchor Selection and Searching
 ------------------------------
 
-The :class:`pykeen.nn.node_piece.AnchorTokenizer` has two fields:
+The :class:`~pykeen.nn.node_piece.AnchorTokenizer` has two fields:
 
 1. ``selection`` controls how we sample anchors from the graph (32 anchors by default)
 2. ``searcher`` controls how we tokenize nodes using selected anchors
-   (:class:`pykeen.nn.node_piece.CSGraphAnchorSearcher` by default)
+   (:class:`~pykeen.nn.node_piece.CSGraphAnchorSearcher` by default)
 
 By default, our models above use 32 anchors selected as top-degree nodes with
-:class:`pykeen.nn.node_piece.DegreeAnchorSelection` (those are default values for the anchor selection resolver) and
-nodes are tokenized using :class:`pykeen.nn.node_piece.CSGraphAnchorSearcher` - it uses :mod:`scipy.sparse` to
+:class:`~pykeen.nn.node_piece.DegreeAnchorSelection` (those are default values for the anchor selection resolver) and
+nodes are tokenized using :class:`~pykeen.nn.node_piece.CSGraphAnchorSearcher` - it uses :mod:`scipy.sparse` to
 explicitly compute shortest paths from all nodes in the graph to all anchors in the deterministic manner. We can afford
 that for relatively small graphs of FB15k237 size.
 
 For larger graphs, we recommend using the breadth-first search (BFS) procedure in
-:class:`pykeen.nn.node_piece.ScipySparseAnchorSearcher` - it applies BFS by iteratively expanding node neighborhood
+:class:`~pykeen.nn.node_piece.ScipySparseAnchorSearcher` - it applies BFS by iteratively expanding node neighborhood
 until it finds a desired number of anchors - this dramatically saves compute time on graphs of size like
-:class:`pykeen.datasets.OGBWikiKG2`.
+:class:`~pykeen.datasets.OGBWikiKG2`.
 
 32 unique anchors might be a bit too small for FB15k237 with 15k nodes - so let's create a
-:class:`pykeen.models.NodePiece` model with 100 anchors selected with the top degree strategy by sending the
+:class:`~pykeen.models.NodePiece` model with 100 anchors selected with the top degree strategy by sending the
 ``tokenizers_kwargs`` list:
 
 .. code-block:: python
@@ -129,7 +129,7 @@ Looks nice, but fasten your seatbelts 🚀 - we can use several anchor selection
 diverse anchors! Mindblowing 😍
 
 Let's create a model with 500 anchors where 50% of them will be top degree nodes and another 50% will be top PageRank
-nodes - for that we have a :class:`pykeen.nn.node_piece.MixtureAnchorSelection` class!
+nodes - for that we have a :class:`~pykeen.nn.node_piece.MixtureAnchorSelection` class!
 
 .. code-block:: python
 
@@ -261,7 +261,7 @@ Let's pack the last NodePiece model into the pipeline:
 Pre-Computed Vocabularies
 -------------------------
 
-We have a :class:`pykeen.nn.node_piece.PrecomputedPoolTokenizer` that can be instantiated with a precomputed vocabulary
+We have a :class:`~pykeen.nn.node_piece.PrecomputedPoolTokenizer` that can be instantiated with a precomputed vocabulary
 either from a local file or using a downloadable link.
 
 For a local file, specify ``path``:
@@ -282,9 +282,9 @@ For a remote file, specify the ``url``:
 
     precomputed_tokenizer = tokenizer_resolver.make("precomputedpool", url="http://link/to/vocab.pkl")
 
-Generally, :class:`pykeen.nn.node_piece.PrecomputedPoolTokenizer` can use any
-:class:`pykeen.nn.node_piece.PrecomputedTokenizerLoader` as a custom processor of vocabulary formats. Right now there is
-one such loader, :class:`pykeen.nn.node_piece.GalkinPrecomputedTokenizerLoader` that expects a dictionary of the
+Generally, :class:`~pykeen.nn.node_piece.PrecomputedPoolTokenizer` can use any
+:class:`~pykeen.nn.node_piece.PrecomputedTokenizerLoader` as a custom processor of vocabulary formats. Right now there is
+one such loader, :class:`~pykeen.nn.node_piece.GalkinPrecomputedTokenizerLoader` that expects a dictionary of the
 following format:
 
 ::
@@ -314,7 +314,7 @@ Configuring the Interaction Function
 ------------------------------------
 
 you can use literally any interaction function available in PyKEEN as a scoring function! By default, NodePiece uses
-DistMult, but it's easy to change as in any :class:`pykeen.models.ERModel`, let's use the RotatE interaction:
+DistMult, but it's easy to change as in any :class:`~pykeen.models.ERModel`, let's use the RotatE interaction:
 
 .. code-block:: python
 
@@ -409,7 +409,7 @@ from a set of inputs. Let's be fancy 😎 and create a `DeepSet <https://arxiv.o
     )
 
 We can even put a Transformer with pooling here. The only thing to keep in mind is the complexity of the encoder - we
-found :class:`pykeen.nn.perceptron.ConcatMLP` to be a good balance between speed and final performance, although at the
+found :class:`~pykeen.nn.perceptron.ConcatMLP` to be a good balance between speed and final performance, although at the
 cost of being not permutation invariant to the input set of tokens.
 
 The aggregation function resembles that of GNNs. Non-parametric avg/min/max did not work that well in the current
@@ -456,7 +456,7 @@ NodePiece + GNN
 
 It is also possible to add a message passing GNN on top of obtained NodePiece representations to further enrich node
 states - we found it shows even better results in inductive LP tasks. We have that implemented with
-:class:`pykeen.models.InductiveNodePieceGNN` that uses a 2-layer `CompGCN <https://arxiv.org/abs/1911.03082>`_ encoder -
+:class:`~pykeen.models.InductiveNodePieceGNN` that uses a 2-layer `CompGCN <https://arxiv.org/abs/1911.03082>`_ encoder -
 please check the Inductive Link Prediction tutorial.
 
 Tokenizing Large Graphs with METIS
@@ -473,12 +473,12 @@ partitioning algorithm with an efficient implementation available in `torch-spar
 <https://github.com/rusty1s/pytorch_sparse>`_. Along with METIS, we leverage `torch-sparse` to offer a new, faster BFS
 procedure that can run on a GPU.
 
-The main tokenizer class is :class:`pykeen.nn.node_piece.MetisAnchorTokenizer`. You can place it instead of the vanilla
+The main tokenizer class is :class:`~pykeen.nn.node_piece.MetisAnchorTokenizer`. You can place it instead of the vanilla
 ``AnchorTokenizer``. With the Metis-based tokenizer, we first partition the input training graph into `k` separate
 partitions and then run anchor selection and anchor search sequentially and independently **for each partition**.
 
 You can use any existing anchor selection and anchor search strategy described above although for larger graphs we
-recommend using a new :class:`pykeen.nn.node_piece.SparseBFSSearcher` as anchor searcher -- it implements faster sparse
+recommend using a new :class:`~pykeen.nn.node_piece.SparseBFSSearcher` as anchor searcher -- it implements faster sparse
 matrix multiplication kernels and can be run on a GPU. The only difference from the vanilla tokenizer is that now the
 ``num_anchors`` argument defines how many anchors will be mined **for each partition**.
 
@@ -491,7 +491,7 @@ The new tokenizer has two special arguments:
   We found ``device="cpu"`` works faster on larger graphs and does not require limited GPU memory, although you can keep
   the device to be resolved automatically or put ``device="cuda"`` to try running it on a GPU.
 
-It is still advisable to run large graph tokenization using :class:`pykeen.nn.node_piece.SparseBFSSearcher` on a GPU
+It is still advisable to run large graph tokenization using :class:`~pykeen.nn.node_piece.SparseBFSSearcher` on a GPU
 thanks to more efficient sparse CUDA kernels. If a GPU is available, it will be used automatically by default.
 
 Let's use the new tokenizer for the Wikidata5M graph of 5M nodes and 20M edges.

--- a/docs/source/howto/running_ablation.rst
+++ b/docs/source/howto/running_ablation.rst
@@ -17,11 +17,11 @@ In PyKEEN, we can define and execute an ablation study within our own program or
 configuration file (``file_name.json``).
 
 First, we show how to run an ablation study within your program. For this purpose, we provide the function
-:func:`pykeen.ablation.ablation_pipeline` that requires the ``datasets``, ``models``, ``losses``, ``optimizers``,
+:func:`~pykeen.ablation.ablation_pipeline` that requires the ``datasets``, ``models``, ``losses``, ``optimizers``,
 ``training_loops``, and ``directory`` arguments to define the datasets, models, loss functions, optimizers (e.g., Adam),
 training approaches for our ablation study, and the output directory in which the experimental artifacts should be
-saved. In the following, we define an ablation study for :class:`pykeen.models.ComplEx` over the
-:class:`pykeen.datasets.Nations` dataset in order to assess the effect of different loss functions (in our example, the
+saved. In the following, we define an ablation study for :class:`~pykeen.models.ComplEx` over the
+:class:`~pykeen.datasets.Nations` dataset in order to assess the effect of different loss functions (in our example, the
 binary cross entropy loss and the margin ranking loss) and the effect of explicitly modeling inverse relations.
 
 Now, let's start with defining the minimal requirements, i.e., the dataset(s), interaction model(s), the loss
@@ -469,7 +469,7 @@ Now that we defined our own hyper-parameter values/ranges, let's have a look at 
     ... )
 
 We are expected to provide the arguments ``datasets``, ``models``, ``losses``, ``optimizers``, and ``training_loops`` to
-:func:`pykeen.ablation.ablation_pipeline`. For all other components and hype-parameters, PyKEEN provides default
+:func:`~pykeen.ablation.ablation_pipeline`. For all other components and hype-parameters, PyKEEN provides default
 values/ranges. However, for achieving optimal performance, we should carefully define the hyper-parameter values/ranges
 ourselves, as explained above. Note that there are many more ranges to configure such hyper-parameters for the loss
 functions or the negative samplers. Check out the examples provided in `tests/resources/hpo_complex_nations.json`` how

--- a/docs/source/howto/trackers/using_file.rst
+++ b/docs/source/howto/trackers/using_file.rst
@@ -79,5 +79,5 @@ argument can still be used to specify an absolute path.
     )
 
 The same concepts can be applied in the HPO pipeline as in the previous tracker tutorials. Additional documentation of
-the valid keyword arguments can be found under :class:`pykeen.trackers.CSVResultTracker` and
-:class:`pykeen.trackers.JSONResultTracker`.
+the valid keyword arguments can be found under :class:`~pykeen.trackers.CSVResultTracker` and
+:class:`~pykeen.trackers.JSONResultTracker`.

--- a/docs/source/howto/trackers/using_mlflow.rst
+++ b/docs/source/howto/trackers/using_mlflow.rst
@@ -11,7 +11,7 @@ be running at http://localhost:5000 by default.
 Pipeline Example
 ----------------
 
-This example shows using MLflow with the :func:`pykeen.pipeline.pipeline` function. Minimally, the ``tracking_uri`` and
+This example shows using MLflow with the :func:`~pykeen.pipeline.pipeline` function. Minimally, the ``tracking_uri`` and
 ``experiment_name`` are required in the ``result_tracker_kwargs``.
 
 .. code-block:: python
@@ -41,7 +41,7 @@ If you click on the experiment, you'll see this:
 HPO Example
 -----------
 
-This example shows using MLflow with the :func:`pykeen.hpo.hpo_pipeline` function.
+This example shows using MLflow with the :func:`~pykeen.hpo.hpo_pipeline` function.
 
 .. code-block:: python
 

--- a/docs/source/howto/trackers/using_neptune.rst
+++ b/docs/source/howto/trackers/using_neptune.rst
@@ -22,7 +22,7 @@ Preparation
 Pipeline Example
 ----------------
 
-This example shows using Neptune with the :func:`pykeen.pipeline.pipeline` function. Minimally, the
+This example shows using Neptune with the :func:`~pykeen.pipeline.pipeline` function. Minimally, the
 ``project_qualified_name`` and ``experiment_name`` must be set.
 
 .. code-block:: python
@@ -95,4 +95,4 @@ For example, if you're using custom input, you might want to add some labels abo
     )
 
 Additional documentation of the valid keyword arguments can be found under
-:class:`pykeen.trackers.NeptuneResultTracker`.
+:class:`~pykeen.trackers.NeptuneResultTracker`.

--- a/docs/source/howto/trackers/using_tensorboard.rst
+++ b/docs/source/howto/trackers/using_tensorboard.rst
@@ -37,7 +37,7 @@ http://localhost:6006/
 Minimal Pipeline Example
 ------------------------
 
-The tensorboard tracker can be used during training with the :func:`pykeen.pipeline.pipeline` as follows:
+The tensorboard tracker can be used during training with the :func:`~pykeen.pipeline.pipeline` as follows:
 
 .. code-block:: python
 

--- a/docs/source/howto/trackers/using_wandb.rst
+++ b/docs/source/howto/trackers/using_wandb.rst
@@ -20,7 +20,7 @@ Now you can simply specify this project name when initializing a pipeline, and e
 Pipeline Example
 ----------------
 
-This example shows using WANDB with the :func:`pykeen.pipeline.pipeline` function.
+This example shows using WANDB with the :func:`~pykeen.pipeline.pipeline` function.
 
 .. code-block:: python
 
@@ -58,7 +58,7 @@ further keyword arguments are passed to :func:`wandb.init`.
 HPO Example
 -----------
 
-This example shows using WANDB with the :func:`pykeen.hpo.hpo_pipeline` function.
+This example shows using WANDB with the :func:`~pykeen.hpo.hpo_pipeline` function.
 
 .. code-block:: python
 
@@ -78,4 +78,4 @@ This example shows using WANDB with the :func:`pykeen.hpo.hpo_pipeline` function
 It's safe to specify the experiment name during HPO. Several runs will be sent to the same experiment under different
 hashes. However, specifying the experiment name is advisable more for single runs and not for batches of multiple runs.
 
-Additional documentation of the valid keyword arguments can be found under :class:`pykeen.trackers.WANDBResultTracker`.
+Additional documentation of the valid keyword arguments can be found under :class:`~pykeen.trackers.WANDBResultTracker`.

--- a/docs/source/howto/using_resolvers.rst
+++ b/docs/source/howto/using_resolvers.rst
@@ -7,7 +7,7 @@ As PyKEEN is a heavily modular and extensible library, we make use of the :mod:`
 configuration of components. In this part of the tutorial, we explain how to use these configuration options, and how to
 figure out what values you can pass here.
 
-We use the initialization method of the base model class :meth:`pykeen.models.base.Model` and its handling of loss
+We use the initialization method of the base model class :meth:`~pykeen.models.base.Model` and its handling of loss
 functions as an example. Its signature is given as
 
 .. code-block:: python
@@ -29,10 +29,10 @@ passing `None`, this is interpreted as an empty dictionary.
 The `loss` parameter takes inputs of type `HintOrType[Loss]`. `HintOrType[Loss]` is a abbreviation of `Union[None, str,
 Type[Loss], Loss]`. Thus, we can either pass
 
-1. an *instance* of the :class:`pykeen.losses.Loss`, e.g., ``pykeen.losses.MarginRankingLoss(margin=2.0)``. If an
-   instance of :class:`pykeen.losses.Loss` is passed, it is used without modification. In this case, `loss_kwargs` will
+1. an *instance* of the :class:`~pykeen.losses.Loss`, e.g., ``pykeen.losses.MarginRankingLoss(margin=2.0)``. If an
+   instance of :class:`~pykeen.losses.Loss` is passed, it is used without modification. In this case, `loss_kwargs` will
    be ignored.
-2. a *subclass* of :class:`pykeen.losses.Loss`, e.g., :class:`pykeen.losses.MarginRankingLoss` In this case, the class
+2. a *subclass* of :class:`~pykeen.losses.Loss`, e.g., :class:`~pykeen.losses.MarginRankingLoss` In this case, the class
    is instantiated with the given `loss_kwargs` as (keyword-based) parameters. For instance,
 
    .. code-block:: python
@@ -72,10 +72,10 @@ using the `ClassResolver.from_subclasses` factory function, which automatically 
 base class as valid choices. Moreover, it will allow you to pass class names without the base class' name as suffix,
 e.g., `loss_resolver` accepts `MarginRanking` instead of `MarginRankingLoss`, since the base class' name `Loss` is
 removed as suffix during the normalization. To utilize this feature, we try to follow an appropriate naming scheme for
-all configurable parts, e.g., :class:`pykeen.nn.representation.Representation`, or
-:class:`pykeen.nn.modules.Interaction`.
+all configurable parts, e.g., :class:`~pykeen.nn.representation.Representation`, or
+:class:`~pykeen.nn.modules.Interaction`.
 
 The allowed parameters for `..._kwargs: OptionalKwargs` are a bit harder to determine, since they vary with your choice
 of the component! For instance, :class:`MarginRankingLoss` has a `margin` parameter, while
-:class:`pykeen.losses.BCEWithLogitsLoss` does not provide such. Hence, you should investigate the documentation of the
+:class:`~pykeen.losses.BCEWithLogitsLoss` does not provide such. Hence, you should investigate the documentation of the
 individual classes to inform yourself about available parameters and allowed values.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -29,7 +29,7 @@ service, start your notebook with the following two lines:
     ! pip install git+https://github.com/pykeen/pykeen.git
     pykeen.env()
 
-This will install the latest code, then output relevant system and environment information with :func:`pykeen.env`. It
+This will install the latest code, then output relevant system and environment information with :func:`~pykeen.env`. It
 works because Jupyter interprets any line beginning with a bang ``!`` that the remainder of the line should be
 interpreted as a bash command. If you want to make your notebook compatible on both hosted and local installations,
 change it slightly to check if PyKEEN is already installed:

--- a/docs/source/tutorial/first_steps.rst
+++ b/docs/source/tutorial/first_steps.rst
@@ -9,7 +9,7 @@ Loading a pre-trained Model
 ---------------------------
 
 Many of the previous examples ended with saving the results using the
-:meth:`pykeen.pipeline.PipelineResult.save_to_directory`. One of the artifacts written to the given directory is the
+:meth:`~pykeen.pipeline.PipelineResult.save_to_directory`. One of the artifacts written to the given directory is the
 ``trained_model.pkl`` file. Because all PyKEEN models inherit from :class:`torch.nn.Module`, we use the PyTorch
 mechanisms for saving and loading them. This means that you can use :func:`torch.load` to load a model like:
 
@@ -54,18 +54,18 @@ representations, so they are respectively stored as sequences in the ``entity_re
 ``relation_representations`` attributes of each model. While the exact contents of these sequences are model-dependent,
 the first element of each is usually the "primary" representation for either the entities or relations.
 
-Typically, the values in these sequences are instances of the :class:`pykeen.nn.representation.Embedding`. This
+Typically, the values in these sequences are instances of the :class:`~pykeen.nn.representation.Embedding`. This
 implements a similar, but more powerful, interface to the built-in :class:`torch.nn.Embedding` class. However, the
 values in these sequences can more generally be instances of any subclasses of
-:class:`pykeen.nn.representation.Representation`. This allows for more powerful encoders those in GNNs such as
-:class:`pykeen.models.RGCN` to be implemented and used.
+:class:`~pykeen.nn.representation.Representation`. This allows for more powerful encoders those in GNNs such as
+:class:`~pykeen.models.RGCN` to be implemented and used.
 
 The entity representations and relation representations can be accessed like this:
 
 .. literalinclude:: ../examples/first_steps/using_learned_embeddings.py
     :lines: 4-14
 
-Most models, like :class:`pykeen.models.TransE`, only have one representation for entities and one for relations. This
+Most models, like :class:`~pykeen.models.TransE`, only have one representation for entities and one for relations. This
 means that the ``entity_representations`` and ``relation_representations`` lists both have a length of 1. All of the
 entity embeddings can be accessed like:
 
@@ -78,7 +78,7 @@ Since all representations are subclasses of :class:`torch.nn.Module`, you need t
 .. literalinclude:: ../examples/first_steps/using_learned_embeddings.py
     :lines: 28-29
 
-The `forward()` function of all :class:`pykeen.nn.representation.Representation` takes an ``indices`` parameter. By
+The `forward()` function of all :class:`~pykeen.nn.representation.Representation` takes an ``indices`` parameter. By
 default, it is ``None`` and returns all values. More explicitly, this looks like:
 
 .. literalinclude:: ../examples/first_steps/using_learned_embeddings.py

--- a/docs/source/tutorial/translational_toy_example.rst
+++ b/docs/source/tutorial/translational_toy_example.rst
@@ -5,7 +5,7 @@ The following tutorial is based on a question originally posed by Heiko Paulheim
 <https://github.com/pykeen/pykeen/issues/97>`_.
 
 Given the following toy example comprising three entities in a triangle, a translational distance model like
-:class:`pykeen.models.TransE` should be able to exactly learn the geometric structure.
+:class:`~pykeen.models.TransE` should be able to exactly learn the geometric structure.
 
 ======== ========== ========
 Head     Relation   Tail

--- a/src/pykeen/__init__.py
+++ b/src/pykeen/__init__.py
@@ -1,15 +1,15 @@
 """PyKEEN is a Python package for reproducible, facile knowledge graph embeddings.
 
-The fastest way to get up and running is to use the :func:`pykeen.pipeline.pipeline`
+The fastest way to get up and running is to use the :func:`~pykeen.pipeline.pipeline`
 function.
 
 It provides a high-level entry into the extensible functionality of
 this package. The following example shows how to train and evaluate the
-TransE model (:class:`pykeen.models.TransE`) on the Nations dataset (:class:`pykeen.datasets.Nations`)
+TransE model (:class:`~pykeen.models.TransE`) on the Nations dataset (:class:`~pykeen.datasets.Nations`)
 by referring to them by name. By default, the training loop uses the stochastic closed world assumption training
 approach
-(:class:`pykeen.training.SLCWATrainingLoop`) and evaluates with rank-based evaluation
-(:class:`pykeen.evaluation.RankBasedEvaluator`).
+(:class:`~pykeen.training.SLCWATrainingLoop`) and evaluates with rank-based evaluation
+(:class:`~pykeen.evaluation.RankBasedEvaluator`).
 
 >>> from pykeen.pipeline import pipeline
 >>> result = pipeline(
@@ -17,7 +17,7 @@ approach
 ...     dataset='Nations',
 ... )
 
-The results are returned in a :class:`pykeen.pipeline.PipelineResult` instance, which has
+The results are returned in a :class:`~pykeen.pipeline.PipelineResult` instance, which has
 attributes for the trained model, the training loop, and the evaluation.
 
 PyKEEN has a function :func:`pykeen.env` that magically prints relevant version information

--- a/src/pykeen/ablation/ablation.py
+++ b/src/pykeen/ablation/ablation.py
@@ -94,7 +94,7 @@ def ablation_pipeline(
     :param create_inverse_triples: Either a boolean for a single entry or a list of booleans.
     :param regularizers: A regularizer name, list of regularizer names, or None if no regularizer is desired.
     :param negative_sampler: A negative sampler name, list of regularizer names, or None if no negative sampler is
-        desired. Negative sampling is used only in combination with :class:`pykeen.training.SLCWATrainingLoop`.
+        desired. Negative sampling is used only in combination with :class:`~pykeen.training.SLCWATrainingLoop`.
     :param evaluator: The name of the evaluator to be used. Defaults to rank-based evaluator.
     :param stopper: The name of the stopper to be used. Defaults to NopStopper which doesn't define a stopping
         criterion.
@@ -104,7 +104,7 @@ def ablation_pipeline(
         model to be used in HPO.
     :param model_to_loss_to_loss_kwargs: A mapping from model name to a mapping of loss name to a mapping of default
         keyword arguments for the instantiation of that loss function. This is useful because for some losses, have
-        hyper-parameters such as :class:`pykeen.losses.MarginRankingLoss`.
+        hyper-parameters such as :class:`~pykeen.losses.MarginRankingLoss`.
     :param model_to_loss_to_loss_kwargs_ranges: A mapping from model name to a mapping of loss name to a mapping of
         keyword argument ranges for that loss to be used in HPO.
     :param model_to_optimizer_to_optimizer_kwargs: A mapping from model name to a mapping of optimizer name to a mapping

--- a/src/pykeen/checkpoints/__init__.py
+++ b/src/pykeen/checkpoints/__init__.py
@@ -15,8 +15,8 @@ Examples
 ========
 
 Below you can find a few examples of how to use them inside the training pipeline. If you want to check before an actual
-training how (static) checkpoint schedules behave, you can take a look at :meth:`pykeen.checkpoints.final_checkpoints`
-and :meth:`pykeen.checkpoints.simulate_checkpoints`.
+training how (static) checkpoint schedules behave, you can take a look at :meth:`~pykeen.checkpoints.final_checkpoints`
+and :meth:`~pykeen.checkpoints.simulate_checkpoints`.
 
 To reduce the number of necessary imports, the examples all use dictionaries/strings to specify components instead of
 passing classes or actual instances. You can find more information about resolution in general at

--- a/src/pykeen/checkpoints/inspection.py
+++ b/src/pykeen/checkpoints/inspection.py
@@ -27,11 +27,11 @@ def simulate_checkpoints(
         additional keyword-based parameters when the schedule needs to instantiated first from a selection,
         cf. :const:`pykeen.checkpoints.scheduler_resolver`
     :param keeper:
-        a checkpoint retention policy instance or selection, cf. :const:`pykeen.checkpoints.keeper_resolver`
+        a checkpoint retention policy instance or selection, cf. :const:`~pykeen.checkpoints.keeper_resolver`
         `None` corresponds to keeping everything that was checkpointed.
     :param keeper_kwargs:
         additional keyword-based parameters when the retention policy needs to instantiated first from a selection,
-        cf. :const:`pykeen.checkpoints.keeper_resolver`
+        cf. :const:`~pykeen.checkpoints.keeper_resolver`
     """
     schedule_instance = schedule_resolver.make(schedule, schedule_kwargs)
     keeper_instance = keeper_resolver.make_safe(keeper, keeper_kwargs)
@@ -99,11 +99,11 @@ def final_checkpoints(
         additional keyword-based parameters when the schedule needs to instantiated first from a selection,
         cf. :const:`pykeen.checkpoints.scheduler_resolver`
     :param keeper:
-        a checkpoint retention policy instance or selection, cf. :const:`pykeen.checkpoints.keeper_resolver`
+        a checkpoint retention policy instance or selection, cf. :const:`~pykeen.checkpoints.keeper_resolver`
         `None` corresponds to keeping everything that was checkpointed.
     :param keeper_kwargs:
         additional keyword-based parameters when the retention policy needs to instantiated first from a selection,
-        cf. :const:`pykeen.checkpoints.keeper_resolver`
+        cf. :const:`~pykeen.checkpoints.keeper_resolver`
 
     :return:
         a sorted list of epochs at which a checkpoint remains after clean-up.

--- a/src/pykeen/contrib/lightning.py
+++ b/src/pykeen/contrib/lightning.py
@@ -56,7 +56,7 @@ class LitModule(pytorch_lightning.LightningModule, ABC):
 
     .. seealso::
 
-        :class:`pykeen.training.training_loop.TrainingLoop`
+        :class:`~pykeen.training.training_loop.TrainingLoop`
     """
 
     def __init__(

--- a/src/pykeen/datasets/__init__.py
+++ b/src/pykeen/datasets/__init__.py
@@ -1,6 +1,6 @@
 """Built-in datasets for PyKEEN.
 
-New datasets (inheriting from :class:`pykeen.datasets.Dataset`) can be registered with PyKEEN using the
+New datasets (inheriting from :class:`~pykeen.datasets.Dataset`) can be registered with PyKEEN using the
 :mod:`pykeen.datasets` group in Python entrypoints in your own `setup.py`, `setup.cfg`, `pyproject.toml`, or other
 package configuration. They are loaded automatically with :func:`importlib.metadata.entry_points` via
 :mod:`class_resolver`.

--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -320,7 +320,7 @@ class Dataset(ExtraReprMixin):
         return normalize_string((self.metadata or {}).get("name") or self.__class__.__name__)
 
     def remix(self, random_state: TorchRandomHint = None, **kwargs) -> Dataset:
-        """Remix a dataset using :func:`pykeen.triples.remix.remix`."""
+        """Remix a dataset using :func:`~pykeen.triples.remix.remix`."""
         return EagerDataset(
             *remix(
                 *self._tup(),
@@ -330,7 +330,7 @@ class Dataset(ExtraReprMixin):
         )
 
     def deteriorate(self, n: int | float, random_state: TorchRandomHint = None) -> Dataset:
-        """Deteriorate n triples from the dataset's training with :func:`pykeen.triples.deteriorate.deteriorate`."""
+        """Deteriorate n triples from the dataset's training with :func:`~pykeen.triples.deteriorate.deteriorate`."""
         return EagerDataset(
             *deteriorate(
                 *self._tup(),
@@ -575,8 +575,8 @@ class LazyDataset(Dataset):
         """Get the appropriate cache root directory.
 
         :param cache_root: If none is passed, defaults to a subfolder of the PyKEEN home directory defined in
-            :data:`pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
-            :class:`pykeen.datasets.base.Dataset`.
+            :data:`~pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
+            :class:`~pykeen.datasets.base.Dataset`.
 
         :returns: A path object for the calculated cache root directory
         """

--- a/src/pykeen/datasets/biokg.py
+++ b/src/pykeen/datasets/biokg.py
@@ -47,7 +47,7 @@ class BioKG(ZipSingleDataset):
         """Initialize the BioKG dataset from [walsh2020]_.
 
         :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TarFileSingleDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TarFileSingleDataset`.
         """
         super().__init__(
             url=URL,

--- a/src/pykeen/datasets/ckg.py
+++ b/src/pykeen/datasets/ckg.py
@@ -50,7 +50,7 @@ class CKG(TabbedDataset):
         """Initialize the `CKG <https://github.com/MannLabs/CKG>`_ dataset from [santos2020]_.
 
         :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TabbedDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TabbedDataset`.
         """
         super().__init__(
             random_state=random_state,

--- a/src/pykeen/datasets/codex.py
+++ b/src/pykeen/datasets/codex.py
@@ -53,7 +53,7 @@ class CoDExSmall(UnpackedRemoteDataset):
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the `CoDEx <https://github.com/tsafavi/codex>`_ small dataset from [safavi2020]_.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             training_url=SMALL_TRAIN_URL,
@@ -86,7 +86,7 @@ class CoDExMedium(UnpackedRemoteDataset):
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the `CoDEx <https://github.com/tsafavi/codex>`_ medium dataset from [safavi2020]_.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             training_url=MEDIUM_TRAIN_URL,
@@ -119,7 +119,7 @@ class CoDExLarge(UnpackedRemoteDataset):
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the `CoDEx <https://github.com/tsafavi/codex>`_ large dataset from [safavi2020]_.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             training_url=LARGE_TRAIN_URL,

--- a/src/pykeen/datasets/conceptnet.py
+++ b/src/pykeen/datasets/conceptnet.py
@@ -45,7 +45,7 @@ class ConceptNet(SingleTabbedDataset):
         """Initialize the `ConceptNet <https://github.com/commonsense/conceptnet5>`_ dataset from [speer2017]_.
 
         :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.SingleTabbedDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.SingleTabbedDataset`.
         """
         super().__init__(
             url=URL,

--- a/src/pykeen/datasets/countries.py
+++ b/src/pykeen/datasets/countries.py
@@ -33,7 +33,7 @@ class Countries(UnpackedRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the Countries small dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             training_url=f"{BASE_URL}/train.txt",

--- a/src/pykeen/datasets/cskg.py
+++ b/src/pykeen/datasets/cskg.py
@@ -45,7 +45,7 @@ class CSKG(SingleTabbedDataset):
         """Initialize the `CSKG <https://github.com/usc-isi-i2/cskg>`_ dataset from [ilievski2020]_.
 
         :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.SingleTabbedDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.SingleTabbedDataset`.
         """
         super().__init__(
             url=URL,

--- a/src/pykeen/datasets/db100k.py
+++ b/src/pykeen/datasets/db100k.py
@@ -34,7 +34,7 @@ class DB100K(UnpackedRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the DB100K small dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             training_url=f"{BASE_URL}/_train.txt",

--- a/src/pykeen/datasets/dbpedia.py
+++ b/src/pykeen/datasets/dbpedia.py
@@ -40,7 +40,7 @@ class DBpedia50(UnpackedRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the DBpedia50 small dataset from [shi2017b]_.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             training_url=TRAIN_URL,

--- a/src/pykeen/datasets/drkg.py
+++ b/src/pykeen/datasets/drkg.py
@@ -44,7 +44,7 @@ class DRKG(TarFileSingleDataset):
         """Initialize the `DRKG <https://github.com/gnn4dr/DRKG>`_ dataset.
 
         :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TarFileSingleDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TarFileSingleDataset`.
         """
         super().__init__(
             url=URL,

--- a/src/pykeen/datasets/freebase.py
+++ b/src/pykeen/datasets/freebase.py
@@ -40,7 +40,7 @@ class FB15k(TarFileRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the FreeBase 15K dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TarFileRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TarFileRemoteDataset`.
 
         .. warning:: This dataset contains testing leakage. Use :class:`FB15k237` instead.
         """

--- a/src/pykeen/datasets/globi.py
+++ b/src/pykeen/datasets/globi.py
@@ -45,7 +45,7 @@ class Globi(SingleTabbedDataset):
         """Initialize the GloBI dataset.
 
         :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.SingleTabbedDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.SingleTabbedDataset`.
         """
         super().__init__(
             url=URL,

--- a/src/pykeen/datasets/hetionet.py
+++ b/src/pykeen/datasets/hetionet.py
@@ -50,7 +50,7 @@ class Hetionet(SingleTabbedDataset):
         """Initialize the `Hetionet <https://github.com/hetio/hetionet>`_ dataset from [himmelstein2017]_.
 
         :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.SingleTabbedDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.SingleTabbedDataset`.
         """
         super().__init__(
             url=URL,

--- a/src/pykeen/datasets/inductive/base.py
+++ b/src/pykeen/datasets/inductive/base.py
@@ -163,8 +163,8 @@ class LazyInductiveDataset(InductiveDataset):
         """Get the appropriate cache root directory.
 
         :param cache_root: If none is passed, defaults to a subfolder of the PyKEEN home directory defined in
-            :data:`pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
-            :class:`pykeen.datasets.base.Dataset`.
+            :data:`~pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
+            :class:`~pykeen.datasets.base.Dataset`.
         :param version: accepts a string "v1" to "v4" to select among Teru et al inductive datasets
         :param sep_train_inference: a flag to store training and inference splits in different folders
 

--- a/src/pykeen/datasets/inductive/ilp_teru.py
+++ b/src/pykeen/datasets/inductive/ilp_teru.py
@@ -91,7 +91,7 @@ class InductiveFB15k237(UnpackedRemoteDisjointInductiveDataset):
         """Initialize a particular version of a dataset (out of 4) from [teru2020]_.
 
         :param version: v1 / v2 / v3 / v4 , differ in the sizes of train and inductive inference graphs
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             transductive_training_url=FB_TRAIN_URL.format(base_url=BASE_URL, version=version),
@@ -157,7 +157,7 @@ class InductiveWN18RR(UnpackedRemoteDisjointInductiveDataset):
         """Initialize a particular version of a dataset (out of 4) from [teru2020]_.
 
         :param version: v1 / v2 / v3 / v4 , differ in the sizes of train and inductive inference graphs
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             transductive_training_url=WN_TRAIN_URL.format(base_url=BASE_URL, version=version),
@@ -223,7 +223,7 @@ class InductiveNELL(UnpackedRemoteDisjointInductiveDataset):
         """Initialize a particular version of a dataset (out of 4) from [teru2020]_.
 
         :param version: v1 / v2 / v3 / v4 , differ in the sizes of train and inductive inference graphs
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             transductive_training_url=NELL_TRAIN_URL.format(base_url=BASE_URL, version=version),

--- a/src/pykeen/datasets/kinships/__init__.py
+++ b/src/pykeen/datasets/kinships/__init__.py
@@ -42,7 +42,7 @@ class Kinships(PathDataset):
     def __init__(self, **kwargs):
         """Initialize the Kinships dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.PathDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.PathDataset`.
         """
         super().__init__(
             training_path=KINSHIPS_TRAIN_PATH,

--- a/src/pykeen/datasets/nations/__init__.py
+++ b/src/pykeen/datasets/nations/__init__.py
@@ -47,7 +47,7 @@ class Nations(PathDataset):
     def __init__(self, **kwargs):
         """Initialize the Nations dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.PathDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.PathDataset`.
         """
         super().__init__(
             training_path=NATIONS_TRAIN_PATH,
@@ -83,7 +83,7 @@ class NationsLiteral(NumericPathDataset):
     def __init__(self, **kwargs):
         """Initialize the Nations dataset with literals.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.PathDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.PathDataset`.
         """
         super().__init__(
             training_path=NATIONS_TRAIN_PATH,

--- a/src/pykeen/datasets/openbiolink.py
+++ b/src/pykeen/datasets/openbiolink.py
@@ -46,7 +46,7 @@ class OpenBioLink(PackedZipRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the OpenBioLink dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.PackedZipRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.PackedZipRemoteDataset`.
         """
         super().__init__(
             url=HQ_URL,
@@ -81,7 +81,7 @@ class OpenBioLinkLQ(PackedZipRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the OpenBioLink (low quality) dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.PackedZipRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.PackedZipRemoteDataset`.
         """
         super().__init__(
             url=LQ_URL,

--- a/src/pykeen/datasets/pharmebinet.py
+++ b/src/pykeen/datasets/pharmebinet.py
@@ -46,7 +46,7 @@ class PharMeBINet(TarFileSingleDataset):
         """Initialize the PharMeBINet dataset from [koenigs2022]_.
 
         :param random_state: An optional random state to make the training/testing/validation split reproducible.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TarFileSingleDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TarFileSingleDataset`.
         """
         super().__init__(
             url=RAW_URL,

--- a/src/pykeen/datasets/pharmkg.py
+++ b/src/pykeen/datasets/pharmkg.py
@@ -50,7 +50,7 @@ class PharmKG8k(UnpackedRemoteDataset):
     ):
         """Initialize the PharmKG8k dataset from [zheng2020]_.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             training_url=TRAIN_URL,
@@ -89,7 +89,7 @@ class PharmKG(SingleTabbedDataset):
         """Initialize the PharmKG dataset from [zheng2020]_.
 
         :param random_state: An optional random state to make the training/testing/validation split reproducible.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             url=RAW_URL,

--- a/src/pykeen/datasets/primekg.py
+++ b/src/pykeen/datasets/primekg.py
@@ -46,7 +46,7 @@ class PrimeKG(SingleTabbedDataset):
         """Initialize the PrimeKG dataset from [chandak2022]_.
 
         :param random_state: The random seed to use in splitting the dataset. Defaults to 0.
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.SingleTabbedDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.SingleTabbedDataset`.
         """
         super().__init__(
             url=URL,

--- a/src/pykeen/datasets/umls/__init__.py
+++ b/src/pykeen/datasets/umls/__init__.py
@@ -42,7 +42,7 @@ class UMLS(PathDataset):
     def __init__(self, **kwargs):
         """Initialize the UMLS dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.PathDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.PathDataset`.
         """
         super().__init__(
             training_path=UMLS_TRAIN_PATH,

--- a/src/pykeen/datasets/utils.py
+++ b/src/pykeen/datasets/utils.py
@@ -111,7 +111,7 @@ def get_dataset(
     :returns: An instantiated dataset
 
     :raises ValueError: for incorrect usage of the input of the function
-    :raises TypeError: If a type is given for ``dataset`` but it's not a subclass of :class:`pykeen.datasets.Dataset`
+    :raises TypeError: If a type is given for ``dataset`` but it's not a subclass of :class:`~pykeen.datasets.Dataset`
     """
     from . import dataset_resolver, has_dataset
 

--- a/src/pykeen/datasets/wd50k.py
+++ b/src/pykeen/datasets/wd50k.py
@@ -42,7 +42,7 @@ class WD50KT(UnpackedRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the WD50K (triples) dataset from [galkin2020]_.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.UnpackedRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.UnpackedRemoteDataset`.
         """
         super().__init__(
             training_url=TRIPLES_TRAIN_URL,

--- a/src/pykeen/datasets/wikidata5m.py
+++ b/src/pykeen/datasets/wikidata5m.py
@@ -49,7 +49,7 @@ class Wikidata5M(TarFileRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the Wikidata5M dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TarFileRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TarFileRemoteDataset`.
         """
         super().__init__(
             url=TRANSDUCTIVE_URL,

--- a/src/pykeen/datasets/wordnet.py
+++ b/src/pykeen/datasets/wordnet.py
@@ -34,7 +34,7 @@ class WN18(TarFileRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the WordNet-18 dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TarFileRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TarFileRemoteDataset`.
 
         .. warning:: This dataset contains testing leakage. Use :class:`WN18RR` instead.
         """
@@ -69,7 +69,7 @@ class WN18RR(TarFileRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the WordNet-18 (RR) dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TarFileRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TarFileRemoteDataset`.
         """
         super().__init__(
             url="https://github.com/TimDettmers/ConvE/raw/master/WN18RR.tar.gz",

--- a/src/pykeen/datasets/yago.py
+++ b/src/pykeen/datasets/yago.py
@@ -33,7 +33,7 @@ class YAGO310(TarFileRemoteDataset):
     def __init__(self, **kwargs):
         """Initialize the YAGO3-10 dataset.
 
-        :param kwargs: keyword arguments passed to :class:`pykeen.datasets.base.TarFileRemoteDataset`.
+        :param kwargs: keyword arguments passed to :class:`~pykeen.datasets.base.TarFileRemoteDataset`.
         """
         super().__init__(
             url="https://github.com/TimDettmers/ConvE/raw/master/YAGO3-10.tar.gz",

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -149,8 +149,8 @@ class RankBasedMetricResults(MetricResults[RankBasedMetricKey]):
         3. The metric name, e.g., "adjusted_mean_rank_index", "adjusted_mean_rank", "mean_rank, "mean_reciprocal_rank",
             "inverse_geometric_mean_rank", or "hits@k" where k defaults to 10 but can be substituted for an integer.
             By default, 1, 3, 5, and 10 are available. Other K's can be calculated by setting the appropriate
-            variable in the ``evaluation_kwargs`` in the :func:`pykeen.pipeline.pipeline` or setting ``ks`` in the
-            :class:`pykeen.evaluation.RankBasedEvaluator`.
+            variable in the ``evaluation_kwargs`` in the :func:`~pykeen.pipeline.pipeline` or setting ``ks`` in the
+            :class:`~pykeen.evaluation.RankBasedEvaluator`.
 
         In general, all metrics are available for all combinations of sides/types except AMR and AMRI, which
         are only calculated for the average type. This is because the calculation of the expected MR in the
@@ -589,7 +589,7 @@ class SampledRankBasedEvaluator(RankBasedEvaluator):
             the entity IDs of negative samples for tail prediction for each evaluation triple
         :param kwargs:
             additional keyword-based arguments passed to
-            :meth:`pykeen.evaluation.rank_based_evaluator.RankBasedEvaluator.__init__`
+            :meth:`~pykeen.evaluation.rank_based_evaluator.RankBasedEvaluator.__init__`
 
         :raises ValueError:
             if only a single side's negatives are given, or the negatives are in wrong shape

--- a/src/pykeen/hpo/__init__.py
+++ b/src/pykeen/hpo/__init__.py
@@ -1,7 +1,7 @@
-"""The easiest way to optimize a model is with the :func:`pykeen.hpo.hpo_pipeline` function.
+"""The easiest way to optimize a model is with the :func:`~pykeen.hpo.hpo_pipeline` function.
 
 All of the following examples are about getting the best model
-when training :class:`pykeen.models.TransE` on the :class:`pykeen.datasets.Nations` dataset.
+when training :class:`~pykeen.models.TransE` on the :class:`~pykeen.datasets.Nations` dataset.
 Each gives a bit of insight into usage of the :func:`hpo_pipeline` function.
 
 The minimal usage of the hyper-parameter optimization is to specify the
@@ -27,7 +27,7 @@ as many trials as possible will be run in 60 seconds.
 ... )
 
 The hyper-parameter optimization pipeline has the ability to optimize hyper-parameters for the corresponding
-``*_kwargs`` arguments in the :func:`pykeen.pipeline.pipeline`:
+``*_kwargs`` arguments in the :func:`~pykeen.pipeline.pipeline`:
 
 - ``model``
 - ``loss``
@@ -47,7 +47,7 @@ samples, training loops), these values are stored in the default valeues of the 
 `__init__()` functions. They can be viewed in the corresponding reference section of the docs.
 
 Some components contain strategies for doing hyper-parameter optimization. When you call the
-:func:`pykeen.hpo.hpo_pipeline`, the following steps are taken to determine what happens for each hyper-parameter
+:func:`~pykeen.hpo.hpo_pipeline`, the following steps are taken to determine what happens for each hyper-parameter
 in each componenent:
 
 1. If an explicit value was passed, use it.
@@ -86,7 +86,7 @@ in which there's a dictionary with all of the default strategies. They keys matc
 respective ``__init__()`` functions.
 
 Since optimizers aren't re-implemented in PyKEEN, there's a specfic dictionary at
-:py:attr:`pykeen.optimizers.optimizers_hpo_defaults` containing their strategies. It's debatable whether
+:py:attr:`~pykeen.optimizers.optimizers_hpo_defaults` containing their strategies. It's debatable whether
 you should optimize the optimizers (yo dawg), so you can always choose to set the learning rate ``lr`` to a constant
 value.
 
@@ -160,7 +160,7 @@ within the bounds specified by the ``low`` and ``high`` arguments. This applies 
 Power Scale (``type=int`` only)
 *******************************
 The power scale was originally implemented as ``scale='power_two'`` to support
-:class:`pykeen.models.ConvE`'s ``output_channels`` parameter. However, using two as a base is a bit limiting, so we
+:class:`~pykeen.models.ConvE`'s ``output_channels`` parameter. However, using two as a base is a bit limiting, so we
 also implemented a more general ``scale='power'`` where you can set set ``base``. Here's an example to optimize over
 the number of negatives per positive ratio using `base=10`:
 
@@ -232,7 +232,7 @@ While the default values for hyper-parameters are encoded with the python syntax
 for default values of the ``__init__()`` function of each model, the ranges/scales can be
 found in the class variable :py:attr:`pykeen.models.Model.hpo_default`. For
 example, the range for TransE's embedding dimension is set to optimize
-between 50 and 350 at increments of 25 in :py:attr:`pykeen.models.TransE.hpo_default`.
+between 50 and 350 at increments of 25 in :py:attr:`~pykeen.models.TransE.hpo_default`.
 TransE also has a scoring function norm that will be optimized by a categorical
 selection of {1, 2} by default.
 
@@ -313,7 +313,7 @@ study pipeline.
 Optimizing the Loss
 ~~~~~~~~~~~~~~~~~~~
 While each model has its own default loss, you can explicitly specify a loss
-the same way as in :func:`pykeen.pipeline.pipeline`.
+the same way as in :func:`~pykeen.pipeline.pipeline`.
 
 >>> from pykeen.hpo import hpo_pipeline
 >>> hpo_pipeline_result = hpo_pipeline(
@@ -329,8 +329,8 @@ For example, the TransE model defines the margin ranking loss as its default in
 :py:attr:`pykeen.models.TransE.loss_default`.
 
 Each model also specifies default hyper-parameters for the loss function in
-:py:attr:`pykeen.models.Model.loss_default_kwargs`. For example, DistMultLiteral
-explicitly sets the margin to `0.0` in  :py:attr:`pykeen.models.DistMultLiteral.loss_default_kwargs`.
+:py:attr:`~pykeen.models.Model.loss_default_kwargs`. For example, DistMultLiteral
+explicitly sets the margin to `0.0` in  :py:attr:`~pykeen.models.DistMultLiteral.loss_default_kwargs`.
 
 Unlike the model's hyper-parameters, the models don't store the strategies for
 optimizing the loss functions' hyper-parameters. The pre-configured strategies
@@ -353,8 +353,8 @@ specify the ``loss_kwargs_ranges`` explicitly, as in the following example.
 Optimizing the Negative Sampler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When the stochastic local closed world assumption (sLCWA) training approach is used for training, a negative sampler
-(subclass of :py:class:`pykeen.sampling.NegativeSampler`) is chosen.
-Each has a strategy stored in :py:attr:`pykeen.sampling.NegativeSampler.hpo_default`.
+(subclass of :py:class:`~pykeen.sampling.NegativeSampler`) is chosen.
+Each has a strategy stored in :py:attr:`~pykeen.sampling.NegativeSampler.hpo_default`.
 
 Like models and regularizers, the rules are the same for specifying ``negative_sampler``,
 ``negative_sampler_kwargs``, and ``negative_sampler_kwargs_ranges``.
@@ -365,7 +365,7 @@ Yo dawg, I heard you liked optimization, so we put an optimizer around your
 optimizer so you can optimize while you optimize. Since all optimizers used
 in PyKEEN come from the PyTorch implementations, they obviously do not have
 ``hpo_defaults`` class variables. Instead, every optimizer has a default
-optimization strategy stored in :py:attr:`pykeen.optimizers.optimizers_hpo_defaults`
+optimization strategy stored in :py:attr:`~pykeen.optimizers.optimizers_hpo_defaults`
 the same way that the default strategies for losses are stored externally.
 
 Optimizing the Optimized Optimizer - a.k.a. Learning Rate Schedulers
@@ -376,7 +376,7 @@ be useful to have a more aggressive learning rate in the beginning to quickly ma
 while lowering the learning rate over time to allow the model to smoothly converge to the optimum.
 
 PyKEEN allows you to use the learning rate schedulers provided by PyTorch, which you can
-simply specify as you would in the :func:`pykeen.pipeline.pipeline`.
+simply specify as you would in the :func:`~pykeen.pipeline.pipeline`.
 
 >>> from pykeen.hpo import hpo_pipeline
 >>> hpo_pipeline_result = hpo_pipeline(
@@ -387,7 +387,7 @@ simply specify as you would in the :func:`pykeen.pipeline.pipeline`.
 >>> pipeline_result.save_to_directory('nations_transe')
 
 The same way as the optimizers don't come with ``hpo_defaults`` class variables, lr_schedulers rely
-on their own optimization strategies provided in :py:attr:`pykeen.lr_schedulers.lr_schedulers_hpo_defaults`
+on their own optimization strategies provided in :py:attr:`~pykeen.lr_schedulers.lr_schedulers_hpo_defaults`
 In case you are ready to explore even more you can of course also set your own ranges with the
 ``lr_scheduler_kwargs_ranges`` keyword argument as in:
 
@@ -404,7 +404,7 @@ In case you are ready to explore even more you can of course also set your own r
 
 Optimizing Everything Else
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-Without loss of generality, the following arguments to :func:`pykeen.pipeline.pipeline`
+Without loss of generality, the following arguments to :func:`~pykeen.pipeline.pipeline`
 have corresponding `*_kwargs` and `*_kwargs_ranges`:
 
 - ``training_loop`` (only kwargs, not kwargs_ranges)

--- a/src/pykeen/hpo/hpo.py
+++ b/src/pykeen/hpo/hpo.py
@@ -579,8 +579,8 @@ def hpo_pipeline(
     """Train a model on the given dataset.
 
     :param dataset:
-        The name of the dataset (a key for the :data:`pykeen.datasets.dataset_resolver`) or the
-        :class:`pykeen.datasets.Dataset` instance. Alternatively, the training triples factory (``training``), testing
+        The name of the dataset (a key for the :data:`~pykeen.datasets.dataset_resolver`) or the
+        :class:`~pykeen.datasets.Dataset` instance. Alternatively, the training triples factory (``training``), testing
         triples factory (``testing``), and validation triples factory (``validation``; optional) can be specified.
     :param dataset_kwargs:
         The keyword arguments passed to the dataset upon instantiation
@@ -593,14 +593,14 @@ def hpo_pipeline(
     :param evaluation_entity_whitelist:
         Optional restriction of evaluation to triples containing *only* these entities. Useful if the downstream task
         is only interested in certain entities, but the relational patterns with other entities improve the entity
-        embedding quality. Passed to :func:`pykeen.pipeline.pipeline`.
+        embedding quality. Passed to :func:`~pykeen.pipeline.pipeline`.
     :param evaluation_relation_whitelist:
         Optional restriction of evaluation to triples containing *only* these relations. Useful if the downstream task
         is only interested in certain relation, but the relational patterns with other relations improve the entity
-        embedding quality. Passed to :func:`pykeen.pipeline.pipeline`.
+        embedding quality. Passed to :func:`~pykeen.pipeline.pipeline`.
 
     :param model:
-        The name of the model or the model class to pass to :func:`pykeen.pipeline.pipeline`
+        The name of the model or the model class to pass to :func:`~pykeen.pipeline.pipeline`
     :param model_kwargs:
         Keyword arguments to pass to the model class on instantiation
     :param model_kwargs_ranges:
@@ -608,7 +608,7 @@ def hpo_pipeline(
         the defaults
 
     :param loss:
-        The name of the loss or the loss class to pass to :func:`pykeen.pipeline.pipeline`
+        The name of the loss or the loss class to pass to :func:`~pykeen.pipeline.pipeline`
     :param loss_kwargs:
         Keyword arguments to pass to the loss on instantiation
     :param loss_kwargs_ranges:
@@ -616,7 +616,7 @@ def hpo_pipeline(
         the defaults
 
     :param regularizer:
-        The name of the regularizer or the regularizer class to pass to :func:`pykeen.pipeline.pipeline`
+        The name of the regularizer or the regularizer class to pass to :func:`~pykeen.pipeline.pipeline`
     :param regularizer_kwargs:
         Keyword arguments to pass to the regularizer on instantiation
     :param regularizer_kwargs_ranges:
@@ -640,12 +640,12 @@ def hpo_pipeline(
 
     :param training_loop:
         The name of the training approach (``'slcwa'`` or ``'lcwa'``) or the training loop class
-        to pass to :func:`pykeen.pipeline.pipeline`
+        to pass to :func:`~pykeen.pipeline.pipeline`
     :param training_loop_kwargs:
         additional keyword-based parameters passed to the training loop upon instantiation.
     :param negative_sampler:
         The name of the negative sampler (``'basic'`` or ``'bernoulli'``) or the negative sampler class
-        to pass to :func:`pykeen.pipeline.pipeline`. Only allowed when training with sLCWA.
+        to pass to :func:`~pykeen.pipeline.pipeline`. Only allowed when training with sLCWA.
     :param negative_sampler_kwargs:
         Keyword arguments to pass to the negative sampler class on instantiation
     :param negative_sampler_kwargs_ranges:
@@ -666,7 +666,7 @@ def hpo_pipeline(
         Keyword arguments to pass to the stopper upon instantiation.
 
     :param evaluator:
-        The name of the evaluator or an evaluator class. Defaults to :class:`pykeen.evaluation.RankBasedEvaluator`.
+        The name of the evaluator or an evaluator class. Defaults to :class:`~pykeen.evaluation.RankBasedEvaluator`.
     :param evaluator_kwargs:
         Keyword arguments to pass to the evaluator on instantiation
     :param evaluation_kwargs:

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -141,7 +141,7 @@ Setwise Loss Functions
 ----------------------
 A setwise loss is applied to a set of triples which can be either positive or negative. It is defined as
 $L: 2^{\mathcal{T}} \rightarrow \mathbb{R}$. The two setwise loss functions implemented in PyKEEN,
-:class:`pykeen.losses.NSSALoss` and :class:`pykeen.losses.CrossEntropyLoss` are both widely different
+:class:`~pykeen.losses.NSSALoss` and :class:`~pykeen.losses.CrossEntropyLoss` are both widely different
 in their paradigms, but both share the notion that triples are not strictly positive or negative.
 
 .. math::
@@ -715,10 +715,10 @@ class MarginRankingLoss(MarginPairwiseLoss):
 
     .. seealso::
 
-        MRL is closely related to :class:`pykeen.losses.SoftMarginRankingLoss`, only differing in that this loss
-        uses the ReLU activation and :class:`pykeen.losses.SoftMarginRankingLoss` uses the softmax activation. MRL
-        is also related to the :class:`pykeen.losses.PairwiseLogisticLoss` as this is a special case of the
-        :class:`pykeen.losses.SoftMarginRankingLoss` with no margin.
+        MRL is closely related to :class:`~pykeen.losses.SoftMarginRankingLoss`, only differing in that this loss
+        uses the ReLU activation and :class:`~pykeen.losses.SoftMarginRankingLoss` uses the softmax activation. MRL
+        is also related to the :class:`~pykeen.losses.PairwiseLogisticLoss` as this is a special case of the
+        :class:`~pykeen.losses.SoftMarginRankingLoss` with no margin.
 
     .. note::
 
@@ -754,14 +754,14 @@ class SoftMarginRankingLoss(MarginPairwiseLoss):
         L(k, \bar{k}) = \log(1 + \exp(f(\bar{k}) - f(k) + \lambda))
 
     Where $k$ are the positive triples, $\bar{k}$ are the negative triples, $f$ is the interaction function (e.g.,
-    :class:`pykeen.models.TransE` has $f(h,r,t)=-||\mathbf{e}_h+\mathbf{e}_r-\mathbf{e}_t||_p$),
+    :class:`~pykeen.models.TransE` has $f(h,r,t)=-||\mathbf{e}_h+\mathbf{e}_r-\mathbf{e}_t||_p$),
     $g(x)=\log(1 + \exp(x))$ is the softmax activation function, and $\lambda$ is the margin.
 
     .. seealso::
 
-        When choosing `margin=0``, this loss becomes equivalent to :class:`pykeen.losses.SoftMarginRankingLoss`.
-        It is also closely related to :class:`pykeen.losses.MarginRankingLoss`, only differing in that this loss
-        uses the softmax activation and :class:`pykeen.losses.MarginRankingLoss` uses the ReLU activation.
+        When choosing `margin=0``, this loss becomes equivalent to :class:`~pykeen.losses.SoftMarginRankingLoss`.
+        It is also closely related to :class:`~pykeen.losses.MarginRankingLoss`, only differing in that this loss
+        uses the softmax activation and :class:`~pykeen.losses.MarginRankingLoss` uses the ReLU activation.
     ---
     name: Soft margin ranking
     """
@@ -790,13 +790,13 @@ class PairwiseLogisticLoss(SoftMarginRankingLoss):
         L(k, \bar{k}) = \log(1 + \exp(f(\bar{k}) - f(k)))
 
     Where $k$ are the positive triples, $\bar{k}$ are the negative triples, $f$ is the interaction function (e.g.,
-    :class:`pykeen.models.TransE` has $f(h,r,t)=-||\mathbf{e}_h+\mathbf{e}_r-\mathbf{e}_t||_p$),
+    :class:`~pykeen.models.TransE` has $f(h,r,t)=-||\mathbf{e}_h+\mathbf{e}_r-\mathbf{e}_t||_p$),
     $g(x)=\log(1 + \exp(x))$ is the softmax activation function.
 
     .. seealso::
 
-        This loss is equivalent to :class:`pykeen.losses.SoftMarginRankingLoss` where ``margin=0``. It is also
-        closely related to :class:`pykeen.losses.MarginRankingLoss` based on the choice of activation function.
+        This loss is equivalent to :class:`~pykeen.losses.SoftMarginRankingLoss` where ``margin=0``. It is also
+        closely related to :class:`~pykeen.losses.MarginRankingLoss` based on the choice of activation function.
     ---
     name: Pairwise logistic
     """
@@ -1041,9 +1041,9 @@ class DeltaPointwiseLoss(PointwiseLoss):
     =============================  ==========  ======================  ========================================================  =============================================
     Pointwise Loss                 Activation  Margin                  Formulation                                               Implementation
     =============================  ==========  ======================  ========================================================  =============================================
-    Pointwise Hinge                ReLU        $\lambda \neq 0$        $g(s, l) = \max(0, \lambda -\hat{l}*s)$                   :class:`pykeen.losses.PointwiseHingeLoss`
-    Soft Pointwise Hinge           softplus    $\lambda \neq 0$        $g(s, l) = \log(1+\exp(\lambda -\hat{l}*s))$              :class:`pykeen.losses.SoftPointwiseHingeLoss`
-    Pointwise Logistic (softplus)  softplus    $\lambda = 0$           $g(s, l) = \log(1+\exp(-\hat{l}*s))$                      :class:`pykeen.losses.SoftplusLoss`
+    Pointwise Hinge                ReLU        $\lambda \neq 0$        $g(s, l) = \max(0, \lambda -\hat{l}*s)$                   :class:`~pykeen.losses.PointwiseHingeLoss`
+    Soft Pointwise Hinge           softplus    $\lambda \neq 0$        $g(s, l) = \log(1+\exp(\lambda -\hat{l}*s))$              :class:`~pykeen.losses.SoftPointwiseHingeLoss`
+    Pointwise Logistic (softplus)  softplus    $\lambda = 0$           $g(s, l) = \log(1+\exp(-\hat{l}*s))$                      :class:`~pykeen.losses.SoftplusLoss`
     =============================  ==========  ======================  ========================================================  =============================================
     """  # noqa:E501
 
@@ -1123,9 +1123,9 @@ class SoftPointwiseHingeLoss(DeltaPointwiseLoss):
 
     .. seealso::
 
-        When choosing ``margin=0``, this loss becomes equivalent to :class:`pykeen.losses.SoftplusLoss`.
-        It is also closely related to :class:`pykeen.losses.PointwiseHingeLoss`, only differing in that this loss
-        uses the softmax activation and :class:`pykeen.losses.PointwiseHingeLoss` uses the ReLU activation.
+        When choosing ``margin=0``, this loss becomes equivalent to :class:`~pykeen.losses.SoftplusLoss`.
+        It is also closely related to :class:`~pykeen.losses.PointwiseHingeLoss`, only differing in that this loss
+        uses the softmax activation and :class:`~pykeen.losses.PointwiseHingeLoss` uses the ReLU activation.
     ---
     name: Soft Pointwise Hinge
     """
@@ -1157,7 +1157,7 @@ class SoftplusLoss(SoftPointwiseHingeLoss):
 
     .. seealso::
 
-        This class is a special case of :class:`pykeen.losses.SoftPointwiseHingeLoss` where the margin
+        This class is a special case of :class:`~pykeen.losses.SoftPointwiseHingeLoss` where the margin
         is set to ``margin=0``.
     ---
     name: Softplus
@@ -1718,7 +1718,7 @@ class FocalLoss(PointwiseLoss):
             class is obtained as 1 - alpha.
             [lin2018]_ recommends to either set this to the inverse class frequency, or treat it as a hyper-parameter.
         :param kwargs:
-            Additional keyword-based arguments passed to :class:`pykeen.losses.PointwiseLoss`.
+            Additional keyword-based arguments passed to :class:`~pykeen.losses.PointwiseLoss`.
         :raises ValueError:
             If alpha is in the wrong range
         """

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -12,61 +12,61 @@ These metrics directly operate on the ranks:
 
 The following metrics measures summarize the central tendency of ranks
 
-- :class:`pykeen.metrics.ranking.ArithmeticMeanRank`
-- :class:`pykeen.metrics.ranking.GeometricMeanRank`
-- :class:`pykeen.metrics.ranking.HarmonicMeanRank`
-- :class:`pykeen.metrics.ranking.MedianRank`
+- :class:`~pykeen.metrics.ranking.ArithmeticMeanRank`
+- :class:`~pykeen.metrics.ranking.GeometricMeanRank`
+- :class:`~pykeen.metrics.ranking.HarmonicMeanRank`
+- :class:`~pykeen.metrics.ranking.MedianRank`
 
 The Hits at K metric is closely related to information retrieval and measures the fraction of times when the correct
 result is in the top-$k$ ranked entries, i.e., the rank is at most $k$
 
-- :class:`pykeen.metrics.ranking.HitsAtK`
+- :class:`~pykeen.metrics.ranking.HitsAtK`
 
 The next metrics summarize the dispersion of ranks
 
-- :class:`pykeen.metrics.ranking.MedianAbsoluteDeviation`
-- :class:`pykeen.metrics.ranking.Variance`
-- :class:`pykeen.metrics.ranking.StandardDeviation`
+- :class:`~pykeen.metrics.ranking.MedianAbsoluteDeviation`
+- :class:`~pykeen.metrics.ranking.Variance`
+- :class:`~pykeen.metrics.ranking.StandardDeviation`
 
 and finally there is a simple metric to store the number of ranks which where aggregated
 
-- :class:`pykeen.metrics.ranking.Count`
+- :class:`~pykeen.metrics.ranking.Count`
 
 Inverse Metrics
 ---------------
 The inverse metrics are reciprocals of the central tendency measures. They offer the advantage of having a fixed value
 range of $(0, 1]$, with a known optimal value of $1$:
 
-- :class:`pykeen.metrics.ranking.InverseArithmeticMeanRank`
-- :class:`pykeen.metrics.ranking.InverseGeometricMeanRank`
-- :class:`pykeen.metrics.ranking.InverseHarmonicMeanRank`
-- :class:`pykeen.metrics.ranking.InverseMedianRank`
+- :class:`~pykeen.metrics.ranking.InverseArithmeticMeanRank`
+- :class:`~pykeen.metrics.ranking.InverseGeometricMeanRank`
+- :class:`~pykeen.metrics.ranking.InverseHarmonicMeanRank`
+- :class:`~pykeen.metrics.ranking.InverseMedianRank`
 
 Adjusted Metrics
 ----------------
 Adjusted metrics build upon base metrics, but adjust them for chance, cf. [berrendorf2020]_ and [hoyt2022]_. All
-adjusted metrics derive from :class:`pykeen.metrics.ranking.DerivedRankBasedMetric` and, for a given evaluation set,
+adjusted metrics derive from :class:`~pykeen.metrics.ranking.DerivedRankBasedMetric` and, for a given evaluation set,
 are affine transformations of the base metric with dataset-dependent, but fixed transformation constants. Thus, they
 can also be computed when the model predictions are not available anymore, but the evaluation set is known.
 
 Expectation-Normalized Metrics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These metrics divide the metric by its expected value under random ordering. Thus, their expected value is always 1
-irrespective of the evaluation set. They derive from :class:`pykeen.metrics.ranking.ExpectationNormalizedMetric`, and
+irrespective of the evaluation set. They derive from :class:`~pykeen.metrics.ranking.ExpectationNormalizedMetric`, and
 there is currently only a single implementation:
 
-- :class:`pykeen.metrics.ranking.AdjustedArithmeticMeanRank`
+- :class:`~pykeen.metrics.ranking.AdjustedArithmeticMeanRank`
 
 Re-indexed Metrics
 ~~~~~~~~~~~~~~~~~~
 Re-indexed metrics subtract the expected value, and then normalize the optimal value to be 1. Thus, their expected value
 under random ordering is 0, their optimal value is 1, and larger values indicate better results. The classes derive from
-:class:`pykeen.metrics.ranking.ReindexedMetric`, and the following implementations are available:
+:class:`~pykeen.metrics.ranking.ReindexedMetric`, and the following implementations are available:
 
-- :class:`pykeen.metrics.ranking.AdjustedHitsAtK`
-- :class:`pykeen.metrics.ranking.AdjustedArithmeticMeanRankIndex`
-- :class:`pykeen.metrics.ranking.AdjustedGeometricMeanRankIndex`
-- :class:`pykeen.metrics.ranking.AdjustedInverseHarmonicMeanRank`
+- :class:`~pykeen.metrics.ranking.AdjustedHitsAtK`
+- :class:`~pykeen.metrics.ranking.AdjustedArithmeticMeanRankIndex`
+- :class:`~pykeen.metrics.ranking.AdjustedGeometricMeanRankIndex`
+- :class:`~pykeen.metrics.ranking.AdjustedInverseHarmonicMeanRank`
 
 z-Adjusted Metrics
 ~~~~~~~~~~~~~~~~~~
@@ -75,12 +75,12 @@ to normalize the metrics similar to `z-score normalization <https://en.wikipedia
 The z-score normalized metrics have an expected value of 0, and a variance of 1, and positive values indicate better
 results. While their value range is unbound, it can be interpreted through the lens of the inverse cumulative
 density function of the standard Gaussian distribution to retrieve a *p*-value. The classes derive from
-:class:`pykeen.metrics.ranking.ZMetric`, and the following implementations are available:
+:class:`~pykeen.metrics.ranking.ZMetric`, and the following implementations are available:
 
-- :class:`pykeen.metrics.ranking.ZArithmeticMeanRank`
-- :class:`pykeen.metrics.ranking.ZGeometricMeanRank`
-- :class:`pykeen.metrics.ranking.ZHitsAtK`
-- :class:`pykeen.metrics.ranking.ZInverseHarmonicMeanRank`
+- :class:`~pykeen.metrics.ranking.ZArithmeticMeanRank`
+- :class:`~pykeen.metrics.ranking.ZGeometricMeanRank`
+- :class:`~pykeen.metrics.ranking.ZHitsAtK`
+- :class:`~pykeen.metrics.ranking.ZInverseHarmonicMeanRank`
 """
 
 import math
@@ -858,7 +858,7 @@ class ArithmeticMeanRank(RankBasedMetric):
     For the expected value, assuming each individual rank $r_i$ follows a discrete uniform
     distribution $\mathcal{U}(1, C_i)$, where $C_i$ denotes the number of candidates for
     ranking task $i$, we have $\mathbb{E}[r_i] = \frac{C_i + 1}{2}$ and thus by the
-    linearity of the expectation (see :func:`pykeen.metrics.utils.weighted_mean_expectation`):
+    linearity of the expectation (see :func:`~pykeen.metrics.utils.weighted_mean_expectation`):
 
     .. math::
 
@@ -869,7 +869,7 @@ class ArithmeticMeanRank(RankBasedMetric):
     For the variance, assuming independent ranks with individual variances
     $\mathbb{V}[r_i] = \frac{C_i^2 - 1}{12}$, we use the quadratic weight scaling
     (from $\mathbb{V}[c \cdot X] = c^2 \cdot \mathbb{V}[X]$) as implemented in
-    :func:`pykeen.metrics.utils.weighted_mean_variance`:
+    :func:`~pykeen.metrics.utils.weighted_mean_variance`:
 
     .. math::
 

--- a/src/pykeen/models/__init__.py
+++ b/src/pykeen/models/__init__.py
@@ -22,7 +22,7 @@ optionally applying a sigmoid activation on the scores to ensure a value range o
 .. warning::
 
     Depending on the model at hand, directly applying sigmoid might not always be sensible. For instance, distance-based
-    interaction functions, such as :class:`pykeen.nn.modules.TransEInteraction`, result in non-positive scores (since
+    interaction functions, such as :class:`~pykeen.nn.modules.TransEInteraction`, result in non-positive scores (since
     they use the *negative* distance as scoring function), and thus the output of the sigmoid only covers the interval
     $[0.5, 1]$.
 

--- a/src/pykeen/models/multimodal/distmult_literal_gated.py
+++ b/src/pykeen/models/multimodal/distmult_literal_gated.py
@@ -19,7 +19,7 @@ __all__ = [
 class DistMultLiteralGated(LiteralModel):
     """An implementation of the LiteralE model with thhe Gated DistMult interaction from [kristiadi2018]_.
 
-    This model is different from :class:`pykeen.models.DistMultLiteral` because it uses a
+    This model is different from :class:`~pykeen.models.DistMultLiteral` because it uses a
     gate (like found in `LSTMs <https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html>`_)
     instead of a LinearDropout module.
 

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -231,7 +231,7 @@ def _repeat_when_missing_representations(
     `score_{h,t}` / `score_r` are always the same. For efficiency, they are thus
     only computed once, but to meet the API, they have to be brought into the correct shape afterwards.
 
-    For example, this is the case for :class:`pykeen.models.UM`, which does not have any relation
+    For example, this is the case for :class:`~pykeen.models.UM`, which does not have any relation
     representation. Therefore, the scores for all ``(h, *, t)`` will be the same. We calculate
     them only once, but need to repeat them for downstream use of the scores.
 
@@ -288,7 +288,7 @@ class ERModel(
     be passed through the ``super().__init__()`` in subclasses of :class:`ERModel`.
 
     Other code can still be put after the call to ``super().__init__()`` in subclasses, such as
-    registering regularizers (as done in :class:`pykeen.models.ConvKB` and :class:`pykeen.models.TransH`).
+    registering regularizers (as done in :class:`~pykeen.models.ConvKB` and :class:`~pykeen.models.TransH`).
     ---
     citation:
         author: Ali

--- a/src/pykeen/models/resolve.py
+++ b/src/pykeen/models/resolve.py
@@ -1,14 +1,14 @@
-"""A :class:`pykeen.models.ERModel` can be constructed from :class:`pykeen.nn.modules.Interaction`.
+"""A :class:`~pykeen.models.ERModel` can be constructed from :class:`~pykeen.nn.modules.Interaction`.
 
-The new style-class, :class:`pykeen.models.ERModel` abstracts the interaction away from the representations
+The new style-class, :class:`~pykeen.models.ERModel` abstracts the interaction away from the representations
 such that different interactions can be used interchangably. A new model can be constructed directly from the
-interaction module, given a ``dimensions`` mapping. In each :class:`pykeen.nn.modules.Interaction`, there
+interaction module, given a ``dimensions`` mapping. In each :class:`~pykeen.nn.modules.Interaction`, there
 is a field called ``entity_shape`` and ``relation_shape`` that allows for using eigen-notation for defining
 the different dimensions of the model. Most models share the ``d`` dimensionality for both the entity and relation
 vectors. Some (but not all) exceptions are:
 
-- :class:`pykeen.nn.modules.RESCALInteraction`, which uses a square matrix for relations written as ``dd``
-- :class:`pykeen.nn.modules.TransDInteraction`, which uses ``d`` for entity shape and ``e`` for a different
+- :class:`~pykeen.nn.modules.RESCALInteraction`, which uses a square matrix for relations written as ``dd``
+- :class:`~pykeen.nn.modules.TransDInteraction`, which uses ``d`` for entity shape and ``e`` for a different
   relation shape.
 
 With this in mind, you'll have to investigate the dimensions of the vectors through the PyKEEN documentation.
@@ -52,7 +52,7 @@ Make a model class from an instantiated interaction module:
 >>> model_cls = make_model_cls({"d": embedding_dim}, TransEInteraction(p=2))
 
 All of these model classes can be passed directly into the ``model``
-argument of :func:`pykeen.pipeline.pipeline`.
+argument of :func:`~pykeen.pipeline.pipeline`.
 """
 
 import logging

--- a/src/pykeen/models/uncertainty.py
+++ b/src/pykeen/models/uncertainty.py
@@ -193,7 +193,7 @@ def predict_hrt_uncertain(
         correspond to less certain predictions.
 
         This function delegates to :func:`predict_uncertain_helper` by using
-        :func:`pykeen.models.Model.score_hrt` as the ``score_method``.
+        :func:`~pykeen.models.Model.score_hrt` as the ``score_method``.
 
     .. warning::
         This function sets the model to evaluation mode and all dropout layers
@@ -254,7 +254,7 @@ def predict_h_uncertain(
         For each r-t pair, the scores for all possible heads.
 
         This function delegates to :func:`predict_uncertain_helper` by using
-        :func:`pykeen.models.Model.score_h` (or :func:`pykeen.models.Model.score_h_inverse`
+        :func:`~pykeen.models.Model.score_h` (or :func:`~pykeen.models.Model.score_h_inverse`
         if the model uses inverse triples) as the ``score_method``.
 
     .. warning::
@@ -300,7 +300,7 @@ def predict_r_uncertain(
         For each h-t pair, the scores for all possible relations.
 
         This function delegates to :func:`predict_uncertain_helper` by using
-        :func:`pykeen.models.Model.score_r` as the ``score_method``.
+        :func:`~pykeen.models.Model.score_r` as the ``score_method``.
 
     .. warning::
         This function sets the model to evaluation mode and all dropout layers
@@ -354,7 +354,7 @@ def predict_t_uncertain(
         For each h-r pair, the scores for all possible tails.
 
         This function delegates to :func:`predict_uncertain_helper` by using
-        :func:`pykeen.models.Model.score_t` as the ``score_method``.
+        :func:`~pykeen.models.Model.score_t` as the ``score_method``.
 
     .. warning::
         This function sets the model to evaluation mode and all dropout layers

--- a/src/pykeen/models/unimodal/auto_sf.py
+++ b/src/pykeen/models/unimodal/auto_sf.py
@@ -68,7 +68,7 @@ class AutoSF(ERModel[Representation, Representation, Representation]):
         :param embedding_kwargs:
             keyword arguments passed to the entity and relation representation
         :param kwargs:
-            remaining keyword arguments passed through to :class:`pykeen.models.ERModel`.
+            remaining keyword arguments passed through to :class:`~pykeen.models.ERModel`.
         """
         embedding_kwargs = embedding_kwargs or {}
         super().__init__(

--- a/src/pykeen/models/unimodal/boxe.py
+++ b/src/pykeen/models/unimodal/boxe.py
@@ -84,12 +84,12 @@ class BoxE(
             and numerically more stable.
 
         :param entity_initializer:
-            Entity initializer function. Defaults to :func:`pykeen.nn.init.uniform_norm_`
+            Entity initializer function. Defaults to :func:`~pykeen.nn.init.uniform_norm_`
         :param entity_initializer_kwargs:
             Keyword arguments to be used when calling the entity initializer
 
         :param relation_initializer:
-            Relation initializer function. Defaults to :func:`pykeen.nn.init.uniform_norm_`
+            Relation initializer function. Defaults to :func:`~pykeen.nn.init.uniform_norm_`
         :param relation_initializer_kwargs:
             Keyword arguments to be used when calling the relation initializer
         :param relation_size_initializer:

--- a/src/pykeen/models/unimodal/compgcn.py
+++ b/src/pykeen/models/unimodal/compgcn.py
@@ -53,13 +53,13 @@ class CompGCN(ERModel[FloatTensor, RelationRepresentation, FloatTensor]):
             ``encoder_kwargs``.
         :param encoder_kwargs:
             Additional keyword arguments for the encoder,
-            cf. :class:`pykeen.nn.representation.CombinedCompGCNRepresentations`.
+            cf. :class:`~pykeen.nn.representation.CombinedCompGCNRepresentations`.
         :param interaction:
             The interaction function to use as decoder.
         :param interaction_kwargs:
             Additional keyword based arguments for the interaction function.
         :param kwargs:
-            Additional keyword based arguments passed to :class:`pykeen.models.ERModel`.
+            Additional keyword based arguments passed to :class:`~pykeen.models.ERModel`.
         """
         encoder_kwargs = {} if encoder_kwargs is None else dict(encoder_kwargs)
         encoder_kwargs.setdefault("entity_representations_kwargs", {"embedding_dim": embedding_dim})

--- a/src/pykeen/models/unimodal/complex.py
+++ b/src/pykeen/models/unimodal/complex.py
@@ -74,7 +74,7 @@ class ComplEx(ERModel[FloatTensor, FloatTensor, FloatTensor]):
         :param regularizer_kwargs:
             additional keyword arguments passed to the regularizer. Defaults to `ComplEx.regularizer_default_kwargs`.
         :param kwargs:
-            remaining keyword arguments to forward to :class:`pykeen.models.ERModel`
+            remaining keyword arguments to forward to :class:`~pykeen.models.ERModel`
         """
         regularizer_kwargs = regularizer_kwargs or ComplEx.regularizer_default_kwargs
         super().__init__(

--- a/src/pykeen/models/unimodal/distma.py
+++ b/src/pykeen/models/unimodal/distma.py
@@ -51,7 +51,7 @@ class DistMA(ERModel[FloatTensor, FloatTensor, FloatTensor]):
         :param entity_normalizer_kwargs: Keyword arguments to be used when calling the entity normalizer
         :param relation_initializer: Relation initializer function. Defaults to None
         :param relation_initializer_kwargs: Keyword arguments to be used when calling the relation initializer
-        :param kwargs: Remaining keyword arguments passed through to :class:`pykeen.models.ERModel`.
+        :param kwargs: Remaining keyword arguments passed through to :class:`~pykeen.models.ERModel`.
         """
         super().__init__(
             interaction=DistMAInteraction,

--- a/src/pykeen/models/unimodal/distmult.py
+++ b/src/pykeen/models/unimodal/distmult.py
@@ -97,13 +97,13 @@ class DistMult(ERModel[FloatTensor, FloatTensor, FloatTensor]):
             default regularizer.
 
         :param entity_representations_kwargs:
-            Additional parameters to ``entity_representations_kwargs`` passed to :class:`pykeen.models.ERModel`.
+            Additional parameters to ``entity_representations_kwargs`` passed to :class:`~pykeen.models.ERModel`.
             Note that those take precedence of those which are filled in by this class.
         :param relation_representations_kwargs:
-            Additional parameters to ``relation_representations_kwargs`` passed to :class:`pykeen.models.ERModel`.
+            Additional parameters to ``relation_representations_kwargs`` passed to :class:`~pykeen.models.ERModel`.
             Note that those take precedence of those which are filled in by this class.
         :param kwargs:
-            Remaining keyword arguments to forward to :class:`pykeen.models.ERModel`
+            Remaining keyword arguments to forward to :class:`~pykeen.models.ERModel`
         """
         if regularizer is LpRegularizer and regularizer_kwargs is None:
             regularizer_kwargs = DistMult.regularizer_default_kwargs

--- a/src/pykeen/models/unimodal/ermlp.py
+++ b/src/pykeen/models/unimodal/ermlp.py
@@ -68,7 +68,7 @@ class ERMLP(ERModel[FloatTensor, FloatTensor, FloatTensor]):
         :param relation_initializer:
             the method to initialize the entity embeddings
         :param kwargs:
-            additional keyword-based parameters passed to :class:`pykeen.models.ERModel`
+            additional keyword-based parameters passed to :class:`~pykeen.models.ERModel`
         """
         super().__init__(
             interaction=ERMLPInteraction,

--- a/src/pykeen/models/unimodal/ermlpe.py
+++ b/src/pykeen/models/unimodal/ermlpe.py
@@ -17,7 +17,7 @@ __all__ = [
 
 
 class ERMLPE(ERModel[FloatTensor, FloatTensor, FloatTensor]):
-    r"""An extension of :class:`pykeen.models.ERMLP` proposed by [sharifzadeh2019]_.
+    r"""An extension of :class:`~pykeen.models.ERMLP` proposed by [sharifzadeh2019]_.
 
     This model represents both entities and relations as $d$-dimensional vectors stored in an
     :class:`~pykeen.nn.representation.Embedding` matrix.
@@ -25,7 +25,7 @@ class ERMLPE(ERModel[FloatTensor, FloatTensor, FloatTensor]):
     scores.
 
     ConvE can be seen as a special case of ER-MLP (E) that contains the unnecessary inductive bias of convolutional
-    filters. The aim of this model is to show that lifting this bias from :class:`pykeen.models.ConvE` (which simply
+    filters. The aim of this model is to show that lifting this bias from :class:`~pykeen.models.ConvE` (which simply
     leaves us with a modified ER-MLP model), not only reduces the number of parameters but also improves performance.
     ---
     name: ER-MLP (E)

--- a/src/pykeen/models/unimodal/kg2e.py
+++ b/src/pykeen/models/unimodal/kg2e.py
@@ -78,12 +78,12 @@ class KG2E(ERModel[tuple[FloatTensor, FloatTensor], tuple[FloatTensor, FloatTens
         :param c_min: covariance clamp minimum bound
         :param c_max: covariance clamp maximum bound
         :param entity_initializer: Entity initializer function. Defaults to :func:`torch.nn.init.uniform_`
-        :param entity_constrainer: Entity constrainer function. Defaults to :func:`pykeen.utils.clamp_norm`
+        :param entity_constrainer: Entity constrainer function. Defaults to :func:`~pykeen.utils.clamp_norm`
         :param entity_constrainer_kwargs: Keyword arguments to be used when calling the entity constrainer
         :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.uniform_`
-        :param relation_constrainer: Relation constrainer function. Defaults to :func:`pykeen.utils.clamp_norm`
+        :param relation_constrainer: Relation constrainer function. Defaults to :func:`~pykeen.utils.clamp_norm`
         :param relation_constrainer_kwargs: Keyword arguments to be used when calling the relation constrainer
-        :param kwargs: Remaining keyword arguments to forward to :class:`pykeen.models.ERModel`
+        :param kwargs: Remaining keyword arguments to forward to :class:`~pykeen.models.ERModel`
         """
         super().__init__(
             interaction=KG2EInteraction,

--- a/src/pykeen/models/unimodal/mure.py
+++ b/src/pykeen/models/unimodal/mure.py
@@ -52,7 +52,7 @@ class MuRE(ERModel[tuple[FloatTensor, FloatTensor], tuple[FloatTensor, FloatTens
         relation_matrix_initializer_kwargs: Mapping[str, Any] | None = None,
         **kwargs,
     ) -> None:
-        r"""Initialize MuRE via the :class:`pykeen.nn.modules.MuREInteraction` interaction.
+        r"""Initialize MuRE via the :class:`~pykeen.nn.modules.MuREInteraction` interaction.
 
         :param embedding_dim: The entity embedding dimension $d$. Defaults to 200. Is usually $d \in [50, 300]$.
 

--- a/src/pykeen/models/unimodal/proj_e.py
+++ b/src/pykeen/models/unimodal/proj_e.py
@@ -64,7 +64,7 @@ class ProjE(ERModel[FloatTensor, FloatTensor, FloatTensor]):
         :param embedding_dim:
             the embedding dimension
         :param inner_non_linearity:
-            the inner non-linearity, of a hint thereof. cf. :class:`pykeen.nn.modules.ProjEInteraction`
+            the inner non-linearity, of a hint thereof. cf. :class:`~pykeen.nn.modules.ProjEInteraction`
         :param inner_non_linearity_kwargs:
             additional keyword-based parameters used to instantiate the non-linearity.
         :param entity_initializer:

--- a/src/pykeen/models/unimodal/quate.py
+++ b/src/pykeen/models/unimodal/quate.py
@@ -99,7 +99,7 @@ class QuatE(ERModel[FloatTensor, FloatTensor, FloatTensor]):
         :param relation_normalizer:
             The normalizer to use for the relation embeddings.
         :param kwargs:
-            Additional keyword based arguments passed to :class:`pykeen.models.ERModel`. Must not contain
+            Additional keyword based arguments passed to :class:`~pykeen.models.ERModel`. Must not contain
             "interaction", "entity_representations", or "relation_representations".
         """
         super().__init__(

--- a/src/pykeen/models/unimodal/rgcn.py
+++ b/src/pykeen/models/unimodal/rgcn.py
@@ -33,7 +33,7 @@ class RGCN(ERModel[FloatTensor, RelationRepresentation, FloatTensor]):
     2. Relation representations $\textbf{R}_{r} \in \mathbb{R}^{d \times d}$ is a diagonal matrix that are learned
        independently from the GCN-based encoder.
     3. An arbitrary interaction model which computes the plausibility of facts given the enriched representations,
-       cf. :class:`pykeen.nn.modules.Interaction`.
+       cf. :class:`~pykeen.nn.modules.Interaction`.
 
     Scores for each triple $(h,r,t) \in \mathcal{K}$ are calculated by using the representations in the final level
     of the GCN-based encoder $\textbf{e}_h^L$ and $\textbf{e}_t^L$ along with relation representation $\textbf{R}_{r}$.

--- a/src/pykeen/models/unimodal/structured_embedding.py
+++ b/src/pykeen/models/unimodal/structured_embedding.py
@@ -61,12 +61,12 @@ class SE(ERModel[FloatTensor, tuple[FloatTensor, FloatTensor], FloatTensor]):
             Whether to use the p-th power of the $L_p$ norm. It has the advantage of being differentiable around 0,
             and numerically more stable.
 
-        :param entity_initializer: Entity initializer function. Defaults to :func:`pykeen.nn.init.xavier_uniform_`.
+        :param entity_initializer: Entity initializer function. Defaults to :func:`~pykeen.nn.init.xavier_uniform_`.
         :param entity_constrainer: Entity constrainer function. Defaults to :func:`torch.nn.functional.normalize`.
         :param entity_constrainer_kwargs: Keyword arguments to be used when calling the entity constrainer.
 
         :param relation_initializer: Relation initializer function. Defaults to
-            :func:`pykeen.nn.init.xavier_uniform_norm_`
+            :func:`~pykeen.nn.init.xavier_uniform_norm_`
 
         :param kwargs:
             Remaining keyword arguments to forward to :class:`~pykeen.models.ERModel`

--- a/src/pykeen/models/unimodal/toruse.py
+++ b/src/pykeen/models/unimodal/toruse.py
@@ -44,7 +44,7 @@ class TorusE(ERModel[FloatTensor, FloatTensor, FloatTensor]):
         relation_initializer_kwargs: Mapping[str, Any] | None = None,
         **kwargs,
     ) -> None:
-        r"""Initialize TorusE via the :class:`pykeen.nn.modules.TorusEInteraction` interaction.
+        r"""Initialize TorusE via the :class:`~pykeen.nn.modules.TorusEInteraction` interaction.
 
         :param embedding_dim: The entity embedding dimension $d$.
 
@@ -60,7 +60,7 @@ class TorusE(ERModel[FloatTensor, FloatTensor, FloatTensor]):
         :param entity_normalizer_kwargs: Keyword arguments to be used when calling the entity normalizer
         :param relation_initializer: Relation initializer function. Defaults to None
         :param relation_initializer_kwargs: Keyword arguments to be used when calling the relation initializer
-        :param kwargs: Remaining keyword arguments passed through to :class:`pykeen.models.ERModel`.
+        :param kwargs: Remaining keyword arguments passed through to :class:`~pykeen.models.ERModel`.
         """
         super().__init__(
             interaction=TorusEInteraction,

--- a/src/pykeen/models/unimodal/trans_d.py
+++ b/src/pykeen/models/unimodal/trans_d.py
@@ -67,14 +67,14 @@ class TransD(
             Additional keyword-based parameters passed to :class:`~pykeen.nn.modules.TransDInteraction`.
 
         :param entity_initializer:
-            The entity representation initializer. Defaults to :func:`pykeen.nn.init.xavier_uniform_`.
+            The entity representation initializer. Defaults to :func:`~pykeen.nn.init.xavier_uniform_`.
         :param entity_constrainer:
-            The entity representation constrainer. Defaults to :func:`pykeen.utils.clamp_norm`.
+            The entity representation constrainer. Defaults to :func:`~pykeen.utils.clamp_norm`.
 
         :param relation_initializer:
-            The relation representation initializer. Defaults to :func:`pykeen.nn.init.xavier_uniform_norm_`.
+            The relation representation initializer. Defaults to :func:`~pykeen.nn.init.xavier_uniform_norm_`.
         :param relation_constrainer:
-            The relation representation constrainer. Defaults to :func:`pykeen.utils.clamp_norm`.
+            The relation representation constrainer. Defaults to :func:`~pykeen.utils.clamp_norm`.
 
         :param kwargs:
             Additional keyword-based parameters passed to :class:`~pykeen.models.ERModel`.

--- a/src/pykeen/models/unimodal/trans_e.py
+++ b/src/pykeen/models/unimodal/trans_e.py
@@ -62,11 +62,11 @@ class TransE(ERModel[FloatTensor, FloatTensor, FloatTensor]):
             Whether to use the p-th power of the $L_p$ norm. It has the advantage of being differentiable around 0,
             and numerically more stable.
 
-        :param entity_initializer: Entity initializer function. Defaults to :func:`pykeen.nn.init.xavier_uniform_`.
+        :param entity_initializer: Entity initializer function. Defaults to :func:`~pykeen.nn.init.xavier_uniform_`.
         :param entity_constrainer: Entity constrainer function. Defaults to :func:`torch.nn.functional.normalize`.
 
         :param relation_initializer:
-            Relation initializer function. Defaults to :func:`pykeen.nn.init.xavier_uniform_norm_`.
+            Relation initializer function. Defaults to :func:`~pykeen.nn.init.xavier_uniform_norm_`.
         :param relation_constrainer: Relation constrainer function. Defaults to none.
 
         :param regularizer:

--- a/src/pykeen/models/unimodal/trans_f.py
+++ b/src/pykeen/models/unimodal/trans_f.py
@@ -53,7 +53,7 @@ class TransF(ERModel[FloatTensor, FloatTensor, FloatTensor]):
         :param entity_normalizer_kwargs: Keyword arguments to be used when calling the entity normalizer
         :param relation_initializer: Relation initializer function. Defaults to :func:`torch.nn.init.uniform_`
         :param relation_initializer_kwargs: Keyword arguments to be used when calling the relation initializer
-        :param kwargs: Remaining keyword arguments passed through to :class:`pykeen.models.ERModel`.
+        :param kwargs: Remaining keyword arguments passed through to :class:`~pykeen.models.ERModel`.
         """
         super().__init__(
             interaction=TransFInteraction,

--- a/src/pykeen/models/unimodal/trans_h.py
+++ b/src/pykeen/models/unimodal/trans_h.py
@@ -90,20 +90,20 @@ class TransH(ERModel[FloatTensor, tuple[FloatTensor, FloatTensor], FloatTensor])
             and numerically more stable.
 
         :param entity_initializer:
-            The entity initializer function. Defaults to :func:`pykeen.nn.init.xavier_normal_`.
+            The entity initializer function. Defaults to :func:`~pykeen.nn.init.xavier_normal_`.
         :param regularizer:
             The entity regularizer. Defaults to :attr:`pykeen.models.TransH.regularizer_default`.
         :param regularizer_kwargs:
             Keyword-based parameters for the entity regularizer. If `entity_regularizer` is None,
-            the default from :attr:`pykeen.models.TransH.regularizer_default_kwargs` will be used instead
+            the default from :attr:`~pykeen.models.TransH.regularizer_default_kwargs` will be used instead
 
         :param relation_initializer:
-            The relation initializer function. Defaults to :func:`pykeen.nn.init.xavier_normal_`.
+            The relation initializer function. Defaults to :func:`~pykeen.nn.init.xavier_normal_`.
         :param relation_regularizer:
             The relation regularizer. Defaults to :attr:`pykeen.models.TransH.relation_regularizer_default`.
         :param relation_regularizer_kwargs:
             Keyword-based parameters for the relation regularizer. If `relation_regularizer` is None,
-            the default from :attr:`pykeen.models.TransH.relation_regularizer_default_kwargs` will be used instead
+            the default from :attr:`~pykeen.models.TransH.relation_regularizer_default_kwargs` will be used instead
 
         :param kwargs:
             Remaining keyword arguments are passed to :class:`~pykeen.models.ERModel`

--- a/src/pykeen/models/unimodal/trans_r.py
+++ b/src/pykeen/models/unimodal/trans_r.py
@@ -95,14 +95,14 @@ class TransR(ERModel[FloatTensor, tuple[FloatTensor, FloatTensor], FloatTensor])
             Whether to use the p-th power of the $L_p$ norm. It has the advantage of being differentiable around 0,
             and numerically more stable.
 
-        :param entity_initializer: Entity initializer function. Defaults to :func:`pykeen.nn.init.xavier_uniform_`.
+        :param entity_initializer: Entity initializer function. Defaults to :func:`~pykeen.nn.init.xavier_uniform_`.
         :param entity_initializer_kwargs: Keyword arguments to be used when calling the entity initializer.
-        :param entity_constrainer: The entity constrainer. Defaults to :func:`pykeen.utils.clamp_norm`.
+        :param entity_constrainer: The entity constrainer. Defaults to :func:`~pykeen.utils.clamp_norm`.
 
         :param relation_initializer:
-            Relation initializer function. Defaults to :func:`pykeen.nn.init.xavier_uniform_norm_`.
+            Relation initializer function. Defaults to :func:`~pykeen.nn.init.xavier_uniform_norm_`.
         :param relation_initializer_kwargs: Keyword arguments to be used when calling the relation initializer.
-        :param relation_constrainer: The relation constrainer. Defaults to :func:`pykeen.utils.clamp_norm`.
+        :param relation_constrainer: The relation constrainer. Defaults to :func:`~pykeen.utils.clamp_norm`.
 
         :param relation_projection_initializer:
             Relation projection initializer function. Defaults to :func:`torch.nn.init.xavier_uniform_`.

--- a/src/pykeen/nn/combination.py
+++ b/src/pykeen/nn/combination.py
@@ -1,4 +1,4 @@
-"""Implementation of combinations for the :class:`pykeen.models.LiteralModel`."""
+"""Implementation of combinations for the :class:`~pykeen.models.LiteralModel`."""
 
 import logging
 from abc import ABC, abstractmethod

--- a/src/pykeen/nn/init.py
+++ b/src/pykeen/nn/init.py
@@ -244,7 +244,7 @@ class PretrainedInitializer:
     def as_embedding(self, **kwargs: Any):
         """Get a static embedding from this pre-trained initializer.
 
-        :param kwargs: Keyword arguments to pass to :class:`pykeen.nn.representation.Embedding`
+        :param kwargs: Keyword arguments to pass to :class:`~pykeen.nn.representation.Embedding`
         :returns: An embedding
         :rtype: pykeen.nn.representation.Embedding
         """

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -58,7 +58,7 @@ class Decomposition(nn.Module, ExtraReprMixin, ABC):
 
     The implementations use the efficient version based on adjacency tensor stacking from [thanapalasingam2021]_.
     The adjacency tensor is reshaped into a sparse matrix to support message passing by a
-    single sparse matrix multiplication, cf. :func:`pykeen.nn.utils.adjacency_tensor_to_stacked_matrix`.
+    single sparse matrix multiplication, cf. :func:`~pykeen.nn.utils.adjacency_tensor_to_stacked_matrix`.
 
     .. note ::
         this module does neither take care of the self-loop, nor of applying an activation function.
@@ -199,7 +199,7 @@ class BasesDecomposition(Decomposition):
         :param num_bases:
             The number of bases.
         :param kwargs:
-            Additional keyword-based parameters passed to :class:`pykeen.nn.message_passing.Decomposition`.
+            Additional keyword-based parameters passed to :class:`~pykeen.nn.message_passing.Decomposition`.
         """
         super().__init__(**kwargs)
 
@@ -307,7 +307,7 @@ class BlockDecomposition(Decomposition):
         :param num_blocks:
             The number of blocks.
         :param kwargs:
-            Keyword-based parameters passed to :class:`pykeen.nn.message_passing.Decomposition`.
+            Keyword-based parameters passed to :class:`~pykeen.nn.message_passing.Decomposition`.
         """
         super().__init__(**kwargs)
 

--- a/src/pykeen/nn/meta.py
+++ b/src/pykeen/nn/meta.py
@@ -79,7 +79,7 @@ class FeatureEnrichedEmbedding(CombinedRepresentation):
             pretrained embeddings.
         :param shape: an explicit shape for the learned embedding. If None, it is inferred from the provided feature
             tensor.
-        :param kwargs: Keyword arguments passed to :meth:`pykeen.nn.CombinedRepresentation.__init__`.
+        :param kwargs: Keyword arguments passed to :meth:`~pykeen.nn.CombinedRepresentation.__init__`.
 
             For example, if you want to make sure that the dimensions of the output are the same as the input, set
             ``combination="ConcatProjection"``. to use :class:`pykeen.nn.ConcatProjectionCombination`.

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -585,7 +585,7 @@ class ComplExInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
     .. note::
         this method generally expects all tensors to be of complex datatype, i.e., `torch.is_complex(x)` to evaluate to
         `True`. However, for backwards compatibility and convenience in use, you can also pass real tensors whose shape
-        is compliant with :func:`torch.view_as_complex`, cf. :func:`pykeen.utils.ensure_complex`.
+        is compliant with :func:`torch.view_as_complex`, cf. :func:`~pykeen.utils.ensure_complex`.
 
     ---
     citation:
@@ -1392,10 +1392,10 @@ class TransRInteraction(NormBasedInteraction[FloatTensor, tuple[FloatTensor, Flo
     for head and tail entity representations $\mathbf{h}, \mathbf{t} \in \mathbb{R}^d$,
     relation representation $\mathbf{r} \in \mathbb{R}^k$,
     and a relation-specific projection matrix $\mathbf{M}_r \in \mathbb{R}^{k \times d}$.
-    $c$ enforces the constraint $\|\cdot\| \leq 1$, cf. :func:`pykeen.utils.clamp_norm`.
+    $c$ enforces the constraint $\|\cdot\| \leq 1$, cf. :func:`~pykeen.utils.clamp_norm`.
 
     .. note ::
-        :class:`pykeen.models.TransR` additionally also enforces $\|\cdot\| \leq 1$ on all embeddings.
+        :class:`~pykeen.models.TransR` additionally also enforces $\|\cdot\| \leq 1$ on all embeddings.
 
     ---
     citation:
@@ -1467,7 +1467,7 @@ class RotatEInteraction(NormBasedInteraction[FloatTensor, FloatTensor, FloatTens
     .. note::
         this method generally expects all tensors to be of complex datatype, i.e., `torch.is_complex(x)` to evaluate to
         `True`. However, for backwards compatibility and convenience in use, you can also pass real tensors whose shape
-        is compliant with :func:`torch.view_as_complex`, cf. :func:`pykeen.utils.ensure_complex`.
+        is compliant with :func:`torch.view_as_complex`, cf. :func:`~pykeen.utils.ensure_complex`.
 
     ---
     citation:
@@ -1669,11 +1669,11 @@ class ProjEInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
         :param outer_activation_kwargs:
             additional keyword-based parameters used to instantiate the outer activation function.
         :param bias_initializer:
-            the initializer to use for the biases; defaults to :func:`pykeen.nn.init.xavier_uniform_`.
+            the initializer to use for the biases; defaults to :func:`~pykeen.nn.init.xavier_uniform_`.
         :param bias_initializer_kwargs:
             additional keyword-based parameters passed to the bias initializer.
         :param projection_initializer:
-            the initializer to use for the projection; defaults to :func:`pykeen.nn.init.xavier_uniform_`.
+            the initializer to use for the projection; defaults to :func:`~pykeen.nn.init.xavier_uniform_`.
         :param projection_initializer_kwargs:
             additional keyword-based parameters passed to the projection initializer.
         """
@@ -2575,7 +2575,7 @@ class DirectionAverageInteraction(
     r"""The directional average interaction module.
 
     This can be considered as a generalization of the SimplE interaction module that can be parametrized
-    with any other interaction module, rather than just :class:`pykeen.nn.modules.DistMultInteraction`.
+    with any other interaction module, rather than just :class:`~pykeen.nn.modules.DistMultInteraction`.
 
     A separate representation is learned for each entity $e \in \mathcal{E}$ for when it appears as the
     subject of a triple $\mathbf{e}_h \in \mathbb{R}^d$ and as the object of a triple $\mathbf{e}_t \in \mathbb{R}^d$.
@@ -2591,8 +2591,8 @@ class DirectionAverageInteraction(
             + f(\mathbf{t}_{h}, \mathbf{r}_{\leftarrow}, \mathbf{h}_{t})
         }{2}
 
-    Where ``f`` is the interaction model used. If :class:`pykeen.nn.modules.DistMultInteraction` is used,
-    then this becomes :class:`pykeen.nn.modules.SimplEInteraction`.
+    Where ``f`` is the interaction model used. If :class:`~pykeen.nn.modules.DistMultInteraction` is used,
+    then this becomes :class:`~pykeen.nn.modules.SimplEInteraction`.
 
     .. todo:: can we generalize the type annotations for this from FloatTensor to HeadRepresentation, etc.?
     """
@@ -2646,7 +2646,7 @@ class DirectionAverageInteraction(
 class SimplEInteraction(DirectionAverageInteraction):
     r"""The SimplE interaction function.
 
-    SimplE can be regarded as extension of (a special case of) :class:`pykeen.nn.modules.CPInteraction`,
+    SimplE can be regarded as extension of (a special case of) :class:`~pykeen.nn.modules.CPInteraction`,
     an early tensor factorization approach in which each entity
     $e \in \mathcal{E}$ is represented by two vectors $\mathbf{e}_h, \mathbf{e}_t \in \mathbb{R}^d$ and each
     relation by a single vector $\mathbf{r} \in \mathbb{R}^d$. Depending whether an entity participates in a
@@ -2693,7 +2693,7 @@ class PairREInteraction(NormBasedInteraction[FloatTensor, tuple[FloatTensor, Flo
     relation-specific head projection, relation-specific tail projection, and tail entity, respectively.
 
     .. note ::
-        :class:`pykeen.models.PairRE` additionally enforces $\|\mathbf{h}\| = \|\mathbf{t}\| = 1$.
+        :class:`~pykeen.models.PairRE` additionally enforces $\|\mathbf{h}\| = \|\mathbf{t}\| = 1$.
 
     ---
     citation:
@@ -2746,7 +2746,7 @@ class QuatEInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
 
     .. warning ::
         In order to representation a rotation, $\mathbf{r}$ must be normalized to unit length,
-        cf. :func:`pykeen.nn.quaternion.normalize`.
+        cf. :func:`~pykeen.nn.quaternion.normalize`.
 
     .. seealso::
         - https://en.wikipedia.org/wiki/Quaternion

--- a/src/pykeen/nn/pyg.py
+++ b/src/pykeen/nn/pyg.py
@@ -363,7 +363,7 @@ class FeaturizedMessagePassingRepresentation(TypedMessagePassingRepresentation):
         :param relation_transformation: An optional transformation to apply to the relation representations after each
             message passing step. If ``None``, do not modify the representations.
         :param kwargs: Additional keyword-based parameters passed to
-            :class:`pykeen.nn.pyg.TypedMessagePassingRepresentation`, except the ``triples_factory``.
+            :class:`~pykeen.nn.pyg.TypedMessagePassingRepresentation`, except the ``triples_factory``.
         """
         super().__init__(triples_factory=triples_factory, **kwargs)
 

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -912,7 +912,7 @@ class CombinedCompGCNRepresentations(nn.Module):
     """A sequence of CompGCN layers.
 
     .. seealso::
-        :class:`pykeen.nn.representation.CompGCNLayer`
+        :class:`~pykeen.nn.representation.CompGCNLayer`
 
     ---
     name: CompGCN (combine)
@@ -1067,7 +1067,7 @@ class SingleCompGCNRepresentation(Representation):
     """A wrapper around the combined representation module.
 
     .. seealso::
-        :class:`pykeen.nn.representation.CombinedCompGCNRepresentations`
+        :class:`~pykeen.nn.representation.CombinedCompGCNRepresentations`
 
     ---
     name: CompGCN
@@ -1097,7 +1097,7 @@ class SingleCompGCNRepresentation(Representation):
         :param shape:
             The shape of an individual representation.
         :param kwargs:
-            Additional keyword-based parameters passed to :class:`pykeen.nn.representation.Representation`.
+            Additional keyword-based parameters passed to :class:`~pykeen.nn.representation.Representation`.
 
         :raises ValueError:
             If an invalid value is given for the position.
@@ -1189,7 +1189,7 @@ class TextRepresentation(Representation):
             Which policy for handling nones in the given labels. If "error", raises an error
             on any nones. If "blank", replaces nones with an empty string.
         :param kwargs:
-            Additional keyword-based parameters passed to :class:`pykeen.nn.representation.Representation`
+            Additional keyword-based parameters passed to :class:`~pykeen.nn.representation.Representation`
 
         :raises MaxIDMismatchError:
             if the ``max_id`` was given explicitly and does not match the length of the labels
@@ -1224,7 +1224,7 @@ class TextRepresentation(Representation):
         :param for_entities:
             Whether to create the initializer for entities (or relations).
         :param kwargs:
-            Additional keyword-based arguments passed to :class:`pykeen.nn.representation.TextRepresentation`
+            Additional keyword-based arguments passed to :class:`~pykeen.nn.representation.TextRepresentation`
 
         :returns:
             a text representation from the triples factory
@@ -1246,7 +1246,7 @@ class TextRepresentation(Representation):
         :param for_entities:
             Whether to create the initializer for entities (or relations).
         :param kwargs:
-            Additional keyword-based arguments passed to :class:`pykeen.nn.representation.TextRepresentation`
+            Additional keyword-based arguments passed to :class:`~pykeen.nn.representation.TextRepresentation`
 
         :return:
             A text representation from the dataset.
@@ -1333,7 +1333,7 @@ class CombinedRepresentation(Representation):
             Additional keyword-based parameters used to instantiate the combination.
 
         :param kwargs:
-            Additional keyword-based parameters passed to :class:`pykeen.nn.representation.Representation`.
+            Additional keyword-based parameters passed to :class:`~pykeen.nn.representation.Representation`.
 
         :raises ValueError:
             If the `max_id` of the base representations are not all the same

--- a/src/pykeen/nn/sim.py
+++ b/src/pykeen/nn/sim.py
@@ -151,7 +151,7 @@ class NegativeKullbackLeiblerDivergence(KG2ESimilarity):
         return -result
 
 
-#: A resolver for similarities for :class:`pykeen.nn.modules.KG2EInteraction`
+#: A resolver for similarities for :class:`~pykeen.nn.modules.KG2EInteraction`
 kg2e_similarity_resolver: ClassResolver[KG2ESimilarity] = ClassResolver.from_subclasses(
     base=KG2ESimilarity,
     synonyms={"kl": NegativeKullbackLeiblerDivergence, "el": ExpectedLikelihood},

--- a/src/pykeen/nn/text/encoder.py
+++ b/src/pykeen/nn/text/encoder.py
@@ -124,7 +124,7 @@ class CharacterEmbeddingTextEncoder(TextEncoder):
     for unknown character and padding. To encoder a sentence, it converts it to a sequence of characters, obtains
     the invidual characters representations and aggregates these representations to a single one.
 
-    With :class:`pykeen.nn.representation.Embedding` character representation and :func:`torch.mean` aggregation,
+    With :class:`~pykeen.nn.representation.Embedding` character representation and :func:`torch.mean` aggregation,
     this encoder is similar to a bag-of-characters model with trainable character embeddings. Therefore, it is
     invariant to the ordering of characters:
 

--- a/src/pykeen/nn/vision/representation.py
+++ b/src/pykeen/nn/vision/representation.py
@@ -229,7 +229,7 @@ class WikidataVisualRepresentation(BackfillRepresentation):
             :meth:`pykeen.nn.vision.cache.WikidataImageCache.get_image_paths`.
         :param cache: A pre-instantiated image cache. If None, :class:`WikidataImageCache` is used.
         :param kwargs: Additional keyword-based parameters passed to
-            :class:`pykeen.nn.vision.representation.VisualRepresentation`.
+            :class:`~pykeen.nn.vision.representation.VisualRepresentation`.
 
         :raises ValueError: If the max_id does not match the number of Wikidata IDs.
         """
@@ -256,7 +256,7 @@ class WikidataVisualRepresentation(BackfillRepresentation):
         :param triples_factory: The triples factory.
         :param for_entities: Whether to create the initializer for entities (or relations).
         :param kwargs: Additional keyword-based arguments passed to
-            :class:`pykeen.nn.vision.representation.WikidataVisualRepresentation`.
+            :class:`~pykeen.nn.vision.representation.WikidataVisualRepresentation`.
 
         :returns: A visual representation from the triples factory.
         """
@@ -279,7 +279,7 @@ class WikidataVisualRepresentation(BackfillRepresentation):
         :param dataset: The dataset; needs to have Wikidata IDs as entity names.
         :param for_entities: Whether to create the initializer for entities (or relations).
         :param kwargs: Additional keyword-based arguments passed to
-            :class:`pykeen.nn.vision.representation.WikidataVisualRepresentation`.
+            :class:`~pykeen.nn.vision.representation.WikidataVisualRepresentation`.
 
         :returns: A visual representation from the training factory in the dataset.
 

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -1,4 +1,4 @@
-"""The easiest way to train and evaluate a model is with the :func:`pykeen.pipeline.pipeline` function.
+"""The easiest way to train and evaluate a model is with the :func:`~pykeen.pipeline.pipeline` function.
 
 It provides a high-level entry point into the extensible functionality of
 this package. Full reference documentation for the pipeline and related functions
@@ -6,11 +6,11 @@ can be found at :mod:`pykeen.pipeline`.
 
 Training a Model
 ~~~~~~~~~~~~~~~~
-The following example shows how to train and evaluate the :class:`pykeen.models.TransE` model
-on the :class:`pykeen.datasets.Nations` dataset. Throughout the documentation, you'll notice
+The following example shows how to train and evaluate the :class:`~pykeen.models.TransE` model
+on the :class:`~pykeen.datasets.Nations` dataset. Throughout the documentation, you'll notice
 that each asset has a corresponding class in PyKEEN. You can follow the links to learn more
 about each and see the reference on how to use them specifically. Don't worry, in this part of
-the tutorial, the :func:`pykeen.pipeline.pipeline` function will take care of everything for you.
+the tutorial, the :func:`~pykeen.pipeline.pipeline` function will take care of everything for you.
 
 >>> from pykeen.pipeline import pipeline
 >>> pipeline_result = pipeline(
@@ -19,7 +19,7 @@ the tutorial, the :func:`pykeen.pipeline.pipeline` function will take care of ev
 ... )
 >>> pipeline_result.save_to_directory('nations_transe')
 
-The results are returned in a :class:`pykeen.pipeline.PipelineResult` instance, which has
+The results are returned in a :class:`~pykeen.pipeline.PipelineResult` instance, which has
 attributes for the trained model, the training loop, and the evaluation.
 
 In this example, the model was given as a string. A list of available models can be found in
@@ -35,7 +35,7 @@ could be used as in:
 >>> pipeline_result.save_to_directory('nations_transe')
 
 In this example, the dataset was given as a string. A list of available datasets can be found in
-:mod:`pykeen.datasets`. Alternatively, a subclass of :class:`pykeen.datasets.Dataset` could be
+:mod:`pykeen.datasets`. Alternatively, a subclass of :class:`~pykeen.datasets.Dataset` could be
 used as in:
 
 >>> from pykeen.pipeline import pipeline
@@ -49,7 +49,7 @@ used as in:
 
 In each of the previous three examples, the training approach, optimizer, and evaluation scheme
 were omitted. By default, the model is trained under the stochastic local closed world assumption (sLCWA;
-:class:`pykeen.training.SLCWATrainingLoop`). This can be explicitly given as a string:
+:class:`~pykeen.training.SLCWATrainingLoop`). This can be explicitly given as a string:
 
 >>> from pykeen.pipeline import pipeline
 >>> pipeline_result = pipeline(
@@ -60,7 +60,7 @@ were omitted. By default, the model is trained under the stochastic local closed
 >>> pipeline_result.save_to_directory('nations_transe')
 
 Alternatively, the model can be trained under the  local closed world assumption (LCWA;
-:class:`pykeen.training.LCWATrainingLoop`) by giving ``'LCWA'``.
+:class:`~pykeen.training.LCWATrainingLoop`) by giving ``'LCWA'``.
 No additional configuration is necessary, but it's worth reading up on the differences between these training
 approaches. A list of available training assumptions can be found in :mod:`pykeen.training`.
 
@@ -174,11 +174,11 @@ best reported values from the paper originally publishing the model unless other
 reference page.
 
 Because the pipeline takes care of looking up classes and instantiating them,
-there are several other parameters to :func:`pykeen.pipeline.pipeline` that
+there are several other parameters to :func:`~pykeen.pipeline.pipeline` that
 can be used to specify the parameters during their respective instantiations.
 
 Arguments can be given to the dataset with ``dataset_kwargs``. These are passed on to
-the :class:`pykeen.datasets.Nations`
+the :class:`~pykeen.datasets.Nations`
 """
 
 from __future__ import annotations
@@ -259,7 +259,7 @@ def triple_hash(*triples: MappedTriples) -> Mapping[str, str]:
 @fix_dataclass_init_docs
 @dataclass
 class PipelineResult(Result):
-    """A dataclass containing the results of running :func:`pykeen.pipeline.pipeline`."""
+    """A dataclass containing the results of running :func:`~pykeen.pipeline.pipeline`."""
 
     #: The random seed used at the beginning of the pipeline
     random_seed: int
@@ -412,8 +412,8 @@ class PipelineResult(Result):
         :func:`torch.load`, cf. `torch's serialization documentation
         <https://pytorch.org/docs/stable/notes/serialization.html>`_. `training_triples` contains the training triples
         factory, including label-to-id mappings, if used. It has been saved via
-        :meth:`pykeen.triples.CoreTriplesFactory.to_path_binary`, and can re-loaded via
-        :meth:`pykeen.triples.CoreTriplesFactory.from_path_binary`.
+        :meth:`~pykeen.triples.CoreTriplesFactory.to_path_binary`, and can re-loaded via
+        :meth:`~pykeen.triples.CoreTriplesFactory.from_path_binary`.
 
         :param directory:
             the directory path. It will be created including all parent directories if necessary
@@ -1714,8 +1714,8 @@ def pipeline(  # noqa: C901
     """Train and evaluate a model.
 
     :param dataset:
-        The name of the dataset (a key for the :data:`pykeen.datasets.dataset_resolver`) or the
-        :class:`pykeen.datasets.Dataset` instance. Alternatively, the training triples factory (``training``), testing
+        The name of the dataset (a key for the :data:`~pykeen.datasets.dataset_resolver`) or the
+        :class:`~pykeen.datasets.Dataset` instance. Alternatively, the training triples factory (``training``), testing
         triples factory (``testing``), and validation triples factory (``validation``; optional) can be specified.
     :param dataset_kwargs:
         The keyword arguments passed to the dataset upon instantiation
@@ -1735,12 +1735,12 @@ def pipeline(  # noqa: C901
         embedding quality.
 
     :param model:
-        The name of the model, subclass of :class:`pykeen.models.Model`, or an instance of
-        :class:`pykeen.models.Model`. Can be given as None if the ``interaction`` keyword is used.
+        The name of the model, subclass of :class:`~pykeen.models.Model`, or an instance of
+        :class:`~pykeen.models.Model`. Can be given as None if the ``interaction`` keyword is used.
     :param model_kwargs:
         Keyword arguments to pass to the model class on instantiation
-    :param interaction: The name of the interaction class, a subclass of :class:`pykeen.nn.modules.Interaction`,
-        or an instance of :class:`pykeen.nn.modules.Interaction`. Can not be given when there is also a model.
+    :param interaction: The name of the interaction class, a subclass of :class:`~pykeen.nn.modules.Interaction`,
+        or an instance of :class:`~pykeen.nn.modules.Interaction`. Can not be given when there is also a model.
     :param interaction_kwargs:
         Keyword arguments to pass during instantiation of the interaction class. Only use with ``interaction``.
     :param dimensions:
@@ -1773,13 +1773,13 @@ def pipeline(  # noqa: C901
 
     :param training_loop:
         The name of the training loop's training approach (``'slcwa'`` or ``'lcwa'``) or the training loop class.
-        Defaults to :class:`pykeen.training.SLCWATrainingLoop`.
+        Defaults to :class:`~pykeen.training.SLCWATrainingLoop`.
     :param training_loop_kwargs:
         Keyword arguments to pass to the training loop on instantiation
     :param negative_sampler:
         The name of the negative sampler (``'basic'`` or ``'bernoulli'``) or the negative sampler class.
         Only allowed when training with sLCWA.
-        Defaults to :class:`pykeen.sampling.BasicNegativeSampler`.
+        Defaults to :class:`~pykeen.sampling.BasicNegativeSampler`.
     :param negative_sampler_kwargs:
         Keyword arguments to pass to the negative sampler class on instantiation
 
@@ -1793,7 +1793,7 @@ def pipeline(  # noqa: C901
         Keyword arguments to pass to the stopper upon instantiation.
 
     :param evaluator:
-        The name of the evaluator or an evaluator class. Defaults to :class:`pykeen.evaluation.RankBasedEvaluator`.
+        The name of the evaluator or an evaluator class. Defaults to :class:`~pykeen.evaluation.RankBasedEvaluator`.
     :param evaluator_kwargs:
         Keyword arguments to pass to the evaluator on instantiation
     :param evaluation_kwargs:
@@ -1811,7 +1811,7 @@ def pipeline(  # noqa: C901
     :param use_testing_data:
         If true, use the testing triples. Otherwise, use the validation triples. Defaults to true - use testing triples.
     :param device: The device or device name to run on. If none is given, the device will be looked up with
-        :func:`pykeen.utils.resolve_device`.
+        :func:`~pykeen.utils.resolve_device`.
     :param random_seed: The random seed to use. If none is specified, one will be assigned before any code
         is run for reproducibility purposes. In the returned :class:`PipelineResult` instance, it can be accessed
         through :data:`PipelineResult.random_seed`.

--- a/src/pykeen/pipeline/plot_utils.py
+++ b/src/pykeen/pipeline/plot_utils.py
@@ -97,7 +97,7 @@ def plot_er(  # noqa: C901
 ):
     """Plot the reduced entities and relation vectors in 2D.
 
-    :param pipeline_result: The result returned by :func:`pykeen.pipeline.pipeline`.
+    :param pipeline_result: The result returned by :func:`~pykeen.pipeline.pipeline`.
     :param model: The dimensionality reduction model from :mod:`sklearn`. Defaults to PCA. Can also use KPCA, GRP, SRP,
         TSNE, LLE, ISOMAP, MDS, or SE.
     :param entities: A subset of entities to plot
@@ -106,7 +106,7 @@ def plot_er(  # noqa: C901
     :param margin: The margin size around the minimum/maximum x and y values
     :param plot_entities: If true, plot the entities based on their reduced embeddings
     :param plot_relations: By default, this is only enabled on translational distance models like
-        :class:`pykeen.models.TransE`.
+        :class:`~pykeen.models.TransE`.
     :param annotation_x_offset: X offset of label from entity position
     :param annotation_y_offset: Y offset of label from entity position
     :param entity_embedding_getter: A function that takes a model and returns its entity embeddings. If none, defaults

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -23,11 +23,11 @@ High-Level
 ==========
 The prediction workflow offers three high-level methods to perform predictions
 
-- :func:`pykeen.predict.predict_triples` can be used to calculate scores for a given set of triples.
-- :func:`pykeen.predict.predict_target` can be used to score choices for a given prediction target, i.e.
+- :func:`~pykeen.predict.predict_triples` can be used to calculate scores for a given set of triples.
+- :func:`~pykeen.predict.predict_target` can be used to score choices for a given prediction target, i.e.
   calculate scores for head entities, relations, or tail entities given the other two.
-- :func:`pykeen.predict.predict_all` can be used to calculate scores for all possible triples.
-  Scientifically, :func:`pykeen.predict.predict_all` is the most interesting in a scenario where
+- :func:`~pykeen.predict.predict_all` can be used to calculate scores for all possible triples.
+  Scientifically, :func:`~pykeen.predict.predict_all` is the most interesting in a scenario where
   predictions could be tested and validated experimentally.
 
 .. warning ::
@@ -38,7 +38,7 @@ The prediction workflow offers three high-level methods to perform predictions
 Triple Scoring
 --------------
 
-When scoring triples with :func:`pykeen.predict.predict_triples`, we obtain a score for each of the given
+When scoring triples with :func:`~pykeen.predict.predict_triples`, we obtain a score for each of the given
 triples. As an example, we will calculate scores for all validation triples from the dataset we trained the model upon.
 
 >>> from pykeen.datasets import get_dataset
@@ -65,7 +65,7 @@ or investigate whether certain entities generally receive larger scores
 Target Scoring
 --------------
 
-:func:`pykeen.predict.predict_target`'s primary usecase is link prediction or relation prediction.
+:func:`~pykeen.predict.predict_target`'s primary usecase is link prediction or relation prediction.
 For instance, we could use our models to score all possible tail entities for the query `("uk", "conferences", ?)` via
 
 >>> from pykeen.datasets import get_dataset
@@ -78,7 +78,7 @@ For instance, we could use our models to score all possible tail entities for th
 ...     triples_factory=result.training,
 ... )
 
-Notice that the result stored into `pred` is a :class:`pykeen.predict.Predictions` object, which offers some
+Notice that the result stored into `pred` is a :class:`~pykeen.predict.Predictions` object, which offers some
 post-processing options. For instance, we can remove all targets which are already know from the training set
 
 >>> pred_filtered = pred.filter_triples(dataset.training)
@@ -128,25 +128,25 @@ which require calculating scores for all triples. The algorithm works are follow
     for consumer in consumers:
       consumer(batch, scores)
 
-Here, `dataset` is a :class:`pykeen.predict.PredictionDataset`, which breaks
+Here, `dataset` is a :class:`~pykeen.predict.PredictionDataset`, which breaks
 the score calculation down into individual target predictions (e.g., tail predictions).
-Implementations include :class:`pykeen.predict.AllPredictionDataset` and
-:class:`pykeen.predict.PartiallyRestrictedPredictionDataset`. Notice that the
+Implementations include :class:`~pykeen.predict.AllPredictionDataset` and
+:class:`~pykeen.predict.PartiallyRestrictedPredictionDataset`. Notice that the
 prediction tasks are built lazily, i.e., only instantiating the prediction tasks when
 accessed. Moreover, the :mod:`torch_max_mem` package is used to automatically tune the
 batch size to maximize the memory utilization of the hardware at hand.
 
 For each batch, the scores of the prediction task are calculated once. Afterwards, multiple
-*consumers* can process these scores. A consumer extends :class:`pykeen.predict.ScoreConsumer`
+*consumers* can process these scores. A consumer extends :class:`~pykeen.predict.ScoreConsumer`
 and receives the batch, i.e., input to the predict method, as well as the tensor of predicted scores.
 Examples include
 
-- :class:`pykeen.predict.CountScoreConsumer`: a simple consumer which only counts how many scores
+- :class:`~pykeen.predict.CountScoreConsumer`: a simple consumer which only counts how many scores
   it has seen. Mostly used for debugging or testing purposes
-- :class:`pykeen.predict.AllScoreConsumer`: accumulates all scores into a single huge tensor.
+- :class:`~pykeen.predict.AllScoreConsumer`: accumulates all scores into a single huge tensor.
   This incurs massive memory requirements for reasonably sized datasets, and often can be avoided by
   interleaving the processing of the scores with calculation of individual batches.
-- :class:`pykeen.predict.TopKScoreConsumer`: keeps only the top $k$ scores as well as the inputs
+- :class:`~pykeen.predict.TopKScoreConsumer`: keeps only the top $k$ scores as well as the inputs
   leading to them. This is a memory-efficient variant of first accumulating all scores, then sorting by
   score and keeping only the top entries.
 

--- a/src/pykeen/sampling/__init__.py
+++ b/src/pykeen/sampling/__init__.py
@@ -46,7 +46,7 @@ defined as:
 Uniform Negative Sampling
 -------------------------
 
-The default negative sampler :class:`pykeen.sampling.BasicNegativeSampler` generates corrupted triples from a known
+The default negative sampler :class:`~pykeen.sampling.BasicNegativeSampler` generates corrupted triples from a known
 positive triple $(h,r,t) \in \mathcal{K}$ by uniformly randomly either using the corrupt heads operation or the corrupt
 tails operation. The default negative sampler is automatically used in the following code:
 
@@ -73,7 +73,7 @@ It can be set explicitly with:
         negative_sampler="basic",
     )
 
-In general, the behavior of the negative sampler can be modified when using the :func:`pykeen.pipeline.pipeline` by
+In general, the behavior of the negative sampler can be modified when using the :func:`~pykeen.pipeline.pipeline` by
 passing the ``negative_sampler_kwargs`` argument. In order to explicitly specifiy which of the head, relation, and tail
 corruption methods are used, the ``corruption_schema`` argument can be used. For example, to use all three, the
 collection ``('h', 'r', 't')`` can be passed as in the following:
@@ -95,7 +95,7 @@ collection ``('h', 'r', 't')`` can be passed as in the following:
 Bernoulli Negative Sampling
 ---------------------------
 
-The Bernoulli negative sampler :class:`pykeen.sampling.BernoulliNegativeSampler` generates corrupted triples from a
+The Bernoulli negative sampler :class:`~pykeen.sampling.BernoulliNegativeSampler` generates corrupted triples from a
 known positive triple $(h,r,t) \in \mathcal{K}$ similarly to the uniform negative sampler, but it pre-computes a
 probability $p_r$ for each relation $r$ to weight whether the head corruption is used with probability $p_r$ or if tail
 corruption is used with probability $1 - p_r$.

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -67,7 +67,7 @@ class BasicNegativeSampler(NegativeSampler):
         """Initialize the basic negative sampler with the given entities.
 
         :param corruption_scheme: What sides ('h', 'r', 't') should be corrupted. Defaults to head and tail ('h', 't').
-        :param kwargs: Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
+        :param kwargs: Additional keyword based arguments passed to :class:`~pykeen.sampling.NegativeSampler`.
         """
         super().__init__(**kwargs)
         self.corruption_scheme = corruption_scheme or (LABEL_HEAD, LABEL_TAIL)

--- a/src/pykeen/sampling/bernoulli_negative_sampler.py
+++ b/src/pykeen/sampling/bernoulli_negative_sampler.py
@@ -44,7 +44,7 @@ class BernoulliNegativeSampler(NegativeSampler):
         :param mapped_triples:
             the positive training triples
         :param kwargs:
-            Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
+            Additional keyword based arguments passed to :class:`~pykeen.sampling.NegativeSampler`.
         """
         super().__init__(mapped_triples=mapped_triples, **kwargs)
         # Preprocessing: Compute corruption probabilities

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -50,7 +50,7 @@ negative examples during training, the ``filtered`` keyword can be given to ``ne
 
 PyKEEN implements several algorithms for filtering with different properties that can be chosen using the
 ``filterer`` keyword argument in ``negative_sampler_kwargs``. By default, an fast and approximate algorithm is used in
-:class:`pykeen.sampling.filtering.BloomFilterer`, which is based on
+:class:`~pykeen.sampling.filtering.BloomFilterer`, which is based on
 `bloom filters <https://en.wikipedia.org/wiki/Bloom_filter>`_. The bloom filterer also has a configurable desired error
 rate, which can be further lowered at the cost of increase in memory and computation costs.
 
@@ -73,7 +73,7 @@ rate, which can be further lowered at the cost of increase in memory and computa
     )
 
 If you want to have a guarantee that all known false negatives are filtered, you can use a slower implementation based
-on Python's built-in sets, the :class:`pykeen.sampling.filtering.PythonSetFilterer`. It can be activated with:
+on Python's built-in sets, the :class:`~pykeen.sampling.filtering.PythonSetFilterer`. It can be activated with:
 
 .. code-block:: python
 
@@ -111,7 +111,7 @@ like in:
 Filtering during evaluation is implemented differently than in negative sampling:
 
 First, there are no choices between an exact or approximate algorithm via a
-:class:`pykeen.sampling.filtering.Filterer`. Instead, the evaluation filtering can modify the
+:class:`~pykeen.sampling.filtering.Filterer`. Instead, the evaluation filtering can modify the
 scores in-place and does so instead of selecting only the non-filtered entries. The reason is
 mainly that evaluation always is done in 1:n scoring, and thus, we gain some efficiently here
 by keeping the tensor in "dense" shape ``(batch_size, num_entities)``.

--- a/src/pykeen/sampling/pseudo_type.py
+++ b/src/pykeen/sampling/pseudo_type.py
@@ -81,7 +81,7 @@ class PseudoTypedNegativeSampler(NegativeSampler):
         """Instantiate the pseudo-typed negative sampler.
 
         :param mapped_triples: the positive training triples
-        :param kwargs: Additional keyword based arguments passed to :class:`pykeen.sampling.NegativeSampler`.
+        :param kwargs: Additional keyword based arguments passed to :class:`~pykeen.sampling.NegativeSampler`.
         """
         super().__init__(mapped_triples=mapped_triples, **kwargs)
         self.data, self.offsets = create_index(mapped_triples=mapped_triples, num_relations=self.num_relations)

--- a/src/pykeen/stoppers/__init__.py
+++ b/src/pykeen/stoppers/__init__.py
@@ -1,8 +1,8 @@
 """Early stoppers.
 
 The following code will create a scenario in which training will stop
-(quite) early when training :class:`pykeen.models.TransE` on the
-:class:`pykeen.datasets.Nations` dataset.
+(quite) early when training :class:`~pykeen.models.TransE` on the
+:class:`~pykeen.datasets.Nations` dataset.
 
 >>> from pykeen.pipeline import pipeline
 >>> pipeline_result = pipeline(

--- a/src/pykeen/stoppers/early_stopping.py
+++ b/src/pykeen/stoppers/early_stopping.py
@@ -165,7 +165,7 @@ class EarlyStopper(Stopper):
     use_tqdm: bool = False
     #: Keyword arguments for the tqdm progress bar
     tqdm_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
-    #: Additional keyword arguments passed to :meth:`pykeen.evaluation.Evaluator.evaluate`.
+    #: Additional keyword arguments passed to :meth:`~pykeen.evaluation.Evaluator.evaluate`.
     #: Do not include ``batch_size`` or ``slice_size`` here; use the dedicated fields instead.
     evaluation_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
 

--- a/src/pykeen/training/callbacks.py
+++ b/src/pykeen/training/callbacks.py
@@ -1,6 +1,6 @@
 """Training callbacks.
 
-Training callbacks allow for arbitrary extension of the functionality of the :class:`pykeen.training.TrainingLoop`
+Training callbacks allow for arbitrary extension of the functionality of the :class:`~pykeen.training.TrainingLoop`
 without subclassing it. Each callback instance has a ``loop`` attribute that allows access to the parent training
 loop and all of its attributes, including the model. The interaction points are similar to those of
 `Keras <https://keras.io/guides/writing_your_own_callbacks/#an-overview-of-callback-methods>`_.
@@ -153,7 +153,7 @@ class TrainingCallback:
 
 class TrackerTrainingCallback(TrainingCallback):
     """
-    An adapter for the :class:`pykeen.trackers.ResultTracker`.
+    An adapter for the :class:`~pykeen.trackers.ResultTracker`.
 
     It logs the loss after each epoch to the given result tracker,
     """
@@ -668,14 +668,14 @@ class CheckpointTrainingCallback(TrainingCallback):
             keyword-based parameters to instantiate the checkpoint schedule, if necessary,
             cf. :const:`pykeen.checkpoints.scheduler_resolver`
         :param keeper:
-            a selection of the checkpoint retention logic, cf. :const:`pykeen.checkpoints.keeper_resolver`.
+            a selection of the checkpoint retention logic, cf. :const:`~pykeen.checkpoints.keeper_resolver`.
             `None` corresponds to keeping all checkpoints (which were created).
         :param keeper_kwargs:
             keyword-based parameters to instantiate the retention policy, if necessary,
-            cf. :const:`pykeen.checkpoints.keeper_resolver`
+            cf. :const:`~pykeen.checkpoints.keeper_resolver`
         :param root:
             the checkpoint root directory. Defaults to a fresh sub-directory of
-            :const:`pykeen.constants.PYKEEN_CHECKPOINTS`
+            :const:`~pykeen.constants.PYKEEN_CHECKPOINTS`
         :param name_template:
             a name template for the checkpoint file. Can contain a format key `{epoch}` which is replaced by the actual
             epoch. This callback does not take care of overwriting existing files, i.e., if you want to keep multiple

--- a/src/pykeen/training/training_loop.py
+++ b/src/pykeen/training/training_loop.py
@@ -273,7 +273,7 @@ class TrainingLoop(Generic[BatchType], ABC):
         :param clear_optimizer: Whether to delete the optimizer instance after training (as the optimizer might have
             additional memory consumption due to e.g. moments in Adam).
         :param checkpoint_directory: An optional directory to store the checkpoint files. If None, a subdirectory named
-            ``checkpoints`` in the directory defined by :data:`pykeen.constants.PYKEEN_HOME` is used. Unless the
+            ``checkpoints`` in the directory defined by :data:`~pykeen.constants.PYKEEN_HOME` is used. Unless the
             environment variable ``PYKEEN_HOME`` is overridden, this will be ``~/.pykeen/checkpoints``.
         :param checkpoint_name: The filename for saving checkpoints. If the given filename exists already, that file
             will be loaded and used to continue training.

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -743,9 +743,9 @@ class CoreTriplesFactory(KGInfo):
         :param random_state:
             The random state used to shuffle and split the triples.
         :param randomize_cleanup:
-            This parameter is forwarded to the underlying :func:`pykeen.triples.splitting.split`.
+            This parameter is forwarded to the underlying :func:`~pykeen.triples.splitting.split`.
         :param method:
-            This parameter is forwarded to the underlying :func:`pykeen.triples.splitting.split`.
+            This parameter is forwarded to the underlying :func:`~pykeen.triples.splitting.split`.
 
 
         :return:
@@ -753,7 +753,7 @@ class CoreTriplesFactory(KGInfo):
             which share everything else with this root triples factory.
 
         .. seealso::
-            :func:`pykeen.triples.splitting.split`
+            :func:`~pykeen.triples.splitting.split`
 
         .. code-block:: python
 

--- a/src/pykeen/typing.py
+++ b/src/pykeen/typing.py
@@ -97,14 +97,14 @@ DeviceHint = Hint[torch.device]
 TorchRandomHint = None | int | torch.Generator
 
 Representation = TypeVar("Representation", bound=OneOrSequence[FloatTensor])
-#: A type variable for head representations used in :class:`pykeen.models.Model`,
-#: :class:`pykeen.nn.modules.Interaction`, etc.
+#: A type variable for head representations used in :class:`~pykeen.models.Model`,
+#: :class:`~pykeen.nn.modules.Interaction`, etc.
 HeadRepresentation = TypeVar("HeadRepresentation", bound=OneOrSequence[FloatTensor])
-#: A type variable for relation representations used in :class:`pykeen.models.Model`,
-#: :class:`pykeen.nn.modules.Interaction`, etc.
+#: A type variable for relation representations used in :class:`~pykeen.models.Model`,
+#: :class:`~pykeen.nn.modules.Interaction`, etc.
 RelationRepresentation = TypeVar("RelationRepresentation", bound=OneOrSequence[FloatTensor])
-#: A type variable for tail representations used in :class:`pykeen.models.Model`,
-#: :class:`pykeen.nn.modules.Interaction`, etc.
+#: A type variable for tail representations used in :class:`~pykeen.models.Model`,
+#: :class:`~pykeen.nn.modules.Interaction`, etc.
 TailRepresentation = TypeVar("TailRepresentation", bound=OneOrSequence[FloatTensor])
 
 


### PR DESCRIPTION
## Summary

Purely mechanical split-off from #1607: prefixes existing, already-valid Sphinx role targets (`:class:`, `:func:`, `:meth:`, `:mod:`, `:data:`, `:attr:`) with `~` so they render as just the short name (e.g. `TransE`) instead of the full dotted path (`pykeen.models.TransE`), matching the predominant style already used across the docs.

No reference targets, paths, or prose were changed — every hunk is a single-character insertion (`` ` `` → `` `~ ``). Big diff, nothing to actually verify beyond "yes, that's a tilde."

The substantive cross-reference fixes (broken/stale references, wrong paths, private→public exports) remain in #1607, based on top of this branch.

## Test plan

- [x] `sphinx -W -b html` builds clean
- [x] `ruff check` / `ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)