### PR TITLE
♻️📦 Compose datasets from sources and loaders instead of inheriting

### DIFF
--- a/docs/source/howto/extending_datasets.rst
+++ b/docs/source/howto/extending_datasets.rst
@@ -37,6 +37,57 @@ that the default separator for Pandas is a comma, but PyKEEN overrides it to be 
 it if you want a comma. Since there's a random aspect to this process, you can also set the seed used for splitting with
 the ``random_state`` keyword argument.
 
+Combining a Source and a Loader
+-------------------------------
+
+The classes above are thin wrappers around two independent pieces, which you can also combine yourself when none of them
+fits:
+
+- A :class:`~pykeen.datasets.sources.Source` says *where the files are*. It resolves a set of logical file keys, e.g.,
+  ``"training"``, to local paths, downloading and unpacking as needed: :class:`~pykeen.datasets.sources.LocalSource`,
+  :class:`~pykeen.datasets.sources.RemoteSource` for one URL per split, and
+  :class:`~pykeen.datasets.sources.TarArchiveSource` / :class:`~pykeen.datasets.sources.ZipArchiveSource` for members of
+  a single archive.
+- A :class:`~pykeen.datasets.loaders.Loader` says *how the files become triples factories*.
+  :class:`~pykeen.datasets.loaders.PreSplitLoader` reads one file per split and makes the evaluation splits share the
+  training split's entity and relation index, while :class:`~pykeen.datasets.loaders.AutoSplitLoader` reads a single
+  table and splits it.
+
+For example, a dataset whose three splits sit next to each other inside a zip archive, using a comma as the separator,
+can be written as:
+
+.. code-block:: python
+
+    import pathlib
+
+    from pykeen.datasets.base import PathDataset
+    from pykeen.datasets.sources import ZipArchiveSource
+
+
+    class MyDataset(PathDataset):
+        """A dataset packed into a zip archive."""
+
+        def __init__(self, cache_root: str | None = None, **kwargs):
+            """Initialize the dataset."""
+            self.cache_root = self._help_cache(cache_root)
+            super().__init__(
+                source=ZipArchiveSource(
+                    members={
+                        "training": pathlib.PurePath("my-data", "train.csv"),
+                        "testing": pathlib.PurePath("my-data", "test.csv"),
+                        "validation": pathlib.PurePath("my-data", "valid.csv"),
+                    },
+                    cache_root=self.cache_root,
+                    url="https://example.org/my-data.zip",
+                ),
+                load_triples_kwargs={"delimiter": ","},
+                **kwargs,
+            )
+
+If neither loader fits, e.g., because the data does not come from files at all, subclass
+:class:`~pykeen.datasets.base.LazyDataset` and override its ``_load_factories`` method to return the mapping of splits
+to triples factories directly. It is called at most once, on first access.
+
 Updating the ``setup.cfg``
 --------------------------
 

--- a/docs/source/reference/datasets.rst
+++ b/docs/source/reference/datasets.rst
@@ -6,6 +6,10 @@ Datasets
 
 .. automodapi:: pykeen.datasets.base
 
+.. automodapi:: pykeen.datasets.sources
+
+.. automodapi:: pykeen.datasets.loaders
+
 .. automodapi:: pykeen.datasets.analysis
 
 Inductive Datasets

--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -1,26 +1,30 @@
-"""Utility classes for constructing datasets."""
+"""Utility classes for constructing datasets.
+
+The dataset classes here are deliberately thin: a dataset is a *named set of triples factories*, and everything
+below that is composed rather than inherited. Where the files come from is a
+:class:`~pykeen.datasets.sources.Source`, and how they become factories is a
+:class:`~pykeen.datasets.loaders.Loader`. The classes in this module pick a source and a loader and give the
+combination a name, so that a new dataset is usually a five-line subclass.
+"""
 
 from __future__ import annotations
 
 import logging
 import pathlib
-import tarfile
-import zipfile
-from abc import abstractmethod
-from collections.abc import Collection, Iterable, Mapping, Sequence
-from io import BytesIO
+from collections.abc import Callable, Collection, Iterable, Mapping, MutableMapping, Sequence
 from typing import Any, ClassVar, cast
 
 import click
 import docdata
 import pandas as pd
-import requests
 import torch
 from more_click import verbose_option
 from pystow.utils import download, name_from_url
 from tabulate import tabulate
 from typing_extensions import Self
 
+from .loaders import DEFAULT_RATIOS, AutoSplitLoader, Loader, PreSplitLoader, SplitSpec
+from .sources import ArchiveSource, LocalSource, RemoteSource, Source, TarArchiveSource, ZipArchiveSource
 from ..constants import PYKEEN_DATASETS
 from ..triples import CoreTriplesFactory, TriplesFactory
 from ..triples.deteriorate import deteriorate
