### PR TITLE
🐛⚖️ Fix raw ranking and LCWA loop masking

### DIFF
--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -414,7 +414,8 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
 
             # create dense positive masks
             # TODO: afaik, dense positive masks are not used on GPU -> we do not need to move the masks around
-            elif self.evaluator.requires_positive_mask:
+            # note: an evaluator may require *both* filtering and the dense masks
+            if self.evaluator.requires_positive_mask:
                 if filter_batch is None:
                     raise AssertionError("Filter indices are required to create dense positive masks.")
                 dense_positive_mask = torch.zeros_like(scores, dtype=torch.bool, device=filter_batch.device)

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -262,6 +262,11 @@ class LCWAEvaluationDataset(Dataset[Mapping[Target, tuple[MappedTriples, torch.T
         if targets is None:
             targets = [LABEL_HEAD, LABEL_TAIL]
         mapped_triples = get_mapped_triples(mapped_triples=mapped_triples, factory=factory)
+        # note: a single tensor or triples factory is a valid hint, and neither has a meaningful truth value;
+        # hence we normalize to a sequence before checking whether anything was passed at all
+        additional_filter_triples = (
+            [] if additional_filter_triples is None else list(upgrade_to_sequence(additional_filter_triples))
+        )
 
         self.mapped_triples = mapped_triples
         self.num_triples = mapped_triples.shape[0]
@@ -272,12 +277,7 @@ class LCWAEvaluationDataset(Dataset[Mapping[Target, tuple[MappedTriples, torch.T
             if not additional_filter_triples:
                 logger.warning("Enabled filtered evaluation, but not additional filter triples are passed.")
             df = pandas.DataFrame(
-                data=torch.cat(
-                    [
-                        mapped_triples,
-                        *(get_mapped_triples(x) for x in upgrade_to_sequence(additional_filter_triples or [])),
-                    ]
-                ),
+                data=torch.cat([mapped_triples, *(get_mapped_triples(x) for x in additional_filter_triples)]),
                 columns=COLUMN_LABELS,
             )
             self.filter_indices = {target: FilterIndex.from_df(df=df, target=target) for target in targets}

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -394,16 +394,19 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
             # {(h, r, t1), (h, r, t1), ..., (h, r, tk)}
             # predict scores for all candidates
             scores = self.model.predict(hrt_batch=hrt_batch, target=target, mode=self.mode)
-            true_scores = dense_positive_mask = None
+            dense_positive_mask = None
+
+            # the true score is required for ranking, independent of whether the filtered protocol is used;
+            # filtering only decides whether the *other* positives are masked out beforehand.
+            batch_ids = torch.arange(scores.shape[0], device=scores.device)
+            target_ids = hrt_batch[:, TARGET_TO_INDEX[target]]
+            # shape: (batch_size, 1)
+            true_scores = scores[batch_ids, target_ids, None]
 
             # filter scores
             if self.evaluator.filtered:
                 if filter_batch is None:
                     raise AssertionError("Filter indices are required to filter scores.")
-                # extract true scores
-                batch_ids = torch.arange(scores.shape[0], device=scores.device)
-                target_ids = hrt_batch[:, TARGET_TO_INDEX[target]]
-                true_scores = scores[batch_ids, target_ids, None]
                 # replace by nan
                 scores = filter_scores_(scores=scores, filter_batch=filter_batch)
                 # rewrite true scores

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -418,7 +418,8 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
                 if filter_batch is None:
                     raise AssertionError("Filter indices are required to create dense positive masks.")
                 dense_positive_mask = torch.zeros_like(scores, dtype=torch.bool, device=filter_batch.device)
-                dense_positive_mask[filter_batch[:, 0], filter_batch[:, 0]] = True
+                # filter_batch is given as (batch_id, entity_id) pairs
+                dense_positive_mask[filter_batch[:, 0], filter_batch[:, 1]] = True
 
             # delegate processing of scores to the evaluator
             self.evaluator.process_scores_(

--- a/src/pykeen/evaluation/evaluator.py
+++ b/src/pykeen/evaluation/evaluator.py
@@ -613,9 +613,14 @@ def _evaluate_batch(
         masks).
     """
     scores = model.predict(hrt_batch=batch, target=target, slice_size=slice_size, mode=mode)
+    column = TARGET_TO_INDEX[target]
+
+    # the true score is required for ranking, independent of whether the filtered protocol is used;
+    # filtering only decides whether the *other* positives are masked out beforehand.
+    # shape: (batch_size, 1)
+    true_scores = scores[torch.arange(0, batch.shape[0]), batch[:, column]].unsqueeze(dim=-1)
 
     if evaluator.filtered or evaluator.requires_positive_mask:
-        column = TARGET_TO_INDEX[target]
         if all_pos_triples is None:
             raise ValueError(
                 "If filtering_necessary of positive_masks_required is True, all_pos_triples has to be "
@@ -634,16 +639,10 @@ def _evaluate_batch(
 
     if evaluator.filtered:
         assert positive_filter is not None
-        # Select scores of true
-        true_scores = scores[torch.arange(0, batch.shape[0]), batch[:, column]]
         # overwrite filtered scores
         scores = filter_scores_(scores=scores, filter_batch=positive_filter)
         # The scores for the true triples have to be rewritten to the scores tensor
-        scores[torch.arange(0, batch.shape[0]), batch[:, column]] = true_scores
-        # the rank-based evaluators needs the true scores with trailing 1-dim
-        true_scores = true_scores.unsqueeze(dim=-1)
-    else:
-        true_scores = None
+        scores[torch.arange(0, batch.shape[0]), batch[:, column]] = true_scores[:, 0]
 
     # Create a positive mask with the size of the scores from the positive filter
     if evaluator.requires_positive_mask:

--- a/tests/test_evaluation/test_evaluation_loop.py
+++ b/tests/test_evaluation/test_evaluation_loop.py
@@ -3,8 +3,14 @@
 from collections.abc import MutableMapping
 from typing import Any
 
+import pytest
+
 import pykeen.evaluation.evaluation_loop
 import pykeen.evaluation.rank_based_evaluator
+from pykeen.datasets import Nations
+from pykeen.evaluation import Evaluator, RankBasedEvaluator
+from pykeen.evaluation.evaluation_loop import LCWAEvaluationLoop
+from pykeen.models import FixedModel
 from pykeen.typing import LABEL_RELATION
 from tests import cases
 
@@ -25,3 +31,33 @@ class RelationPredictionLinkPredictionEvaluationLoopTestCase(LinkPredictionEvalu
 
     cls = pykeen.evaluation.evaluation_loop.LCWAEvaluationLoop
     kwargs = {"targets": (LABEL_RELATION,)}
+
+
+@pytest.mark.parametrize(
+    "evaluator",
+    [
+        RankBasedEvaluator(filtered=True),
+        # the raw / unfiltered ranking protocol has to work, too
+        RankBasedEvaluator(filtered=False),
+    ],
+)
+def test_loop_matches_evaluate(evaluator: Evaluator):
+    """Test that the LCWA evaluation loop agrees with :meth:`Evaluator.evaluate`."""
+    dataset = Nations()
+    model = FixedModel(triples_factory=dataset.training)
+    # note: the filter triples are ignored by both paths if neither filtering nor masks are required
+    additional_filter_triples = [dataset.training.mapped_triples]
+    loop_result = LCWAEvaluationLoop(
+        model=model,
+        triples_factory=dataset.testing,
+        evaluator=evaluator,
+        additional_filter_triples=additional_filter_triples,
+    ).evaluate(batch_size=8, use_tqdm=False)
+    result = evaluator.evaluate(
+        model=model,
+        mapped_triples=dataset.testing.mapped_triples,
+        additional_filter_triples=additional_filter_triples,
+        batch_size=8,
+        use_tqdm=False,
+    )
+    assert loop_result.to_flat_dict() == pytest.approx(result.to_flat_dict())

--- a/tests/test_evaluation/test_evaluation_loop.py
+++ b/tests/test_evaluation/test_evaluation_loop.py
@@ -11,7 +11,7 @@ import pykeen.evaluation.rank_based_evaluator
 from pykeen.datasets import Nations
 from pykeen.evaluation import Evaluator, RankBasedEvaluator
 from pykeen.evaluation.classification_evaluator import ClassificationEvaluator
-from pykeen.evaluation.evaluation_loop import LCWAEvaluationLoop
+from pykeen.evaluation.evaluation_loop import LCWAEvaluationDataset, LCWAEvaluationLoop
 from pykeen.models import FixedModel
 from pykeen.typing import LABEL_RELATION
 from tests import cases
@@ -83,3 +83,16 @@ def test_process_batch_filtered_and_masked():
     # note: the classification evaluator raises if the dense positive mask is missing
     loop.process_batch(batch=next(iter(loop.get_loader(batch_size=2))))
     assert evaluator.all_positives
+
+
+@pytest.mark.parametrize("as_sequence", [False, True])
+@pytest.mark.parametrize("filtered", [False, True])
+def test_dataset_additional_filter_triples(filtered: bool, as_sequence: bool):
+    """Test that a single tensor is accepted as additional filter triples."""
+    dataset = Nations()
+    additional_filter_triples = dataset.training.mapped_triples
+    LCWAEvaluationDataset(
+        factory=dataset.testing,
+        filtered=filtered,
+        additional_filter_triples=[additional_filter_triples] if as_sequence else additional_filter_triples,
+    )

--- a/tests/test_evaluation/test_evaluation_loop.py
+++ b/tests/test_evaluation/test_evaluation_loop.py
@@ -4,6 +4,7 @@ from collections.abc import MutableMapping
 from typing import Any
 
 import pytest
+import torch
 
 import pykeen.evaluation.evaluation_loop
 import pykeen.evaluation.rank_based_evaluator
@@ -64,3 +65,21 @@ def test_loop_matches_evaluate(evaluator: Evaluator):
         use_tqdm=False,
     )
     assert loop_result.to_flat_dict() == pytest.approx(result.to_flat_dict())
+
+
+@torch.inference_mode()
+def test_process_batch_filtered_and_masked():
+    """Test that filtering and the dense positive masks are not mutually exclusive."""
+    dataset = Nations()
+    # note: no in-tree evaluator requires both, but the combination is supported by Evaluator.evaluate
+    evaluator = ClassificationEvaluator()
+    evaluator.filtered = True
+    loop = LCWAEvaluationLoop(
+        model=FixedModel(triples_factory=dataset.training),
+        triples_factory=dataset.testing,
+        evaluator=evaluator,
+        additional_filter_triples=[dataset.training.mapped_triples],
+    )
+    # note: the classification evaluator raises if the dense positive mask is missing
+    loop.process_batch(batch=next(iter(loop.get_loader(batch_size=2))))
+    assert evaluator.all_positives

--- a/tests/test_evaluation/test_evaluation_loop.py
+++ b/tests/test_evaluation/test_evaluation_loop.py
@@ -9,6 +9,7 @@ import pykeen.evaluation.evaluation_loop
 import pykeen.evaluation.rank_based_evaluator
 from pykeen.datasets import Nations
 from pykeen.evaluation import Evaluator, RankBasedEvaluator
+from pykeen.evaluation.classification_evaluator import ClassificationEvaluator
 from pykeen.evaluation.evaluation_loop import LCWAEvaluationLoop
 from pykeen.models import FixedModel
 from pykeen.typing import LABEL_RELATION
@@ -39,6 +40,8 @@ class RelationPredictionLinkPredictionEvaluationLoopTestCase(LinkPredictionEvalu
         RankBasedEvaluator(filtered=True),
         # the raw / unfiltered ranking protocol has to work, too
         RankBasedEvaluator(filtered=False),
+        # exercises the dense positive mask code path
+        ClassificationEvaluator(),
     ],
 )
 def test_loop_matches_evaluate(evaluator: Evaluator):

--- a/tests/test_evaluation/test_evaluators.py
+++ b/tests/test_evaluation/test_evaluators.py
@@ -494,6 +494,21 @@ class TestEvaluationFiltering(unittest.TestCase):
         )
         assert eval_results.get_metric(name="mr") == 1, "The rank should equal 1"
 
+    def test_evaluation_unfiltered(self):
+        """Test that the raw (unfiltered) ranking protocol is supported.
+
+        Filtering only decides whether the *other* positives are masked out; the true score - and thus a rank - is
+        available either way.
+        """
+        eval_results = RankBasedEvaluator(filtered=False).evaluate(
+            model=self.model,
+            mapped_triples=self.test_triples,
+            batch_size=1,
+            use_tqdm=False,
+        )
+        # the true entity receives the third-highest score on both sides, and nothing is filtered out
+        assert eval_results.get_metric(name="mr") == 3, "The raw mean rank should equal 3"
+
 
 @pytest.mark.parametrize(
     ("string", "expected"),


### PR DESCRIPTION
Fixes four bugs in the evaluation code paths.

- **Raw ranking crashed.** `RankBasedEvaluator(filtered=False)` raised `ValueError: RankBasedEvaluator needs the true scores!` for every target. Since #767, the true scores were only extracted inside the `if evaluator.filtered` branch, although ranking always needs them; filtering only decides whether the *other* positives are masked out. `_evaluate_batch` and `LCWAEvaluationLoop.process_batch` now always extract them. This also fixes `SampledRankBasedEvaluator` and `MacroRankBasedEvaluator` with `filtered=False`; `OGBEvaluator`'s own `evaluate()` never used these paths.
- **Wrong dense positive masks in the LCWA loop.** The mask was indexed as `[filter_batch[:, 0], filter_batch[:, 0]]` instead of by `(batch_id, entity_id)`, so `ClassificationEvaluator` silently produced wrong metrics through the loop (e.g. Nations `both.accuracy` 0.862 vs. 0.533 via `Evaluator.evaluate`).
- **Filtering and dense masks were mutually exclusive in the LCWA loop** (`elif`), unlike in `Evaluator.evaluate`.
- **A single tensor as `additional_filter_triples` crashed `LCWAEvaluationDataset`**, which truth-tested the hint (`Boolean value of Tensor with more than one value is ambiguous`), although the type hint allows it. It is now normalized to a sequence first.

## Tests

- raw mean rank on the existing filtering fixture (3 raw vs. 2 filtered)
- `LCWAEvaluationLoop` and `Evaluator.evaluate` agree for filtered and raw rank-based evaluation and for classification
- filtering combined with dense positive masks in the loop
- `additional_filter_triples` as a single tensor and as a sequence

## Out of scope

- Relation prediction via `Evaluator.evaluate` still raises `NotImplementedError` (#728); `LCWAEvaluationLoop` handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
