### PR TITLE
🐛🔗 Fix inverse relation ID handling

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -334,6 +334,7 @@ nitpick_ignore = [
     ("py:class", "pykeen.datasets.ea.combination.FactoryType"),
     ("py:class", "pykeen.evaluation.evaluation_loop.BatchType"),
     ("py:class", "pykeen.evaluation.evaluator.MetricKeyType"),
+    ("py:class", "pykeen.inverse.RelationID"),
     ("py:class", "pykeen.utils.K"),
     ("py:class", "pykeen.utils.V"),
     ("py:class", "pykeen.utils.X"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -317,7 +317,6 @@ nitpick_ignore = [
     ("py:class", "LookupOrType"),
     ("py:class", "MappedTriples"),
     ("py:class", "MarginRankingLoss"),
-    ("py:class", "OModel"),
     ("py:class", "OneOrManyHintOrType"),
     ("py:class", "OneOrManyOptionalKwargs"),
     ("py:class", "OneOrSequence"),

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,6 +57,7 @@ four kinds of content: learning-oriented *tutorials*, goal-oriented *how-to guid
     reference/models
     reference/datasets
     reference/triples
+    reference/inverse
     reference/training
     reference/stoppers
     reference/losses

--- a/docs/source/reference/inverse.rst
+++ b/docs/source/reference/inverse.rst
@@ -1,0 +1,4 @@
+Inverse Relations
+=================
+
+.. automodapi:: pykeen.inverse

--- a/src/pykeen/datasets/utils.py
+++ b/src/pykeen/datasets/utils.py
@@ -184,11 +184,7 @@ def _digest_kwargs(dataset_kwargs: Mapping[str, Any], ignore: Collection[str] = 
 
 def _set_inverse_triples_(dataset_instance: Dataset, create_inverse_triples: bool) -> Dataset:
     # note: we only need to set the create_inverse_triples in the training factory.
-    if dataset_instance.create_inverse_triples and not create_inverse_triples:
-        assert dataset_instance.training.num_relations % 2 == 0
-        dataset_instance.training.num_relations //= 2
-    elif create_inverse_triples and not dataset_instance.training.create_inverse_triples:
-        dataset_instance.training.num_relations *= 2
+    # the setter keeps the factory's num_relations in sync.
     dataset_instance.training.create_inverse_triples = create_inverse_triples
     return dataset_instance
 

--- a/src/pykeen/datasets/utils.py
+++ b/src/pykeen/datasets/utils.py
@@ -182,13 +182,6 @@ def _digest_kwargs(dataset_kwargs: Mapping[str, Any], ignore: Collection[str] = 
     return base64.urlsafe_b64encode(digester.digest()).decode("utf8")[:32]
 
 
-def _set_inverse_triples_(dataset_instance: Dataset, create_inverse_triples: bool) -> Dataset:
-    # note: we only need to set the create_inverse_triples in the training factory.
-    # the setter keeps the factory's num_relations in sync.
-    dataset_instance.training.create_inverse_triples = create_inverse_triples
-    return dataset_instance
-
-
 def _cached_get_dataset(
     dataset: str,
     dataset_kwargs: Mapping[str, Any] | None,
@@ -216,10 +209,11 @@ def _cached_get_dataset(
     # try to use cached dataset
     if path.is_dir() and not force:
         logger.info(f"Loading cached preprocessed dataset from {path.as_uri()}")
-        return _set_inverse_triples_(
-            dataset_cls.from_directory_binary(path),
-            create_inverse_triples=dataset_kwargs.get("create_inverse_triples", False),
-        )
+        dataset_instance = dataset_cls.from_directory_binary(path)
+        # the cache is shared across create_inverse_triples settings, cf. the ignored key above.
+        # note: we only need to set the flag on the training factory; its setter keeps num_relations in sync.
+        dataset_instance.training.create_inverse_triples = dataset_kwargs.get("create_inverse_triples", False)
+        return dataset_instance
 
     # load dataset without cache
     dataset_instance = dataset_resolver.make(dataset, dataset_kwargs)

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -382,36 +382,6 @@ class Evaluator(ABC, Generic[MetricKeyType]):
                 **kwargs,
             )
 
-    @staticmethod
-    def _check_slicing_availability(model: Model, batch_size: int, entities: bool, relations: bool) -> None:
-        """Raise an error if the necessary slicing operations are not supported.
-
-        :param model: the model
-        :param batch_size: the batch-size; only used for creating the error message
-        :param entities: whether entities need to be scored
-        :param relations: whether relations need to be scored
-
-        :raises MemoryError: if the necessary slicing operations are not supported by the model
-        """
-        reasons = []
-        if entities:
-            # if inverse triples are used, we only do score_t (TODO: by default; can this be changed?)
-            if not model.can_slice_t:
-                reasons.append("score_t")
-            # otherwise, i.e., without inverse triples, we also need score_h
-            if not model.use_inverse_triples and not model.can_slice_t:
-                reasons.append("score_h")
-        # if relations are to be predicted, we need to slice score_r
-        if relations and not model.can_slice_r:
-            reasons.append("score_r")
-        # raise an error, if any of the required methods cannot slice
-        if reasons:
-            raise MemoryError(
-                f"The current model can't be evaluated on this hardware with these parameters, as "
-                f"evaluation batch_size={batch_size} is too big and slicing is not implemented for this "
-                f"model yet (missing support for: {reasons})"
-            )
-
 
 def _optimal_batch_size_group_id(kwargs: Mapping[str, Any]) -> int:
     """Share optimal batch size whenever this hash matches."""

--- a/src/pykeen/experiments/inverse_stability.py
+++ b/src/pykeen/experiments/inverse_stability.py
@@ -91,7 +91,7 @@ def run_inverse_stability_workflow(
     # triples factory when training with inverse relations
     batch = test_tf.mapped_triples
     if model_inst.use_inverse_triples:
-        batch = model_inst.relation_inverter.map(batch=batch)
+        batch = model_inst.relation_inverter.to_internal_batch(batch=batch)
 
     # Score with original triples
     scores_forward = model_inst.score_hrt(batch, mode=mode)

--- a/src/pykeen/experiments/inverse_stability.py
+++ b/src/pykeen/experiments/inverse_stability.py
@@ -85,12 +85,20 @@ def run_inverse_stability_workflow(
     )
     test_tf = dataset_instance.testing
     model_inst = pipeline_result.model
+    model_inst.eval()
+
+    # the model operates on "internal" relation IDs, which differ from the ones stored in the
+    # triples factory when training with inverse relations
+    batch = test_tf.mapped_triples
+    if model_inst.use_inverse_triples:
+        batch = model_inst.relation_inverter.map(batch=batch)
+
     # Score with original triples
-    scores_forward = model_inst.score_hrt(test_tf.mapped_triples, mode=mode)
+    scores_forward = model_inst.score_hrt(batch, mode=mode)
     scores_forward_np = scores_forward.detach().numpy()[:, 0]
 
     # Score with inverse triples
-    scores_inverse = model_inst.score_hrt_inverse(test_tf.mapped_triples, mode=mode)
+    scores_inverse = model_inst.score_hrt_inverse(batch, mode=mode)
     scores_inverse_np = scores_inverse.detach().numpy()[:, 0]
 
     scores_path = dataset_dir / f"{model_name}_{training_loop}_scores.tsv"

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -8,11 +8,13 @@ from class_resolver import Resolver
 from .typing import BoolTensor, LongTensor
 
 __all__ = [
+    "RelationID",
     "RelationInverter",
     "DefaultRelationInverter",
     "relation_inverter_resolver",
 ]
 
+#: A relation ID, either a single one, or a batch thereof
 RelationID = TypeVar("RelationID", int, LongTensor)
 
 
@@ -46,8 +48,8 @@ class RelationInverter(ABC):
         """
 
     @abstractmethod
-    def is_inverse(self, ids: LongTensor) -> BoolTensor:
-        """Return a mask whether the relation IDs correspond to inverse relations."""
+    def is_inverse(self, relation_id: RelationID) -> bool | BoolTensor:
+        """Return whether the internal relation IDs correspond to inverse relations."""
 
     def invert_internal_batch(self, batch: LongTensor, index: int = 1) -> LongTensor:
         """Invert the internal relation IDs in a batch, leaving the input batch unmodified."""
@@ -92,8 +94,8 @@ class DefaultRelationInverter(RelationInverter):
         return relation_id ^ 1
 
     # docstr-coverage: inherited
-    def is_inverse(self, ids: LongTensor) -> BoolTensor:  # noqa: D102
-        return (ids & 1) == 1
+    def is_inverse(self, relation_id: RelationID) -> bool | BoolTensor:  # noqa: D102
+        return (relation_id & 1) == 1
 
 
 #: A resolver for relation inverter protocols

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -47,9 +47,11 @@ class RelationInverter(ABC):
         input ID again. In particular, it maps the ID of an inverse relation back to its forward one.
         """
 
+    # docstr-coverage:excused `overload`
     @overload
     def is_inverse(self, relation_id: int) -> bool: ...
 
+    # docstr-coverage:excused `overload`
     @overload
     def is_inverse(self, relation_id: LongTensor) -> BoolTensor: ...
 

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -25,6 +25,8 @@ class RelationInverter(ABC):
       inside a :class:`~pykeen.triples.CoreTriplesFactory`, and
     - the *internal* relation IDs, ``0 ... 2 * num_real_relations - 1``, as used by models trained
       with inverse relations, which comprise a forward and an inverse ID for each real relation.
+
+    Subclasses only define the ID-level translation; the batch-level operations are derived from it.
     """
 
     @abstractmethod
@@ -40,28 +42,27 @@ class RelationInverter(ABC):
         """Get the internal inverse ID for a given internal (forward) relation ID."""
         # TODO: inverse of inverse?
 
-    def _map(self, batch: LongTensor, index: int = 1) -> LongTensor:
-        """Map relations in a batch from real to internal IDs."""
-        batch = batch.clone()
-        batch[:, index] = self.to_internal(batch[:, index])
-        return batch
-
-    @abstractmethod
-    def invert_(self, batch: LongTensor, index: int = 1) -> LongTensor:
-        """Invert relations in a batch (in-place)."""
-
-    def invert(self, batch: LongTensor, index: int = 1) -> LongTensor:
-        """Invert relations in a batch, leaving the input batch unmodified."""
-        return self.invert_(batch=batch.clone(), index=index)
-
-    def map(self, batch: LongTensor, index: int = 1, invert: bool = False) -> LongTensor:
-        """Map relations in a batch, optionally also inverting them."""
-        batch = self._map(batch=batch, index=index)
-        return self.invert_(batch=batch, index=index) if invert else batch
-
     @abstractmethod
     def is_inverse(self, ids: LongTensor) -> BoolTensor:
         """Return a mask whether the relation IDs correspond to inverse relations."""
+
+    def invert(self, batch: LongTensor, index: int = 1) -> LongTensor:
+        """Invert the (internal) relations in a batch, leaving the input batch unmodified."""
+        batch = batch.clone()
+        batch[:, index] = self.get_inverse_id(batch[:, index])
+        return batch
+
+    def map(self, batch: LongTensor, index: int = 1, invert: bool = False) -> LongTensor:
+        """Map relations in a batch from real to internal IDs, optionally also inverting them.
+
+        The input batch is left unmodified.
+        """
+        relation_id = self.to_internal(batch[:, index])
+        if invert:
+            relation_id = self.get_inverse_id(relation_id)
+        batch = batch.clone()
+        batch[:, index] = relation_id
+        return batch
 
 
 class DefaultRelationInverter(RelationInverter):
@@ -78,13 +79,6 @@ class DefaultRelationInverter(RelationInverter):
     # docstr-coverage: inherited
     def get_inverse_id(self, relation_id: RelationID) -> RelationID:  # noqa: D102
         return relation_id + 1
-
-    # docstr-coverage: inherited
-    def invert_(self, batch: LongTensor, index: int = 1) -> LongTensor:  # noqa: D102
-        # The number of relations stored in the triples factory includes the number of inverse relations
-        # Id of inverse relation: relation + 1
-        batch[:, index] += 1
-        return batch
 
     # docstr-coverage: inherited
     def is_inverse(self, ids: LongTensor) -> BoolTensor:  # noqa: D102

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -34,6 +34,10 @@ class RelationInverter(ABC):
     def invert_(self, batch: LongTensor, index: int = 1) -> LongTensor:
         """Invert relations in a batch (in-place)."""
 
+    def invert(self, batch: LongTensor, index: int = 1) -> LongTensor:
+        """Invert relations in a batch, leaving the input batch unmodified."""
+        return self.invert_(batch=batch.clone(), index=index)
+
     def map(self, batch: LongTensor, index: int = 1, invert: bool = False) -> LongTensor:
         """Map relations in a batch, optionally also inverting them."""
         batch = self._map(batch=batch, index=index)

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -1,7 +1,7 @@
 """Relation inversion logic."""
 
 from abc import ABC, abstractmethod
-from typing import TypeVar
+from typing import TypeVar, overload
 
 from class_resolver import Resolver
 
@@ -46,6 +46,12 @@ class RelationInverter(ABC):
         Implementations have to be involutions, i.e., applying this method twice has to yield the
         input ID again. In particular, it maps the ID of an inverse relation back to its forward one.
         """
+
+    @overload
+    def is_inverse(self, relation_id: int) -> bool: ...
+
+    @overload
+    def is_inverse(self, relation_id: LongTensor) -> BoolTensor: ...
 
     @abstractmethod
     def is_inverse(self, relation_id: RelationID) -> bool | BoolTensor:

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -49,14 +49,14 @@ class RelationInverter(ABC):
     def is_inverse(self, ids: LongTensor) -> BoolTensor:
         """Return a mask whether the relation IDs correspond to inverse relations."""
 
-    def invert(self, batch: LongTensor, index: int = 1) -> LongTensor:
-        """Invert the (internal) relations in a batch, leaving the input batch unmodified."""
+    def invert_internal_batch(self, batch: LongTensor, index: int = 1) -> LongTensor:
+        """Invert the internal relation IDs in a batch, leaving the input batch unmodified."""
         batch = batch.clone()
         batch[:, index] = self.get_inverse_id(batch[:, index])
         return batch
 
-    def map(self, batch: LongTensor, index: int = 1, invert: bool = False) -> LongTensor:
-        """Map relations in a batch from real to internal IDs, optionally also inverting them.
+    def to_internal_batch(self, batch: LongTensor, index: int = 1, invert: bool = False) -> LongTensor:
+        """Convert the real relation IDs in a batch to internal ones, optionally also inverting them.
 
         The input batch is left unmodified.
         """

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -39,8 +39,11 @@ class RelationInverter(ABC):
 
     @abstractmethod
     def get_inverse_id(self, relation_id: RelationID) -> RelationID:
-        """Get the internal inverse ID for a given internal (forward) relation ID."""
-        # TODO: inverse of inverse?
+        """Get the internal ID of the inverse of an internal relation ID.
+
+        Implementations have to be involutions, i.e., applying this method twice has to yield the
+        input ID again. In particular, it maps the ID of an inverse relation back to its forward one.
+        """
 
     @abstractmethod
     def is_inverse(self, ids: LongTensor) -> BoolTensor:
@@ -66,23 +69,31 @@ class RelationInverter(ABC):
 
 
 class DefaultRelationInverter(RelationInverter):
-    """Maps normal relations to even IDs, and the corresponding inverse to the next odd ID."""
+    """Uses the lowest bit of the internal relation ID as the "is inverse" flag.
+
+    The internal ID is the real relation ID shifted up by one bit, with the lowest bit set for
+    inverse relations, i.e., ``internal_id = (real_id << 1) | is_inverse``. Equivalently, forward
+    relations get even IDs, and the corresponding inverse the next odd one.
+    """
 
     # docstr-coverage: inherited
     def to_internal(self, relation_id: RelationID) -> RelationID:  # noqa: D102
-        return 2 * relation_id
+        # shift up to make room for the flag, which is unset for forward relations
+        return relation_id << 1
 
     # docstr-coverage: inherited
     def to_real(self, relation_id: RelationID) -> RelationID:  # noqa: D102
-        return relation_id // 2
+        # shift the flag out again
+        return relation_id >> 1
 
     # docstr-coverage: inherited
     def get_inverse_id(self, relation_id: RelationID) -> RelationID:  # noqa: D102
-        return relation_id + 1
+        # toggling the flag switches between a relation and its inverse in either direction
+        return relation_id ^ 1
 
     # docstr-coverage: inherited
     def is_inverse(self, ids: LongTensor) -> BoolTensor:  # noqa: D102
-        return ids % 2 == 1
+        return (ids & 1) == 1
 
 
 #: A resolver for relation inverter protocols

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -17,18 +17,34 @@ RelationID = TypeVar("RelationID", int, LongTensor)
 
 
 class RelationInverter(ABC):
-    """An interface for inverse-relation ID mapping."""
+    """An interface for inverse-relation ID mapping.
 
-    # TODO: method is_inverse?
+    Implementations translate between two ID spaces:
+
+    - the *real* relation IDs, ``0 ... num_real_relations - 1``, as used by the triples stored
+      inside a :class:`~pykeen.triples.CoreTriplesFactory`, and
+    - the *internal* relation IDs, ``0 ... 2 * num_real_relations - 1``, as used by models trained
+      with inverse relations, which comprise a forward and an inverse ID for each real relation.
+    """
+
+    @abstractmethod
+    def to_internal(self, relation_id: RelationID) -> RelationID:
+        """Convert a real relation ID to the corresponding internal (forward) relation ID."""
+
+    @abstractmethod
+    def to_real(self, relation_id: RelationID) -> RelationID:
+        """Convert an internal relation ID to the corresponding real relation ID."""
 
     @abstractmethod
     def get_inverse_id(self, relation_id: RelationID) -> RelationID:
-        """Get the inverse ID for a given relation."""
+        """Get the internal inverse ID for a given internal (forward) relation ID."""
         # TODO: inverse of inverse?
 
-    @abstractmethod
     def _map(self, batch: LongTensor, index: int = 1) -> LongTensor:
-        """Map relations in a batch."""
+        """Map relations in a batch from real to internal IDs."""
+        batch = batch.clone()
+        batch[:, index] = self.to_internal(batch[:, index])
+        return batch
 
     @abstractmethod
     def invert_(self, batch: LongTensor, index: int = 1) -> LongTensor:
@@ -52,14 +68,16 @@ class DefaultRelationInverter(RelationInverter):
     """Maps normal relations to even IDs, and the corresponding inverse to the next odd ID."""
 
     # docstr-coverage: inherited
-    def get_inverse_id(self, relation_id: RelationID) -> RelationID:  # noqa: D102
-        return relation_id + 1
+    def to_internal(self, relation_id: RelationID) -> RelationID:  # noqa: D102
+        return 2 * relation_id
 
     # docstr-coverage: inherited
-    def _map(self, batch: LongTensor, index: int = 1) -> LongTensor:  # noqa: D102
-        batch = batch.clone()
-        batch[:, index] *= 2
-        return batch
+    def to_real(self, relation_id: RelationID) -> RelationID:  # noqa: D102
+        return relation_id // 2
+
+    # docstr-coverage: inherited
+    def get_inverse_id(self, relation_id: RelationID) -> RelationID:  # noqa: D102
+        return relation_id + 1
 
     # docstr-coverage: inherited
     def invert_(self, batch: LongTensor, index: int = 1) -> LongTensor:  # noqa: D102

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -261,11 +261,11 @@ class Model(nn.Module, ABC):
         :param relations: shape: (num_relations,) | (batch_size, num_relations)
             relation indices to score against. If None, scores against all relations (from the given mode).
 
-        :return: shape: (batch_size, num_real_relations), dtype: float
-            For each h-t pair, the scores for all possible relations.
+        :return: shape: (batch_size, num_relations), dtype: float
+            For each h-t pair, the scores for all possible relations. As for the other scoring
+            methods, the relations are the model's *internal* ones, so this comprises the
+            artificial inverse relations when the model is trained with them.
         """
-        # TODO: this currently compute (batch_size, num_relations) instead,
-        # i.e., scores for normal and inverse relations
 
     @abstractmethod
     def score_h(

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -466,19 +466,25 @@ class Model(nn.Module, ABC):
 
         :param ht_batch: shape: (batch_size, 2), dtype: long
             The indices of (head, tail) pairs.
-        :param relations: shape: (num_relations,)
-            The relations to score against, given as *real* relation IDs. If None, scores against all
-            relations, which comprise the inverse relations if the model has been trained with them.
+        :param relations: shape: (num_real_relations,)
+            The relations to score against, given as *real* relation IDs. If None, scores against
+            all real relations.
         :param kwargs:
             additional keyword-based parameters passed to :meth:`Model.score_r`
 
-        :return: shape: (batch_size, num_relations), dtype: float
-            For each h-t pair, the scores for all possible relations.
+        :return: shape: (batch_size, num_real_relations), dtype: float
+            For each h-t pair, the scores for all possible relations, with the columns indexed by
+            *real* relation ID. The artificial inverse relations are never scored against; use
+            :meth:`Model.score_r` directly to obtain their scores.
         """
         self.eval()  # Enforce evaluation mode
         ht_batch = ht_batch.to(self.device)
-        # when trained on inverse relations, the internal relation ID is twice the original relation ID
-        if relations is not None and self.use_inverse_triples:
+        if self.use_inverse_triples:
+            # score_r operates on the model's internal relations, which comprise the artificial
+            # inverse ones. Asking for the forward IDs explicitly keeps the columns indexed by
+            # "real" relation ID, without computing the inverse scores just to discard them.
+            if relations is None:
+                relations = torch.arange(self.num_real_relations, device=self.device)
             relations = self.relation_inverter.to_internal(relations)
         scores = self.score_r(ht_batch, relations=relations, **kwargs)
         if self.predict_with_sigmoid:

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -45,6 +45,25 @@ class Model(nn.Module, ABC):
     relations' representations, how they want to be looked up, and how they should
     be scored. The :class:`~pykeen.models.ERModel` provides a commonly used interface for models storing entity
     and relation representations in the form of :class:`~pykeen.nn.representation.Embedding`.
+
+    .. note::
+
+        There are two families of scoring methods, and they use *different* relation ID spaces.
+
+        The ``score_*`` methods, e.g., :meth:`Model.score_hrt`, are the low-level interface implemented
+        by subclasses. They expect the model's *internal* relation IDs, which comprise a forward
+        and an inverse ID for each relation when the model is trained with inverse relations,
+        cf. :class:`~pykeen.inverse.RelationInverter`. They also expect the batch to already be
+        on the model's device.
+
+        The ``predict_*`` methods, e.g., :meth:`Model.predict_hrt`, are the user-facing interface. They
+        expect the *real* relation IDs, i.e., the ones stored in the triples factory's
+        :attr:`~pykeen.triples.TriplesFactory.relation_to_id` and ``mapped_triples``, accept
+        batches on any device, and additionally take care of setting the evaluation mode and of
+        optionally applying a sigmoid. Internally, they delegate to the ``score_*`` methods after
+        converting the batch via ``_prepare_batch``.
+
+        Unless the model uses inverse relations, the two ID spaces coincide.
     """
 
     #: The default strategy for optimizing the model's hyper-parameters
@@ -315,6 +334,22 @@ class Model(nn.Module, ABC):
     """Prediction methods"""
 
     def _prepare_batch(self, batch: LongTensor, index_relation: int) -> LongTensor:
+        """Prepare a batch of "real" IDs for the scoring methods.
+
+        The prediction methods, e.g., :meth:`Model.predict_hrt`, take the relation IDs stored
+        inside the triples factory, while the scoring methods, e.g., :meth:`Model.score_hrt`,
+        operate on the model's internal ones, cf. :class:`~pykeen.inverse.RelationInverter`.
+        This method translates between the two, and moves the batch onto the model's device.
+
+        :param batch: shape: (batch_size, num_columns), dtype: long
+            The batch of IDs, with relations given as the "real" IDs used by the triples factory.
+        :param index_relation:
+            The column containing the relation IDs.
+
+        :return: shape: (batch_size, num_columns), dtype: long
+            The batch on the model's device, with relations given as internal IDs. Unless the
+            model uses inverse relations, the two ID spaces coincide and the IDs are unchanged.
+        """
         # send to device
         batch = batch.to(self.device)
 

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -419,6 +419,8 @@ class Model(nn.Module, ABC):
     def predict_r(
         self,
         ht_batch: LongTensor,
+        *,
+        relations: LongTensor | None = None,
         **kwargs,
     ) -> FloatTensor:
         """Forward pass using middle (relation) prediction for obtaining scores of all possible relations.
@@ -429,6 +431,9 @@ class Model(nn.Module, ABC):
 
         :param ht_batch: shape: (batch_size, 2), dtype: long
             The indices of (head, tail) pairs.
+        :param relations: shape: (num_relations,)
+            The relations to score against, given as *real* relation IDs. If None, scores against all
+            relations, which comprise the inverse relations if the model has been trained with them.
         :param kwargs:
             additional keyword-based parameters passed to :meth:`Model.score_r`
 
@@ -437,7 +442,10 @@ class Model(nn.Module, ABC):
         """
         self.eval()  # Enforce evaluation mode
         ht_batch = ht_batch.to(self.device)
-        scores = self.score_r(ht_batch, **kwargs)
+        # when trained on inverse relations, the internal relation ID is twice the original relation ID
+        if relations is not None and self.use_inverse_triples:
+            relations = self.relation_inverter.to_internal(relations)
+        scores = self.score_r(ht_batch, relations=relations, **kwargs)
         if self.predict_with_sigmoid:
             scores = torch.sigmoid(scores)
         return scores

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -43,7 +43,7 @@ class Model(nn.Module, ABC):
 
     Subclasses of :class:`Model` can decide however they want on how to store entities' and
     relations' representations, how they want to be looked up, and how they should
-    be scored. The :class:`OModel` provides a commonly used interface for models storing entity
+    be scored. The :class:`~pykeen.models.ERModel` provides a commonly used interface for models storing entity
     and relation representations in the form of :class:`~pykeen.nn.representation.Embedding`.
     """
 

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -323,7 +323,7 @@ class Model(nn.Module, ABC):
             return batch
 
         # when trained on inverse relations, the internal relation ID is twice the original relation ID
-        return self.relation_inverter.map(batch=batch, index=index_relation, invert=False)
+        return self.relation_inverter.to_internal_batch(batch=batch, index=index_relation)
 
     def predict_hrt(self, hrt_batch: LongTensor, *, mode: InductiveMode | None = None) -> FloatTensor:
         """Calculate the scores for triples.
@@ -552,7 +552,7 @@ class Model(nn.Module, ABC):
                 " Set ``create_inverse_triples=True`` when creating the dataset/triples factory"
                 " or using the pipeline().",
             )
-        return self.relation_inverter.invert(batch=batch, index=index_relation).flip(1)
+        return self.relation_inverter.invert_internal_batch(batch=batch, index=index_relation).flip(1)
 
     def score_hrt_inverse(
         self,

--- a/src/pykeen/models/base.py
+++ b/src/pykeen/models/base.py
@@ -544,7 +544,7 @@ class Model(nn.Module, ABC):
                 " Set ``create_inverse_triples=True`` when creating the dataset/triples factory"
                 " or using the pipeline().",
             )
-        return self.relation_inverter.invert_(batch=batch, index=index_relation).flip(1)
+        return self.relation_inverter.invert(batch=batch, index=index_relation).flip(1)
 
     def score_hrt_inverse(
         self,

--- a/src/pykeen/models/uncertainty.py
+++ b/src/pykeen/models/uncertainty.py
@@ -212,7 +212,7 @@ def predict_hrt_uncertain(
     """
     return predict_uncertain_helper(
         model=model,
-        batch=hrt_batch,
+        batch=model._prepare_batch(batch=hrt_batch, index_relation=1),
         score_method=model.score_hrt,
         num_samples=num_samples,
         mode=mode,
@@ -263,7 +263,7 @@ def predict_h_uncertain(
     """
     return predict_uncertain_helper(
         model=model,
-        batch=rt_batch,
+        batch=model._prepare_batch(batch=rt_batch, index_relation=0),
         score_method=model.score_h_inverse if model.use_inverse_triples else model.score_h,
         num_samples=num_samples,
         slice_size=slice_size,
@@ -362,7 +362,7 @@ def predict_t_uncertain(
     """
     return predict_uncertain_helper(
         model=model,
-        batch=hr_batch,
+        batch=model._prepare_batch(batch=hr_batch, index_relation=1),
         score_method=model.score_t,
         num_samples=num_samples,
         slice_size=slice_size,

--- a/src/pykeen/nn/node_piece/representation.py
+++ b/src/pykeen/nn/node_piece/representation.py
@@ -317,11 +317,9 @@ class NodePieceRepresentation(CombinedRepresentation):
         if max_id:
             assert max_id == triples_factory.num_entities
 
-        # normalize triples
+        # note: the factory's triples never contain the artificial inverse triples -- those are only
+        # materialized when creating training instances -- so we always tokenize on "real" relation IDs
         mapped_triples = triples_factory.mapped_triples
-        if triples_factory.create_inverse_triples:
-            # inverse triples are created afterwards implicitly
-            mapped_triples = mapped_triples[mapped_triples[:, 1] < triples_factory.real_num_relations]
 
         token_representations, token_representations_kwargs, num_tokens = broadcast_upgrade_to_sequences(
             token_representations, token_representations_kwargs, num_tokens

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -1090,15 +1090,6 @@ def predict_target(
     if ids is None:
         ids = range(len(scores))
 
-    # when scoring against *all* relations, the scores comprise the artificial inverse relations,
-    # which we drop here and translate back to the "real" relation IDs.
-    # note: maybe we want to expose these scores, too?
-    if target == LABEL_RELATION and model.use_inverse_triples and targets is None:
-        ids_t = torch.as_tensor(ids)
-        non_inv_mask = ~model.relation_inverter.is_inverse(ids_t)
-        ids = model.relation_inverter.to_real(ids_t[non_inv_mask]).tolist()
-        scores = scores[non_inv_mask]
-
     # create raw dataframe
     data = {f"{target}_id": ids, "score": scores.tolist()}
     if labels is not None:

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -1090,11 +1090,13 @@ def predict_target(
     if ids is None:
         ids = range(len(scores))
 
+    # when scoring against *all* relations, the scores comprise the artificial inverse relations,
+    # which we drop here and translate back to the "real" relation IDs.
     # note: maybe we want to expose these scores, too?
-    if target == LABEL_RELATION and model.use_inverse_triples:
+    if target == LABEL_RELATION and model.use_inverse_triples and targets is None:
         ids_t = torch.as_tensor(ids)
         non_inv_mask = ~model.relation_inverter.is_inverse(ids_t)
-        ids = ids_t[non_inv_mask].tolist()
+        ids = model.relation_inverter.to_real(ids_t[non_inv_mask]).tolist()
         scores = scores[non_inv_mask]
 
     # create raw dataframe

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1016,8 +1016,13 @@ class CoreTriplesFactory(KGInfo):
         if relations is not None:
             extra_metadata["relation_restriction"] = relations
             relations = self.relations_to_ids(relations=relations)
-            remaining_relations = (self.num_relations - len(relations)) if invert_relation_selection else len(relations)
-            logger.info(f"keeping {format_relative_comparison(remaining_relations, self.num_relations)} relations.")
+            # note: the restriction is given in terms of the factory's own ("real") relation IDs
+            remaining_relations = (
+                (self.real_num_relations - len(relations)) if invert_relation_selection else len(relations)
+            )
+            logger.info(
+                f"keeping {format_relative_comparison(remaining_relations, self.real_num_relations)} relations."
+            )
 
         # Delegate to function
         mapped_triples = restrict_triples(

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -270,9 +270,6 @@ class KGInfo(ExtraReprMixin):
     #: the number of relations (maybe including "artificial" inverse relations)
     num_relations: int
 
-    #: whether to create inverse triples
-    create_inverse_triples: bool
-
     #: the number of real relations, i.e., without artificial inverses
     real_num_relations: int
 
@@ -294,10 +291,21 @@ class KGInfo(ExtraReprMixin):
         """
         self.num_entities = num_entities
         self.real_num_relations = num_relations
-        if create_inverse_triples:
-            num_relations *= 2
-        self.num_relations = num_relations
-        self.create_inverse_triples = create_inverse_triples
+        self._create_inverse_triples = create_inverse_triples
+        self.num_relations = 2 * num_relations if create_inverse_triples else num_relations
+
+    @property
+    def create_inverse_triples(self) -> bool:
+        """Whether to create inverse triples."""
+        return self._create_inverse_triples
+
+    @create_inverse_triples.setter
+    def create_inverse_triples(self, create_inverse_triples: bool) -> None:
+        """Set whether to create inverse triples, keeping :attr:`num_relations` in sync."""
+        if create_inverse_triples == self._create_inverse_triples:
+            return
+        self._create_inverse_triples = create_inverse_triples
+        self.num_relations = 2 * self.real_num_relations if create_inverse_triples else self.real_num_relations
 
     def iter_extra_repr(self) -> Iterable[str]:
         """Iterate over extra_repr components."""

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -585,10 +585,23 @@ class CoreTriplesFactory(KGInfo):
         )
 
     def get_inverse_relation_id(self, relation: int) -> int:
-        """Get the inverse relation identifier for the given relation."""
+        """Get the inverse relation identifier for the given relation.
+
+        :param relation:
+            The relation ID as used by this factory's triples, i.e., in ``0 ... real_num_relations - 1``.
+
+        :raises ValueError:
+            If no inverse triples are created, or the relation ID is out of range.
+
+        :return:
+            The *internal* ID of the corresponding inverse relation, i.e., in
+            ``0 ... num_relations - 1``, as used by models trained on this factory.
+        """
         if not self.create_inverse_triples:
             raise ValueError("Can not get inverse triple, they have not been created.")
-        return self.relation_inverter.get_inverse_id(relation_id=relation)
+        if not (0 <= relation < self.real_num_relations):
+            raise ValueError(f"Invalid {relation=}; must be in [0, {self.real_num_relations})")
+        return self.relation_inverter.get_inverse_id(relation_id=self.relation_inverter.to_internal(relation))
 
     def _add_inverse_triples_if_necessary(self, mapped_triples: MappedTriples) -> MappedTriples:
         """Add inverse triples if they shall be created."""

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -625,8 +625,8 @@ class CoreTriplesFactory(KGInfo):
         logger.info("Creating inverse triples.")
         return torch.cat(
             [
-                self.relation_inverter.map(batch=mapped_triples),
-                self.relation_inverter.map(batch=mapped_triples, invert=True).flip(1),
+                self.relation_inverter.to_internal_batch(batch=mapped_triples),
+                self.relation_inverter.to_internal_batch(batch=mapped_triples, invert=True).flip(1),
             ]
         )
 

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -695,7 +695,7 @@ class CoreTriplesFactory(KGInfo):
         return self.__class__(
             mapped_triples=condenser(self.mapped_triples),
             num_entities=condenser.entities.apply_to_num(self.num_entities),
-            num_relations=condenser.relations.apply_to_num(self.num_relations),
+            num_relations=condenser.relations.apply_to_num(self.real_num_relations),
             create_inverse_triples=self.create_inverse_triples,
             metadata=self.metadata,
         )
@@ -1302,7 +1302,7 @@ class TriplesFactory(CoreTriplesFactory):
             entity_to_id=condenser.entities.apply_to_map(self.entity_id_to_label),
             relation_to_id=condenser.relations.apply_to_map(self.relation_id_to_label),
             num_entities=condenser.entities.apply_to_num(self.num_entities),
-            num_relations=condenser.relations.apply_to_num(self.num_relations),
+            num_relations=condenser.relations.apply_to_num(self.real_num_relations),
             create_inverse_triples=self.create_inverse_triples,
             metadata=self.metadata,
         )
@@ -1327,7 +1327,7 @@ class TriplesFactory(CoreTriplesFactory):
         return CoreTriplesFactory(
             mapped_triples=self.mapped_triples,
             num_entities=self.num_entities,
-            num_relations=self.num_relations,
+            num_relations=self.real_num_relations,
             create_inverse_triples=self.create_inverse_triples,
             metadata=self.metadata,
         )

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -267,9 +267,6 @@ class KGInfo(ExtraReprMixin):
     #: the number of unique entities
     num_entities: int
 
-    #: the number of relations (maybe including "artificial" inverse relations)
-    num_relations: int
-
     #: the number of real relations, i.e., without artificial inverses
     real_num_relations: int
 
@@ -292,7 +289,11 @@ class KGInfo(ExtraReprMixin):
         self.num_entities = num_entities
         self.real_num_relations = num_relations
         self._create_inverse_triples = create_inverse_triples
-        self.num_relations = 2 * num_relations if create_inverse_triples else num_relations
+
+    @property
+    def num_relations(self) -> int:
+        """The number of relations, including the "artificial" inverse relations."""
+        return 2 * self.real_num_relations if self.create_inverse_triples else self.real_num_relations
 
     @property
     def create_inverse_triples(self) -> bool:
@@ -301,11 +302,16 @@ class KGInfo(ExtraReprMixin):
 
     @create_inverse_triples.setter
     def create_inverse_triples(self, create_inverse_triples: bool) -> None:
-        """Set whether to create inverse triples, keeping :attr:`num_relations` in sync."""
-        if create_inverse_triples == self._create_inverse_triples:
-            return
+        """Set whether to create inverse triples; :attr:`num_relations` follows."""
         self._create_inverse_triples = create_inverse_triples
-        self.num_relations = 2 * self.real_num_relations if create_inverse_triples else self.real_num_relations
+
+    def __setstate__(self, state: MutableMapping[str, Any]) -> None:
+        """Restore from a pickled state, tolerating states written before the properties were introduced."""
+        if "_create_inverse_triples" not in state:
+            state["_create_inverse_triples"] = state.pop("create_inverse_triples")
+        # num_relations is derived nowadays
+        state.pop("num_relations", None)
+        self.__dict__.update(state)
 
     def iter_extra_repr(self) -> Iterable[str]:
         """Iterate over extra_repr components."""

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -30,6 +30,17 @@ def test_batch_methods_do_not_modify_input(relation_inverter: RelationInverter, 
     assert not torch.equal(result, copy)
 
 
+def test_get_inverse_id_is_involution(relation_inverter: RelationInverter):
+    """Test that applying the inverse-ID mapping twice is the identity."""
+    relation_id = torch.arange(10)
+    inverse_id = relation_inverter.get_inverse_id(relation_id=relation_id)
+    # an inverse relation's inverse is the forward relation again
+    assert torch.equal(relation_inverter.get_inverse_id(relation_id=inverse_id), relation_id)
+    # ... and forward and inverse IDs are never the same
+    assert not torch.equal(inverse_id, relation_id)
+    assert relation_inverter.is_inverse(inverse_id).sum() == relation_id.numel() // 2
+
+
 def test_default_inverter_ids():
     """Test the ID scheme of the default relation inverter."""
     inverter = DefaultRelationInverter()

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -1,0 +1,54 @@
+"""Tests for inverse relation handling."""
+
+import pytest
+import torch
+
+from pykeen.datasets import Nations
+from pykeen.inverse import DefaultRelationInverter, RelationInverter, relation_inverter_resolver
+from pykeen.models import Model, TransE
+
+
+@pytest.fixture(params=relation_inverter_resolver.lookup_dict.values())
+def relation_inverter(request) -> RelationInverter:
+    """Return a relation inverter."""
+    return request.param()
+
+
+@pytest.fixture
+def model() -> Model:
+    """Return a model trained with inverse relations."""
+    return TransE(triples_factory=Nations(create_inverse_triples=True).training, embedding_dim=2, random_seed=0)
+
+
+def test_invert_does_not_modify_input(relation_inverter: RelationInverter):
+    """Test that the non-inplace variant leaves its input alone."""
+    batch = torch.as_tensor([[0, 1, 2], [3, 4, 5]])
+    copy = batch.clone()
+    inverted = relation_inverter.invert(batch=batch)
+    assert torch.equal(batch, copy)
+    assert not torch.equal(inverted, copy)
+    # the in-place variant applied to a copy has to agree
+    assert torch.equal(inverted, relation_inverter.invert_(batch=copy))
+
+
+def test_default_inverter_ids():
+    """Test the ID scheme of the default relation inverter."""
+    inverter = DefaultRelationInverter()
+    batch = torch.as_tensor([[0, 3, 1]])
+    mapped = inverter.map(batch=batch)
+    assert mapped[0, 1].item() == 6
+    assert inverter.get_inverse_id(relation_id=mapped[0, 1]).item() == 7
+    assert not inverter.is_inverse(mapped[:, 1]).any()
+    assert inverter.is_inverse(inverter.map(batch=batch, invert=True)[:, 1]).all()
+
+
+@pytest.mark.parametrize(
+    ("method_name", "columns"),
+    [("score_hrt_inverse", [0, 1, 2]), ("score_t_inverse", [0, 1]), ("score_h_inverse", [1, 2])],
+)
+def test_score_inverse_does_not_modify_input(model: Model, method_name: str, columns: list[int]):
+    """Test that the public inverse scoring methods do not modify their input batch."""
+    batch = Nations().testing.mapped_triples[:3, columns].clone()
+    copy = batch.clone()
+    getattr(model, method_name)(batch)
+    assert torch.equal(batch, copy)

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -73,6 +73,24 @@ def test_score_inverse_does_not_modify_input(model: Model, method_name: str, col
     assert torch.equal(batch, copy)
 
 
+@pytest.mark.parametrize("create_inverse_triples", [False, True])
+def test_predict_r_uses_real_relation_ids(create_inverse_triples: bool):
+    """Test that predict_r scores against the real relations, while score_r stays internal."""
+    factory = Nations(create_inverse_triples=create_inverse_triples).training
+    model = TransE(triples_factory=factory, embedding_dim=2, random_seed=0)
+    ht_batch = torch.as_tensor([[0, 1], [2, 3]])
+
+    # score_r operates on the model's internal relations, which comprise the inverse ones
+    assert model.score_r(ht_batch).shape[-1] == factory.num_relations
+
+    # predict_r drops them again, so that the columns are indexed by the factory's relation IDs ...
+    scores = model.predict_r(ht_batch)
+    assert scores.shape[-1] == factory.real_num_relations
+    # ... in the same order as when they are requested explicitly
+    explicit = model.predict_r(ht_batch, relations=torch.arange(factory.real_num_relations))
+    assert torch.allclose(scores, explicit)
+
+
 def test_get_inverse_relation_id():
     """Test that the factory's inverse relation ID matches the one used by models."""
     factory = Nations(create_inverse_triples=True).training

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -20,7 +20,7 @@ def model() -> Model:
     return TransE(triples_factory=Nations(create_inverse_triples=True).training, embedding_dim=2, random_seed=0)
 
 
-@pytest.mark.parametrize("method_name", ["invert", "map"])
+@pytest.mark.parametrize("method_name", ["invert_internal_batch", "to_internal_batch"])
 def test_batch_methods_do_not_modify_input(relation_inverter: RelationInverter, method_name: str):
     """Test that the batch-level methods leave their input alone."""
     batch = torch.as_tensor([[0, 1, 2], [3, 4, 5]])
@@ -45,11 +45,11 @@ def test_default_inverter_ids():
     """Test the ID scheme of the default relation inverter."""
     inverter = DefaultRelationInverter()
     batch = torch.as_tensor([[0, 3, 1]])
-    mapped = inverter.map(batch=batch)
+    mapped = inverter.to_internal_batch(batch=batch)
     assert mapped[0, 1].item() == 6
     assert inverter.get_inverse_id(relation_id=mapped[0, 1]).item() == 7
     assert not inverter.is_inverse(mapped[:, 1]).any()
-    assert inverter.is_inverse(inverter.map(batch=batch, invert=True)[:, 1]).all()
+    assert inverter.is_inverse(inverter.to_internal_batch(batch=batch, invert=True)[:, 1]).all()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -41,6 +41,15 @@ def test_get_inverse_id_is_involution(relation_inverter: RelationInverter):
     assert relation_inverter.is_inverse(inverse_id).sum() == relation_id.numel() // 2
 
 
+def test_is_inverse_accepts_plain_ints(relation_inverter: RelationInverter):
+    """Test that the ID-level methods work on plain integers, too."""
+    for relation in range(5):
+        internal = relation_inverter.to_internal(relation_id=relation)
+        assert not relation_inverter.is_inverse(relation_id=internal)
+        assert relation_inverter.is_inverse(relation_id=relation_inverter.get_inverse_id(relation_id=internal))
+        assert relation_inverter.to_real(relation_id=internal) == relation
+
+
 def test_default_inverter_ids():
     """Test the ID scheme of the default relation inverter."""
     inverter = DefaultRelationInverter()

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -52,3 +52,26 @@ def test_score_inverse_does_not_modify_input(model: Model, method_name: str, col
     copy = batch.clone()
     getattr(model, method_name)(batch)
     assert torch.equal(batch, copy)
+
+
+def test_get_inverse_relation_id():
+    """Test that the factory's inverse relation ID matches the one used by models."""
+    factory = Nations(create_inverse_triples=True).training
+    model = TransE(triples_factory=factory, embedding_dim=2, random_seed=0)
+    for relation in range(factory.real_num_relations):
+        inverse_id = factory.get_inverse_relation_id(relation)
+        assert 0 <= inverse_id < factory.num_relations
+        assert model.relation_inverter.is_inverse(torch.as_tensor([inverse_id])).item()
+        # this is the relation ID a model actually uses for the inverse of ``relation``
+        batch = torch.as_tensor([[0, relation, 1]])
+        expected = model._prepare_inverse_batch(model._prepare_batch(batch, index_relation=1), index_relation=1)
+        assert expected[0, 1].item() == inverse_id
+
+
+def test_get_inverse_relation_id_errors():
+    """Test the input validation of the factory's inverse relation ID lookup."""
+    factory = Nations(create_inverse_triples=True).training
+    with pytest.raises(ValueError, match="Invalid relation"):
+        factory.get_inverse_relation_id(factory.real_num_relations)
+    with pytest.raises(ValueError, match="they have not been created"):
+        Nations().training.get_inverse_relation_id(0)

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -20,15 +20,14 @@ def model() -> Model:
     return TransE(triples_factory=Nations(create_inverse_triples=True).training, embedding_dim=2, random_seed=0)
 
 
-def test_invert_does_not_modify_input(relation_inverter: RelationInverter):
-    """Test that the non-inplace variant leaves its input alone."""
+@pytest.mark.parametrize("method_name", ["invert", "map"])
+def test_batch_methods_do_not_modify_input(relation_inverter: RelationInverter, method_name: str):
+    """Test that the batch-level methods leave their input alone."""
     batch = torch.as_tensor([[0, 1, 2], [3, 4, 5]])
     copy = batch.clone()
-    inverted = relation_inverter.invert(batch=batch)
+    result = getattr(relation_inverter, method_name)(batch=batch)
     assert torch.equal(batch, copy)
-    assert not torch.equal(inverted, copy)
-    # the in-place variant applied to a copy has to agree
-    assert torch.equal(inverted, relation_inverter.invert_(batch=copy))
+    assert not torch.equal(result, copy)
 
 
 def test_default_inverter_ids():

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -75,3 +75,18 @@ def test_get_inverse_relation_id_errors():
         factory.get_inverse_relation_id(factory.real_num_relations)
     with pytest.raises(ValueError, match="they have not been created"):
         Nations().training.get_inverse_relation_id(0)
+
+
+@pytest.mark.parametrize("create_inverse_triples", [False, True])
+def test_create_inverse_triples_setter(create_inverse_triples: bool):
+    """Test that toggling the flag keeps the number of relations consistent."""
+    factory = Nations(create_inverse_triples=create_inverse_triples).training
+    real_num_relations = factory.real_num_relations
+    for flag in (True, False, True, create_inverse_triples):
+        factory.create_inverse_triples = flag
+        assert factory.create_inverse_triples == flag
+        assert factory.real_num_relations == real_num_relations
+        assert factory.num_relations == (2 * real_num_relations if flag else real_num_relations)
+        # the (possibly inverted) triples have to stay within the ID range
+        mapped_triples = factory._add_inverse_triples_if_necessary(mapped_triples=factory.mapped_triples)
+        assert mapped_triples[:, 1].max().item() < factory.num_relations

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -374,6 +374,25 @@ def test_predict_target(
     assert pred.factory == factory
 
 
+@pytest.mark.parametrize("targets", [None, [1, 2, 3]])
+def test_predict_relation_target_with_inverse_triples(targets: None | Sequence[int]):
+    """Test that relation prediction reports "real" relation IDs when using inverse relations."""
+    factory = Nations(create_inverse_triples=True).training
+    model = pykeen.models.mocks.FixedModel(triples_factory=factory)
+    pred = pykeen.predict.predict_target(model=model, head=0, tail=1, triples_factory=factory, targets=targets)
+
+    # the IDs have to be the "real" ones, i.e., match the factory's relation labeling ...
+    expected_ids = set(range(factory.real_num_relations)) if targets is None else set(targets)
+    assert set(pred.df["relation_id"]) == expected_ids
+    # ... and be consistent with the labels
+    assert all(
+        factory.relation_to_id[label] == identifier
+        for identifier, label in zip(pred.df["relation_id"], pred.df["relation_label"], strict=True)
+    )
+    # ... such that they can be compared against the factory's triples
+    pred.add_membership_columns(training=factory)
+
+
 @pytest.mark.parametrize(
     ("heads", "relations", "tails", "target"),
     [

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -1,6 +1,7 @@
 """Unit tests for triples factories."""
 
 import itertools as itt
+import pickle
 import tempfile
 import unittest
 from collections.abc import Collection, Iterable, Mapping
@@ -583,6 +584,34 @@ class TestUtils(unittest.TestCase):
         """Test binary i/o on core triples factory with inverse relations."""
         tf1 = Nations(create_inverse_triples=True).training.to_core_triples_factory()
         self.assert_binary_io(tf1, CoreTriplesFactory)
+
+    def test_pickle_roundtrip(self):
+        """Test that a triples factory survives being pickled."""
+        for create_inverse_triples in (False, True):
+            with self.subTest(create_inverse_triples=create_inverse_triples):
+                tf1 = Nations(create_inverse_triples=create_inverse_triples).training
+                tf2 = pickle.loads(pickle.dumps(tf1))  # noqa: S301
+                self.assert_tf_equal(tf1, tf2)
+                assert tf2.num_relations == tf1.num_relations
+                assert tf2.real_num_relations == tf1.real_num_relations
+
+    def test_unpickle_legacy_state(self):
+        """Test that states pickled before num_relations & co. became properties still load."""
+        for create_inverse_triples in (False, True):
+            with self.subTest(create_inverse_triples=create_inverse_triples):
+                tf1 = Nations(create_inverse_triples=create_inverse_triples).training
+                # emulate the instance state as written by an older PyKEEN, where both were plain attributes
+                state = dict(tf1.__dict__)
+                state["create_inverse_triples"] = state.pop("_create_inverse_triples")
+                state["num_relations"] = tf1.num_relations
+
+                tf2 = tf1.__class__.__new__(tf1.__class__)
+                tf2.__setstate__(state)
+                self.assert_tf_equal(tf1, tf2)
+                assert tf2.create_inverse_triples == create_inverse_triples
+                assert tf2.num_relations == tf1.num_relations
+                # the stale copy must not shadow the derived property
+                assert "num_relations" not in tf2.__dict__
 
     def assert_binary_io(self, tf, tf_cls):
         """Check the triples factory can be written and reloaded properly."""

--- a/tests/test_triples_factory.py
+++ b/tests/test_triples_factory.py
@@ -224,6 +224,39 @@ class TestTriplesFactory(unittest.TestCase):
         # check that in all other splits no inverse triples are to be created
         assert not any(f.create_inverse_triples for f in others)
 
+    def test_num_relations_preserved_with_inverse_triples(self):
+        """Test that derived factories do not re-double the number of relations."""
+        factory = Nations(create_inverse_triples=True).training
+        real_num_relations = factory.real_num_relations
+        assert factory.num_relations == 2 * real_num_relations
+
+        # drop a "middle" entity, so that condensing actually has to re-assign IDs
+        mapped_triples = factory.mapped_triples
+        mapped_triples = mapped_triples[(mapped_triples[:, 0] != 5) & (mapped_triples[:, 2] != 5)]
+        derived = [
+            factory.to_core_triples_factory(),
+            factory.clone_and_exchange_triples(mapped_triples=mapped_triples).condense(),
+        ]
+        for derived_factory in derived:
+            with self.subTest(derived=derived_factory.__class__.__name__):
+                assert derived_factory.create_inverse_triples
+                assert derived_factory.real_num_relations == real_num_relations
+                assert derived_factory.num_relations == 2 * real_num_relations
+
+    def test_fully_inductive_split_with_inverse_triples(self):
+        """Test that a fully inductive split does not re-double the number of relations."""
+        factory = Nations(create_inverse_triples=True).training
+        real_num_relations = factory.real_num_relations
+        training, inference, *evaluation = factory.split_fully_inductive(random_state=0)
+        for part in (training, inference):
+            assert part.create_inverse_triples
+            assert part.real_num_relations == real_num_relations
+            assert part.num_relations == 2 * real_num_relations
+        # inverse triples for evaluation are handled by the evaluation code
+        for part in evaluation:
+            assert not part.create_inverse_triples
+            assert part.num_relations == real_num_relations
+
     @needs_packages("wordcloud", "IPython")
     def test_entity_word_cloud(self):
         """Test word cloud generation."""

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import pytest
 import torch
 
+from pykeen.datasets import Nations
 from pykeen.models import ERMLPE, TransE
 from pykeen.models.uncertainty import (
     MissingDropoutError,
@@ -87,3 +88,40 @@ class UncertaintyPredictionTestCase(cases.PredictBaseTestCase):
             expected_shape=(self.batch_size, self.factory.num_entities),
             hr_batch=self.batch[:, :2],
         )
+
+
+@pytest.mark.parametrize(
+    ("uncertain_method", "deterministic_method_name", "batch_name", "columns"),
+    [
+        (predict_hrt_uncertain, "predict_hrt", "hrt_batch", [0, 1, 2]),
+        (predict_h_uncertain, "predict_h", "rt_batch", [1, 2]),
+        (predict_t_uncertain, "predict_t", "hr_batch", [0, 1]),
+    ],
+)
+def test_uncertain_prediction_with_inverse_triples(
+    uncertain_method: Callable[..., UncertainPrediction],
+    deterministic_method_name: str,
+    batch_name: str,
+    columns: list[int],
+):
+    """Test that uncertainty prediction maps relation IDs like its deterministic counterpart."""
+    dataset = Nations(create_inverse_triples=True)
+    # disable dropout, so that the MC samples coincide with the deterministic prediction
+    model = ERMLPE(
+        triples_factory=dataset.training,
+        embedding_dim=2,
+        hidden_dim=3,
+        random_seed=0,
+        input_dropout=0.0,
+        hidden_dropout=0.0,
+    )
+    batch = dataset.testing.mapped_triples[:3, columns]
+    copy = batch.clone()
+
+    result = uncertain_method(model=model, num_samples=3, **{batch_name: batch})
+
+    # the input batch must not be modified
+    assert torch.equal(batch, copy)
+    # ... and the same relations have to be scored as by the deterministic method
+    expected = getattr(model, deterministic_method_name)(batch.clone())
+    assert torch.allclose(result.score, expected, atol=1.0e-06)


### PR DESCRIPTION
A review of the inverse-relation machinery turned up a group of bugs sharing one cause, plus the cleanups and documentation needed to keep it from recurring.

## The underlying problem

Two relation ID spaces are in play, and neither was named anywhere:

- **real** IDs `0 … R-1` — used by `mapped_triples`, `relation_to_id`, and all stored triples, *even when* `create_inverse_triples=True`. Inverses are materialized only when training instances are built.
- **internal** IDs `0 … 2R-1` — used by models: forward = `2r`, inverse = `2r+1`.

Every bug here is a place where the two got mixed, or where the doubled `num_relations` reached a parameter meaning "real". `RelationInverter` now names both spaces and translates between them, and the affected call sites route through it.

## What was broken

- **Silently wrong relation counts** — `apply_condenser` and `to_core_triples_factory` re-doubled `num_relations`, so `split_fully_inductive` handed models twice the relations they need, and `TriplesFactory.condense()` raised outright.
- **Silently wrong relations scored** — relation prediction and the uncertainty helpers skipped the real→internal mapping. `predict_target` also returned internal IDs under real labels, so `relation_id` disagreed with `relation_label` and with the factory's own triples.
- **Caller tensors mutated** — the three public `score_*_inverse` methods incremented the relation column of the batch handed to them, so calling one on `mapped_triples` corrupted the factory.
- **Inconsistent factories** — `create_inverse_triples` was a plain attribute although `num_relations` derives from it, so assigning it afterwards led to `IndexError` during training. `EADataset` and the inductive-LP tutorial both assign it that way.
- **`get_inverse_relation_id`** returned the *forward* ID of the given relation rather than its inverse (correct only for relation 0). `get_inverse_id` was also not an involution, so applying it twice silently landed on the next relation.

Plus cleanups: dead evaluator code that would `AttributeError` if reached, a no-op NodePiece filter written against a contradictory ID scheme, a halved percentage in a log message, and a `:class:` reference to `OModel`, a class that has not existed since #257.

## Behavioural changes

- **`predict_r` now reports real relation IDs.** It previously returned `2R` columns in internal order, so indexing the result by an ID from the triples factory picked the wrong column — callers needed `[::2]`. It now also computes only the forward scores rather than discarding half of them.
- **`create_inverse_triples` is a property.** Reads are unaffected; writes do the bookkeeping callers previously had to do by hand.
- **`RelationInverter`** gained `to_internal` / `to_real`, and its batch methods are named after the ID space they consume: `map` → `to_internal_batch`, and the in-place `invert_` → the non-mutating `invert_internal_batch`. External subclasses need updating.

## Notes for review

- Each fix carries a regression test that fails without it.
- `pykeen.inverse` gets a reference page, and `Model` a note stating that `score_*` takes internal IDs while `predict_*` takes real ones — the distinction behind all of the above.
- Relation-prediction *evaluation* still raises `NotImplementedError` (#728), so the ranking path is untouched.
- The binary cache format is unchanged, and caches round-trip across this PR in both directions (verified for `to_directory_binary`, `to_path_binary`, and the `get_dataset` digest cache). `__setstate__` covers factories *pickled* by an older version. One caveat: a cache written by an older version from one of the affected paths — `split_fully_inductive` or `condense()` with inverse triples — stored an already-doubled count as its real relation count, and needs regenerating with `force=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