@@ -31,6 +35,8 @@ from ..utils import ExtraReprMixin, format_relative_comparison, normalize_path, 
 
 __all__ = [
     # Base classes
+    "DatasetBase",
+    "LazyFactoryMixin",
     "Dataset",
     "EagerDataset",
     "LazyDataset",
@@ -138,69 +144,90 @@ def _restrict_mapping(id_to_label: Mapping[int, str], kept_ids: Sequence[int]) -
     return {id_to_label[old_id]: new_id for new_id, old_id in enumerate(kept_ids)}
 
 
-class Dataset(ExtraReprMixin):
-    """The base dataset class."""
+def _reorder_columns(df: pd.DataFrame, usecols: Sequence[Any] | None) -> pd.DataFrame:
+    """Restore the column order requested via ``usecols``, which :func:`pandas.read_csv` does not honor."""
+    if usecols is None:
+        return df
+    logger.info("reordering columns: %s", usecols)
+    return df[usecols]
 
-    #: A factory wrapping the training triples
-    training: CoreTriplesFactory
-    #: A factory wrapping the testing triples, that share indices with the training triples
-    testing: CoreTriplesFactory
-    #: A factory wrapping the validation triples, that share indices with the training triples
-    validation: CoreTriplesFactory | None
-    #: the dataset's name
+
+class DatasetBase(ExtraReprMixin):
+    """A named collection of triples factories.
+
+    This holds everything which does not depend on *which* splits a dataset has, so that the transductive
+    :class:`Dataset` and the fully inductive :class:`~pykeen.datasets.inductive.base.InductiveDataset` can share
+    it instead of maintaining two copies. Subclasses declare their splits via ``_factory_keys``.
+    """
+
+    #: The names of the factories, in canonical order. The first one is the *reference* factory, whose entity and
+    #: relation index the dataset reports and from which examples are shown in the summary.
+    _factory_keys: ClassVar[tuple[str, ...]]
+
+    #: Additional metadata to store inside the dataset
     metadata: Mapping[str, Any] | None = None
 
     metadata_file_name: ClassVar[str] = "metadata.pth"
     triples_factory_cls: ClassVar[type[CoreTriplesFactory]] = TriplesFactory
 
-    def __eq__(self, __o: object) -> bool:  # noqa: D105
-        return (
-            isinstance(__o, Dataset)
-            and (self.training == __o.training)
-            and (self.testing == __o.testing)
-            and ((self.validation is None and __o.validation is None) or (self.validation == __o.validation))
-            and (self.create_inverse_triples == __o.create_inverse_triples)
-        )
+    @classmethod
+    def _eager_cls(cls) -> type[DatasetBase]:
+        """Return the eager counterpart of this dataset family, used when loading from a binary directory."""
+        raise NotImplementedError
 
     @property
     def factory_dict(self) -> Mapping[str, CoreTriplesFactory]:
-        """Return a dictionary of the three factories."""
-        rv = {
-            "training": self.training,
-            "testing": self.testing,
-        }
-        if self.validation:
-            rv["validation"] = self.validation
-        return rv
+        """Return a dictionary of the factories, keyed by split name, omitting absent optional splits.
+
+        .. note::
+
+            Lazy datasets override this to *be* the primitive, cf. :class:`LazyFactoryMixin`, and expose the
+            individual splits as properties reading from it.
+        """
+        return {key: factory for key in self._factory_keys if (factory := getattr(self, key, None)) is not None}
+
+    @property
+    def _reference_factory(self) -> CoreTriplesFactory:
+        return self.factory_dict[self._factory_keys[0]]
+
+    def __eq__(self, other: object) -> bool:  # noqa: D105
+        return (
+            isinstance(other, DatasetBase)
+            and self._factory_keys == other._factory_keys
+            and self.factory_dict == other.factory_dict
+            and self.create_inverse_triples == other.create_inverse_triples
+        )
 
     @property
     def entity_to_id(self):  # noqa: D401
         """The mapping of entity labels to IDs."""
-        if not isinstance(self.training, TriplesFactory):
-            raise AttributeError(f"{self.training.__class__} does not have labeling information.")
-        return self.training.entity_to_id
+        factory = self._reference_factory
+        if not isinstance(factory, TriplesFactory):
+            raise AttributeError(f"{factory.__class__} does not have labeling information.")
+        return factory.entity_to_id
 
     @property
     def relation_to_id(self):  # noqa: D401
         """The mapping of relation labels to IDs."""
-        if not isinstance(self.training, TriplesFactory):
-            raise AttributeError(f"{self.training.__class__} does not have labeling information.")
-        return self.training.relation_to_id
+        factory = self._reference_factory
+        if not isinstance(factory, TriplesFactory):
+            raise AttributeError(f"{factory.__class__} does not have labeling information.")
+        return factory.relation_to_id
 
     @property
     def num_entities(self):  # noqa: D401
         """The number of entities."""
-        return self.training.num_entities
+        return self._reference_factory.num_entities
 
     @property
     def num_relations(self):  # noqa: D401
         """The number of relations."""
-        return self.training.num_relations
+        return self._reference_factory.num_relations
 
     @property
     def create_inverse_triples(self):
-        """Return whether inverse triples are created *for the training factory*."""
-        return self.training.create_inverse_triples
+        """Return whether inverse triples are created *for the reference factory*."""
+        return self._reference_factory.create_inverse_triples
 
     @classmethod
     def docdata(cls, *parts: str) -> Any:
@@ -211,21 +238,19 @@ class Dataset(ExtraReprMixin):
         return rv
 
     @staticmethod
-    def triples_sort_key(cls: type[Dataset]) -> int:
+    def triples_sort_key(cls: type[DatasetBase]) -> int:
         """Get the number of triples for sorting."""
         return cls.docdata("statistics", "triples")
 
     @classmethod
-    def triples_pair_sort_key(cls, pair: tuple[str, type[Dataset]]) -> int:
+    def triples_pair_sort_key(cls, pair: tuple[str, type[DatasetBase]]) -> int:
         """Get the number of triples for sorting in an iterator context."""
         return cls.triples_sort_key(pair[1])
 
     def _summary_rows(self):
         return [
-            (label, triples_factory.num_entities, triples_factory.num_relations, triples_factory.num_triples)
-            for label, triples_factory in zip(
-                ("Training", "Testing", "Validation"), (self.training, self.testing, self.validation), strict=False
-            )
+            (key.replace("_", " ").title(), factory.num_entities, factory.num_relations, factory.num_triples)
+            for key, factory in self.factory_dict.items()
         ]
 
     def summary_str(self, title: str | None = None, show_examples: int | None = 5, end="\n") -> str:
@@ -236,10 +261,11 @@ class Dataset(ExtraReprMixin):
         t = tabulate(rows, headers=["Name", "Entities", "Relations", "Triples"])
         rv = f"{title or self.__class__.__name__} (create_inverse_triples={self.create_inverse_triples})\n{t}"
         if show_examples:
-            if not isinstance(self.training, TriplesFactory):
-                raise AttributeError(f"{self.training.__class__} does not have labeling information.")
+            factory = self._reference_factory
+            if not isinstance(factory, TriplesFactory):
+                raise AttributeError(f"{factory.__class__} does not have labeling information.")
             examples = tabulate(
-                self.training.label_triples(self.training.mapped_triples[:show_examples]),
+                factory.label_triples(factory.mapped_triples[:show_examples]),
                 headers=["Head", "Relation", "tail"],
             )
             rv += "\n" + examples
@@ -256,22 +282,23 @@ class Dataset(ExtraReprMixin):
         yield f"create_inverse_triples={self.create_inverse_triples}"
 
     @classmethod
-    def from_path(cls, path: str | pathlib.Path, ratios: list[float] | None = None) -> Dataset:
-        """Create a dataset from a single triples factory by splitting it in 3."""
-        tf = TriplesFactory.from_path(path=path)
-        return cls.from_tf(tf=tf, ratios=ratios)
+    def from_directory_binary(cls, path: str | pathlib.Path) -> DatasetBase:
+        """Load a dataset from a directory.
 
-    @classmethod
-    def from_directory_binary(cls, path: str | pathlib.Path) -> Dataset:
-        """Load a dataset from a directory."""
+        :param path: The directory a dataset was stored to with
+            :meth:`~pykeen.datasets.base.DatasetBase.to_directory_binary`.
+
+        :returns: An eager dataset with the stored factories.
+
+        :raises NotADirectoryError: If the path does not refer to a directory.
+        """
         path = pathlib.Path(path)
 
         if not path.is_dir():
             raise NotADirectoryError(path)
 
         tfs = {}
-        # TODO: Make a constant for the names
-        for key in ("training", "testing", "validation"):
+        for key in cls._factory_keys:
             tf_path = path.joinpath(key)
             if tf_path.is_dir():
                 tfs[key] = cls.triples_factory_cls.from_path_binary(path=tf_path)
@@ -280,7 +307,8 @@ class Dataset(ExtraReprMixin):
         metadata_path = path.joinpath(cls.metadata_file_name)
         # TODO: consider restricting metadata to JSON
         metadata = torch.load(metadata_path, weights_only=False) if metadata_path.is_file() else None
-        return EagerDataset(**tfs, metadata=metadata)
+        eager_cls = cast("Callable[..., DatasetBase]", cls._eager_cls())
+        return eager_cls(**tfs, metadata=metadata)
 
     def to_directory_binary(self, path: str | pathlib.Path) -> None:
         """Store a dataset to a path in binary format."""
@@ -292,15 +320,6 @@ class Dataset(ExtraReprMixin):
         metadata = dict(self.metadata or {})
         metadata.setdefault("name", self.get_normalized_name())
         torch.save(metadata, path.joinpath(self.metadata_file_name))
-
-    @staticmethod
-    def from_tf(tf: TriplesFactory, ratios: list[float] | None = None) -> Dataset:
-        """Create a dataset from a single triples factory by splitting it in 3."""
-        training, testing, validation = cast(
-            tuple[TriplesFactory, TriplesFactory, TriplesFactory],
-            tf.split(ratios or [0.8, 0.1, 0.1]),
-        )
-        return EagerDataset(training=training, testing=testing, validation=validation)
 
     @classmethod
     def cli(cls) -> None:
@@ -318,6 +337,121 @@ class Dataset(ExtraReprMixin):
     def get_normalized_name(self) -> str:
         """Get the normalized name of the dataset."""
         return normalize_string((self.metadata or {}).get("name") or self.__class__.__name__)
+
+
+class LazyFactoryMixin:
+    """Lazily materialize a mapping of named triples factories.
+
+    This is the single lazy-loading primitive: subclasses implement ``_load_factories``, which is called at
+    most once, and everything else goes through :attr:`factory_dict`.
+    """
+
+    #: The loaded factories, or ``None`` if they have not been loaded yet
+    _factories: MutableMapping[str, CoreTriplesFactory] | None = None
+    #: The directory in which the cached data is stored
+    cache_root: pathlib.Path
+    #: The loader used to materialize the factories
+    loader: Loader | None = None
+
+    def __init__(
+        self,
+        loader: Loader | None = None,
+        *,
+        eager: bool = False,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize the lazy dataset.
+
+        :param loader: The loader producing the triples factories. May be ``None`` for subclasses which override
+            ``_load_factories`` instead.
+        :param eager: Whether to load the data immediately rather than on first access.
+        :param metadata: Additional metadata to store inside the dataset.
+        """
+        self.loader = loader
+        self.metadata = metadata
+        if eager:
+            _ = self.factory_dict
+
+    def _load_factories(self) -> Mapping[str, CoreTriplesFactory]:
+        """Load all triples factories of this dataset.
+
+        :returns: A mapping from split name to factory, omitting splits the dataset does not provide.
+
+        :raises NotImplementedError: If there is neither a loader nor an override of this method.
+        """
+        if self.loader is None:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} has neither a loader nor an implementation of `_load_factories`."
+            )
+        return self.loader.load()
+
+    @property
+    def _loaded(self) -> bool:
+        """Whether the factories have already been loaded."""
+        return self._factories is not None
+
+    @property
+    def factory_dict(self) -> Mapping[str, CoreTriplesFactory]:
+        """Return the triples factories, loading them on first access."""
+        if self._factories is None:
+            self._factories = dict(self._load_factories())
+        return self._factories
+
+    def _help_cache(self, cache_root: None | str | pathlib.Path) -> pathlib.Path:
+        """Get the appropriate cache root directory.
+
+        :param cache_root: If none is passed, defaults to a subfolder of the PyKEEN home directory defined in
+            :data:`~pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
+            :class:`~pykeen.datasets.base.Dataset`.
+
+        :returns: A path object for the calculated cache root directory
+        """
+        cache_root = normalize_path(cache_root, *self._cache_sub_directories(), mkdir=True, default=PYKEEN_DATASETS)
+        logger.debug("using cache root at %s", cache_root.as_uri())
+        return cache_root
+
+    def _cache_sub_directories(self) -> Iterable[str]:
+        """Iterate over appropriate cache sub-directory."""
+        # TODO: use class-resolver normalize?
+        yield self.__class__.__name__.lower()
+
+
+class Dataset(DatasetBase):
+    """The base dataset class."""
+
+    _factory_keys: ClassVar[tuple[str, ...]] = ("training", "testing", "validation")
+
+    #: A factory wrapping the training triples
+    training: CoreTriplesFactory
+    #: A factory wrapping the testing triples, that share indices with the training triples
+    testing: CoreTriplesFactory
+    #: A factory wrapping the validation triples, that share indices with the training triples
+    validation: CoreTriplesFactory | None
+
+    # docstr-coverage: inherited
+    @classmethod
+    def _eager_cls(cls) -> type[DatasetBase]:  # noqa: D102
+        return EagerDataset
+
+    # docstr-coverage: inherited
+    @classmethod
+    def from_directory_binary(cls, path: str | pathlib.Path) -> Dataset:  # noqa: D102
+        return cast(Dataset, super().from_directory_binary(path))
+
+    @classmethod
+    def from_path(cls, path: str | pathlib.Path, ratios: list[float] | None = None) -> Dataset:
+        """Create a dataset from a single triples factory by splitting it in 3."""
+        tf = TriplesFactory.from_path(path=path)
+        return cls.from_tf(tf=tf, ratios=ratios)
+
+    @staticmethod
+    def from_tf(tf: TriplesFactory, ratios: list[float] | None = None) -> Dataset:
+        """Create a dataset from a single triples factory by splitting it in 3."""
+        training, testing, validation = cast(
+            tuple[TriplesFactory, TriplesFactory, TriplesFactory],
+            tf.split(ratios or [0.8, 0.1, 0.1]),
+        )
+        return EagerDataset(training=training, testing=testing, validation=validation)
 
     def remix(self, random_state: TorchRandomHint = None, **kwargs) -> Dataset:
         """Remix a dataset using :func:`~pykeen.triples.remix.remix`."""
@@ -520,87 +654,49 @@ class EagerDataset(Dataset):
         yield f"metadata={self.metadata}"
 
 
-class LazyDataset(Dataset):
-    """A dataset whose training, testing, and optional validation factories are lazily loaded."""
+class LazyDataset(LazyFactoryMixin, Dataset):
+    """A dataset whose training, testing, and optional validation factories are lazily loaded.
 
-    #: The actual instance of the training factory, which is exposed to the user through `training`
-    _training: TriplesFactory | None = None
-    #: The actual instance of the testing factory, which is exposed to the user through `testing`
-    _testing: TriplesFactory | None = None
-    #: The actual instance of the validation factory, which is exposed to the user through `validation`
-    _validation: TriplesFactory | None = None
-    #: The directory in which the cached data is stored
-    cache_root: pathlib.Path
+    The loading itself is delegated to a :class:`~pykeen.datasets.loaders.Loader`. Subclasses which cannot express
+    their loading that way may instead override ``_load_factories``.
+    """
 
     @property
     def training(self) -> TriplesFactory:  # type: ignore[override]  # noqa: D401
         """The training triples factory."""
-        if not self._loaded:
-            self._load()
-        assert self._training is not None
-        return self._training
+        return cast(TriplesFactory, self.factory_dict["training"])
 
     @property
     def testing(self) -> TriplesFactory:  # type: ignore[override]  # noqa: D401
         """The testing triples factory that shares indices with the training triples factory."""
-        if not self._loaded:
-            self._load()
-        assert self._testing is not None
-        return self._testing
+        return cast(TriplesFactory, self.factory_dict["testing"])
 
     @property
     def validation(self) -> TriplesFactory | None:  # type: ignore[override]  # noqa: D401
         """The validation triples factory that shares indices with the training triples factory."""
-        if not self._loaded:
-            self._load()
-        if not self._loaded_validation:
-            self._load_validation()
-        return self._validation
-
-    @property
-    def _loaded(self) -> bool:
-        return self._training is not None and self._testing is not None
-
-    @property
-    def _loaded_validation(self):
-        return self._validation is not None
-
-    def _load(self) -> None:
-        raise NotImplementedError
-
-    def _load_validation(self) -> None:
-        raise NotImplementedError
-
-    def _help_cache(self, cache_root: None | str | pathlib.Path) -> pathlib.Path:
-        """Get the appropriate cache root directory.
-
-        :param cache_root: If none is passed, defaults to a subfolder of the PyKEEN home directory defined in
-            :data:`~pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
-            :class:`~pykeen.datasets.base.Dataset`.
-
-        :returns: A path object for the calculated cache root directory
-        """
-        cache_root = normalize_path(cache_root, *self._cache_sub_directories(), mkdir=True, default=PYKEEN_DATASETS)
-        logger.debug("using cache root at %s", cache_root.as_uri())
-        return cache_root
-
-    def _cache_sub_directories(self) -> Iterable[str]:
-        """Iterate over appropriate cache sub-directory."""
-        # TODO: use class-resolver normalize?
-        yield self.__class__.__name__.lower()
+        return cast("TriplesFactory | None", self.factory_dict.get("validation"))
 
 
 class PathDataset(LazyDataset):
-    """Contains a lazy reference to a training, testing, and validation dataset."""
+    """A dataset which stores each split in its own file.
+
+    The files may be local, downloaded one-by-one, or extracted from an archive; that choice is made by the
+    :class:`~pykeen.datasets.sources.Source` and does not affect the loading itself.
+    """
 
     def __init__(
         self,
-        training_path: str | pathlib.Path,
-        testing_path: str | pathlib.Path,
-        validation_path: None | str | pathlib.Path,
+        training_path: None | str | pathlib.Path = None,
+        testing_path: None | str | pathlib.Path = None,
+        validation_path: None | str | pathlib.Path = None,
         eager: bool = False,
         create_inverse_triples: bool = False,
         load_triples_kwargs: Mapping[str, Any] | None = None,
+        *,
+        source: Source | None = None,
+        plan: Mapping[str, SplitSpec] | None = None,
+        factory_cls: type[TriplesFactory] | None = None,
+        factory_kwargs: Mapping[str, Any] | None = None,
     ) -> None:
         """Initialize the dataset.
 
@@ -611,48 +707,47 @@ class PathDataset(LazyDataset):
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         :param load_triples_kwargs: Arguments to pass through to :func:`~pykeen.triples.TriplesFactory.from_path`
             and ultimately through to :func:`~pykeen.triples.utils.load_triples`.
+        :param source: An explicit source for the files, as an alternative to the three path parameters. Used by
+            the subclasses which download their files.
+        :param plan: The index-sharing plan, cf. ``pykeen.datasets.loaders.TRANSDUCTIVE_PLAN``, which is also the
+            default.
+        :param factory_cls: The triples factory class. Defaults to ``triples_factory_cls``.
+        :param factory_kwargs: Additional keyword-based arguments for every triples factory.
+
+        :raises ValueError: If neither a source nor a training and testing path are given.
         """
-        self.training_path = pathlib.Path(training_path)
-        self.testing_path = pathlib.Path(testing_path)
-        self.validation_path = pathlib.Path(validation_path) if validation_path else None
-
-        self._create_inverse_triples = create_inverse_triples
+        if source is None:
+            if training_path is None or testing_path is None:
+                raise ValueError("must give either a source, or both a training_path and a testing_path")
+            source = LocalSource(training=training_path, testing=testing_path, validation=validation_path)
+        self.source = source
         self.load_triples_kwargs = load_triples_kwargs
-
-        if eager:
-            self._load()
-            self._load_validation()
-
-    def _load(self) -> None:
-        self._training = TriplesFactory.from_path(
-            path=self.training_path,
-            create_inverse_triples=self._create_inverse_triples,
-            load_triples_kwargs=self.load_triples_kwargs,
-        )
-        self._testing = TriplesFactory.from_path(
-            path=self.testing_path,
-            entity_to_id=self._training.entity_to_id,  # share entity index with training
-            relation_to_id=self._training.relation_to_id,  # share relation index with training
-            # do not explicitly create inverse triples for testing; this is handled by the evaluation code
-            create_inverse_triples=False,
-            load_triples_kwargs=self.load_triples_kwargs,
+        super().__init__(
+            loader=PreSplitLoader(
+                source=source,
+                plan=plan,
+                create_inverse_triples=create_inverse_triples,
+                factory_cls=factory_cls or cast(type[TriplesFactory], self.triples_factory_cls),
+                load_triples_kwargs=load_triples_kwargs,
+                factory_kwargs=factory_kwargs,
+            ),
+            eager=eager,
         )
 
-    def _load_validation(self) -> None:
-        # don't call this function by itself. assumes called through the `validation`
-        # property and the _training factory has already been loaded
-        assert self._training is not None
-        if self.validation_path is None:
-            self._validation = None
-        else:
-            self._validation = TriplesFactory.from_path(
-                path=self.validation_path,
-                entity_to_id=self._training.entity_to_id,  # share entity index with training
-                relation_to_id=self._training.relation_to_id,  # share relation index with training
-                # do not explicitly create inverse triples for testing; this is handled by the evaluation code
-                create_inverse_triples=False,
-                load_triples_kwargs=self.load_triples_kwargs,
-            )
+    @property
+    def training_path(self) -> pathlib.Path | None:
+        """The path of the training triples file."""
+        return self.source.expected_paths().get("training")
+
+    @property
+    def testing_path(self) -> pathlib.Path | None:
+        """The path of the testing triples file."""
+        return self.source.expected_paths().get("testing")
+
+    @property
+    def validation_path(self) -> pathlib.Path | None:
+        """The path of the validation triples file, if any."""
+        return self.source.expected_paths().get("validation")
 
     def __repr__(self) -> str:  # noqa: D105
         return (
@@ -697,25 +792,13 @@ class UnpackedRemoteDataset(PathDataset):
         self.testing_url = testing_url
         self.validation_url = validation_url
 
-        training_path = self.cache_root.joinpath(name_from_url(self.training_url))
-        testing_path = self.cache_root.joinpath(name_from_url(self.testing_url))
-        validation_path = self.cache_root.joinpath(name_from_url(self.validation_url))
-
-        download_kwargs = {} if download_kwargs is None else dict(download_kwargs)
-        download_kwargs.setdefault("backend", "urllib")
-
-        for url, path in [
-            (self.training_url, training_path),
-            (self.testing_url, testing_path),
-            (self.validation_url, validation_path),
-        ]:
-            if force or not path.is_file():
-                download(url, path, **download_kwargs)
-
         super().__init__(
-            training_path=training_path,
-            testing_path=testing_path,
-            validation_path=validation_path,
+            source=RemoteSource(
+                urls={"training": training_url, "testing": testing_url, "validation": validation_url},
+                cache_root=self.cache_root,
+                force=force,
+                download_kwargs=download_kwargs,
+            ),
             eager=eager,
             create_inverse_triples=create_inverse_triples,
             load_triples_kwargs=load_triples_kwargs,
@@ -723,7 +806,12 @@ class UnpackedRemoteDataset(PathDataset):
 
 
 class RemoteDataset(PathDataset):
-    """Contains a lazy reference to a remote dataset that is loaded if needed."""
+    """A dataset whose splits are packed into a single remote archive."""
+
+    #: The source class used to unpack the archive
+    source_cls: ClassVar[type[ArchiveSource]]
+    #: Whether the whole archive is unpacked, rather than only the requested members
+    extract_all: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -757,57 +845,42 @@ class RemoteDataset(PathDataset):
         self._relative_testing_path = pathlib.PurePath(relative_testing_path)
         self._relative_validation_path = pathlib.PurePath(relative_validation_path)
 
-        training_path, testing_path, validation_path = self._get_paths()
+        # note: requests cannot handle file:// URLs, which are convenient for testing
+        download_kwargs: Mapping[str, Any] = (
+            {"backend": "requests", "timeout": self.timeout}
+            if url.startswith(("http://", "https://"))
+            else {"backend": "urllib"}
+        )
         super().__init__(
-            training_path=training_path,
-            testing_path=testing_path,
-            validation_path=validation_path,
+            source=self.source_cls(
+                members={
+                    "training": self._relative_training_path,
+                    "testing": self._relative_testing_path,
+                    "validation": self._relative_validation_path,
+                },
+                cache_root=self.cache_root,
+                url=url,
+                extract_all=self.extract_all,
+                download_kwargs=download_kwargs,
+            ),
             eager=eager,
             create_inverse_triples=create_inverse_triples,
         )
 
     def _get_paths(self) -> tuple[pathlib.Path, pathlib.Path, pathlib.Path]:  # noqa: D401
         """Get the paths where the extracted files can be found."""
-        return (
-            self.cache_root.joinpath(self._relative_training_path),
-            self.cache_root.joinpath(self._relative_testing_path),
-            self.cache_root.joinpath(self._relative_validation_path),
-        )
-
-    @abstractmethod
-    def _extract(self, archive_file: BytesIO) -> None:
-        """Extract from the downloaded file."""
-        raise NotImplementedError
-
-    def _get_bytes(self) -> BytesIO:
-        logger.info(f"Requesting dataset from {self.url}")
-        res = requests.get(url=self.url, timeout=self.timeout)
-        res.raise_for_status()
-        return BytesIO(res.content)
-
-    # docstr-coverage: inherited
-    def _load(self) -> None:  # noqa: D102
-        all_unpacked = all(path.is_file() for path in self._get_paths())
-
-        if not all_unpacked:
-            archive_file = self._get_bytes()
-            self._extract(archive_file=archive_file)
-            logger.info(f"Extracted to {self.cache_root}.")
-
-        super()._load()
+        paths = self.source.expected_paths()
+        return paths["training"], paths["testing"], paths["validation"]
 
 
 class TarFileRemoteDataset(RemoteDataset):
     """A remote dataset stored as a tar file."""
 
-    # docstr-coverage: inherited
-    def _extract(self, archive_file: BytesIO) -> None:  # noqa: D102
-        with tarfile.open(fileobj=archive_file) as tf:
-            tf.extractall(path=self.cache_root)  # noqa:S202
+    source_cls = TarArchiveSource
 
 
-class PackedZipRemoteDataset(LazyDataset):
-    """Contains a lazy reference to a remote dataset that is loaded if needed."""
+class PackedZipRemoteDataset(PathDataset):
+    """A dataset whose splits are packed into a single remote zip archive."""
 
     head_column: int = 0
     relation_column: int = 1
@@ -839,197 +912,51 @@ class PackedZipRemoteDataset(LazyDataset):
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
 
-        :raises ValueError: if there's no URL specified and there is no data already at the calculated path
+        :raises ValueError: if the ``header`` class attribute was overridden, or if there's no URL specified and
+            there is no data already at the calculated path
         """
+        if self.header is not None:
+            raise ValueError(f"{self.__class__.__name__} does not support a header row; got header={self.header}")
+
         self.cache_root = self._help_cache(cache_root)
-
-        if name:
-            self.name = name
-        elif url:
-            self.name = name_from_url(url)
-        else:
-            raise ValueError("must give at least one of name or URL")
-        self.path = self.cache_root.joinpath(self.name)
-        logger.debug("file path at %s", self.path)
-
-        self.url = url
-        if not self.path.is_file() and not self.url:
-            raise ValueError(f"must specify url to download from since path does not exist: {self.path}")
 
         self.relative_training_path = pathlib.PurePath(relative_training_path)
         self.relative_testing_path = pathlib.PurePath(relative_testing_path)
         self.relative_validation_path = pathlib.PurePath(relative_validation_path)
-        self._create_inverse_triples = create_inverse_triples
-        if eager:
-            self._load()
-            self._load_validation()
 
-    # docstr-coverage: inherited
-    def _load(self) -> None:  # noqa: D102
-        self._training = self._load_helper(self.relative_training_path)
-        self._testing = self._load_helper(
-            self.relative_testing_path,
-            entity_to_id=self._training.entity_to_id,
-            relation_to_id=self._training.relation_to_id,
-        )
-
-    def _load_validation(self) -> None:
-        assert self._training is not None
-        self._validation = self._load_helper(
-            self.relative_validation_path,
-            entity_to_id=self._training.entity_to_id,
-            relation_to_id=self._training.relation_to_id,
-        )
-
-    def _load_helper(
-        self,
-        relative_path: pathlib.PurePath,
-        entity_to_id: Mapping[str, Any] | None = None,
-        relation_to_id: Mapping[str, Any] | None = None,
-    ) -> TriplesFactory:
-        if not self.path.is_file():
-            if self.url is None:
-                raise ValueError("url should be set")
-            logger.info("downloading data from %s to %s", self.url, self.path)
-            download(url=self.url, path=self.path)
-
-        # relative paths within zip file's always follow Posix path, even on Windows
-        with zipfile.ZipFile(file=self.path) as zf, zf.open(relative_path.as_posix()) as file:
-            logger.debug("loading %s", relative_path)
-            df = pd.read_csv(
-                file,
-                usecols=[self.head_column, self.relation_column, self.tail_column],
-                header=self.header,
-                sep=self.sep,
-            )
-            return TriplesFactory.from_labeled_triples(
-                triples=df.values,
-                create_inverse_triples=self._create_inverse_triples,
-                metadata={"path": relative_path},
-                entity_to_id=entity_to_id,
-                relation_to_id=relation_to_id,
-            )
-
-
-class CompressedSingleDataset(LazyDataset):
-    """Loads a dataset that's a single file inside an archive."""
-
-    ratios = (0.8, 0.1, 0.1)
-
-    def __init__(
-        self,
-        url: str,
-        relative_path: str | pathlib.PurePosixPath,
-        name: str | None = None,
-        cache_root: str | None = None,
-        eager: bool = False,
-        create_inverse_triples: bool = False,
-        delimiter: str | None = None,
-        random_state: TorchRandomHint = None,
-        read_csv_kwargs: dict[str, Any] | None = None,
-    ):
-        """Initialize dataset.
-
-        :param url: The url where to download the dataset from
-        :param relative_path: The path inside the archive to the contained dataset.
-        :param name: The name of the file. If not given, tries to get the name from the end of the URL
-        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
-            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
-            ``~/.pykeen``.
-        :param create_inverse_triples: Should inverse triples be created? Defaults to false.
-        :param eager: Should the data be loaded eagerly? Defaults to false.
-        :param random_state: An optional random state to make the training/testing/validation split reproducible.
-        :param delimiter: The delimiter for the contained dataset.
-        :param read_csv_kwargs: Keyword arguments to pass through to :func:`pandas.read_csv`.
-        """
-        self.cache_root = self._help_cache(cache_root)
-
-        self.name = name or name_from_url(url)
-        self.random_state = random_state
-        self.delimiter = delimiter or "\t"
         self.url = url
-        self._create_inverse_triples = create_inverse_triples
-        self._relative_path = pathlib.PurePosixPath(relative_path)
-        self.read_csv_kwargs = read_csv_kwargs or {}
-        self.read_csv_kwargs.setdefault("sep", self.delimiter)
+        self.name = name or (name_from_url(url) if url else None)
+        if self.name is None:
+            raise ValueError("must give at least one of name or URL")
+        self.path = self.cache_root.joinpath(self.name)
+        logger.debug("file path at %s", self.path)
+        if not self.path.is_file() and not self.url:
+            raise ValueError(f"must specify url to download from since path does not exist: {self.path}")
 
-        if eager:
-            self._load()
-
-    def _get_path(self) -> pathlib.Path:
-        return self.cache_root.joinpath(self.name)
-
-    def _load(self) -> None:
-        df = self._get_df()
-        tf_path = self._get_path()
-        tf = TriplesFactory.from_labeled_triples(
-            triples=df.values,
-            create_inverse_triples=self._create_inverse_triples,
-            metadata={"path": tf_path},
-        )
-        self._training, self._testing, self._validation = cast(
-            tuple[TriplesFactory, TriplesFactory, TriplesFactory],
-            tf.split(
-                ratios=self.ratios,
-                random_state=self.random_state,
+        super().__init__(
+            source=ZipArchiveSource(
+                members={
+                    "training": self.relative_training_path,
+                    "testing": self.relative_testing_path,
+                    "validation": self.relative_validation_path,
+                },
+                cache_root=self.cache_root,
+                url=url,
+                name=self.name,
             ),
+            eager=eager,
+            create_inverse_triples=create_inverse_triples,
+            load_triples_kwargs={
+                "delimiter": self.sep,
+                "column_remapping": (self.head_column, self.relation_column, self.tail_column),
+            },
         )
-        logger.info("[%s] done splitting data from %s", self.__class__.__name__, tf_path)
-
-    def _get_df(self) -> pd.DataFrame:
-        raise NotImplementedError
-
-    def _load_validation(self) -> None:
-        pass  # already loaded by _load()
-
-
-class ZipSingleDataset(CompressedSingleDataset):
-    """Loads a dataset that's a single file inside a zip archive."""
-
-    def _get_df(self) -> pd.DataFrame:
-        path = self._get_path()
-        if not path.is_file():
-            download(self.url, self._get_path())  # noqa:S310
-
-        with zipfile.ZipFile(path) as zip_file, zip_file.open(self._relative_path.as_posix()) as file:
-            return pd.read_csv(file, sep=self.delimiter)
-
-
-class TarFileSingleDataset(CompressedSingleDataset):
-    """Loads a dataset that's a single file inside a tar.gz archive."""
-
-    def _get_df(self) -> pd.DataFrame:
-        if not self._get_path().is_file():
-            download(self.url, self._get_path())  # noqa:S310
-
-        _actual_path = self.cache_root.joinpath(self._relative_path)
-        if not _actual_path.is_file():
-            logger.error(
-                "[%s] untaring from %s (%s) to %s",
-                self.__class__.__name__,
-                self._get_path(),
-                self._relative_path,
-                _actual_path,
-            )
-            with tarfile.open(self._get_path()) as tar_file:
-                # tarfile does not like pathlib
-                tar_file.extract(str(self._relative_path), self.cache_root)
-
-        df = pd.read_csv(_actual_path, **self.read_csv_kwargs)
-
-        usecols = self.read_csv_kwargs.get("usecols")
-        if usecols is not None:
-            logger.info("reordering columns: %s", usecols)
-            df = df[usecols]
-
-        return df
 
 
 class TabbedDataset(LazyDataset):
-    """This class is for when you've got a single TSV of edges and want them to get auto-split."""
+    """A dataset which ships a single table of triples and gets split automatically."""
 
-    ratios: ClassVar[Sequence[float]] = (0.8, 0.1, 0.1)
-    _triples_factory: TriplesFactory | None
+    ratios: ClassVar[Sequence[float]] = DEFAULT_RATIOS
 
     def __init__(
         self,
@@ -1037,6 +964,8 @@ class TabbedDataset(LazyDataset):
         eager: bool = False,
         create_inverse_triples: bool = False,
         random_state: TorchRandomHint = None,
+        *,
+        factory_cls: type[TriplesFactory] | None = None,
     ):
         """Initialize dataset.
 
@@ -1046,50 +975,35 @@ class TabbedDataset(LazyDataset):
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         :param random_state: An optional random state to make the training/testing/validation split reproducible.
+        :param factory_cls: The triples factory class. Defaults to ``triples_factory_cls``.
         """
         self.cache_root = self._help_cache(cache_root)
-
-        self._triples_factory = None
         self.random_state = random_state
-        self._create_inverse_triples = create_inverse_triples
-        self._training = None
-        self._testing = None
-        self._validation = None
 
-        if eager:
-            self._load()
+        super().__init__(
+            loader=AutoSplitLoader(
+                # note: bound methods, so that subclasses overriding the hooks still take effect
+                read_df=self._get_df,
+                get_path=self._get_path,
+                ratios=self.ratios,
+                random_state=random_state,
+                create_inverse_triples=create_inverse_triples,
+                factory_cls=factory_cls or cast(type[TriplesFactory], self.triples_factory_cls),
+            ),
+            eager=eager,
+        )
 
     def _get_path(self) -> pathlib.Path | None:
         """Get the path of the data if there's a single file."""
+        return None
 
     def _get_df(self) -> pd.DataFrame:
+        """Get the dataframe of labeled triples."""
         raise NotImplementedError
-
-    def _load(self) -> None:
-        df = self._get_df()
-        path = self._get_path()
-        tf = TriplesFactory.from_labeled_triples(
-            triples=df.values,
-            create_inverse_triples=self._create_inverse_triples,
-            metadata={"path": path} if path else None,
-        )
-        self._training, self._testing, self._validation = cast(
-            tuple[TriplesFactory, TriplesFactory, TriplesFactory],
-            tf.split(
-                ratios=self.ratios,
-                random_state=self.random_state,
-            ),
-        )
-
-    def _load_validation(self) -> None:
-        pass  # already loaded by _load()
 
 
 class SingleTabbedDataset(TabbedDataset):
-    """This class is for when you've got a single TSV of edges and want them to get auto-split."""
-
-    ratios: ClassVar[Sequence[float]] = (0.8, 0.1, 0.1)
-    _triples_factory: TriplesFactory | None
+    """A dataset which ships a single, downloaded table of triples and gets split automatically."""
 
     #: URL to the data to download
     url: str
@@ -1117,41 +1031,113 @@ class SingleTabbedDataset(TabbedDataset):
         :param random_state: An optional random state to make the training/testing/validation split reproducible.
         :param download_kwargs: Keyword arguments to pass through to :func:`pystow.utils.download`.
         :param read_csv_kwargs: Keyword arguments to pass through to :func:`pandas.read_csv`.
-
-        :raises ValueError: if there's no URL specified and there is no data already at the calculated path
         """
+        # note: these are set before `super().__init__`, since an eager load reads them
+        self.url = url
+        self.name = name or name_from_url(url)
+        self.download_kwargs = download_kwargs or {}
+        self.read_csv_kwargs = dict(read_csv_kwargs or {})
+        self.read_csv_kwargs.setdefault("sep", "\t")
+
         super().__init__(
             cache_root=cache_root,
             create_inverse_triples=create_inverse_triples,
             random_state=random_state,
-            eager=False,  # because it gets hooked below
+            eager=eager,
         )
 
-        self.name = name or name_from_url(url)
-
-        self.download_kwargs = download_kwargs or {}
-        self.read_csv_kwargs = read_csv_kwargs or {}
-        self.read_csv_kwargs.setdefault("sep", "\t")
-
-        self.url = url
-        if not self._get_path().is_file() and not self.url:
-            raise ValueError(f"must specify url to download from since path does not exist: {self._get_path()}")
-
-        if eager:
-            self._load()
-
-    def _get_path(self) -> pathlib.Path:
+    # docstr-coverage: inherited
+    def _get_path(self) -> pathlib.Path:  # noqa: D102
         return self.cache_root.joinpath(self.name)
 
-    def _get_df(self) -> pd.DataFrame:
-        if not self._get_path().is_file():
-            logger.info("downloading data from %s to %s", self.url, self._get_path())
-            download(url=self.url, path=self._get_path(), **self.download_kwargs)  # noqa:S310
-        df = pd.read_csv(self._get_path(), **self.read_csv_kwargs)
+    # docstr-coverage: inherited
+    def _get_df(self) -> pd.DataFrame:  # noqa: D102
+        path = self._get_path()
+        if not path.is_file():
+            if not self.url:
+                raise ValueError(f"must specify url to download from since path does not exist: {path}")
+            logger.info("downloading data from %s to %s", self.url, path)
+            download(url=self.url, path=path, **self.download_kwargs)  # noqa:S310
+        df = pd.read_csv(path, **self.read_csv_kwargs)
+        return _reorder_columns(df, self.read_csv_kwargs.get("usecols"))
 
-        usecols = self.read_csv_kwargs.get("usecols")
-        if usecols is not None:
-            logger.info("reordering columns: %s", usecols)
-            df = df[usecols]
 
-        return df
+class CompressedSingleDataset(TabbedDataset):
+    """A dataset which ships a single table of triples inside an archive and gets split automatically."""
+
+    #: The source class used to unpack the archive
+    source_cls: ClassVar[type[ArchiveSource]]
+
+    def __init__(
+        self,
+        url: str,
+        relative_path: str | pathlib.PurePosixPath,
+        name: str | None = None,
+        cache_root: str | None = None,
+        eager: bool = False,
+        create_inverse_triples: bool = False,
+        delimiter: str | None = None,
+        random_state: TorchRandomHint = None,
+        read_csv_kwargs: dict[str, Any] | None = None,
+    ):
+        """Initialize dataset.
+
+        :param url: The url where to download the dataset from
+        :param relative_path: The path inside the archive to the contained dataset.
+        :param name: The name of the file. If not given, tries to get the name from the end of the URL
+        :param cache_root: An optional directory to store the extracted files. Is none is given, the default PyKEEN
+            directory is used. This is defined either by the environment variable ``PYKEEN_HOME`` or defaults to
+            ``~/.pykeen``.
+        :param create_inverse_triples: Should inverse triples be created? Defaults to false.
+        :param eager: Should the data be loaded eagerly? Defaults to false.
+        :param random_state: An optional random state to make the training/testing/validation split reproducible.
+        :param delimiter: The delimiter for the contained dataset.
+        :param read_csv_kwargs: Keyword arguments to pass through to :func:`pandas.read_csv`.
+        """
+        # note: these are set before `super().__init__`, since an eager load reads them
+        self.url = url
+        self.name = name or name_from_url(url)
+        self.delimiter = delimiter or "\t"
+        self._relative_path = pathlib.PurePosixPath(relative_path)
+        self.read_csv_kwargs = read_csv_kwargs or {}
+        self.read_csv_kwargs.setdefault("sep", self.delimiter)
+
+        super().__init__(
+            cache_root=cache_root,
+            create_inverse_triples=create_inverse_triples,
+            random_state=random_state,
+            eager=eager,
+        )
+
+    # docstr-coverage: inherited
+    def _get_path(self) -> pathlib.Path:  # noqa: D102
+        """Get the path of the *archive*, which is also used as the dataset's metadata path."""
+        return self.cache_root.joinpath(self.name)
+
+    def _get_source(self) -> ArchiveSource:
+        """Build the source for the single member of the archive."""
+        return self.source_cls(
+            members={"data": self._relative_path},
+            cache_root=self.cache_root,
+            url=self.url,
+            # note: goes through `_get_path` so that subclasses can point at a pre-existing archive
+            archive_path=self._get_path(),
+        )
+
+    # docstr-coverage: inherited
+    def _get_df(self) -> pd.DataFrame:  # noqa: D102
+        path = self._get_source().paths()["data"]
+        df = pd.read_csv(path, **self.read_csv_kwargs)
+        return _reorder_columns(df, self.read_csv_kwargs.get("usecols"))
+
+
+class ZipSingleDataset(CompressedSingleDataset):
+    """Loads a dataset that's a single file inside a zip archive."""
+
+    source_cls = ZipArchiveSource
+
+
+class TarFileSingleDataset(CompressedSingleDataset):
+    """Loads a dataset that's a single file inside a tar.gz archive."""
+
+    source_cls = TarArchiveSource

--- a/src/pykeen/datasets/ckg.py
+++ b/src/pykeen/datasets/ckg.py
@@ -56,16 +56,21 @@ class CKG(TabbedDataset):
             random_state=random_state,
             **kwargs,
         )
-        self.preloaded_path = self.cache_root.joinpath("preloaded.tsv.gz")
+
+    @property
+    def preloaded_path(self) -> Path:
+        """The path of the concatenated dataframe, which is cached across runs."""
+        return self.cache_root.joinpath("preloaded.tsv.gz")
 
     def _get_path(self) -> Path | None:
         return self.preloaded_path
 
     def _get_df(self) -> pd.DataFrame:
-        if self.preloaded_path.exists():
-            return pd.read_csv(self.preloaded_path, sep="\t", dtype=str)
+        path = self.preloaded_path
+        if path.exists():
+            return pd.read_csv(path, sep="\t", dtype=str)
         df = pd.concat(self._iterate_dataframes())
-        df.to_csv(self.preloaded_path, sep="\t", index=False)
+        df.to_csv(path, sep="\t", index=False)
         return df
 
     def _iterate_dataframes(self) -> Iterable[pd.DataFrame]:

--- a/src/pykeen/datasets/inductive/base.py
+++ b/src/pykeen/datasets/inductive/base.py
@@ -1,4 +1,9 @@
-"""Utility classes for constructing inductive datasets."""
+"""Utility classes for constructing inductive datasets.
+
+These share the machinery of :mod:`pykeen.datasets.base` -- lazy loading, caching, summaries, and binary
+(de)serialization -- and only differ in *which* splits they have and in how those splits share their entity and
+relation indices, cf. ``pykeen.datasets.loaders.INDUCTIVE_PLAN``.
+"""
 
 from __future__ import annotations
 
@@ -6,14 +11,12 @@ import logging
 import pathlib
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar, cast
 
-from pystow.utils import download, name_from_url
-from tabulate import tabulate
-
-from ...constants import PYKEEN_DATASETS
+from ..base import DatasetBase, LazyFactoryMixin
+from ..loaders import INDUCTIVE_PLAN, PreSplitLoader
+from ..sources import LocalSource, RemoteSource
 from ...triples import CoreTriplesFactory, TriplesFactory
-from ...utils import normalize_path
 
 __all__ = [
     # Base class
@@ -28,8 +31,15 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-class InductiveDataset:
+class InductiveDataset(DatasetBase):
     """Contains transductive train and inductive inference/validation/test datasets."""
+
+    _factory_keys: ClassVar[tuple[str, ...]] = (
+        "transductive_training",
+        "inductive_inference",
+        "inductive_testing",
+        "inductive_validation",
+    )
 
     #: A factory wrapping the training triples
     transductive_training: CoreTriplesFactory
@@ -40,44 +50,15 @@ class InductiveDataset:
     inductive_testing: CoreTriplesFactory
     #: A factory wrapping the validation triples, that share indices with the INDUCTIVE INFERENCE triples
     inductive_validation: CoreTriplesFactory | None = None
-    #: All datasets should take care of inverse triple creation
+    #: All datasets should take care of inverse triple creation.
+    #: note: unlike :class:`~pykeen.datasets.base.Dataset`, this is a plain attribute rather than being derived
+    #: from the reference factory, since it is declared up-front by the dataset rather than by its files.
     create_inverse_triples: bool = True
 
-    def _summary_rows(self):
-        return [
-            (label, triples_factory.num_entities, triples_factory.num_relations, triples_factory.num_triples)
-            for label, triples_factory in zip(
-                ("Transductive Training", "Inductive Inference", "Inductive Testing", "Inductive Validation"),
-                (
-                    self.transductive_training,
-                    self.inductive_inference,
-                    self.inductive_testing,
-                    self.inductive_validation,
-                ),
-                strict=False,
-            )
-        ]
-
-    def summary_str(self, title: str | None = None, show_examples: int | None = 5, end="\n") -> str:
-        """Make a summary string of all of the factories."""
-        rows = self._summary_rows()
-        n_triples = sum(count for *_, count in rows)
-        rows.append(("Total", "-", "-", n_triples))
-        t = tabulate(rows, headers=["Name", "Entities", "Relations", "Triples"])
-        rv = f"{title or self.__class__.__name__} (create_inverse_triples={self.create_inverse_triples})\n{t}"
-        if show_examples:
-            if not isinstance(self.transductive_training, TriplesFactory):
-                raise AttributeError(f"{self.transductive_training.__class__} does not have labeling information.")
-            examples = tabulate(
-                self.transductive_training.label_triples(self.transductive_training.mapped_triples[:show_examples]),
-                headers=["Head", "Relation", "tail"],
-            )
-            rv += "\n" + examples
-        return rv + end
-
-    def summarize(self, title: str | None = None, show_examples: int | None = 5, file=None) -> None:
-        """Print a summary of the dataset."""
-        print(self.summary_str(title=title, show_examples=show_examples), file=file)  # noqa:T201
+    # docstr-coverage: inherited
+    @classmethod
+    def _eager_cls(cls) -> type[DatasetBase]:  # noqa: D102
+        return EagerInductiveDataset
 
     def __str__(self) -> str:  # noqa: D105
         return (
@@ -95,98 +76,31 @@ class EagerInductiveDataset(InductiveDataset):
     inductive_testing: CoreTriplesFactory
     inductive_validation: CoreTriplesFactory | None = None
     create_inverse_triples: bool = True
+    metadata: Mapping[str, Any] | None = None
 
 
-class LazyInductiveDataset(InductiveDataset):
+class LazyInductiveDataset(LazyFactoryMixin, InductiveDataset):
     """An inductive dataset that has lazy loading."""
-
-    #: The actual instance of the training factory, which is exposed to the user through `transductive_training`
-    _transductive_training: TriplesFactory | None = None
-    #: The actual instance of the inductive inference factory,
-    #: which is exposed to the user through `inductive_inference`
-    _inductive_inference: TriplesFactory | None = None
-    #: The actual instance of the testing factory, which is exposed to the user through `inductive_testing`
-    _inductive_testing: TriplesFactory | None = None
-    #: The actual instance of the validation factory, which is exposed to the user through `inductive_validation`
-    _inductive_validation: TriplesFactory | None = None
-    #: The directory in which the cached data is stored
-    cache_root: pathlib.Path
 
     @property
     def transductive_training(self) -> TriplesFactory:  # type: ignore[override]  # noqa: D401
         """The training triples factory."""
-        if not self._loaded:
-            self._load()
-        assert self._transductive_training is not None
-        return self._transductive_training
+        return cast(TriplesFactory, self.factory_dict["transductive_training"])
 
     @property
     def inductive_inference(self) -> TriplesFactory:  # type: ignore[override]  # noqa: D401
         """The inductive inference triples factory. MIGHT or MIGHT NOT share indices with the transductive train."""
-        if not self._loaded:
-            self._load()
-        assert self._inductive_inference is not None
-        return self._inductive_inference
+        return cast(TriplesFactory, self.factory_dict["inductive_inference"])
 
     @property
     def inductive_testing(self) -> TriplesFactory:  # type: ignore[override]  # noqa: D401
         """The testing triples factory that share indices with the INDUCTIVE INFERENCE triples factory."""
-        if not self._loaded:
-            self._load()
-        assert self._inductive_testing is not None
-        return self._inductive_testing
+        return cast(TriplesFactory, self.factory_dict["inductive_testing"])
 
     @property
     def inductive_validation(self) -> TriplesFactory | None:  # type: ignore[override]  # noqa: D401
         """The validation triples factory that shares indices with the INDUCTIVE INFERENCE triples factory."""
-        if not self._loaded:
-            self._load()
-        assert self._inductive_validation is not None
-        return self._inductive_validation
-
-    @property
-    def _loaded(self) -> bool:
-        return self._transductive_training is not None and self._inductive_inference is not None
-
-    def _load(self) -> None:
-        raise NotImplementedError
-
-    def _load_validation(self) -> None:
-        raise NotImplementedError
-
-    def _help_cache(
-        self,
-        cache_root: None | str | pathlib.Path,
-        version: str | None = None,
-        sep_train_inference: bool = False,
-    ) -> pathlib.Path:
-        """Get the appropriate cache root directory.
-
-        :param cache_root: If none is passed, defaults to a subfolder of the PyKEEN home directory defined in
-            :data:`~pykeen.constants.PYKEEN_HOME`. The subfolder is named based on the class inheriting from
-            :class:`~pykeen.datasets.base.Dataset`.
-        :param version: accepts a string "v1" to "v4" to select among Teru et al inductive datasets
-        :param sep_train_inference: a flag to store training and inference splits in different folders
-
-        :returns: A path object for the calculated cache root directory
-        """
-        cache_root = normalize_path(
-            cache_root, *self._cache_sub_directories(version=version), default=PYKEEN_DATASETS, mkdir=True
-        )
-        if sep_train_inference:
-            # generate subfolders 'training' and  'inference'
-            for name in ("training", "inference"):
-                cache_root.joinpath(name).mkdir(parents=True, exist_ok=True)
-        logger.debug("using cache root at %s", cache_root.as_uri())
-        return cache_root
-
-    def _cache_sub_directories(self, version: str | None) -> Iterable[str]:
-        """Iterate over appropriate cache sub-directory."""
-        # TODO: use class-resolver normalize?
-        yield self.__class__.__name__.lower()
-        # add v1 / v2 / v3 / v4 for inductive splits if available
-        if version:
-            yield version
+        return cast("TriplesFactory | None", self.factory_dict.get("inductive_validation"))
 
 
 class DisjointInductivePathDataset(LazyInductiveDataset):
@@ -198,13 +112,15 @@ class DisjointInductivePathDataset(LazyInductiveDataset):
 
     def __init__(
         self,
-        transductive_training_path: str | pathlib.Path,
-        inductive_inference_path: str | pathlib.Path,
-        inductive_testing_path: str | pathlib.Path,
-        inductive_validation_path: str | str | pathlib.Path,
+        transductive_training_path: None | str | pathlib.Path = None,
+        inductive_inference_path: None | str | pathlib.Path = None,
+        inductive_testing_path: None | str | pathlib.Path = None,
+        inductive_validation_path: None | str | pathlib.Path = None,
         eager: bool = False,
         create_inverse_triples: bool = False,
         load_triples_kwargs: Mapping[str, Any] | None = None,
+        *,
+        source: LocalSource | RemoteSource | None = None,
     ) -> None:
         """Initialize the dataset.
 
@@ -216,52 +132,57 @@ class DisjointInductivePathDataset(LazyInductiveDataset):
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         :param load_triples_kwargs: Arguments to pass through to :func:`~pykeen.triples.TriplesFactory.from_path`
             and ultimately through to :func:`~pykeen.triples.utils.load_triples`.
-        """
-        self.transductive_training_path = pathlib.Path(transductive_training_path)
-        self.inductive_inference_path = pathlib.Path(inductive_inference_path)
-        self.inductive_testing_path = pathlib.Path(inductive_testing_path)
-        self.inductive_validation_path = pathlib.Path(inductive_validation_path)
+        :param source: An explicit source for the files, as an alternative to the four path parameters. Used by
+            the subclasses which download their files.
 
+        :raises ValueError: If neither a source nor the four paths are given.
+        """
+        if source is None:
+            paths = {
+                "transductive_training": transductive_training_path,
+                "inductive_inference": inductive_inference_path,
+                "inductive_testing": inductive_testing_path,
+                "inductive_validation": inductive_validation_path,
+            }
+            if any(path is None for path in paths.values()):
+                raise ValueError("must give either a source, or all four paths")
+            source = LocalSource(**paths)
+        self.source = source
         self.create_inverse_triples = create_inverse_triples
         self.load_triples_kwargs = load_triples_kwargs
-
-        if eager:
-            self._load()
-
-    def _load(self) -> None:
-        self._transductive_training = TriplesFactory.from_path(
-            path=self.transductive_training_path,
-            create_inverse_triples=self.create_inverse_triples,
-            load_triples_kwargs=self.load_triples_kwargs,
+        super().__init__(
+            loader=PreSplitLoader(
+                source=source,
+                plan=INDUCTIVE_PLAN,
+                create_inverse_triples=create_inverse_triples,
+                factory_cls=cast(type[TriplesFactory], self.triples_factory_cls),
+                load_triples_kwargs=load_triples_kwargs,
+            ),
+            eager=eager,
         )
 
-        # important: inductive_inference shares the same RELATIONS with the transductive training graph
-        self._inductive_inference = TriplesFactory.from_path(
-            path=self.inductive_inference_path,
-            create_inverse_triples=self.create_inverse_triples,
-            relation_to_id=self._transductive_training.relation_to_id,
-            load_triples_kwargs=self.load_triples_kwargs,
-        )
+    def _path(self, key: str) -> pathlib.Path | None:
+        return self.source.expected_paths().get(key)
 
-        # inductive validation shares both ENTITIES and RELATIONS with the inductive inference graph
-        self._inductive_validation = TriplesFactory.from_path(
-            path=self.inductive_validation_path,
-            entity_to_id=self._inductive_inference.entity_to_id,  # shares entity index with inductive inference
-            relation_to_id=self._inductive_inference.relation_to_id,  # shares relation index with inductive inference
-            # do not explicitly create inverse triples for testing; this is handled by the evaluation code
-            create_inverse_triples=False,
-            load_triples_kwargs=self.load_triples_kwargs,
-        )
+    @property
+    def transductive_training_path(self) -> pathlib.Path | None:
+        """The path of the transductive training triples file."""
+        return self._path("transductive_training")
 
-        # inductive testing shares both ENTITIES and RELATIONS with the inductive inference graph
-        self._inductive_testing = TriplesFactory.from_path(
-            path=self.inductive_testing_path,
-            entity_to_id=self._inductive_inference.entity_to_id,  # share entity index with inductive inference
-            relation_to_id=self._inductive_inference.relation_to_id,  # share relation index with inductive inference
-            # do not explicitly create inverse triples for testing; this is handled by the evaluation code
-            create_inverse_triples=False,
-            load_triples_kwargs=self.load_triples_kwargs,
-        )
+    @property
+    def inductive_inference_path(self) -> pathlib.Path | None:
+        """The path of the inductive inference triples file."""
+        return self._path("inductive_inference")
+
+    @property
+    def inductive_testing_path(self) -> pathlib.Path | None:
+        """The path of the inductive testing triples file."""
+        return self._path("inductive_testing")
+
+    @property
+    def inductive_validation_path(self) -> pathlib.Path | None:
+        """The path of the inductive validation triples file."""
+        return self._path("inductive_validation")
 
     def __repr__(self) -> str:  # noqa: D105
         return (
@@ -306,36 +227,41 @@ class UnpackedRemoteDisjointInductiveDataset(DisjointInductivePathDataset):
         :param download_kwargs: Keyword arguments to pass to :func:`pystow.utils.download`
         :param version: accepts a string "v1" to "v4" to select among Teru et al inductive datasets
         """
-        self.cache_root = self._help_cache(cache_root, version, sep_train_inference=True)
+        self.version = version
+        self.cache_root = self._help_cache(cache_root)
 
         self.transductive_training_url = transductive_training_url
         self.inductive_inference_url = inductive_inference_url
         self.inductive_testing_url = inductive_testing_url
         self.inductive_validation_url = inductive_validation_url
 
-        transductive_training_path = self.cache_root.joinpath("training", name_from_url(self.transductive_training_url))
-        inductive_inference_path = self.cache_root.joinpath("inference", name_from_url(self.inductive_inference_url))
-        inductive_testing_path = self.cache_root.joinpath("inference", name_from_url(self.inductive_testing_url))
-        inductive_validation_path = self.cache_root.joinpath("inference", name_from_url(self.inductive_validation_url))
-
-        download_kwargs = {} if download_kwargs is None else dict(download_kwargs)
-        download_kwargs.setdefault("backend", "urllib")
-
-        for url, path in [
-            (self.transductive_training_url, transductive_training_path),
-            (self.inductive_inference_url, inductive_inference_path),
-            (self.inductive_testing_url, inductive_testing_path),
-            (self.inductive_validation_url, inductive_validation_path),
-        ]:
-            if force or not path.is_file():
-                download(url, path, **download_kwargs)
-
         super().__init__(
-            transductive_training_path=transductive_training_path,
-            inductive_inference_path=inductive_inference_path,
-            inductive_testing_path=inductive_testing_path,
-            inductive_validation_path=inductive_validation_path,
+            source=RemoteSource(
+                urls={
+                    "transductive_training": transductive_training_url,
+                    "inductive_inference": inductive_inference_url,
+                    "inductive_testing": inductive_testing_url,
+                    "inductive_validation": inductive_validation_url,
+                },
+                cache_root=self.cache_root,
+                # the transductive training graph and the inductive part are kept apart
+                sub_directories={
+                    "transductive_training": "training",
+                    "inductive_inference": "inference",
+                    "inductive_testing": "inference",
+                    "inductive_validation": "inference",
+                },
+                force=force,
+                download_kwargs=download_kwargs,
+            ),
             eager=eager,
             create_inverse_triples=create_inverse_triples,
             load_triples_kwargs=load_triples_kwargs,
         )
+
+    # docstr-coverage: inherited
+    def _cache_sub_directories(self) -> Iterable[str]:  # noqa: D102
+        yield from super()._cache_sub_directories()
+        # add v1 / v2 / v3 / v4 for inductive splits if available
+        if self.version:
+            yield self.version

--- a/src/pykeen/datasets/literal_base.py
+++ b/src/pykeen/datasets/literal_base.py
@@ -1,9 +1,8 @@
 """Base classes for literal datasets."""
 
 import pathlib
-from typing import TextIO
 
-from .base import LazyDataset
+from .base import PathDataset
 from ..triples import TriplesNumericLiteralsFactory
 
 __all__ = [
@@ -11,17 +10,21 @@ __all__ = [
 ]
 
 
-class NumericPathDataset(LazyDataset):
-    """Contains a lazy reference to a training, testing, and validation dataset."""
+class NumericPathDataset(PathDataset):
+    """A path dataset which additionally loads numeric literals for its entities.
+
+    This is an ordinary :class:`~pykeen.datasets.base.PathDataset` with a different triples factory class; the
+    literals file is passed to every factory.
+    """
 
     triples_factory_cls = TriplesNumericLiteralsFactory
 
     def __init__(
         self,
-        training_path: str | pathlib.Path | TextIO,
-        testing_path: str | pathlib.Path | TextIO,
-        validation_path: str | pathlib.Path | TextIO,
-        literals_path: str | pathlib.Path | TextIO,
+        training_path: str | pathlib.Path,
+        testing_path: str | pathlib.Path,
+        validation_path: str | pathlib.Path,
+        literals_path: str | pathlib.Path,
         eager: bool = False,
         create_inverse_triples: bool = False,
     ) -> None:
@@ -34,39 +37,14 @@ class NumericPathDataset(LazyDataset):
         :param eager: Should the data be loaded eagerly? Defaults to false.
         :param create_inverse_triples: Should inverse triples be created? Defaults to false.
         """
-        self.training_path = training_path
-        self.testing_path = testing_path
-        self.validation_path = validation_path
-        self.literals_path = literals_path
-
-        self._create_inverse_triples = create_inverse_triples
-
-        if eager:
-            self._load()
-            self._load_validation()
-
-    def _load(self) -> None:
-        self._training = self.triples_factory_cls.from_path(
-            path=self.training_path,
-            path_to_numeric_triples=self.literals_path,
-            create_inverse_triples=self._create_inverse_triples,
-        )
-        self._testing = self.triples_factory_cls.from_path(
-            path=self.testing_path,
-            path_to_numeric_triples=self.literals_path,
-            entity_to_id=self._training.entity_to_id,  # share entity index with training
-            relation_to_id=self._training.relation_to_id,  # share relation index with training
-        )
-
-    def _load_validation(self) -> None:
-        # don't call this function by itself. assumes called through the `validation`
-        # property and the _training factory has already been loaded
-        assert self._training is not None
-        self._validation = self.triples_factory_cls.from_path(
-            path=self.validation_path,
-            path_to_numeric_triples=self.literals_path,
-            entity_to_id=self._training.entity_to_id,  # share entity index with training
-            relation_to_id=self._training.relation_to_id,  # share relation index with training
+        self.literals_path = pathlib.Path(literals_path)
+        super().__init__(
+            training_path=training_path,
+            testing_path=testing_path,
+            validation_path=validation_path,
+            eager=eager,
+            create_inverse_triples=create_inverse_triples,
+            factory_kwargs={"path_to_numeric_triples": self.literals_path},
         )
 
     def __repr__(self) -> str:  # noqa: D105

--- a/src/pykeen/datasets/loaders.py
+++ b/src/pykeen/datasets/loaders.py
@@ -1,0 +1,208 @@
+"""Loaders turn dataset files into triples factories.
+
+A :class:`Loader` encapsulates *how* the raw data becomes a mapping of named
+:class:`~pykeen.triples.CoreTriplesFactory` instances, and is deliberately ignorant of where the files came from.
+That is the job of a :class:`~pykeen.datasets.sources.Source`.
+
+There are two recipes in use:
+
+1. :class:`PreSplitLoader` for datasets which ship one file per split. The evaluation splits re-use the index of
+   the training split so that the factories are comparable; which split inherits from which is described by a
+   *plan*, cf. ``TRANSDUCTIVE_PLAN`` and ``INDUCTIVE_PLAN``.
+2. :class:`AutoSplitLoader` for datasets which ship a single table of triples which needs to be split.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pandas
+
+from .sources import Source
+from ..triples import CoreTriplesFactory, TriplesFactory
+from ..typing import TorchRandomHint
+
+__all__ = [
+    "SplitSpec",
+    "TRANSDUCTIVE_PLAN",
+    "INDUCTIVE_PLAN",
+    "Loader",
+    "PreSplitLoader",
+    "AutoSplitLoader",
+]
+
+logger = logging.getLogger(__name__)
+
+#: The default ratios used when a single table of triples has to be split.
+DEFAULT_RATIOS: Sequence[float] = (0.8, 0.1, 0.1)
+
+
+@dataclass(frozen=True)
+class SplitSpec:
+    """How to build one factory of a pre-split dataset."""
+
+    #: The key of the factory whose entity index is re-used, or ``None`` to build a fresh one.
+    entity_index_from: str | None = None
+    #: The key of the factory whose relation index is re-used, or ``None`` to build a fresh one.
+    relation_index_from: str | None = None
+    #: Whether the dataset-level ``create_inverse_triples`` applies to this factory. It never applies to
+    #: evaluation factories, since inverse triples are handled by the evaluation code.
+    create_inverse_triples: bool = False
+
+
+#: The plan for an ordinary transductive dataset: the evaluation splits share the training index.
+TRANSDUCTIVE_PLAN: Mapping[str, SplitSpec] = {
+    "training": SplitSpec(create_inverse_triples=True),
+    "testing": SplitSpec(entity_index_from="training", relation_index_from="training"),
+    "validation": SplitSpec(entity_index_from="training", relation_index_from="training"),
+}
+
+#: The plan for a fully inductive dataset: the inference graph shares only the *relations* of the transductive
+#: training graph -- its entities are new -- and the evaluation splits share the inference index.
+INDUCTIVE_PLAN: Mapping[str, SplitSpec] = {
+    "transductive_training": SplitSpec(create_inverse_triples=True),
+    "inductive_inference": SplitSpec(
+        relation_index_from="transductive_training",
+        create_inverse_triples=True,
+    ),
+    "inductive_testing": SplitSpec(
+        entity_index_from="inductive_inference",
+        relation_index_from="inductive_inference",
+    ),
+    "inductive_validation": SplitSpec(
+        entity_index_from="inductive_inference",
+        relation_index_from="inductive_inference",
+    ),
+}
+
+
+class Loader(ABC):
+    """A loader for the triples factories of a dataset."""
+
+    @abstractmethod
+    def load(self) -> Mapping[str, CoreTriplesFactory]:
+        """Load the triples factories.
+
+        :returns: A mapping from split name, e.g., ``"training"``, to the corresponding factory. Splits which the
+            dataset does not provide are omitted.
+        """
+        raise NotImplementedError
+
+    def __repr__(self) -> str:  # noqa: D105
+        return f"{self.__class__.__name__}()"
+
+
+class PreSplitLoader(Loader):
+    """Load a dataset which ships one file per split."""
+
+    def __init__(
+        self,
+        source: Source,
+        *,
+        plan: Mapping[str, SplitSpec] | None = None,
+        create_inverse_triples: bool = False,
+        factory_cls: type[TriplesFactory] = TriplesFactory,
+        load_triples_kwargs: Mapping[str, Any] | None = None,
+        factory_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize the loader.
+
+        :param source: The source providing one path per split.
+        :param plan: The index-sharing plan, cf. ``TRANSDUCTIVE_PLAN``, which is also the default. It must be
+            ordered such that a split occurs after the splits it inherits an index from.
+        :param create_inverse_triples: Whether to create inverse triples. This only applies to the splits whose
+            :attr:`SplitSpec.create_inverse_triples` is set, since inverse triples for evaluation splits are
+            handled by the evaluation code.
+        :param factory_cls: The triples factory class to instantiate.
+        :param load_triples_kwargs: Keyword arguments to pass through to
+            :meth:`~pykeen.triples.TriplesFactory.from_path` and ultimately to
+            :func:`~pykeen.triples.utils.load_triples`.
+        :param factory_kwargs: Additional keyword arguments for every ``from_path`` call, e.g., the path to the
+            numeric literals for :class:`~pykeen.triples.TriplesNumericLiteralsFactory`.
+        """
+        self.source = source
+        self.plan = TRANSDUCTIVE_PLAN if plan is None else plan
+        self.create_inverse_triples = create_inverse_triples
+        self.factory_cls = factory_cls
+        self.load_triples_kwargs = load_triples_kwargs
+        self.factory_kwargs = dict(factory_kwargs or {})
+
+    # docstr-coverage: inherited
+    def load(self) -> Mapping[str, CoreTriplesFactory]:  # noqa: D102
+        paths = self.source.paths()
+        factories: dict[str, TriplesFactory] = {}
+        for key, spec in self.plan.items():
+            path = paths.get(key)
+            if path is None:
+                logger.debug("no path for %s; skipping", key)
+                continue
+            index_kwargs: dict[str, Any] = {}
+            if spec.entity_index_from is not None:
+                index_kwargs["entity_to_id"] = factories[spec.entity_index_from].entity_to_id
+            if spec.relation_index_from is not None:
+                index_kwargs["relation_to_id"] = factories[spec.relation_index_from].relation_to_id
+            if self.load_triples_kwargs is not None:
+                # note: not all factory classes accept this parameter, so only pass it when it is set
+                index_kwargs["load_triples_kwargs"] = self.load_triples_kwargs
+            factories[key] = self.factory_cls.from_path(
+                path=path,
+                create_inverse_triples=self.create_inverse_triples and spec.create_inverse_triples,
+                **self.factory_kwargs,
+                **index_kwargs,
+            )
+        return factories
+
+    def __repr__(self) -> str:  # noqa: D105
+        return f"{self.__class__.__name__}(source={self.source})"
+
+
+class AutoSplitLoader(Loader):
+    """Load a single table of labeled triples and split it into training, testing, and validation."""
+
+    def __init__(
+        self,
+        read_df: Callable[[], pandas.DataFrame],
+        *,
+        get_path: Callable[[], pathlib.Path | None] = lambda: None,
+        ratios: Sequence[float] = DEFAULT_RATIOS,
+        random_state: TorchRandomHint = None,
+        create_inverse_triples: bool = False,
+        factory_cls: type[TriplesFactory] = TriplesFactory,
+    ) -> None:
+        """Initialize the loader.
+
+        :param read_df: A callable returning the table of labeled triples, with the head, relation, and tail in
+            this order in the first three columns.
+        :param get_path: A callable returning the path the data was read from, if any. It is only used as metadata.
+        :param ratios: The training / testing / validation split ratios.
+        :param random_state: The random state, to make the split reproducible.
+        :param create_inverse_triples: Whether to create inverse triples for the training factory.
+        :param factory_cls: The triples factory class to instantiate.
+        """
+        self.read_df = read_df
+        self.get_path = get_path
+        self.ratios = ratios
+        self.random_state = random_state
+        self.create_inverse_triples = create_inverse_triples
+        self.factory_cls = factory_cls
+
+    # docstr-coverage: inherited
+    def load(self) -> Mapping[str, CoreTriplesFactory]:  # noqa: D102
+        df = self.read_df()
+        path = self.get_path()
+        tf = self.factory_cls.from_labeled_triples(
+            triples=df.values,
+            create_inverse_triples=self.create_inverse_triples,
+            metadata={"path": path} if path else None,
+        )
+        training, testing, validation = cast(
+            tuple[TriplesFactory, TriplesFactory, TriplesFactory],
+            tf.split(ratios=self.ratios, random_state=self.random_state),
+        )
+        logger.info("done splitting data from %s", path)
+        return {"training": training, "testing": testing, "validation": validation}

--- a/src/pykeen/datasets/ogb.py
+++ b/src/pykeen/datasets/ogb.py
@@ -9,7 +9,7 @@ import abc
 import logging
 import pathlib
 import typing
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import ClassVar, Generic, Literal, TypedDict, TypeVar, cast, overload
 
 import click
@@ -20,7 +20,7 @@ from docdata import parse_docdata
 from more_click import verbose_option
 
 from .base import LazyDataset
-from ..triples import TriplesFactory
+from ..triples import CoreTriplesFactory, TriplesFactory
 from ..typing import EntityMapping, RelationMapping
 
 if typing.TYPE_CHECKING:
@@ -59,32 +59,25 @@ class OGBLoader(LazyDataset, Generic[PreprocessedTrainDictType, PreprocessedEval
         """
         self.cache_root = self._help_cache(cache_root)
         self._create_inverse_triples = create_inverse_triples
+        super().__init__()
 
     # docstr-coverage: inherited
-    def _load(self) -> None:  # noqa: D102
+    def _load_factories(self) -> Mapping[str, CoreTriplesFactory]:  # noqa: D102
         dataset = self._load_ogb_dataset()
         # label mapping is in dataset.root/mapping
         entity_to_id, relation_to_id = self._load_mappings(pathlib.Path(dataset.root).joinpath("mapping"))
-        self._training = TriplesFactory(
-            mapped_triples=self._compose_mapped_triples(data_dict=self._load_data_dict_for_split(dataset, "train")),
-            entity_to_id=entity_to_id,
-            relation_to_id=relation_to_id,
-            create_inverse_triples=self._create_inverse_triples,
-        )
-        self._testing = TriplesFactory(
-            mapped_triples=self._compose_mapped_triples(data_dict=self._load_data_dict_for_split(dataset, "test")),
-            entity_to_id=entity_to_id,
-            relation_to_id=relation_to_id,
-        )
-
-    # docstr-coverage: inherited
-    def _load_validation(self) -> None:  # noqa: D102
-        dataset = self._load_ogb_dataset()
-        self._validation = TriplesFactory(
-            mapped_triples=self._compose_mapped_triples(data_dict=self._load_data_dict_for_split(dataset, "valid")),
-            entity_to_id=self.entity_to_id,
-            relation_to_id=self.relation_to_id,
-        )
+        return {
+            key: TriplesFactory(
+                mapped_triples=self._compose_mapped_triples(
+                    data_dict=self._load_data_dict_for_split(dataset, cast(SplitKey, which))
+                ),
+                entity_to_id=entity_to_id,
+                relation_to_id=relation_to_id,
+                # note: inverse triples for the evaluation factories are handled by the evaluation code
+                create_inverse_triples=self._create_inverse_triples and key == "training",
+            )
+            for key, which in (("training", "train"), ("testing", "test"), ("validation", "valid"))
+        }
 
     def _load_ogb_dataset(self) -> LinkPropPredDataset:
         """

--- a/src/pykeen/datasets/sources.py
+++ b/src/pykeen/datasets/sources.py
@@ -1,0 +1,265 @@
+"""Sources resolve the files backing a dataset to local paths.
+
+A :class:`Source` encapsulates *where the data lives* -- a local directory, one URL per split, or members of a
+remote archive -- and is deliberately ignorant of how those files are turned into triples factories. Turning files
+into factories is the job of a :class:`~pykeen.datasets.loaders.Loader`.
+
+Keeping the two apart means that a new location, e.g., a new archive format, does not require re-implementing the
+loading logic, and vice versa. The dataset classes in :mod:`pykeen.datasets.base` are thin wrappers which pick a
+source and a loader.
+
+Every source distinguishes the paths it *will* have, cf. :meth:`Source.expected_paths`, from the paths it *does*
+have, cf. :meth:`Source.paths`. Only the latter triggers a download, which keeps lazy datasets lazy while still
+allowing them to report where their data lives.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import tarfile
+import zipfile
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import Any
+
+from pystow.utils import download, name_from_url
+
+__all__ = [
+    "Source",
+    "LocalSource",
+    "RemoteSource",
+    "ArchiveSource",
+    "TarArchiveSource",
+    "ZipArchiveSource",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class Source(ABC):
+    """A resolver from logical file keys to local paths."""
+
+    @abstractmethod
+    def expected_paths(self) -> Mapping[str, pathlib.Path]:
+        """Return where the files are (or will be), *without* downloading anything.
+
+        Keys which the source cannot provide are omitted rather than mapped to ``None``. This is how an absent
+        optional split, e.g., validation, is expressed.
+
+        :returns: A mapping from logical file key, e.g., ``"training"``, to a local path.
+        """
+        raise NotImplementedError
+
+    def materialize(self) -> None:
+        """Ensure the files are present locally, downloading and extracting them if necessary.
+
+        The default does nothing, which is correct for sources whose files are always present.
+        """
+        return
+
+    def paths(self) -> Mapping[str, pathlib.Path]:
+        """Materialize the files and return the mapping from key to local path.
+
+        :returns: A mapping from logical file key, e.g., ``"training"``, to an existing local path.
+        """
+        self.materialize()
+        return self.expected_paths()
+
+    def __repr__(self) -> str:  # noqa: D105
+        return f"{self.__class__.__name__}()"
+
+
+class LocalSource(Source):
+    """Files which are already present on the local file system."""
+
+    def __init__(self, **paths: None | str | pathlib.Path) -> None:
+        """Initialize the source.
+
+        :param paths: The local paths, keyed by their logical file key. ``None`` values are dropped.
+        """
+        self._paths = {key: pathlib.Path(path) for key, path in paths.items() if path is not None}
+
+    # docstr-coverage: inherited
+    def expected_paths(self) -> Mapping[str, pathlib.Path]:  # noqa: D102
+        return self._paths
+
+    def __repr__(self) -> str:  # noqa: D105
+        inner = ", ".join(f'{key}="{path}"' for key, path in self._paths.items())
+        return f"{self.__class__.__name__}({inner})"
+
+
+class RemoteSource(Source):
+    """One separately downloaded file per key."""
+
+    def __init__(
+        self,
+        urls: Mapping[str, str],
+        cache_root: pathlib.Path,
+        *,
+        sub_directories: Mapping[str, str] | None = None,
+        force: bool = False,
+        download_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize the source.
+
+        :param urls: The URL for each logical file key.
+        :param cache_root: The directory into which the files are downloaded.
+        :param sub_directories: An optional sub-directory of ``cache_root`` per key. Used by datasets which keep,
+            e.g., the training and the inference part in separate directories.
+        :param force: Whether to re-download files which are already present.
+        :param download_kwargs: Keyword arguments to pass to :func:`pystow.utils.download`.
+        """
+        self.urls = dict(urls)
+        self.cache_root = cache_root
+        self.sub_directories = dict(sub_directories or {})
+        self.force = force
+        download_kwargs = {} if download_kwargs is None else dict(download_kwargs)
+        download_kwargs.setdefault("backend", "urllib")
+        self.download_kwargs = download_kwargs
+
+    # docstr-coverage: inherited
+    def expected_paths(self) -> Mapping[str, pathlib.Path]:  # noqa: D102
+        result = {}
+        for key, url in self.urls.items():
+            directory = self.cache_root
+            sub_directory = self.sub_directories.get(key)
+            if sub_directory is not None:
+                directory = directory.joinpath(sub_directory)
+            result[key] = directory.joinpath(name_from_url(url))
+        return result
+
+    # docstr-coverage: inherited
+    def materialize(self) -> None:  # noqa: D102
+        for key, path in self.expected_paths().items():
+            if not self.force and path.is_file():
+                continue
+            path.parent.mkdir(parents=True, exist_ok=True)
+            download(url=self.urls[key], path=path, force=self.force, **self.download_kwargs)
+
+    def __repr__(self) -> str:  # noqa: D105
+        inner = ", ".join(f'{key}="{url}"' for key, url in self.urls.items())
+        return f"{self.__class__.__name__}({inner})"
+
+
+class ArchiveSource(Source):
+    """Members of a single archive, which is downloaded once and extracted into the cache root."""
+
+    def __init__(
+        self,
+        members: Mapping[str, str | pathlib.PurePath],
+        cache_root: pathlib.Path,
+        *,
+        url: str | None = None,
+        name: str | None = None,
+        archive_path: pathlib.Path | None = None,
+        extract_all: bool = False,
+        force: bool = False,
+        download_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize the source.
+
+        :param members: The path *inside* the archive for each logical file key. After extraction, the file is
+            found at ``cache_root / member``.
+        :param cache_root: The directory into which the archive is downloaded and extracted.
+        :param url: The URL from which to download the archive. May be ``None`` if the archive is already present.
+        :param name: The file name of the archive. Defaults to the last part of the URL.
+        :param archive_path: An explicit location for the archive, overriding ``cache_root / name``.
+        :param extract_all: Whether to unpack the whole archive rather than only the requested members. This is
+            appropriate for archives which contain little besides the dataset itself, and is more robust against
+            member names which do not exactly match the requested ones.
+        :param force: Whether to re-download and re-extract even if the files are already present.
+        :param download_kwargs: Keyword arguments to pass to :func:`pystow.utils.download`.
+
+        :raises ValueError: If neither a URL, a name, nor an archive path is given.
+        """
+        if name is None and archive_path is None:
+            if url is None:
+                raise ValueError("must give at least one of name, archive_path, or url")
+            name = name_from_url(url)
+        self.members = {key: pathlib.PurePath(member) for key, member in members.items()}
+        self.cache_root = cache_root
+        self.url = url
+        self.name = name
+        self._archive_path = archive_path
+        self.extract_all = extract_all
+        self.force = force
+        download_kwargs = {} if download_kwargs is None else dict(download_kwargs)
+        download_kwargs.setdefault("backend", "urllib")
+        self.download_kwargs = download_kwargs
+
+    @property
+    def archive_path(self) -> pathlib.Path:
+        """The local path of the archive."""
+        if self._archive_path is not None:
+            return self._archive_path
+        assert self.name is not None
+        return self.cache_root.joinpath(self.name)
+
+    def _ensure_archive(self) -> pathlib.Path:
+        """Download the archive if it is not present yet.
+
+        :returns: The local path of the archive.
+
+        :raises ValueError: If the archive is missing and there is no URL to download it from.
+        """
+        path = self.archive_path
+        if path.is_file() and not self.force:
+            return path
+        if self.url is None:
+            raise ValueError(f"must specify url to download from since path does not exist: {path}")
+        logger.info("downloading data from %s to %s", self.url, path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        download(url=self.url, path=path, force=self.force, **self.download_kwargs)
+        return path
+
+    @abstractmethod
+    def _extract(self, archive_path: pathlib.Path) -> None:
+        """Extract the archive into :attr:`cache_root`.
+
+        :param archive_path: The local path of the archive.
+        """
+        raise NotImplementedError
+
+    # docstr-coverage: inherited
+    def expected_paths(self) -> Mapping[str, pathlib.Path]:  # noqa: D102
+        return {key: self.cache_root.joinpath(member) for key, member in self.members.items()}
+
+    # docstr-coverage: inherited
+    def materialize(self) -> None:  # noqa: D102
+        if not self.force and all(path.is_file() for path in self.expected_paths().values()):
+            return
+        self.cache_root.mkdir(parents=True, exist_ok=True)
+        self._extract(archive_path=self._ensure_archive())
+        logger.info("extracted %s to %s", self.archive_path, self.cache_root)
+
+    def __repr__(self) -> str:  # noqa: D105
+        return f'{self.__class__.__name__}(url="{self.url}", archive_path="{self.archive_path}")'
+
+
+class TarArchiveSource(ArchiveSource):
+    """Members of a tar archive."""
+
+    # docstr-coverage: inherited
+    def _extract(self, archive_path: pathlib.Path) -> None:  # noqa: D102
+        with tarfile.open(archive_path) as tar_file:
+            if self.extract_all:
+                tar_file.extractall(path=self.cache_root)  # noqa:S202
+                return
+            for member in self.members.values():
+                # tarfile does not like pathlib
+                tar_file.extract(str(member), self.cache_root)
+
+
+class ZipArchiveSource(ArchiveSource):
+    """Members of a zip archive."""
+
+    # docstr-coverage: inherited
+    def _extract(self, archive_path: pathlib.Path) -> None:  # noqa: D102
+        with zipfile.ZipFile(file=archive_path) as zip_file:
+            if self.extract_all:
+                zip_file.extractall(path=self.cache_root)  # noqa:S202
+                return
+            for member in self.members.values():
+                # paths inside a zip file always use POSIX separators, even on Windows
+                zip_file.extract(member.as_posix(), self.cache_root)

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -149,48 +149,26 @@ class DatasetTestCase(unittest.TestCase):
     #: The instantiated dataset
     dataset: LazyDataset
 
-    #: Should the validation be assumed to have been loaded with train/test?
-    autoloaded_validation: ClassVar[bool] = False
-
     def test_dataset(self):
         """Generic test for datasets."""
         assert isinstance(self.dataset, LazyDataset)
 
         # Not loaded
-        assert self.dataset._training is None
-        assert self.dataset._testing is None
-        assert self.dataset._validation is None
         assert not self.dataset._loaded
-        assert not self.dataset._loaded_validation
 
         # Load
-        self.dataset._load()
+        factory_dict = self.dataset.factory_dict
+        assert self.dataset._loaded
+        assert set(factory_dict) == {"training", "testing", "validation"}
 
         assert isinstance(self.dataset.training, TriplesFactory)
         assert isinstance(self.dataset.testing, TriplesFactory)
-        assert self.dataset._loaded
-
-        if self.autoloaded_validation:
-            assert self.dataset._loaded_validation
-        else:
-            assert not self.dataset._loaded_validation
-            self.dataset._load_validation()
-
         assert isinstance(self.dataset.validation, TriplesFactory)
-
-        assert self.dataset._training is not None
-        assert self.dataset._testing is not None
-        assert self.dataset._validation is not None
-        assert self.dataset._loaded
-        assert self.dataset._loaded_validation
 
         assert self.dataset.num_entities == self.exp_num_entities
         assert self.dataset.num_relations == self.exp_num_relations
 
-        num_triples = sum(
-            triples_factory.num_triples
-            for triples_factory in (self.dataset._training, self.dataset._testing, self.dataset._validation)
-        )
+        num_triples = sum(triples_factory.num_triples for triples_factory in factory_dict.values())
         if self.exp_num_triples_tolerance is None:
             assert self.exp_num_triples == num_triples
         else:

--- a/tests/test_datasets/test_loading.py
+++ b/tests/test_datasets/test_loading.py
@@ -2,8 +2,6 @@
 
 import pathlib
 import unittest
-from io import BytesIO
-from urllib.request import urlopen
 
 from pykeen.datasets import Kinships, Nations, dataset_resolver
 from pykeen.datasets.base import (
@@ -12,6 +10,7 @@ from pykeen.datasets.base import (
     TarFileRemoteDataset,
     TarFileSingleDataset,
     UnpackedRemoteDataset,
+    ZipSingleDataset,
 )
 from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH, NATIONS_VALIDATE_PATH
 from tests import cases, constants
@@ -73,6 +72,21 @@ class MockTarFileSingleDataset(TarFileSingleDataset):
         return constants.RESOURCES.joinpath("nations.tar.gz")
 
 
+class MockZipFileSingleDataset(ZipSingleDataset):
+    """Mock downloading a zip archive with a single file."""
+
+    def __init__(self, cache_root: str):  # noqa:D107
+        super().__init__(
+            url=...,
+            name=...,
+            relative_path="nations/train.txt",
+            cache_root=cache_root,
+        )
+
+    def _get_path(self) -> pathlib.Path:
+        return constants.RESOURCES.joinpath("nations.zip")
+
+
 class MockTarFileRemoteDataset(TarFileRemoteDataset):
     """Mock downloading a tar.gz archive with three pre-stratified files."""
 
@@ -84,9 +98,6 @@ class MockTarFileRemoteDataset(TarFileRemoteDataset):
             relative_training_path=pathlib.PurePath("nations", "train.txt"),
             relative_validation_path=pathlib.PurePath("nations", "valid.txt"),
         )
-
-    def _get_bytes(self) -> BytesIO:
-        return BytesIO(urlopen(self.url).read())  # noqa:S310
 
 
 class MockUnpackedRemoteDataset(UnpackedRemoteDataset):
@@ -125,7 +136,6 @@ class TestSingle(cases.CachedDatasetCase):
     exp_num_relations = 55
     exp_num_triples = 1592  # because only loading training set from Nations
     exp_num_triples_tolerance = 5
-    autoloaded_validation = True
     dataset_cls = MockSingleTabbedDataset
 
 
@@ -141,8 +151,22 @@ class TestTarFileSingle(cases.CachedDatasetCase):
     exp_num_relations = 55
     exp_num_triples = 1592  # because only loading training set from Nations
     exp_num_triples_tolerance = 5
-    autoloaded_validation = True
     dataset_cls = MockTarFileSingleDataset
+
+
+class TestZipFileSingle(cases.CachedDatasetCase):
+    """Test the base classes.
+
+    .. note::
+
+        This uses the nations training dataset
+    """
+
+    exp_num_entities = 14
+    exp_num_relations = 55
+    exp_num_triples = 1592  # because only loading training set from Nations
+    exp_num_triples_tolerance = 5
+    dataset_cls = MockZipFileSingleDataset
 
 
 class TestTarRemote(cases.CachedDatasetCase):

--- a/tests/test_datasets/test_sources.py
+++ b/tests/test_datasets/test_sources.py
@@ -1,0 +1,216 @@
+"""Tests for the dataset sources and loaders."""
+
+import pathlib
+import tempfile
+import unittest
+
+import pytest
+
+from pykeen.datasets.loaders import INDUCTIVE_PLAN, TRANSDUCTIVE_PLAN, PreSplitLoader
+from pykeen.datasets.nations import NATIONS_TEST_PATH, NATIONS_TRAIN_PATH, NATIONS_VALIDATE_PATH
+from pykeen.datasets.sources import (
+    ArchiveSource,
+    LocalSource,
+    RemoteSource,
+    TarArchiveSource,
+    ZipArchiveSource,
+)
+from tests import constants
+
+
+class TestLocalSource(unittest.TestCase):
+    """Tests for :class:`pykeen.datasets.sources.LocalSource`."""
+
+    def test_paths(self):
+        """Test that the paths are passed through."""
+        source = LocalSource(training=NATIONS_TRAIN_PATH, testing=str(NATIONS_TEST_PATH))
+        assert source.paths() == {"training": NATIONS_TRAIN_PATH, "testing": NATIONS_TEST_PATH}
+
+    def test_none_is_dropped(self):
+        """Test that a ``None`` path is dropped rather than mapped to ``None``."""
+        source = LocalSource(training=NATIONS_TRAIN_PATH, testing=NATIONS_TEST_PATH, validation=None)
+        assert "validation" not in source.paths()
+
+
+class TestRemoteSource(unittest.TestCase):
+    """Tests for :class:`pykeen.datasets.sources.RemoteSource`."""
+
+    def setUp(self):
+        """Set up a temporary cache directory."""
+        self.directory = tempfile.TemporaryDirectory()
+        self.cache_root = pathlib.Path(self.directory.name)
+
+    def tearDown(self):
+        """Clean up the temporary cache directory."""
+        self.directory.cleanup()
+
+    def _make(self, **kwargs) -> RemoteSource:
+        return RemoteSource(
+            urls={
+                "training": NATIONS_TRAIN_PATH.as_uri(),
+                "testing": NATIONS_TEST_PATH.as_uri(),
+                "validation": NATIONS_VALIDATE_PATH.as_uri(),
+            },
+            cache_root=self.cache_root,
+            **kwargs,
+        )
+
+    def test_expected_paths_do_not_download(self):
+        """Test that asking where the files will be does not download them."""
+        source = self._make()
+        paths = source.expected_paths()
+        assert set(paths) == {"training", "testing", "validation"}
+        assert not any(path.is_file() for path in paths.values())
+
+    def test_download(self):
+        """Test that materializing downloads the files."""
+        source = self._make()
+        paths = source.paths()
+        assert all(path.is_file() for path in paths.values())
+        assert paths["training"] == self.cache_root.joinpath("train.txt")
+
+    def test_sub_directories(self):
+        """Test that the per-key sub-directories are used."""
+        source = self._make(sub_directories={"training": "a", "testing": "b", "validation": "b"})
+        paths = source.paths()
+        assert paths["training"] == self.cache_root.joinpath("a", "train.txt")
+        assert paths["testing"] == self.cache_root.joinpath("b", "test.txt")
+        assert all(path.is_file() for path in paths.values())
+
+
+class ArchiveSourceTests:
+    """A base test case for archive sources.
+
+    .. note::
+
+        This is a plain mixin rather than a :class:`unittest.TestCase`, so that pytest does not collect it.
+    """
+
+    #: The source class under test
+    source_cls: type[ArchiveSource]
+    #: The name of the archive inside the test resources
+    archive_name: str
+
+    def setUp(self):
+        """Set up a temporary cache directory."""
+        self.directory = tempfile.TemporaryDirectory()
+        self.cache_root = pathlib.Path(self.directory.name)
+        self.archive_path = constants.RESOURCES.joinpath(self.archive_name)
+
+    def tearDown(self):
+        """Clean up the temporary cache directory."""
+        self.directory.cleanup()
+
+    def _make(self, **kwargs) -> ArchiveSource:
+        return self.source_cls(
+            members={"training": pathlib.PurePath("nations", "train.txt")},
+            cache_root=self.cache_root,
+            archive_path=self.archive_path,
+            **kwargs,
+        )
+
+    def test_extract_member(self):
+        """Test that only the requested member is extracted."""
+        source = self._make()
+        paths = source.paths()
+        assert paths["training"] == self.cache_root.joinpath("nations", "train.txt")
+        assert paths["training"].is_file()
+        assert not self.cache_root.joinpath("nations", "test.txt").is_file()
+
+    def test_extract_all(self):
+        """Test that the whole archive is unpacked on request."""
+        source = self._make(extract_all=True)
+        source.materialize()
+        assert self.cache_root.joinpath("nations", "test.txt").is_file()
+
+    def test_no_url_no_archive(self):
+        """Test that a missing archive without a URL is reported."""
+        source = self.source_cls(
+            members={"training": pathlib.PurePath("nations", "train.txt")},
+            cache_root=self.cache_root,
+            name="does-not-exist",
+        )
+        with pytest.raises(ValueError, match="must specify url"):
+            source.paths()
+
+
+class TestTarArchiveSource(ArchiveSourceTests, unittest.TestCase):
+    """Tests for :class:`pykeen.datasets.sources.TarArchiveSource`."""
+
+    source_cls = TarArchiveSource
+    archive_name = "nations.tar.gz"
+
+
+class TestZipArchiveSource(ArchiveSourceTests, unittest.TestCase):
+    """Tests for :class:`pykeen.datasets.sources.ZipArchiveSource`."""
+
+    source_cls = ZipArchiveSource
+    archive_name = "nations.zip"
+
+
+class TestArchiveSourceValidation(unittest.TestCase):
+    """Tests for the construction-time validation of archive sources."""
+
+    def test_missing_name(self):
+        """Test that a source without any way to locate its archive is rejected."""
+        with pytest.raises(ValueError, match="at least one of"):
+            TarArchiveSource(members={}, cache_root=pathlib.Path())
+
+
+class TestPreSplitLoader(unittest.TestCase):
+    """Tests for :class:`pykeen.datasets.loaders.PreSplitLoader`."""
+
+    def test_transductive_plan(self):
+        """Test that the evaluation splits share the training index."""
+        loader = PreSplitLoader(
+            source=LocalSource(
+                training=NATIONS_TRAIN_PATH, testing=NATIONS_TEST_PATH, validation=NATIONS_VALIDATE_PATH
+            ),
+            create_inverse_triples=True,
+        )
+        factories = loader.load()
+        assert set(factories) == {"training", "testing", "validation"}
+        training = factories["training"]
+        # inverse triples are only created for training; evaluation handles them itself
+        assert training.create_inverse_triples
+        for key in ("testing", "validation"):
+            assert not factories[key].create_inverse_triples
+            assert factories[key].entity_to_id == training.entity_to_id
+            assert factories[key].relation_to_id == training.relation_to_id
+
+    def test_missing_optional_split(self):
+        """Test that an absent validation split is simply omitted."""
+        loader = PreSplitLoader(source=LocalSource(training=NATIONS_TRAIN_PATH, testing=NATIONS_TEST_PATH))
+        assert set(loader.load()) == {"training", "testing"}
+
+    def test_inductive_plan(self):
+        """Test that the inductive plan shares relations with training, but entities with the inference graph."""
+        # note: the actual triples do not matter here, only which index each factory inherits
+        loader = PreSplitLoader(
+            source=LocalSource(
+                transductive_training=NATIONS_TRAIN_PATH,
+                inductive_inference=NATIONS_TRAIN_PATH,
+                inductive_testing=NATIONS_TEST_PATH,
+                inductive_validation=NATIONS_VALIDATE_PATH,
+            ),
+            plan=INDUCTIVE_PLAN,
+            create_inverse_triples=True,
+        )
+        factories = loader.load()
+        transductive_training = factories["transductive_training"]
+        inference = factories["inductive_inference"]
+        assert inference.relation_to_id == transductive_training.relation_to_id
+        assert inference.create_inverse_triples
+        for key in ("inductive_testing", "inductive_validation"):
+            assert not factories[key].create_inverse_triples
+            assert factories[key].entity_to_id == inference.entity_to_id
+            assert factories[key].relation_to_id == inference.relation_to_id
+
+    def test_plans_are_topologically_ordered(self):
+        """Test that a split never inherits an index from a split which is built later."""
+        for plan in (TRANSDUCTIVE_PLAN, INDUCTIVE_PLAN):
+            seen: set[str] = set()
+            for key, spec in plan.items():
+                for source_key in (spec.entity_index_from, spec.relation_index_from):
+                    assert source_key is None or source_key in seen, f"{key} inherits from a later split"
+                seen.add(key)


### PR DESCRIPTION
## Motivation

The dataset hierarchy collapsed four orthogonal axes into a single inheritance chain:

1. eager vs. lazy,
2. where the bytes come from (local path / one URL per split / archive / single file),
3. how bytes become factories (pre-split files, single table + auto-split, literals, OGB tensors),
4. what the split structure is (transductive, fully inductive, EA).

Since a class can only sit at one point in a chain, every combination needed its own class, and the combinations that didn't fit were copy-pasted:

- The *"evaluation splits share the training index"* logic existed in **five** copies (`PathDataset`, `NumericPathDataset`, `PackedZipRemoteDataset`, `DisjointInductivePathDataset`, `OGBLoader`).
- The *"read one table → `from_labeled_triples` → `split()`"* recipe existed in **two** near-identical copies (`CompressedSingleDataset._load`, `TabbedDataset._load`).
- Downloading was done **seven** ways: `pystow.download` at four call sites, a raw `requests.get` that pulled whole archives into memory, and a bare `urlretrieve` in `ckg.py`.
- `PackedZipRemoteDataset` extended `LazyDataset` rather than `PathDataset`, because "zip member" couldn't be composed with "path loading" — so it reimplemented the whole load path.
- `datasets/inductive/base.py` was a **fork** of `datasets/base.py`: `_loaded`, `_load`, `_help_cache`, `_cache_sub_directories`, `_summary_rows`, `summary_str`, and `summarize` were duplicated near-verbatim, and `InductiveDataset` wasn't even a `Dataset`.

Full composition (datasets as configured instances in a registry) is off the table: `dataset_resolver` is built with `ClassResolver.from_subclasses`, `docdata` parses **class** docstrings for the statistics that drive the docs table and `triples_sort_key`, cache paths derive from `self.__class__.__name__`, and `pykeen.datasets.Nations` plus third-party entrypoint datasets are public API. So the leaves stay classes — but essentially nothing outside the module uses the hierarchy polymorphically (the only `isinstance` on a base class in the whole repo is `tests/cases.py`), which leaves the internals free.

## Approach

Two collaborators, plus one lazy core.

**`pykeen/datasets/sources.py` — *where the files are*.** `LocalSource`, `RemoteSource` (one URL per split), `TarArchiveSource` / `ZipArchiveSource` (members of one archive). Each separates `expected_paths()` (pure, no I/O) from `paths()` (materializes), which keeps lazy datasets lazy while still letting them report where their data lives.

**`pykeen/datasets/loaders.py` — *how files become factories*.** `PreSplitLoader` holds the index-sharing logic once, parameterized by a *plan* — so `TRANSDUCTIVE_PLAN` and `INDUCTIVE_PLAN` are now **data** rather than two hand-written implementations:

```python
TRANSDUCTIVE_PLAN = {
    "training": SplitSpec(create_inverse_triples=True),
    "testing": SplitSpec(entity_index_from="training", relation_index_from="training"),
    "validation": SplitSpec(entity_index_from="training", relation_index_from="training"),
}
```

`AutoSplitLoader` holds the read-and-split recipe once.

**`DatasetBase` + `LazyFactoryMixin`** carry the split-agnostic core, driven by a `_factory_keys` class var. `InductiveDataset` now extends `DatasetBase` as a sibling of `Dataset` — deliberately *not* a subclass, so `dataset_resolver` (which resolves subclasses of `Dataset`) is unaffected.

**`_load` / `_load_validation` collapse into one `_load_factories`** returning a mapping of splits. The two-phase split bought nothing: `CompressedSingleDataset._load_validation` and `TabbedDataset._load_validation` were literally `pass`, and every other implementation loaded validation immediately.

All twelve base classes remain as thin shims, so **not one of the ~35 leaf dataset files changed**.

## Compatibility

- All 40+ concrete dataset `__init__` signatures diffed **identical** against `master`.
- `dataset_resolver` contents diffed **identical** against `master`.
- Cache layout on disk is unchanged, so nobody re-downloads anything.

Removed protected API (documented in the commit): the `_training` / `_testing` / `_validation` attributes, `_loaded_validation`, `_load` / `_load_validation`, and `RemoteDataset._extract`. A downstream subclass overriding `_load` now fails loudly with `NotImplementedError` naming `_load_factories`, rather than silently.

`isinstance(x, PathDataset)` is *widened* (`PackedZipRemoteDataset` now qualifies), never narrowed.

## Behavior changes

| Change | Rationale |
| --- | --- |
| `UnpackedRemoteDataset` no longer downloads in `__init__` | It's a `LazyDataset`; it should be lazy |
| Remote archives stream to disk instead of `BytesIO(res.content)` | Wikidata5M's ~1 GB tar no longer sits in RAM |
| `RemoteDataset` uses the urllib backend for non-HTTP URLs | `file://` URLs now work (useful for tests); `timeout` still routes through `requests` for HTTP |
| `PackedZipRemoteDataset` reads via `load_triples` | Labels parse as `dtype=str` with `keep_default_na=False` — see the review note below |
| `ZipSingleDataset` honors `read_csv_kwargs` | `TarFileSingleDataset` already did; this was a latent bug |
| `summarize()` no longer raises without a validation split | The old `zip` produced a `None` row and hit `None.num_entities` |
| `LazyInductiveDataset.inductive_validation` returns `None` | It was typed `| None` but asserted not-`None` |
| Inductive datasets gained `to_directory_binary` / `from_directory_binary` | Falls out of sharing the core |

## Two things worth a reviewer's eye

1. **`PackedZipRemoteDataset` label parsing.** Moving to `load_triples` means `dtype=str` and `keep_default_na=False`. Both are more correct than the old bare `pd.read_csv` (which could yield integer entity labels, and silently turned a literal `NA` entity into `NaN`), but it touches FB15k-237, OpenBioLink, OpenBioLinkLQ, and Aristo-v4, whose docdata statistics I could not verify without downloading them. If one of those has an entity labeled literally `NA` or `null`, its entity count would tick up.
2. **`InductiveDataset.create_inverse_triples` stays a plain attribute** while `Dataset`'s is a property derived from the training factory. Unifying them means dropping the field from the `EagerInductiveDataset` dataclass, which breaks `mocks.create_inductive_dataset` and a documented example for no functional gain — so I left the divergence, with a comment explaining it.

## Testing

- New `tests/test_datasets/test_sources.py` (16 tests) covering both source families, the download/extract paths, and both index-sharing plans — including a check that every plan is topologically ordered.
- New `MockZipFileSingleDataset` case: `ZipSingleDataset` had no test coverage before, and its behavior changed here.
- `MockTarFileRemoteDataset` no longer needs its `_get_bytes` override, since `file://` now works through the source.
- `DatasetTestCase` rewritten against `factory_dict`; the `autoloaded_validation` flag is gone, as all datasets now load in one shot.
- Locally: `tests/test_datasets`, `test_triples_factory`, `test_leakage`, `test_pipeline` → 142 passed, 1 skipped. Rest left to CI.
- mypy: 293 errors on both `master` and this branch — no new ones.
- Docs build with `-n -W`: 0 warnings. `sphinx-lint`, `docstrfmt`, `ruff`, and 100% `docstr-coverage` all pass.

## Docs

`docs/source/reference/datasets.rst` gains the two new modules, and `extending_datasets.rst` gains a section on combining a source and a loader directly — the new extension point for datasets that none of the existing base classes fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
