### PR TITLE
🗑️📚 Replace docstr-coverage with ruff's D102 rule

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,9 +47,6 @@ jobs:
 
     - name: Check package metadata with Pyroma
       run: tox -e pyroma
-    
-    - name: Check docstring coverage
-      run: tox -e docstr-coverage
 
     - name: Check manifest
       run: tox -e manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,7 +326,7 @@ ignore = [
 "tests/**/*.py" = [
     "INP001", # tests are not a package
     "PIE790", # allow pass in test stubs/abstract methods
-    "D102",   # tests were never covered by docstr-coverage's src/pykeen-only scan
+    "D102",   # test methods document intent via their name, not a docstring
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,6 @@ select = [
 ignore = [
     "D105", # Missing docstring in magic method
     "S101", # Use of assert detected, TODO remove
-    "D102", # Missing docstring in public method, TODO remove
 ]
 
 # See https://docs.astral.sh/ruff/settings/#per-file-ignores
@@ -327,6 +326,7 @@ ignore = [
 "tests/**/*.py" = [
     "INP001", # tests are not a package
     "PIE790", # allow pass in test stubs/abstract methods
+    "D102",   # tests were never covered by docstr-coverage's src/pykeen-only scan
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/src/pykeen/checkpoints/keeper.py
+++ b/src/pykeen/checkpoints/keeper.py
@@ -46,7 +46,7 @@ class LastCheckpointKeeper(CheckpointKeeper):
     #: the number of checkpoints to keep
     keep: int = 1
 
-    def __call__(self, steps: Sequence[int]) -> Iterator[int]:
+    def __call__(self, steps: Sequence[int]) -> Iterator[int]:  # noqa: D102  # dunder override, see D105
         yield from steps[-self.keep :]
 
 
@@ -56,7 +56,7 @@ class ModuloCheckpointKeeper(CheckpointKeeper):
 
     divisor: int = 10
 
-    def __call__(self, steps: Sequence[int]) -> Iterator[int]:
+    def __call__(self, steps: Sequence[int]) -> Iterator[int]:  # noqa: D102  # dunder override, see D105
         for step in steps:
             if step % self.divisor == 0:
                 yield step
@@ -72,7 +72,7 @@ class ExplicitCheckpointKeeper(CheckpointKeeper):
         # convert to set for better lookup speed
         self.keep = set(self.keep)
 
-    def __call__(self, steps: Sequence[int]) -> Iterator[int]:
+    def __call__(self, steps: Sequence[int]) -> Iterator[int]:  # noqa: D102  # dunder override, see D105
         # the set operation should be a nop of sets
         yield from set(self.keep).intersection(steps)
 
@@ -95,7 +95,7 @@ class BestCheckpointKeeper(CheckpointKeeper):
     def __post_init__(self):
         self._adapter = ResultListenerAdapter(self.result_tracker, metric_selection=self.metric_selection)
 
-    def __call__(self, steps: Sequence[int]) -> Iterator[int]:
+    def __call__(self, steps: Sequence[int]) -> Iterator[int]:  # noqa: D102  # dunder override, see D105
         return filter(self._adapter.is_best, steps)
 
 
@@ -111,7 +111,7 @@ class UnionCheckpointKeeper(CheckpointKeeper):
     def __post_init__(self):
         self._bases = keeper_resolver.make_many(self.bases, self.bases_kwargs)
 
-    def __call__(self, steps: Sequence[int]) -> Iterator[int]:
+    def __call__(self, steps: Sequence[int]) -> Iterator[int]:  # noqa: D102  # dunder override, see D105
         result: set[int] = set()
         for base in self._bases:
             result.update(base(steps))

--- a/src/pykeen/checkpoints/schedule.py
+++ b/src/pykeen/checkpoints/schedule.py
@@ -36,7 +36,7 @@ class EveryCheckpointSchedule(CheckpointSchedule):
     #: The checkpoint frequency
     frequency: int = 10
 
-    def __call__(self, step: int) -> bool:
+    def __call__(self, step: int) -> bool:  # noqa: D102  # dunder override, see D105
         return not step % self.frequency
 
 
@@ -46,7 +46,7 @@ class ExplicitCheckpointSchedule(CheckpointSchedule):
 
     steps: Collection[int]
 
-    def __call__(self, step: int) -> bool:
+    def __call__(self, step: int) -> bool:  # noqa: D102  # dunder override, see D105
         return step in self.steps
 
 
@@ -68,7 +68,7 @@ class BestCheckpointSchedule(CheckpointSchedule):
     def __post_init__(self):
         self._adapter = ResultListenerAdapter(self.result_tracker, metric_selection=self.metric_selection)
 
-    def __call__(self, step: int) -> bool:
+    def __call__(self, step: int) -> bool:  # noqa: D102  # dunder override, see D105
         return self._adapter.is_best(step)
 
 
@@ -84,7 +84,7 @@ class UnionCheckpointSchedule(CheckpointSchedule):
     def __post_init__(self):
         self._bases = schedule_resolver.make_many(self.bases, self.bases_kwargs)
 
-    def __call__(self, step: int) -> bool:
+    def __call__(self, step: int) -> bool:  # noqa: D102  # dunder override, see D105
         return any(base(step) for base in self._bases)
 
 

--- a/src/pykeen/checkpoints/utils.py
+++ b/src/pykeen/checkpoints/utils.py
@@ -45,8 +45,7 @@ class ResultListenerAdapter(ResultTracker):
         self.base_log_metrics = self.base.log_metrics
         self.base.log_metrics = self.log_metrics
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,

--- a/src/pykeen/contrib/lightning.py
+++ b/src/pykeen/contrib/lightning.py
@@ -149,7 +149,6 @@ class LitModule(pytorch_lightning.LightningModule, ABC):
             self.optimizer, self.optimizer_kwargs, params=self.parameters(), lr=self.learning_rate
         )
 
-    # docstr-coverage: inherited
     def on_before_zero_grad(self, optimizer: torch.optim.Optimizer) -> None:  # noqa: D102
         # call post_parameter_update
         self.model.post_parameter_update()
@@ -180,7 +179,6 @@ class SLCWALitModule(LitModule):
         self.negative_sampler_kwargs = negative_sampler_kwargs
         self.grouped = grouped
 
-    # docstr-coverage: inherited
     def _step(self, batch, prefix: str):  # noqa: D102
         loss = SLCWATrainingLoop._process_batch_static(
             model=self.model,
@@ -196,7 +194,6 @@ class SLCWALitModule(LitModule):
         self.log(f"{prefix}_loss", loss)
         return loss
 
-    # docstr-coverage: inherited
     def _dataloader(self, triples_factory: CoreTriplesFactory, shuffle: bool = False) -> torch.utils.data.DataLoader:  # noqa: D102
         return torch.utils.data.DataLoader(
             dataset=BatchedSLCWAInstances.from_triples_factory(
@@ -225,7 +222,6 @@ class LCWALitModule(LitModule):
         https://github.com/pykeen/pykeen/pull/905
     """
 
-    # docstr-coverage: inherited
     def _step(self, batch, prefix: str):  # noqa: D102
         loss = LCWATrainingLoop._process_batch_static(
             model=self.model,
@@ -243,7 +239,6 @@ class LCWALitModule(LitModule):
         self.log(f"{prefix}_loss", loss)
         return loss
 
-    # docstr-coverage: inherited
     def _dataloader(self, triples_factory: CoreTriplesFactory, shuffle: bool = False) -> torch.utils.data.DataLoader:  # noqa: D102
         return torch.utils.data.DataLoader(
             dataset=LCWAInstances.from_triples_factory(triples_factory),

--- a/src/pykeen/datasets/base.py
+++ b/src/pykeen/datasets/base.py
@@ -514,7 +514,6 @@ class EagerDataset(Dataset):
         self.validation = validation
         self.metadata = metadata
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"metadata={self.metadata}"
@@ -785,7 +784,6 @@ class RemoteDataset(PathDataset):
         res.raise_for_status()
         return BytesIO(res.content)
 
-    # docstr-coverage: inherited
     def _load(self) -> None:  # noqa: D102
         all_unpacked = all(path.is_file() for path in self._get_paths())
 
@@ -800,7 +798,6 @@ class RemoteDataset(PathDataset):
 class TarFileRemoteDataset(RemoteDataset):
     """A remote dataset stored as a tar file."""
 
-    # docstr-coverage: inherited
     def _extract(self, archive_file: BytesIO) -> None:  # noqa: D102
         with tarfile.open(fileobj=archive_file) as tf:
             tf.extractall(path=self.cache_root)  # noqa:S202
@@ -864,7 +861,6 @@ class PackedZipRemoteDataset(LazyDataset):
             self._load()
             self._load_validation()
 
-    # docstr-coverage: inherited
     def _load(self) -> None:  # noqa: D102
         self._training = self._load_helper(self.relative_training_path)
         self._testing = self._load_helper(

--- a/src/pykeen/datasets/ea/base.py
+++ b/src/pykeen/datasets/ea/base.py
@@ -90,7 +90,6 @@ class EADataset(EagerDataset):
         """Load the entity alignment."""
         raise NotImplementedError
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"self.side={self.side}"

--- a/src/pykeen/datasets/ea/combination.py
+++ b/src/pykeen/datasets/ea/combination.py
@@ -347,7 +347,7 @@ class DisjointGraphPairCombinator(GraphPairCombinator[FactoryType]):
         mapped_triples: MappedTriples,
         alignment: LongTensor,
         offsets: LongTensor,
-    ) -> ProcessedTuple:  # noqa: D102
+    ) -> ProcessedTuple:
         return ProcessedTuple(
             mapped_triples,
             alignment,
@@ -363,7 +363,7 @@ class SwapGraphPairCombinator(GraphPairCombinator[FactoryType]):
         mapped_triples: MappedTriples,
         alignment: LongTensor,
         offsets: LongTensor,
-    ) -> ProcessedTuple:  # noqa: D102
+    ) -> ProcessedTuple:
         # add swap triples
         # e1 ~ e2 => (e1, r, t) ~> (e2, r, t), or (h, r, e1) ~> (h, r, e2)
         # create dense entity remapping for swap
@@ -401,7 +401,7 @@ class ExtraRelationGraphPairCombinator(GraphPairCombinator[FactoryType]):
         mapped_triples: MappedTriples,
         alignment: LongTensor,
         offsets: LongTensor,
-    ) -> ProcessedTuple:  # noqa: D102
+    ) -> ProcessedTuple:
         # add alignment triples with extra relation
         left_id, right_id = alignment
         alignment_relation_id = get_num_ids(mapped_triples[:, 1])
@@ -460,7 +460,7 @@ class CollapseGraphPairCombinator(GraphPairCombinator[FactoryType]):
         mapped_triples: MappedTriples,
         alignment: LongTensor,
         offsets: LongTensor,
-    ) -> ProcessedTuple:  # noqa: D102
+    ) -> ProcessedTuple:
         # determine connected components regarding the same-as relation (i.e., applies transitivity)
         entity_id_mapping = torch.arange(get_num_ids(mapped_triples[:, 0::2]))
         for cc in get_connected_components(pairs=alignment.t().tolist()):

--- a/src/pykeen/datasets/ea/combination.py
+++ b/src/pykeen/datasets/ea/combination.py
@@ -342,8 +342,7 @@ class GraphPairCombinator(Generic[FactoryType], ABC):
 class DisjointGraphPairCombinator(GraphPairCombinator[FactoryType]):
     """This combinator keeps both graphs as disconnected components."""
 
-    # docstr-coverage: inherited
-    def process(
+    def process(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         alignment: LongTensor,
@@ -359,8 +358,7 @@ class DisjointGraphPairCombinator(GraphPairCombinator[FactoryType]):
 class SwapGraphPairCombinator(GraphPairCombinator[FactoryType]):
     """Add extra triples by swapping aligned entities."""
 
-    # docstr-coverage: inherited
-    def process(
+    def process(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         alignment: LongTensor,
@@ -398,8 +396,7 @@ class ExtraRelationGraphPairCombinator(GraphPairCombinator[FactoryType]):
     #: the name of the additional alignment relation
     ALIGNMENT_RELATION_NAME: ClassVar[str] = "same-as"
 
-    # docstr-coverage: inherited
-    def process(
+    def process(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         alignment: LongTensor,
@@ -458,8 +455,7 @@ def iter_entity_mappings(
 class CollapseGraphPairCombinator(GraphPairCombinator[FactoryType]):
     """This combinator merges all matching entity pairs into a single ID."""
 
-    # docstr-coverage: inherited
-    def process(
+    def process(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         alignment: LongTensor,

--- a/src/pykeen/datasets/ea/openea.py
+++ b/src/pykeen/datasets/ea/openea.py
@@ -119,7 +119,6 @@ class OpenEA(EADataset):
         # delegate to super class
         super().__init__(**kwargs)
 
-    # docstr-coverage: inherited
     def _load_graph(self, side: EASide) -> TriplesFactory:  # noqa: D102
         # left side has files ending with 1, right side with 2
         one_or_two = "1" if side == EA_SIDE_LEFT else "2"
@@ -137,7 +136,6 @@ class OpenEA(EADataset):
             metadata={"path": self.zip_path},
         )
 
-    # docstr-coverage: inherited
     def _load_alignment(self) -> pandas.DataFrame:  # noqa: D102
         return read_zipfile_csv(
             path=self.zip_path,

--- a/src/pykeen/datasets/ea/wk3l.py
+++ b/src/pykeen/datasets/ea/wk3l.py
@@ -104,7 +104,6 @@ class MTransEDataset(EADataset, ABC):
             **kwargs,
         )
 
-    # docstr-coverage: inherited
     def _load_graph(self, side: EASide) -> TriplesFactory:  # noqa: D102
         logger.info(f"Loading graph for side: {side}")
         df = self._load_df(key=side, names=COLUMN_LABELS)
@@ -113,7 +112,6 @@ class MTransEDataset(EADataset, ABC):
             triples=df.values, metadata={"graph_pair": self.graph_pair, "side": side}
         )
 
-    # docstr-coverage: inherited
     def _load_alignment(self) -> pandas.DataFrame:  # noqa: D102
         """Load entity alignment information for the given graph pair."""
         logger.info("Loading alignment information")

--- a/src/pykeen/datasets/ogb.py
+++ b/src/pykeen/datasets/ogb.py
@@ -60,7 +60,6 @@ class OGBLoader(LazyDataset, Generic[PreprocessedTrainDictType, PreprocessedEval
         self.cache_root = self._help_cache(cache_root)
         self._create_inverse_triples = create_inverse_triples
 
-    # docstr-coverage: inherited
     def _load(self) -> None:  # noqa: D102
         dataset = self._load_ogb_dataset()
         # label mapping is in dataset.root/mapping
@@ -77,7 +76,6 @@ class OGBLoader(LazyDataset, Generic[PreprocessedTrainDictType, PreprocessedEval
             relation_to_id=relation_to_id,
         )
 
-    # docstr-coverage: inherited
     def _load_validation(self) -> None:  # noqa: D102
         dataset = self._load_ogb_dataset()
         self._validation = TriplesFactory(
@@ -172,7 +170,6 @@ class OGBWikiKG2(OGBLoader[WikiKG2TrainDict, WikiKG2EvalDict]):
 
     name = "ogbl-wikikg2"
 
-    # docstr-coverage: inherited
     def _load_mappings(self, mapping_root: pathlib.Path) -> tuple[EntityMapping, RelationMapping]:  # noqa: D102
         df_ent = pandas.read_csv(mapping_root.joinpath("nodeidx2entityid.csv.gz"))
         entity_to_id = dict(zip(df_ent["entity id"].tolist(), df_ent["node idx"].tolist(), strict=False))
@@ -180,7 +177,6 @@ class OGBWikiKG2(OGBLoader[WikiKG2TrainDict, WikiKG2EvalDict]):
         relation_to_id = dict(zip(df_rel["rel id"].tolist(), df_rel["reltype"].tolist(), strict=False))
         return entity_to_id, relation_to_id
 
-    # docstr-coverage: inherited
     def _load_data_dict_for_split(self, dataset, which):
         # noqa: D102
         data_dict = torch.load(
@@ -189,7 +185,6 @@ class OGBWikiKG2(OGBLoader[WikiKG2TrainDict, WikiKG2EvalDict]):
         )
         return cast(WikiKG2TrainDict, data_dict) if which == "train" else cast(WikiKG2EvalDict, data_dict)
 
-    # docstr-coverage: inherited
     def _compose_mapped_triples(self, data_dict: WikiKG2TrainDict | WikiKG2EvalDict) -> numpy.ndarray:  # noqa: D102
         return numpy.stack([data_dict["head"], data_dict["relation"], data_dict["tail"]], axis=-1)
 
@@ -252,7 +247,6 @@ class OGBBioKG(OGBLoader[BioKGTrainDict, BioKGEvalDict]):
 
     name = "ogbl-biokg"
 
-    # docstr-coverage: inherited
     def _load_mappings(self, mapping_root: pathlib.Path) -> tuple[EntityMapping, RelationMapping]:  # noqa: D102
         df_rel = pandas.read_csv(mapping_root.joinpath("relidx2relname.csv.gz"))
         LOGGER.info(f"Loaded relation mapping for {len(df_rel)} relations.")
@@ -276,7 +270,6 @@ class OGBBioKG(OGBLoader[BioKGTrainDict, BioKGEvalDict]):
 
         return entity_to_id, relation_to_id
 
-    # docstr-coverage: inherited
     def _compose_mapped_triples(self, data_dict: BioKGTrainDict | BioKGEvalDict) -> numpy.ndarray:
         return numpy.stack(
             [
@@ -287,7 +280,6 @@ class OGBBioKG(OGBLoader[BioKGTrainDict, BioKGEvalDict]):
             axis=-1,
         )
 
-    # docstr-coverage: inherited
     def _load_data_dict_for_split(self, dataset, which):  # noqa: D102
         data_dict = torch.load(
             pathlib.Path(dataset.root).joinpath("split", dataset.meta_info["split"], which).with_suffix(".pt"),

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -121,7 +121,7 @@ class ClassificationEvaluator(Evaluator[ClassificationMetricKey]):
         scores: FloatTensor,
         true_scores: FloatTensor | None = None,
         dense_positive_mask: FloatTensor | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         if dense_positive_mask is None:
             raise KeyError("Sklearn evaluators need the positive mask!")
 

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -115,8 +115,7 @@ class ClassificationEvaluator(Evaluator[ClassificationMetricKey]):
             for metric_cls in classification_metric_resolver.lookup_dict.values()
         )
 
-    # docstr-coverage: inherited
-    def process_scores_(
+    def process_scores_(  # noqa: D102
         self,
         hrt_batch: MappedTriples,
         target: Target,

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -41,7 +41,6 @@ class ClassificationMetricResults(MetricResults[ClassificationMetricKey]):
 
     metrics = classification_metric_resolver.lookup_dict
 
-    # docstr-coverage: inherited
     @classmethod
     def key_from_string(cls, s: str | None) -> ClassificationMetricKey:  # noqa: D102
         if s is None:
@@ -140,12 +139,10 @@ class ClassificationEvaluator(Evaluator[ClassificationMetricKey]):
             self.all_scores[target][key] = scores_np[i]
             self.all_positives[target][key] = dense_positive_mask_np[i]
 
-    # docstr-coverage: inherited
     def clear(self) -> None:  # noqa: D102
         self.all_positives.clear()
         self.all_scores.clear()
 
-    # docstr-coverage: inherited
     def finalize(self) -> ClassificationMetricResults:  # noqa: D102
         result = ClassificationMetricResults.from_scores(
             metrics=self.metrics,

--- a/src/pykeen/evaluation/evaluation_loop.py
+++ b/src/pykeen/evaluation/evaluation_loop.py
@@ -381,11 +381,9 @@ class LCWAEvaluationLoop(EvaluationLoop[Mapping[Target, MappedTriples]]):
         self.targets = targets
         self.mode = mode
 
-    # docstr-coverage: inherited
     def get_collator(self):  # noqa: D102
         return LCWAEvaluationDataset.collate
 
-    # docstr-coverage: inherited
     def process_batch(self, batch: Mapping[Target, MappedTriples]) -> None:  # noqa: D102
         # note: most of the time, this loop will only make a single iteration, since the evaluation dataset typically is
         #       not shuffled, and contains evaluation ranking tasks sorted by target

--- a/src/pykeen/evaluation/ogb_evaluator.py
+++ b/src/pykeen/evaluation/ogb_evaluator.py
@@ -37,7 +37,6 @@ logger = logging.getLogger(__name__)
 class OGBEvaluator(SampledRankBasedEvaluator):
     """A sampled, rank-based evaluator that applies a custom OGB evaluation."""
 
-    # docstr-coverage: inherited
     def __init__(self, filtered: bool = False, **kwargs):  # noqa:D107
         if filtered:
             raise ValueError(

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -356,7 +356,7 @@ class RankBasedEvaluator(Evaluator[RankBasedMetricKey]):
         scores: FloatTensor,
         true_scores: FloatTensor | None = None,
         dense_positive_mask: FloatTensor | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         if true_scores is None:
             raise ValueError(f"{self.__class__.__name__} needs the true scores!")
 
@@ -632,7 +632,7 @@ class SampledRankBasedEvaluator(RankBasedEvaluator):
         scores: FloatTensor,
         true_scores: FloatTensor | None = None,
         dense_positive_mask: FloatTensor | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         if true_scores is None:
             raise ValueError(f"{self.__class__.__name__} needs the true scores!")
 
@@ -707,7 +707,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         scores: FloatTensor,
         true_scores: FloatTensor | None = None,
         dense_positive_mask: FloatTensor | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         super().process_scores_(
             hrt_batch=hrt_batch,
             target=target,

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -369,12 +369,10 @@ class RankBasedEvaluator(Evaluator[RankBasedMetricKey]):
             self.ranks[target, rank_type].append(v.detach().cpu().numpy())
         self.num_candidates[target].append(batch_ranks.number_of_options.detach().cpu().numpy())
 
-    # docstr-coverage: inherited
     def clear(self) -> None:  # noqa: D102
         self.ranks.clear()
         self.num_candidates.clear()
 
-    # docstr-coverage: inherited
     def finalize(self) -> RankBasedMetricResults:  # noqa: D102
         if self.num_entities is None:
             raise ValueError
@@ -723,12 +721,10 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         # (and much larger) hrt_batch tensor in memory for the duration.
         self.keys[target].append(hrt_batch[:, TARGET_TO_KEYS[target]].detach().clone().cpu().numpy())
 
-    # docstr-coverage: inherited
     def clear(self) -> None:  # noqa: D102
         super().clear()
         self.keys.clear()
 
-    # docstr-coverage: inherited
     def finalize(self) -> RankBasedMetricResults:  # noqa: D102
         if self.num_entities is None:
             raise ValueError

--- a/src/pykeen/evaluation/rank_based_evaluator.py
+++ b/src/pykeen/evaluation/rank_based_evaluator.py
@@ -349,8 +349,7 @@ class RankBasedEvaluator(Evaluator[RankBasedMetricKey]):
                 continue
             yield key, None
 
-    # docstr-coverage: inherited
-    def process_scores_(
+    def process_scores_(  # noqa: D102
         self,
         hrt_batch: MappedTriples,
         target: Target,
@@ -628,8 +627,7 @@ class SampledRankBasedEvaluator(RankBasedEvaluator):
         self.negative_samples = negatives
         self.num_entities = evaluation_factory.num_entities
 
-    # docstr-coverage: inherited
-    def process_scores_(
+    def process_scores_(  # noqa: D102
         self,
         hrt_batch: MappedTriples,
         target: Target,
@@ -704,8 +702,7 @@ class MacroRankBasedEvaluator(RankBasedEvaluator):
         # broadcast to samples
         return weights[inverse]
 
-    # docstr-coverage: inherited
-    def process_scores_(
+    def process_scores_(  # noqa: D102
         self,
         hrt_batch: MappedTriples,
         target: Target,

--- a/src/pykeen/inverse.py
+++ b/src/pykeen/inverse.py
@@ -47,24 +47,20 @@ class RelationInverter(ABC):
 class DefaultRelationInverter(RelationInverter):
     """Maps normal relations to even IDs, and the corresponding inverse to the next odd ID."""
 
-    # docstr-coverage: inherited
     def get_inverse_id(self, relation_id: RelationID) -> RelationID:  # noqa: D102
         return relation_id + 1
 
-    # docstr-coverage: inherited
     def _map(self, batch: LongTensor, index: int = 1) -> LongTensor:  # noqa: D102
         batch = batch.clone()
         batch[:, index] *= 2
         return batch
 
-    # docstr-coverage: inherited
     def invert_(self, batch: LongTensor, index: int = 1) -> LongTensor:  # noqa: D102
         # The number of relations stored in the triples factory includes the number of inverse relations
         # Id of inverse relation: relation + 1
         batch[:, index] += 1
         return batch
 
-    # docstr-coverage: inherited
     def is_inverse(self, ids: LongTensor) -> BoolTensor:  # noqa: D102
         return ids % 2 == 1
 

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -554,7 +554,6 @@ class BCEWithLogitsLoss(PointwiseLoss):
         else:
             self.pos_weight = None
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: D102
         return functional.binary_cross_entropy_with_logits(
             x, target, reduction=self.reduction, weight=weight, pos_weight=self.pos_weight
@@ -575,7 +574,6 @@ class MSELoss(PointwiseLoss):
 
     synonyms = {"Mean Square Error Loss", "Mean Squared Error Loss"}
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: D102
         if weight is None:
             return functional.mse_loss(x, target, reduction=self.reduction)
@@ -1018,7 +1016,6 @@ class DoubleMarginLoss(PointwiseLoss):
 
         return self(x=predictions, target=labels, weight=weights)
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: D102
         self._raise_on_weights(weight)
         return self.positive_weight * self._reduction_method(
@@ -1181,7 +1178,6 @@ class BCEAfterSigmoidLoss(PointwiseLoss):
     name: Binary cross entropy (after sigmoid)
     """
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: D102
         return functional.binary_cross_entropy(x.sigmoid(), target, weight=weight, reduction=self.reduction)
 
@@ -1712,7 +1708,6 @@ class FocalLoss(PointwiseLoss):
         self.alpha = alpha
         self.gamma = gamma
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: D102
         p = x.sigmoid()
         ce_loss = functional.binary_cross_entropy_with_logits(x, target, reduction="none")

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -406,8 +406,7 @@ class PointwiseLoss(Loss):
         """
         raise NotImplementedError
 
-    # docstr-coverage: inherited
-    def process_slcwa_scores(
+    def process_slcwa_scores(  # noqa: D102
         self,
         positive_scores: FloatTensor,
         negative_scores: FloatTensor,
@@ -443,8 +442,7 @@ class PointwiseLoss(Loss):
             weights=weights,
         )
 
-    # docstr-coverage: inherited
-    def process_lcwa_scores(
+    def process_lcwa_scores(  # noqa: D102
         self,
         predictions: FloatTensor,
         labels: FloatTensor,
@@ -627,8 +625,7 @@ class MarginPairwiseLoss(PairwiseLoss):
         self.margin = margin
         self.margin_activation = margin_activation_resolver.make(margin_activation)
 
-    # docstr-coverage: inherited
-    def process_slcwa_scores(
+    def process_slcwa_scores(  # noqa: D102
         self,
         positive_scores: FloatTensor,
         negative_scores: FloatTensor,
@@ -652,8 +649,7 @@ class MarginPairwiseLoss(PairwiseLoss):
             pos_scores=positive_scores, neg_scores=negative_scores, pos_weights=pos_weights, neg_weights=neg_weights
         )
 
-    # docstr-coverage: inherited
-    def process_lcwa_scores(
+    def process_lcwa_scores(  # noqa: D102
         self,
         predictions: FloatTensor,
         labels: FloatTensor,
@@ -685,8 +681,7 @@ class MarginPairwiseLoss(PairwiseLoss):
 
         return self(pos_scores=positive_scores, neg_scores=negative_scores)
 
-    # docstr-coverage: inherited
-    def forward(
+    def forward(  # noqa: D102
         self,
         pos_scores: FloatTensor,
         neg_scores: FloatTensor,
@@ -967,8 +962,7 @@ class DoubleMarginLoss(PointwiseLoss):
         self.positive_weight = positive_negative_balance
         self.margin_activation = margin_activation_resolver.make(margin_activation)
 
-    # docstr-coverage: inherited
-    def process_slcwa_scores(
+    def process_slcwa_scores(  # noqa: D102
         self,
         positive_scores: FloatTensor,
         negative_scores: FloatTensor,
@@ -1006,8 +1000,7 @@ class DoubleMarginLoss(PointwiseLoss):
         negative_loss = self._reduction_method(self.margin_activation(self.negative_margin + negative_scores))
         return self.positive_weight * positive_loss + self.negative_weight * negative_loss
 
-    # docstr-coverage: inherited
-    def process_lcwa_scores(
+    def process_lcwa_scores(  # noqa: D102
         self,
         predictions: FloatTensor,
         labels: FloatTensor,
@@ -1075,8 +1068,7 @@ class DeltaPointwiseLoss(PointwiseLoss):
         self.margin = margin
         self.margin_activation = margin_activation_resolver.make(margin_activation)
 
-    # docstr-coverage: inherited
-    def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:
+    def forward(self, x: FloatTensor, target: FloatTensor, weight: FloatTensor | None = None) -> FloatTensor:  # noqa: D102
         # scale labels from [0, 1] to [-1, 1]
         target = 2 * target - 1
         loss = self.margin_activation(self.margin - target * x)
@@ -1246,8 +1238,7 @@ class CrossEntropyLoss(SetwiseLoss):
     name: Cross entropy
     """
 
-    # docstr-coverage: inherited
-    def process_slcwa_scores(
+    def process_slcwa_scores(  # noqa: D102
         self,
         positive_scores: FloatTensor,
         negative_scores: FloatTensor,
@@ -1284,8 +1275,7 @@ class CrossEntropyLoss(SetwiseLoss):
             reduction=self.reduction,
         )
 
-    # docstr-coverage: inherited
-    def process_lcwa_scores(
+    def process_lcwa_scores(  # noqa: D102
         self,
         predictions: FloatTensor,
         labels: FloatTensor,
@@ -1371,8 +1361,7 @@ class InfoNCELoss(CrossEntropyLoss):
         self.inverse_softmax_temperature = math.exp(log_adversarial_temperature)
         self.margin = margin
 
-    # docstr-coverage: inherited
-    def process_lcwa_scores(
+    def process_lcwa_scores(  # noqa: D102
         self,
         predictions: FloatTensor,
         labels: FloatTensor,
@@ -1394,8 +1383,7 @@ class InfoNCELoss(CrossEntropyLoss):
             weights=weights,
         )
 
-    # docstr-coverage: inherited
-    def process_slcwa_scores(
+    def process_slcwa_scores(  # noqa: D102
         self,
         positive_scores: FloatTensor,
         negative_scores: FloatTensor,
@@ -1439,8 +1427,7 @@ class AdversarialLoss(SetwiseLoss):
         self.inverse_softmax_temperature = inverse_softmax_temperature
         self.factor = 0.5 if self._reduction_method is torch.mean else 1.0
 
-    # docstr-coverage: inherited
-    def process_lcwa_scores(
+    def process_lcwa_scores(  # noqa: D102
         self,
         predictions: FloatTensor,
         labels: FloatTensor,
@@ -1475,8 +1462,7 @@ class AdversarialLoss(SetwiseLoss):
 
         return self.factor * (pos_loss + neg_loss)
 
-    # docstr-coverage: inherited
-    def process_slcwa_scores(
+    def process_slcwa_scores(  # noqa: D102
         self,
         positive_scores: FloatTensor,
         negative_scores: FloatTensor,
@@ -1603,8 +1589,7 @@ class NSSALoss(AdversarialLoss):
         super().__init__(reduction=reduction, inverse_softmax_temperature=adversarial_temperature)
         self.margin = margin
 
-    # docstr-coverage: inherited
-    def positive_loss_term(
+    def positive_loss_term(  # noqa: D102
         self,
         pos_scores: FloatTensor,
         label_smoothing: float | None = None,
@@ -1615,8 +1600,7 @@ class NSSALoss(AdversarialLoss):
             raise UnsupportedLabelSmoothingError(self)
         return -self._reduction_method(functional.logsigmoid(self.margin + pos_scores))
 
-    # docstr-coverage: inherited
-    def negative_loss_term_unreduced(
+    def negative_loss_term_unreduced(  # noqa: D102
         self,
         neg_scores: FloatTensor,
         label_smoothing: float | None = None,
@@ -1644,8 +1628,7 @@ class AdversarialBCEWithLogitsLoss(AdversarialLoss):
     name: Adversarially weighted binary cross entropy (with logits)
     """
 
-    # docstr-coverage: inherited
-    def positive_loss_term(
+    def positive_loss_term(  # noqa: D102
         self,
         pos_scores: FloatTensor,
         label_smoothing: float | None = None,
@@ -1658,8 +1641,7 @@ class AdversarialBCEWithLogitsLoss(AdversarialLoss):
             reduction=self.reduction,
         )
 
-    # docstr-coverage: inherited
-    def negative_loss_term_unreduced(
+    def negative_loss_term_unreduced(  # noqa: D102
         self,
         neg_scores: FloatTensor,
         label_smoothing: float | None = None,

--- a/src/pykeen/losses.py
+++ b/src/pykeen/losses.py
@@ -632,7 +632,7 @@ class MarginPairwiseLoss(PairwiseLoss):
         num_entities: int | None = None,
         pos_weights: FloatTensor | None = None,
         neg_weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -654,7 +654,7 @@ class MarginPairwiseLoss(PairwiseLoss):
         label_smoothing: float | None = None,
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -685,7 +685,7 @@ class MarginPairwiseLoss(PairwiseLoss):
         neg_scores: FloatTensor,
         pos_weights: FloatTensor | None = None,
         neg_weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         self._raise_on_weights(pos_weights)
         self._raise_on_weights(neg_weights)
         return self._reduction_method(
@@ -969,7 +969,7 @@ class DoubleMarginLoss(PointwiseLoss):
         num_entities: int | None = None,
         pos_weights: FloatTensor | None = None,
         neg_weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -1005,7 +1005,7 @@ class DoubleMarginLoss(PointwiseLoss):
         label_smoothing: float | None = None,
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # Sanity check
         if label_smoothing:
             labels = apply_label_smoothing(
@@ -1243,7 +1243,7 @@ class CrossEntropyLoss(SetwiseLoss):
         num_entities: int | None = None,
         pos_weights: FloatTensor | None = None,
         neg_weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         self._raise_on_weights(pos_weights)
         self._raise_on_weights(neg_weights)
         # we need dense negative scores => unfilter if necessary
@@ -1278,7 +1278,7 @@ class CrossEntropyLoss(SetwiseLoss):
         label_smoothing: float | None = None,
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # make sure labels form a proper probability distribution
         labels = functional.normalize(labels, p=1, dim=-1)
         # calculate cross entropy loss
@@ -1364,7 +1364,7 @@ class InfoNCELoss(CrossEntropyLoss):
         label_smoothing: float | None = None,
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # determine positive; do not check with == since the labels are floats
         pos_mask = labels > 0.5
         # subtract margin from positive scores
@@ -1388,7 +1388,7 @@ class InfoNCELoss(CrossEntropyLoss):
         num_entities: int | None = None,
         pos_weights: FloatTensor | None = None,
         neg_weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # subtract margin from positive scores
         positive_scores = positive_scores - self.margin
         # normalize positive score shape
@@ -1430,7 +1430,7 @@ class AdversarialLoss(SetwiseLoss):
         label_smoothing: float | None = None,
         num_entities: int | None = None,
         weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         self._raise_on_weights(weights)
         # determine positive; do not check with == since the labels are floats
         pos_mask = labels > 0.5
@@ -1467,7 +1467,7 @@ class AdversarialLoss(SetwiseLoss):
         num_entities: int | None = None,
         pos_weights: FloatTensor | None = None,
         neg_weights: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # Sanity check
         self._raise_on_weights(pos_weights)
         self._raise_on_weights(neg_weights)
@@ -1590,7 +1590,7 @@ class NSSALoss(AdversarialLoss):
         pos_scores: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -1601,7 +1601,7 @@ class NSSALoss(AdversarialLoss):
         neg_scores: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # Sanity check
         if label_smoothing:
             raise UnsupportedLabelSmoothingError(self)
@@ -1629,7 +1629,7 @@ class AdversarialBCEWithLogitsLoss(AdversarialLoss):
         pos_scores: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         return functional.binary_cross_entropy_with_logits(
             pos_scores,
             # TODO: maybe we can make this more efficient?
@@ -1642,7 +1642,7 @@ class AdversarialBCEWithLogitsLoss(AdversarialLoss):
         neg_scores: FloatTensor,
         label_smoothing: float | None = None,
         num_entities: int | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         return functional.binary_cross_entropy_with_logits(
             neg_scores,
             # TODO: maybe we can make this more efficient?

--- a/src/pykeen/metrics/classification.py
+++ b/src/pykeen/metrics/classification.py
@@ -145,7 +145,6 @@ class NumScores(ClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("score_count",)
 
-    # docstr-coverage: inherited
     def forward(self, y_true: numpy.ndarray, y_score: numpy.ndarray, weights: numpy.ndarray | None = None) -> float:  # noqa: D102
         return y_score.size
 
@@ -155,7 +154,6 @@ class BinarizedClassificationMetric(ClassificationMetric, abc.ABC):
 
     binarize: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
     def __call__(self, y_true: numpy.ndarray, y_score: numpy.ndarray, weights: numpy.ndarray | None = None) -> float:  # noqa: D102
         return super().__call__(
             y_true=y_true, y_score=construct_indicator(y_score=y_score, y_true=y_true), weights=weights
@@ -177,7 +175,6 @@ class BalancedAccuracyScore(BinarizedClassificationMetric):
     synonyms: ClassVar[Collection[str]] = ("b-acc", "bas")
     supports_weights: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
     def forward(
         self, y_true: numpy.ndarray, y_score: numpy.ndarray, sample_weight: numpy.ndarray | None = None
     ) -> float:  # noqa: D102
@@ -206,7 +203,6 @@ class AveragePrecisionScore(ClassificationMetric):
     synonyms: ClassVar[Collection[str]] = ("aps", "ap")
     supports_weights: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
     def forward(
         self, y_true: numpy.ndarray, y_score: numpy.ndarray, sample_weight: numpy.ndarray | None = None
     ) -> float:  # noqa: D102
@@ -228,7 +224,6 @@ class AreaUnderTheReceiverOperatingCharacteristicCurve(ClassificationMetric):
     synonyms: ClassVar[Collection[str]] = ("roc-auc",)
     supports_weights: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
     def forward(
         self, y_true: numpy.ndarray, y_score: numpy.ndarray, sample_weight: numpy.ndarray | None = None
     ) -> float:  # noqa: D102
@@ -265,7 +260,6 @@ class ConfusionMatrixClassificationMetric(ClassificationMetric, abc.ABC):
         """
         # todo: it would make sense to have a separate evaluator which constructs the confusion matrix only once
 
-    # docstr-coverage: inherited
     def forward(self, y_true: numpy.ndarray, y_score: numpy.ndarray, weights: numpy.ndarray | None = None) -> float:  # noqa: D102
         y_pred = construct_indicator(y_score=y_score, y_true=y_true)
         matrix = metrics.confusion_matrix(y_true=y_true, y_pred=y_pred, sample_weight=weights, normalize=None)
@@ -292,7 +286,6 @@ class TruePositiveRate(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("tpr", "sensitivity", "recall", "hit rate")
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=tp, denominator=tp + fn, zero_division=self.zero_division)
 
@@ -320,7 +313,6 @@ class TrueNegativeRate(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("tnr", "specificity", "selectivity")
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=tn, denominator=tn + fp, zero_division=self.zero_division)
 
@@ -343,7 +335,6 @@ class FalsePositiveRate(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = False
     synonyms: ClassVar[Collection[str]] = ("fpr", "fall-out", "false alarm ratio")
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=fp, denominator=fp + tn, zero_division=self.zero_division)
 
@@ -366,7 +357,6 @@ class FalseNegativeRate(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = False
     synonyms: ClassVar[Collection[str]] = ("fnr", "miss-rate")
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=fn, denominator=fn + tp, zero_division=self.zero_division)
 
@@ -389,7 +379,6 @@ class PositivePredictiveValue(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("ppv",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=tp, denominator=tp + fp, zero_division=self.zero_division)
 
@@ -412,7 +401,6 @@ class NegativePredictiveValue(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("npv",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=tn, denominator=tn + fn, zero_division=self.zero_division)
 
@@ -435,7 +423,6 @@ class FalseDiscoveryRate(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = False
     synonyms: ClassVar[Collection[str]] = ("fdr",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=fp, denominator=fp + tp, zero_division=self.zero_division)
 
@@ -458,7 +445,6 @@ class FalseOmissionRate(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = False
     synonyms: ClassVar[Collection[str]] = ("fom",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=fn, denominator=fn + tn, zero_division=self.zero_division)
 
@@ -481,7 +467,6 @@ class PositiveLikelihoodRatio(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("lr+",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(
             numerator=tp * (tn + fp),
@@ -508,7 +493,6 @@ class NegativeLikelihoodRatio(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = False
     synonyms: ClassVar[Collection[str]] = ("lr-",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(
             numerator=fn * (tn + fp),
@@ -537,7 +521,6 @@ class DiagnosticOddsRatio(ConfusionMatrixClassificationMetric):
 
     # todo: https://en.wikipedia.org/wiki/Diagnostic_odds_ratio#Confidence_interval
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=tp * tn, denominator=fp * fn, zero_division=self.zero_division)
 
@@ -560,7 +543,6 @@ class Accuracy(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("acc", "fraction correct", "fc")
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=tp + tn, denominator=tp + tn + fp + fn, zero_division=self.zero_division)
 
@@ -583,7 +565,6 @@ class F1Score(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("f1",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=2 * tp, denominator=2 * tp + fp + fn, zero_division=self.zero_division)
 
@@ -607,7 +588,6 @@ class PrevalenceThreshold(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = False
     synonyms: ClassVar[Collection[str]] = ("pt",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         fpr = FalsePositiveRate().extract_from_confusion_matrix(tn=tn, fp=fp, fn=fn, tp=tp)
         tpr = TruePositiveRate().extract_from_confusion_matrix(tn=tn, fp=fp, fn=fn, tp=tp)
@@ -636,7 +616,6 @@ class ThreatScore(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("ts", "critical success index", "csi", "jaccard index")
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(numerator=tp, denominator=tp + fn + fp, zero_division=self.zero_division)
 
@@ -659,7 +638,6 @@ class FowlkesMallowsIndex(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("fm", "fmi")
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return math.sqrt(safe_divide(numerator=tp**2, denominator=2 * tp + fp + fn, zero_division=self.zero_division))
 
@@ -682,7 +660,6 @@ class Informedness(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("Youden's J", "Youden's Index", "yi")
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return (
             safe_divide(numerator=tp, denominator=tp + fn, zero_division=self.zero_division)
@@ -711,7 +688,6 @@ class MatthewsCorrelationCoefficient(ConfusionMatrixClassificationMetric):
     increasing: ClassVar[bool] = True
     synonyms: ClassVar[Collection[str]] = ("mcc",)
 
-    # docstr-coverage: inherited
     def extract_from_confusion_matrix(self, tn: float, fp: float, fn: float, tp: float) -> float:  # noqa: D102
         return safe_divide(
             numerator=tp * tn - fp * fn,

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -570,8 +570,7 @@ class DerivedRankBasedMetric(RankBasedMetric, ABC):
         """
         self.base = rank_based_metric_resolver.make(base_cls or self.base_cls, pos_kwargs=kwargs)
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         if num_candidates is None:
@@ -604,8 +603,7 @@ class DerivedRankBasedMetric(RankBasedMetric, ABC):
         parameters = self.get_coefficients(num_candidates=num_candidates, weights=weights)
         return parameters.scale * base_metric_result + parameters.offset
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -622,8 +620,7 @@ class DerivedRankBasedMetric(RankBasedMetric, ABC):
             weights=weights,
         )
 
-    # docstr-coverage: inherited
-    def variance(
+    def variance(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -710,8 +707,7 @@ class ZMetric(DerivedRankBasedMetric):
     closed_expectation: ClassVar[bool] = True
     closed_variance: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def get_coefficients(
+    def get_coefficients(  # noqa: D102
         self, num_candidates: np.ndarray, weights: np.ndarray | None = None
     ) -> AffineTransformationParameters:  # noqa: D102
         mean = self.base.expected_value(num_candidates=num_candidates, weights=weights)
@@ -722,8 +718,7 @@ class ZMetric(DerivedRankBasedMetric):
         offset = -scale * mean
         return AffineTransformationParameters(scale=scale, offset=offset)
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -733,8 +728,7 @@ class ZMetric(DerivedRankBasedMetric):
         # should be exactly 0.0
         return 0.0  # centered
 
-    # docstr-coverage: inherited
-    def variance(
+    def variance(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -764,16 +758,14 @@ class ExpectationNormalizedMetric(DerivedRankBasedMetric):
 
     closed_expectation: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def get_coefficients(
+    def get_coefficients(  # noqa: D102
         self, num_candidates: np.ndarray, weights: np.ndarray | None = None
     ) -> AffineTransformationParameters:  # noqa: D102
         return AffineTransformationParameters(
             scale=_safe_divide(1, self.base.expected_value(num_candidates=num_candidates, weights=weights))
         )
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -806,8 +798,7 @@ class ReindexedMetric(DerivedRankBasedMetric):
     supported_rank_types = (RANK_REALISTIC,)
     closed_expectation: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def get_coefficients(
+    def get_coefficients(  # noqa: D102
         self, num_candidates: np.ndarray, weights: np.ndarray | None = None
     ) -> AffineTransformationParameters:  # noqa: D102
         mean = self.base.expected_value(num_candidates=num_candidates, weights=weights)
@@ -815,8 +806,7 @@ class ReindexedMetric(DerivedRankBasedMetric):
         offset = -scale * mean
         return AffineTransformationParameters(scale=scale, offset=offset)
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -905,14 +895,12 @@ class ArithmeticMeanRank(RankBasedMetric):
     closed_expectation: ClassVar[bool] = True
     closed_variance: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         return np.average(np.asanyarray(ranks), weights=weights).item()
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -923,8 +911,7 @@ class ArithmeticMeanRank(RankBasedMetric):
         individual_expectation = 0.5 * (num_candidates + 1)
         return weighted_mean_expectation(individual=individual_expectation, weights=weights)
 
-    # docstr-coverage: inherited
-    def variance(
+    def variance(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -966,8 +953,7 @@ class InverseArithmeticMeanRank(RankBasedMetric):
     synonyms: ClassVar[Collection[str]] = ("iamr",)
     supports_weights = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         return np.reciprocal(np.average(np.asanyarray(ranks), weights=weights)).item()
@@ -1035,8 +1021,7 @@ class GeometricMeanRank(RankBasedMetric):
     closed_expectation: ClassVar[bool] = True
     closed_variance: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         return stats.gmean(ranks, weights=weights).item()
@@ -1049,8 +1034,7 @@ class GeometricMeanRank(RankBasedMetric):
         safe_total = np.clip(total, a_min=np.finfo(weights.dtype).eps, a_max=None)
         return weights / safe_total
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -1065,8 +1049,7 @@ class GeometricMeanRank(RankBasedMetric):
 
         return np.exp(log_expectation)
 
-    # docstr-coverage: inherited
-    def variance(
+    def variance(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -1126,8 +1109,7 @@ class InverseGeometricMeanRank(RankBasedMetric):
     synonyms: ClassVar[Collection[str]] = ("igmr",)
     supports_weights = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         return np.reciprocal(stats.gmean(ranks, weights=weights)).item()
@@ -1177,8 +1159,7 @@ class HarmonicMeanRank(RankBasedMetric):
     synonyms: ClassVar[Collection[str]] = ("hmr",)
     supports_weights = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         return weighted_harmonic_mean(a=ranks, weights=weights).item()
@@ -1318,14 +1299,12 @@ class InverseHarmonicMeanRank(RankBasedMetric):
     closed_expectation: ClassVar[bool] = True
     closed_variance: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         return np.reciprocal(weighted_harmonic_mean(a=ranks, weights=weights)).item()
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -1338,8 +1317,7 @@ class InverseHarmonicMeanRank(RankBasedMetric):
         individual = expectation[num_candidates - 1]
         return weighted_mean_expectation(individual, weights)
 
-    # docstr-coverage: inherited
-    def variance(
+    def variance(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -1478,8 +1456,7 @@ class MedianRank(RankBasedMetric):
     closed_expectation: ClassVar[bool] = True
     closed_variance: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         if weights is None:
@@ -1487,8 +1464,7 @@ class MedianRank(RankBasedMetric):
 
         return weighted_median(a=ranks, weights=weights).item()
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -1508,8 +1484,7 @@ class MedianRank(RankBasedMetric):
         # We slice [:-1] because the array goes up to x=k_max, and P(M > k_max) is 0.
         return np.sum(sf[:-1])
 
-    # docstr-coverage: inherited
-    def variance(
+    def variance(  # noqa: D102
         self, num_candidates: np.ndarray, num_samples: int | None = None, weights: np.ndarray | None = None, **kwargs
     ) -> float:  # noqa: D102
         # weighted case is equivalent to Subset Sum Problem (~NP complete)
@@ -1546,8 +1521,7 @@ class InverseMedianRank(RankBasedMetric):
     increasing = True
     supports_weights = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         return np.reciprocal(weighted_median(a=ranks, weights=weights), dtype=float).item()
@@ -1577,8 +1551,7 @@ class StandardDeviation(RankBasedMetric):
     synonyms: ClassVar[Collection[str]] = ("rank_std", "std")
     supports_weights: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         ranks = np.asanyarray(ranks)
@@ -1620,8 +1593,7 @@ class Variance(RankBasedMetric):
     synonyms: ClassVar[Collection[str]] = ("rank_var", "var")
     supports_weights: ClassVar[bool] = True
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         ranks = np.asanyarray(ranks)
@@ -1701,8 +1673,7 @@ class Count(RankBasedMetric):
     synonyms: ClassVar[Collection[str]] = ("rank_count",)
     supports_weights: ClassVar[bool] = False
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         # TODO: should we return the sum of weights?
@@ -1797,8 +1768,7 @@ class HitsAtK(RankBasedMetric):
         yield from super().iter_extra_repr()
         yield f"k={self.k}"
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
         return np.average(np.less_equal(ranks, self.k), weights=weights).item()
@@ -1808,8 +1778,7 @@ class HitsAtK(RankBasedMetric):
     def key(self) -> str:  # noqa: D102
         return super().key[:-1] + str(self.k)
 
-    # docstr-coverage: inherited
-    def expected_value(
+    def expected_value(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,
@@ -1821,8 +1790,7 @@ class HitsAtK(RankBasedMetric):
         individual = np.minimum(self.k / num_candidates, 1.0)
         return weighted_mean_expectation(individual=individual, weights=weights)
 
-    # docstr-coverage: inherited
-    def variance(
+    def variance(  # noqa: D102
         self,
         num_candidates: np.ndarray,
         num_samples: int | None = None,

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -1634,7 +1634,6 @@ class MedianAbsoluteDeviation(RankBasedMetric):
     synonyms: ClassVar[Collection[str]] = ("rank_mad", "mad")
     supports_weights = True
 
-    # docstr-coverage: inherited
     def __call__(
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
     ) -> float:  # noqa: D102
@@ -1763,7 +1762,6 @@ class HitsAtK(RankBasedMetric):
         super().__init__()
         self.k = k
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"k={self.k}"
@@ -1773,7 +1771,6 @@ class HitsAtK(RankBasedMetric):
     ) -> float:  # noqa: D102
         return np.average(np.less_equal(ranks, self.k), weights=weights).item()
 
-    # docstr-coverage: inherited
     @property
     def key(self) -> str:  # noqa: D102
         return super().key[:-1] + str(self.k)

--- a/src/pykeen/metrics/ranking.py
+++ b/src/pykeen/metrics/ranking.py
@@ -572,7 +572,7 @@ class DerivedRankBasedMetric(RankBasedMetric, ABC):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         if num_candidates is None:
             raise ValueError(f"{self.__class__.__name__} requires number of candidates.")
         return self.adjust(
@@ -609,7 +609,7 @@ class DerivedRankBasedMetric(RankBasedMetric, ABC):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         # since scale and offset are constant for a given number of candidates, we have
         # E[scale * M + offset] = scale * E[M] + offset
         return self.adjust(
@@ -626,7 +626,7 @@ class DerivedRankBasedMetric(RankBasedMetric, ABC):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         # since scale and offset are constant for a given number of candidates, we have
         # V[scale * M + offset] = scale^2 * V[M]
         parameters = self.get_coefficients(num_candidates=num_candidates, weights=weights)
@@ -709,7 +709,7 @@ class ZMetric(DerivedRankBasedMetric):
 
     def get_coefficients(  # noqa: D102
         self, num_candidates: np.ndarray, weights: np.ndarray | None = None
-    ) -> AffineTransformationParameters:  # noqa: D102
+    ) -> AffineTransformationParameters:
         mean = self.base.expected_value(num_candidates=num_candidates, weights=weights)
         std = self.base.std(num_candidates=num_candidates, weights=weights)
         scale = _safe_divide(1.0, std)
@@ -724,7 +724,7 @@ class ZMetric(DerivedRankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         # should be exactly 0.0
         return 0.0  # centered
 
@@ -734,7 +734,7 @@ class ZMetric(DerivedRankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         # should be exactly 1.0
         return 1.0  # re-scaled
 
@@ -760,7 +760,7 @@ class ExpectationNormalizedMetric(DerivedRankBasedMetric):
 
     def get_coefficients(  # noqa: D102
         self, num_candidates: np.ndarray, weights: np.ndarray | None = None
-    ) -> AffineTransformationParameters:  # noqa: D102
+    ) -> AffineTransformationParameters:
         return AffineTransformationParameters(
             scale=_safe_divide(1, self.base.expected_value(num_candidates=num_candidates, weights=weights))
         )
@@ -771,7 +771,7 @@ class ExpectationNormalizedMetric(DerivedRankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         return 1.0  # centered
 
 
@@ -800,7 +800,7 @@ class ReindexedMetric(DerivedRankBasedMetric):
 
     def get_coefficients(  # noqa: D102
         self, num_candidates: np.ndarray, weights: np.ndarray | None = None
-    ) -> AffineTransformationParameters:  # noqa: D102
+    ) -> AffineTransformationParameters:
         mean = self.base.expected_value(num_candidates=num_candidates, weights=weights)
         scale = _safe_divide(1.0, 1.0 - mean)
         offset = -scale * mean
@@ -812,7 +812,7 @@ class ReindexedMetric(DerivedRankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         # should be exactly 0.0
         return 0.0
 
@@ -897,7 +897,7 @@ class ArithmeticMeanRank(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         return np.average(np.asanyarray(ranks), weights=weights).item()
 
     def expected_value(  # noqa: D102
@@ -906,7 +906,7 @@ class ArithmeticMeanRank(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         num_candidates = np.asanyarray(num_candidates)
         individual_expectation = 0.5 * (num_candidates + 1)
         return weighted_mean_expectation(individual=individual_expectation, weights=weights)
@@ -917,7 +917,7 @@ class ArithmeticMeanRank(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         num_candidates = np.asanyarray(num_candidates)
         individual_variance = (num_candidates**2 - 1) / 12.0
         return weighted_mean_variance(individual=individual_variance, weights=weights)
@@ -955,7 +955,7 @@ class InverseArithmeticMeanRank(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         return np.reciprocal(np.average(np.asanyarray(ranks), weights=weights)).item()
 
 
@@ -1023,7 +1023,7 @@ class GeometricMeanRank(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         return stats.gmean(ranks, weights=weights).item()
 
     @staticmethod
@@ -1040,7 +1040,7 @@ class GeometricMeanRank(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         alpha = self._normalize_weights(weights, n=len(num_candidates))
 
         # E[G] = Product( E[ X_i^alpha_i ] )
@@ -1055,7 +1055,7 @@ class GeometricMeanRank(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         alpha = self._normalize_weights(weights, n=len(num_candidates))
 
         # 1. Calculate Log of First Moment E[G]
@@ -1111,7 +1111,7 @@ class InverseGeometricMeanRank(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         return np.reciprocal(stats.gmean(ranks, weights=weights)).item()
 
 
@@ -1161,7 +1161,7 @@ class HarmonicMeanRank(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         return weighted_harmonic_mean(a=ranks, weights=weights).item()
 
 
@@ -1301,7 +1301,7 @@ class InverseHarmonicMeanRank(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         return np.reciprocal(weighted_harmonic_mean(a=ranks, weights=weights)).item()
 
     def expected_value(  # noqa: D102
@@ -1310,7 +1310,7 @@ class InverseHarmonicMeanRank(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         num_candidates = np.asanyarray(num_candidates)
         n = num_candidates.max().item()
         expectation = generalized_harmonic_numbers(n, p=-1.0) / np.arange(1, n + 1)
@@ -1323,7 +1323,7 @@ class InverseHarmonicMeanRank(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         num_candidates = np.asanyarray(num_candidates)
         n = num_candidates.max().item()
         individual = harmonic_variances(n)[num_candidates - 1]
@@ -1458,7 +1458,7 @@ class MedianRank(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         if weights is None:
             return np.median(ranks).item()
 
@@ -1470,7 +1470,7 @@ class MedianRank(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         # weighted case is equivalent to Subset Sum Problem (~NP complete)
         if weights is not None:
             return super().expected_value(
@@ -1486,7 +1486,7 @@ class MedianRank(RankBasedMetric):
 
     def variance(  # noqa: D102
         self, num_candidates: np.ndarray, num_samples: int | None = None, weights: np.ndarray | None = None, **kwargs
-    ) -> float:  # noqa: D102
+    ) -> float:
         # weighted case is equivalent to Subset Sum Problem (~NP complete)
         if weights is not None:
             return super().variance(num_candidates=num_candidates, num_samples=num_samples, weights=weights, **kwargs)
@@ -1523,7 +1523,7 @@ class InverseMedianRank(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         return np.reciprocal(weighted_median(a=ranks, weights=weights), dtype=float).item()
 
 
@@ -1553,7 +1553,7 @@ class StandardDeviation(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         ranks = np.asanyarray(ranks)
         if weights is None:
             return ranks.std().item()
@@ -1595,7 +1595,7 @@ class Variance(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         ranks = np.asanyarray(ranks)
         if weights is None:
             return ranks.var().item()
@@ -1674,7 +1674,7 @@ class Count(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         # TODO: should we return the sum of weights?
         if weights is not None:
             raise NoWeightSupportError(
@@ -1768,7 +1768,7 @@ class HitsAtK(RankBasedMetric):
 
     def __call__(  # noqa: D102
         self, ranks: np.ndarray, num_candidates: np.ndarray | None = None, weights: np.ndarray | None = None
-    ) -> float:  # noqa: D102
+    ) -> float:
         return np.average(np.less_equal(ranks, self.k), weights=weights).item()
 
     @property
@@ -1781,7 +1781,7 @@ class HitsAtK(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         num_candidates = np.asanyarray(num_candidates, dtype=float)
         # for each individual ranking task, we have I[r_i <= k] ~ Bernoulli(k/C_i)
         individual = np.minimum(self.k / num_candidates, 1.0)
@@ -1793,7 +1793,7 @@ class HitsAtK(RankBasedMetric):
         num_samples: int | None = None,
         weights: np.ndarray | None = None,
         **kwargs,
-    ) -> float:  # noqa: D102
+    ) -> float:
         # for each individual ranking task, we have I[r_i <= k] ~ Bernoulli(k/C_i)
         num_candidates = np.asanyarray(num_candidates, dtype=float)
         p = np.minimum(self.k / num_candidates, 1.0)

--- a/src/pykeen/models/baseline/models.py
+++ b/src/pykeen/models/baseline/models.py
@@ -119,7 +119,6 @@ class MarginalDistributionBaseline(EvaluationOnlyModel):
         else:
             self.head_per_tail = self.tail_per_head = None
 
-    # docstr-coverage: inherited
     def score_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return marginal_score(
             entity_relation_batch=hr_batch,
@@ -128,7 +127,6 @@ class MarginalDistributionBaseline(EvaluationOnlyModel):
             num_entities=self.num_entities,
         )
 
-    # docstr-coverage: inherited
     def score_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return marginal_score(
             entity_relation_batch=rt_batch.flip(1),
@@ -177,14 +175,12 @@ class SoftInverseTripleBaseline(EvaluationOnlyModel):
             for col_indices in (h, t)
         )
 
-    # docstr-coverage: inherited
     def score_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         r = hr_batch[:, 1].cpu().numpy()
         scores = self.sim[r, :] @ self.rel_to_tail + self.sim_inv[r, :] @ self.rel_to_head
         scores = numpy.asarray(scores.todense())
         return torch.from_numpy(scores)
 
-    # docstr-coverage: inherited
     def score_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         r = rt_batch[:, 0].cpu().numpy()
         scores = self.sim[r, :] @ self.rel_to_head + self.sim_inv[r, :] @ self.rel_to_tail

--- a/src/pykeen/models/inductive/base.py
+++ b/src/pykeen/models/inductive/base.py
@@ -105,7 +105,6 @@ class InductiveERModel(ERModel):
         self._mode_to_representations[key] = nn.ModuleList(representation).to(self.device)
         return old
 
-    # docstr-coverage: inherited
     def _get_entity_representations_from_inductive_mode(
         self, *, mode: InductiveMode | None
     ) -> Sequence[Representation]:  # noqa: D102
@@ -118,6 +117,5 @@ class InductiveERModel(ERModel):
             return self._mode_to_representations[key]
         raise ValueError(f"{self.__class__.__name__} does not support mode={mode}")
 
-    # docstr-coverage: inherited
     def _get_entity_len(self, *, mode: InductiveMode | None) -> int:  # noqa: D102
         return self._get_entity_representations_from_inductive_mode(mode=mode)[0].max_id

--- a/src/pykeen/models/meta/filtered.py
+++ b/src/pykeen/models/meta/filtered.py
@@ -155,25 +155,20 @@ class CooccurrenceFilteredModel(Model):
         new_scores[rows, cols] = scores[rows, cols]
         return new_scores
 
-    # docstr-coverage: inherited
     def _get_entity_len(self, *, mode: InductiveMode | None) -> int:
         return self.base._get_entity_len(mode=mode)
 
-    # docstr-coverage: inherited
     def _reset_parameters_(self):
         return self.base._reset_parameters_()
 
-    # docstr-coverage: inherited
     def collect_regularization_term(self) -> FloatTensor:  # noqa: D102
         return self.base.collect_regularization_term()
 
-    # docstr-coverage: inherited
     def score_hrt(self, hrt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         if self.apply_in_training:
             raise NotImplementedError
         return self.base.score_hrt(hrt_batch=hrt_batch, **kwargs)
 
-    # docstr-coverage: inherited
     def score_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=self.base.score_h(rt_batch=rt_batch, **kwargs),
@@ -182,7 +177,6 @@ class CooccurrenceFilteredModel(Model):
             in_training=True,
         )
 
-    # docstr-coverage: inherited
     def score_r(self, ht_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=self.base.score_r(ht_batch=ht_batch, **kwargs),
@@ -191,7 +185,6 @@ class CooccurrenceFilteredModel(Model):
             in_training=True,
         )
 
-    # docstr-coverage: inherited
     def score_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=self.base.score_t(hr_batch=hr_batch, **kwargs),
@@ -200,7 +193,6 @@ class CooccurrenceFilteredModel(Model):
             in_training=True,
         )
 
-    # docstr-coverage: inherited
     def predict_h(self, rt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=super().predict_h(rt_batch, **kwargs),
@@ -209,7 +201,6 @@ class CooccurrenceFilteredModel(Model):
             in_training=False,
         )
 
-    # docstr-coverage: inherited
     def predict_t(self, hr_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=super().predict_t(hr_batch, **kwargs),
@@ -218,7 +209,6 @@ class CooccurrenceFilteredModel(Model):
             in_training=False,
         )
 
-    # docstr-coverage: inherited
     def predict_r(self, ht_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._mask(
             scores=super().predict_r(ht_batch, **kwargs),

--- a/src/pykeen/models/mocks.py
+++ b/src/pykeen/models/mocks.py
@@ -54,7 +54,6 @@ class FixedModel(Model):
         # up the optimizer
         self.dummy = torch.nn.Parameter(torch.empty(1), requires_grad=True)
 
-    # docstr-coverage: inherited
     def collect_regularization_term(self):  # noqa: D102
         return 0.0
 
@@ -63,7 +62,6 @@ class FixedModel(Model):
             raise NotImplementedError
         return self.num_entities
 
-    # docstr-coverage: inherited
     def _reset_parameters_(self):  # noqa: D102
         pass  # Not needed for mock model
 
@@ -76,23 +74,19 @@ class FixedModel(Model):
         """Generate fake scores."""
         return (h * (self.num_entities * self.num_relations) + r * self.num_entities + t).float().requires_grad_(True)
 
-    # docstr-coverage: inherited
     def score_hrt(self, hrt_batch: LongTensor, **kwargs) -> FloatTensor:  # noqa: D102
         return self._generate_fake_scores(*hrt_batch.t()).unsqueeze(dim=-1)
 
-    # docstr-coverage: inherited
     def score_t(self, hr_batch: LongTensor, tails: LongTensor | None = None, **kwargs) -> FloatTensor:  # noqa: D102
         if tails is None:
             tails = torch.arange(self.num_entities, device=hr_batch.device).unsqueeze(dim=0)
         return self._generate_fake_scores(h=hr_batch[:, 0:1], r=hr_batch[:, 1:2], t=tails)
 
-    # docstr-coverage: inherited
     def score_r(self, ht_batch: LongTensor, relations: LongTensor | None = None, **kwargs) -> FloatTensor:  # noqa: D102
         if relations is None:
             relations = torch.arange(self.num_relations, device=ht_batch.device).unsqueeze(dim=0)
         return self._generate_fake_scores(h=ht_batch[:, 0:1], r=relations, t=ht_batch[:, 1:2])
 
-    # docstr-coverage: inherited
     def score_h(self, rt_batch: LongTensor, heads: LongTensor | None = None, **kwargs) -> FloatTensor:  # noqa: D102
         if heads is None:
             heads = torch.arange(self.num_entities, device=rt_batch.device).unsqueeze(dim=0)

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -139,7 +139,6 @@ class _NewAbstractModel(Model, ABC):
             if hasattr(module, "post_parameter_update"):
                 module.post_parameter_update()
 
-    # docstr-coverage: inherited
     def collect_regularization_term(self):  # noqa: D102
         return sum(
             regularizer.pop_regularization_term()

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -510,7 +510,7 @@ class ERModel(
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
         tails: LongTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # normalize before checking
         if slice_size and slice_size >= self.num_entities:
             slice_size = None
@@ -547,7 +547,7 @@ class ERModel(
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
         heads: LongTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # normalize before checking
         if slice_size and slice_size >= self.num_entities:
             slice_size = None
@@ -584,7 +584,7 @@ class ERModel(
         slice_size: int | None = None,
         mode: InductiveMode | None = None,
         relations: LongTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         # normalize before checking
         if slice_size and slice_size >= self.num_relations:
             slice_size = None

--- a/src/pykeen/models/nbase.py
+++ b/src/pykeen/models/nbase.py
@@ -504,8 +504,7 @@ class ERModel(
         if self.training and get_batchnorm_modules(self):
             raise ValueError("This model does not support slicing, since it has batch normalization layers.")
 
-    # docstr-coverage: inherited
-    def score_t(
+    def score_t(  # noqa: D102
         self,
         hr_batch: LongTensor,
         *,
@@ -542,8 +541,7 @@ class ERModel(
             num=self._get_entity_len(mode=mode) if tails is None else tails.shape[-1],
         )
 
-    # docstr-coverage: inherited
-    def score_h(
+    def score_h(  # noqa: D102
         self,
         rt_batch: LongTensor,
         *,
@@ -580,8 +578,7 @@ class ERModel(
             num=self._get_entity_len(mode=mode) if heads is None else heads.shape[-1],
         )
 
-    # docstr-coverage: inherited
-    def score_r(
+    def score_r(  # noqa: D102
         self,
         ht_batch: LongTensor,
         *,

--- a/src/pykeen/nn/combination.py
+++ b/src/pykeen/nn/combination.py
@@ -73,11 +73,9 @@ class ConcatCombination(Combination):
         super().__init__()
         self.dim = dim
 
-    # docstr-coverage: inherited
     def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         return torch.cat(xs, dim=self.dim)
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"dim={self.dim}"
@@ -116,7 +114,6 @@ class ConcatProjectionCombination(ConcatCombination):
             activation_resolver.make(activation, activation_kwargs),
         )
 
-    # docstr-coverage: inherited
     def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         return self.projection(super().forward(xs))
 
@@ -143,11 +140,9 @@ class ConcatAggregationCombination(ConcatCombination):
         self.dim = dim
         self.aggregation = aggregation_resolver.make(aggregation, aggregation_kwargs)
 
-    # docstr-coverage: inherited
     def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         return self.aggregation(super().forward(xs=xs), dim=self.dim)
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"aggregation={self.aggregation}"
@@ -183,7 +178,6 @@ class ComplexSeparatedCombination(Combination):
         self.real_combination = combination_resolver.make(combination, combination_kwargs)
         self.imag_combination = combination_resolver.make(imag_combination, imag_combination_kwargs)
 
-    # docstr-coverage: inherited
     def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         if not any(x.is_complex() for x in xs):
             raise ValueError(
@@ -198,7 +192,6 @@ class ComplexSeparatedCombination(Combination):
         # combine
         return combine_complex(x_re=x_re, x_im=x_im)
 
-    # docstr-coverage: inherited
     def output_shape(self, input_shapes: Sequence[tuple[int, ...]]) -> tuple[int, ...]:  # noqa: D102
         # symbolic output to avoid dtype issue
         # we only need to consider real part here
@@ -287,7 +280,6 @@ class GatedCombination(Combination):
             activation_kwargs=hidden_activation_kwargs,
         )
 
-    # docstr-coverage: inherited
     def forward(self, xs: Sequence[FloatTensor]) -> FloatTensor:  # noqa: D102
         assert len(xs) == 2
         z = self.gate(xs)

--- a/src/pykeen/nn/compositions.py
+++ b/src/pykeen/nn/compositions.py
@@ -49,7 +49,6 @@ class FunctionalCompositionModule(CompositionModule):
     #: The stateless function that gets composed
     func: ClassVar[Composition]
 
-    # docstr-coverage: inherited
     def forward(self, a: FloatTensor, b: FloatTensor) -> FloatTensor:  # noqa: D102
         return self.__class__.func(a, b)
 

--- a/src/pykeen/nn/message_passing.py
+++ b/src/pykeen/nn/message_passing.py
@@ -219,7 +219,6 @@ class BasesDecomposition(Decomposition):
             base_kwargs={"initializer": nn.init.xavier_normal_},
         )
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"num_bases={self.relation_representations.num_bases}"
@@ -234,18 +233,15 @@ class BasesDecomposition(Decomposition):
         """Return the base weights."""
         return self.relation_representations.weight(indices=None)
 
-    # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102
         # note: the only parameters are inside the relation representation module, which has its own reset_parameters
         pass
 
-    # docstr-coverage: inherited
     def forward_horizontally_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
         x = einsum("ni, rb, bio -> rno", x, self.base_weights, self.bases)
         # TODO: can we change the dimension order to make this contiguous?
         return torch.spmm(adj, x.reshape(-1, self.output_dim))
 
-    # docstr-coverage: inherited
     def forward_vertically_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
         x = torch.spmm(adj, x)
         x = x.view(self.num_relations, -1, self.input_dim)
@@ -341,7 +337,6 @@ class BlockDecomposition(Decomposition):
         """Reset the layer's parameters."""
         xavier_normal_(self.blocks.data)
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"num_blocks={self.num_blocks}"
@@ -351,7 +346,6 @@ class BlockDecomposition(Decomposition):
             yield f"input_block_size={self.input_block_size}"
             yield f"output_block_size={self.output_block_size}"
 
-    # docstr-coverage: inherited
     def forward_horizontally_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
         # apply padding if necessary
         x = _pad_if_necessary(x=x, dim=self.padded_input_dim)
@@ -367,7 +361,6 @@ class BlockDecomposition(Decomposition):
         # remove padding if necessary
         return _unpad_if_necessary(x=x, dim=self.padded_output_dim)
 
-    # docstr-coverage: inherited
     def forward_vertically_stacked(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:  # noqa: D102
         # apply padding if necessary
         x = _pad_if_necessary(x=x, dim=self.padded_input_dim)
@@ -683,14 +676,12 @@ class RGCNRepresentation(Representation):
         self.enriched_embeddings = None
         self.cache = cache
 
-    # docstr-coverage: inherited
     def post_parameter_update(self) -> None:  # noqa: D102
         super().post_parameter_update()
 
         # invalidate enriched embeddings
         self.enriched_embeddings = None
 
-    # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102
         self.entity_embeddings.reset_parameters()
 

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -2557,8 +2557,7 @@ class ClampedInteraction(Interaction[HeadRepresentation, RelationRepresentation,
         """Expose the base interaction's relation shape."""
         return self.base.relation_shape
 
-    # docstr-coverage: inherited
-    def forward(self, h: HeadRepresentation, r: RelationRepresentation, t: TailRepresentation) -> FloatTensor:
+    def forward(self, h: HeadRepresentation, r: RelationRepresentation, t: TailRepresentation) -> FloatTensor:  # noqa: D102
         scores = self.base(h, r, t)
         if self.clamp_score is None:
             return scores
@@ -2873,8 +2872,7 @@ class MonotonicAffineTransformationInteraction(
         self.bias.data = self.initial_bias.to(device=self.bias.device)
         self.log_scale.data = self.initial_log_scale.to(device=self.bias.device)
 
-    # docstr-coverage: inherited
-    def forward(
+    def forward(  # noqa: D102
         self,
         h: HeadRepresentation,
         r: RelationRepresentation,

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -150,12 +150,10 @@ def parallel_slice_batches(
         yield unpack_singletons(*(batch[start:stop] for start, stop in zip(splits, splits[1:], strict=False)))  # type: ignore[misc]
 
 
-# docstr-coverage:excused `overload`
 @overload
 def parallel_unsqueeze(x: Sequence[FloatTensor], dim: int) -> Sequence[FloatTensor]: ...
 
 
-# docstr-coverage:excused `overload`
 @overload
 def parallel_unsqueeze(x: FloatTensor, dim: int) -> FloatTensor: ...
 
@@ -1058,7 +1056,6 @@ class ConvKBInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
         self.hidden_dropout = nn.Dropout(p=hidden_dropout_rate)
         self.linear = nn.Linear(embedding_dim * num_filters, 1, bias=True)
 
-    # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102
         # Use Xavier initialization for weight; bias to zero
         nn.init.xavier_uniform_(self.linear.weight, gain=nn.init.calculate_gain("relu"))
@@ -1280,7 +1277,6 @@ class ERMLPInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
             )
         return self.hidden_to_score(self.activation(x)).squeeze(dim=-1)
 
-    # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102
         # Initialize biases with zero
         nn.init.zeros_(self.hidden.bias)
@@ -1732,7 +1728,6 @@ class ProjEInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
         # dot product with t
         return self.outer_activation(batched_dot(x, t) + self.b_p)
 
-    # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102
         self.projection_initializer(self.d_e)
         self.projection_initializer(self.d_r)
@@ -1946,7 +1941,6 @@ class TuckERInteraction(Interaction[FloatTensor, FloatTensor, FloatTensor]):
 
         self.reset_parameters()
 
-    # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102
         # instantiate here to make module easily serializable
         core_initializer = init.initializer_resolver.make(
@@ -2867,7 +2861,6 @@ class MonotonicAffineTransformationInteraction(
             dtype=torch.get_default_dtype(),
         ).squeeze()
 
-    # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102
         self.bias.data = self.initial_bias.to(device=self.bias.device)
         self.log_scale.data = self.initial_log_scale.to(device=self.bias.device)
@@ -3367,7 +3360,6 @@ class MultiLinearTuckerInteraction(Interaction[FloatTensor, FloatTensor, FloatTe
             requires_grad=True,
         )
 
-    # docstr-coverage: inherited
     def reset_parameters(self):  # noqa: D102
         # initialize core tensor
         nn.init.normal_(

--- a/src/pykeen/nn/modules.py
+++ b/src/pykeen/nn/modules.py
@@ -2870,7 +2870,7 @@ class MonotonicAffineTransformationInteraction(
         h: HeadRepresentation,
         r: RelationRepresentation,
         t: TailRepresentation,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         return self.log_scale.exp() * self.base(h=h, r=r, t=t) + self.bias
 
 

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -112,7 +112,6 @@ class ScipySparseAnchorSearcher(AnchorSearcher):
         """
         self.max_iter = max_iter
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"max_iter={self.max_iter}"
@@ -244,7 +243,6 @@ class SparseBFSSearcher(AnchorSearcher):
         self.max_iter = max_iter
         self.device = resolve_device(device)
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"max_iter={self.max_iter}"
@@ -400,7 +398,6 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
         self.page_rank_kwargs = page_rank_kwargs or {}
         self.use_tqdm = use_tqdm
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield f"batch_size={self.batch_size}"
         yield f"use_tqdm={self.use_tqdm}"

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -85,7 +85,7 @@ class CSGraphAnchorSearcher(AnchorSearcher):
 
     def __call__(  # noqa: D102
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
-    ) -> numpy.ndarray:  # noqa: D102
+    ) -> numpy.ndarray:
         # convert to adjacency matrix
         adjacency = edge_index_to_sparse_matrix(edge_index=torch.as_tensor(edge_index, dtype=torch.long)).coalesce()
         # convert to scipy sparse csr
@@ -225,7 +225,7 @@ class ScipySparseAnchorSearcher(AnchorSearcher):
 
     def __call__(  # noqa: D102
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
-    ) -> numpy.ndarray:  # noqa: D102
+    ) -> numpy.ndarray:
         adjacency = self.create_adjacency(edge_index=edge_index, num_entities=num_entities)
         pool = self.bfs(anchors=anchors, adjacency=adjacency, max_iter=self.max_iter, k=k)
         return self.select(pool=pool, k=k)
@@ -372,7 +372,7 @@ class SparseBFSSearcher(AnchorSearcher):
 
     def __call__(  # noqa: D102
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
-    ) -> numpy.ndarray:  # noqa: D102
+    ) -> numpy.ndarray:
         edge_list = self.create_adjacency(edge_index=edge_index, num_entities=num_entities)
         pool = self.bfs(anchors=anchors, edge_list=edge_list, max_iter=self.max_iter, k=k, device=self.device)
         return self.select(pool=pool, k=k)
@@ -428,7 +428,7 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
 
     def __call__(  # noqa: D102
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
-    ) -> numpy.ndarray:  # noqa: D102
+    ) -> numpy.ndarray:
         num_entities = ensure_num_entities(edge_index, num_entities=num_entities)
         result = numpy.full(shape=(num_entities, k), fill_value=-1)
         i = 0

--- a/src/pykeen/nn/node_piece/anchor_search.py
+++ b/src/pykeen/nn/node_piece/anchor_search.py
@@ -83,8 +83,7 @@ class CSGraphAnchorSearcher(AnchorSearcher):
         top_dist = numpy.take_along_axis(arr=array, indices=top_k_indices, axis=0)
         return numpy.take_along_axis(arr=top_k_indices, indices=numpy.argsort(top_dist, axis=0), axis=0)
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
     ) -> numpy.ndarray:  # noqa: D102
         # convert to adjacency matrix
@@ -225,8 +224,7 @@ class ScipySparseAnchorSearcher(AnchorSearcher):
             tokens[i, : len(chosen)] = chosen
         return tokens
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
     ) -> numpy.ndarray:  # noqa: D102
         adjacency = self.create_adjacency(edge_index=edge_index, num_entities=num_entities)
@@ -374,8 +372,7 @@ class SparseBFSSearcher(AnchorSearcher):
         # since the output is sorted, no need for random sampling, we just take top-k nearest
         return indices[:, :k].detach().cpu().numpy()
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
     ) -> numpy.ndarray:  # noqa: D102
         edge_list = self.create_adjacency(edge_index=edge_index, num_entities=num_entities)
@@ -432,8 +429,7 @@ class PersonalizedPageRankAnchorSearcher(AnchorSearcher):
             .numpy()
         )
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, edge_index: numpy.ndarray, anchors: numpy.ndarray, k: int, num_entities: int | None = None
     ) -> numpy.ndarray:  # noqa: D102
         num_entities = ensure_num_entities(edge_index, num_entities=num_entities)

--- a/src/pykeen/nn/node_piece/anchor_selection.py
+++ b/src/pykeen/nn/node_piece/anchor_selection.py
@@ -236,8 +236,7 @@ class MixtureAnchorSelection(AnchorSelection):
         yield from super().iter_extra_repr()
         yield f"selections={self.selections}"
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self,
         edge_index: numpy.ndarray,
         known_anchors: numpy.ndarray | None = None,

--- a/src/pykeen/nn/node_piece/anchor_selection.py
+++ b/src/pykeen/nn/node_piece/anchor_selection.py
@@ -235,7 +235,7 @@ class MixtureAnchorSelection(AnchorSelection):
         self,
         edge_index: numpy.ndarray,
         known_anchors: numpy.ndarray | None = None,
-    ) -> numpy.ndarray:  # noqa: D102
+    ) -> numpy.ndarray:
         # split this up into first and rest, because once
         # we apply one selection, even to a none value for `known_anchors`,
         # we are guaranteed to have a non-none anchor

--- a/src/pykeen/nn/node_piece/anchor_selection.py
+++ b/src/pykeen/nn/node_piece/anchor_selection.py
@@ -130,7 +130,6 @@ class SingleSelection(AnchorSelection, ABC):
 class DegreeAnchorSelection(SingleSelection):
     """Select entities according to their (undirected) degree."""
 
-    # docstr-coverage: inherited
     def rank(self, edge_index: numpy.ndarray) -> numpy.ndarray:  # noqa: D102
         unique, counts = numpy.unique(edge_index, return_counts=True)
         # sort by decreasing degree
@@ -159,13 +158,11 @@ class PageRankAnchorSelection(SingleSelection):
         super().__init__(num_anchors=num_anchors)
         self.kwargs = kwargs
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         for key, value in self.kwargs.items():
             yield f"{key}={value}"
 
-    # docstr-coverage: inherited
     @torch.inference_mode()
     def rank(self, edge_index: numpy.ndarray) -> numpy.ndarray:  # noqa: D102
         # sort by decreasing page rank
@@ -188,7 +185,6 @@ class RandomAnchorSelection(SingleSelection):
         super().__init__(num_anchors=num_anchors)
         self.generator: numpy.random.Generator = numpy.random.default_rng(random_seed)
 
-    # docstr-coverage: inherited
     def rank(self, edge_index: numpy.ndarray) -> numpy.ndarray:  # noqa: D102
         return self.generator.permutation(edge_index.max())
 
@@ -231,7 +227,6 @@ class MixtureAnchorSelection(AnchorSelection):
                 logger.warning(f"{selection} had wrong number of anchors. Setting to {num}")
                 selection.num_anchors = num
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"selections={self.selections}"

--- a/src/pykeen/nn/node_piece/loader.py
+++ b/src/pykeen/nn/node_piece/loader.py
@@ -42,7 +42,6 @@ class GalkinPrecomputedTokenizerLoader(PrecomputedTokenizerLoader):
         https://github.com/migalkin/NodePiece/blob/9adc57efe302919d017d74fc648f853308cf75fd/ogb/download.sh
     """
 
-    # docstr-coverage: inherited
     def __call__(self, path: pathlib.Path) -> tuple[Mapping[int, Collection[int]], int]:  # noqa: D102
         with path.open(mode="rb") as pickle_file:
             # contains: anchor_ids, entity_ids, mapping {entity_id -> {"ancs": anchors, "dists": distances}}
@@ -80,7 +79,6 @@ class TorchPrecomputedTokenizerLoader(PrecomputedTokenizerLoader):
             path,
         )
 
-    # docstr-coverage: inherited
     def __call__(self, path: pathlib.Path) -> tuple[Mapping[int, Collection[int]], int]:  # noqa: D102
         c = torch.load(path, weights_only=False)
         order = c["order"]

--- a/src/pykeen/nn/node_piece/representation.py
+++ b/src/pykeen/nn/node_piece/representation.py
@@ -185,14 +185,12 @@ class TokenizationRepresentation(Representation):
             **kwargs,
         )
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"max_id={self.assignment.shape[0]}"
         yield f"num_tokens={self.num_tokens}"
         yield f"vocabulary_size={self.vocabulary_size}"
 
-    # docstr-coverage: inherited
     def _plain_forward(
         self,
         indices: LongTensor | None = None,

--- a/src/pykeen/nn/node_piece/tokenization.py
+++ b/src/pykeen/nn/node_piece/tokenization.py
@@ -61,8 +61,7 @@ class Tokenizer:
 class RelationTokenizer(Tokenizer):
     """Tokenize entities by representing them as a bag of relations."""
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         num_tokens: int,
@@ -143,8 +142,7 @@ class AnchorTokenizer(Tokenizer):
         # convert to torch
         return len(anchors) + 1, torch.as_tensor(tokens, dtype=torch.long)
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         num_tokens: int,
@@ -177,8 +175,7 @@ class MetisAnchorTokenizer(AnchorTokenizer):
         self.num_partitions = num_partitions
         self.device = resolve_device(device)
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         num_tokens: int,
@@ -306,8 +303,7 @@ class PrecomputedPoolTokenizer(Tokenizer):
             raise ValueError("Expected pool to contain contiguous keys 0...(N-1)")
         self.randomize_selection = randomize_selection
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self, mapped_triples: MappedTriples, num_tokens: int, num_entities: int, num_relations: int
     ) -> tuple[int, LongTensor]:  # noqa: D102
         if num_entities != len(self.pool):

--- a/src/pykeen/nn/node_piece/tokenization.py
+++ b/src/pykeen/nn/node_piece/tokenization.py
@@ -67,7 +67,7 @@ class RelationTokenizer(Tokenizer):
         num_tokens: int,
         num_entities: int,
         num_relations: int,
-    ) -> tuple[int, LongTensor]:  # noqa: D102
+    ) -> tuple[int, LongTensor]:
         # tokenize: represent entities by bag of relations
         h, r, t = mapped_triples.t()
 
@@ -148,7 +148,7 @@ class AnchorTokenizer(Tokenizer):
         num_tokens: int,
         num_entities: int,
         num_relations: int,
-    ) -> tuple[int, LongTensor]:  # noqa: D102
+    ) -> tuple[int, LongTensor]:
         return self._call(
             edge_index=get_edge_index(mapped_triples=mapped_triples),
             num_tokens=num_tokens,
@@ -181,7 +181,7 @@ class MetisAnchorTokenizer(AnchorTokenizer):
         num_tokens: int,
         num_entities: int,
         num_relations: int,
-    ) -> tuple[int, LongTensor]:  # noqa: D102
+    ) -> tuple[int, LongTensor]:
         try:
             import torch_sparse
         except ImportError as err:
@@ -305,7 +305,7 @@ class PrecomputedPoolTokenizer(Tokenizer):
 
     def __call__(  # noqa: D102
         self, mapped_triples: MappedTriples, num_tokens: int, num_entities: int, num_relations: int
-    ) -> tuple[int, LongTensor]:  # noqa: D102
+    ) -> tuple[int, LongTensor]:
         if num_entities != len(self.pool):
             raise ValueError(f"Invalid number of entities ({num_entities}); expected {len(self.pool)}")
         if self.randomize_selection:

--- a/src/pykeen/nn/pyg.py
+++ b/src/pykeen/nn/pyg.py
@@ -206,7 +206,6 @@ class MessagePassingRepresentation(Representation, ABC):
         #   * replace base representations
         #   * keep layers & activations
 
-    # docstr-coverage: inherited
     def _plain_forward(self, indices: LongTensor | None = None) -> FloatTensor:  # noqa: D102
         if self.restrict_k_hop and indices is not None:
             # we can restrict the message passing to the k-hop neighborhood of the desired indices;
@@ -270,7 +269,6 @@ class SimpleMessagePassingRepresentation(MessagePassingRepresentation):
     name: Simple Message Passing
     """
 
-    # docstr-coverage: inherited
     def pass_messages(self, x: FloatTensor, edge_index: LongTensor, edge_mask: BoolTensor | None = None) -> FloatTensor:  # noqa: D102
         for layer, activation in zip(self.layers, self.activations, strict=False):
             x = activation(layer(x, edge_index=edge_index))
@@ -317,7 +315,6 @@ class TypedMessagePassingRepresentation(MessagePassingRepresentation):
             return self.edge_type
         return self.edge_type[edge_mask]
 
-    # docstr-coverage: inherited
     def pass_messages(self, x: FloatTensor, edge_index: LongTensor, edge_mask: BoolTensor | None = None) -> FloatTensor:  # noqa: D102
         edge_type = self._get_edge_type(edge_mask=edge_mask)
         for layer, activation in zip(self.layers, self.activations, strict=False):
@@ -376,7 +373,6 @@ class FeaturizedMessagePassingRepresentation(TypedMessagePassingRepresentation):
         )
         self.relation_transformation = relation_transformation
 
-    # docstr-coverage: inherited
     def pass_messages(self, x: FloatTensor, edge_index: LongTensor, edge_mask: BoolTensor | None = None) -> FloatTensor:  # noqa: D102
         edge_type = self._get_edge_type(edge_mask=edge_mask)
         # get initial relation representations

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1424,9 +1424,8 @@ class CachedTextRepresentation(TextRepresentation):
         # delegate to super class
         super().__init__(labels=labels, **kwargs)
 
-    # docstr-coverage: inherited
     @classmethod
-    def from_triples_factory(
+    def from_triples_factory(  # noqa: D102
         cls,
         triples_factory: TriplesFactory,
         for_entities: bool = True,

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -1420,7 +1420,7 @@ class CachedTextRepresentation(TextRepresentation):
         triples_factory: TriplesFactory,
         for_entities: bool = True,
         **kwargs,
-    ) -> TextRepresentation:  # noqa: D102
+    ) -> TextRepresentation:
         labeling: Labeling = triples_factory.entity_labeling if for_entities else triples_factory.relation_labeling
         return cls(identifiers=labeling.all_labels().tolist(), **kwargs)
 

--- a/src/pykeen/nn/representation.py
+++ b/src/pykeen/nn/representation.py
@@ -320,7 +320,6 @@ class SubsetRepresentation(Representation):
         super().__init__(max_id=max_id, shape=ShapeError.verify(shape=base.shape, reference=shape), **kwargs)
         self.base = base
 
-    # docstr-coverage: inherited
     def _plain_forward(
         self,
         indices: LongTensor | None = None,
@@ -469,14 +468,12 @@ class Embedding(Representation):
         max_id, *shape = tensor.tensor.shape
         return cls(max_id=max_id, shape=shape, initializer=tensor, trainable=trainable, **kwargs)
 
-    # docstr-coverage: inherited
     def reset_parameters(self) -> None:  # noqa: D102
         # initialize weights in-place
         self._embeddings.weight.data = self.initializer(
             self._embeddings.weight.data.view(self.max_id, *self._shape),
         ).view(*self._embeddings.weight.data.shape)
 
-    # docstr-coverage: inherited
     def post_parameter_update(self):  # noqa: D102
         # apply constraints in-place
         if self.constrainer is not None:
@@ -487,7 +484,6 @@ class Embedding(Representation):
                 x = torch.view_as_real(x)
             self._embeddings.weight.data = x.view(*self._embeddings.weight.data.shape)
 
-    # docstr-coverage: inherited
     def _plain_forward(
         self,
         indices: LongTensor | None = None,
@@ -641,7 +637,6 @@ class LowRankRepresentation(Representation):
         """Return the number of bases."""
         return self.base.max_id
 
-    # docstr-coverage: inherited
     def _plain_forward(
         self,
         indices: LongTensor | None = None,
@@ -1029,12 +1024,10 @@ class CombinedCompGCNRepresentations(nn.Module):
         # initialize buffer of enriched representations
         self.enriched_representations = None
 
-    # docstr-coverage: inherited
     def post_parameter_update(self) -> None:  # noqa: D102
         # invalidate enriched embeddings
         self.enriched_representations = None
 
-    # docstr-coverage: inherited
     def train(self, mode: bool = True):  # noqa: D102
         # when changing from evaluation to training mode, the buffered representations have been computed without
         # gradient tracking. hence, we need to invalidate them.
@@ -1119,7 +1112,6 @@ class SingleCompGCNRepresentation(Representation):
         self.position = position_index
         self.reset_parameters()
 
-    # docstr-coverage: inherited
     def _plain_forward(
         self,
         indices: LongTensor | None = None,
@@ -1260,7 +1252,6 @@ class TextRepresentation(Representation):
             raise TypeError(f"{cls.__name__} requires access to labels, but dataset.training does not provide such.")
         return cls.from_triples_factory(triples_factory=dataset.training, **kwargs)
 
-    # docstr-coverage: inherited
     def _plain_forward(
         self,
         indices: LongTensor | None = None,
@@ -1391,7 +1382,6 @@ class CombinedRepresentation(Representation):
         """
         return combination([b._plain_forward(indices=indices) for b in base])
 
-    # docstr-coverage: inherited
     def _plain_forward(
         self,
         indices: LongTensor | None = None,
@@ -1572,7 +1562,6 @@ class PartitionRepresentation(Representation):
         self.bases = nn.ModuleList(bases)
         self.register_buffer(name="assignment", tensor=assignment)
 
-    # docstr-coverage: inherited
     def _plain_forward(self, indices: LongTensor | None = None) -> FloatTensor:  # noqa: D102
         assignment = self.assignment
         if indices is not None:
@@ -1869,7 +1858,6 @@ class TransformedRepresentation(Representation):
         """
         return transformation(base(indices=indices))
 
-    # docstr-coverage: inherited
     def _plain_forward(self, indices: LongTensor | None = None) -> FloatTensor:  # noqa: D102
         return self._help_forward(base=self.base, transformation=self.transformation, indices=indices)
 
@@ -2138,13 +2126,11 @@ class TensorTrainRepresentation(Representation):
             )
         )
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"num_cores={len(self.bases)}"
         yield f"eq='{self.eq}'"
 
-    # docstr-coverage: inherited
     def _plain_forward(self, indices: LongTensor | None = None) -> FloatTensor:  # noqa: D102
         assignment = self.assignment
         if indices is not None:
@@ -2235,7 +2221,6 @@ class EmbeddingBagRepresentation(Representation):
         # set-up embedding bag
         self.embedding_bag = nn.EmbeddingBag(num_embeddings=num_components + 1, embedding_dim=embedding_dim, mode=mode)
 
-    # docstr-coverage: inherited
     def _plain_forward(self, indices: LongTensor | None = None) -> FloatTensor:  # noqa: D102
         if indices is None:
             indices = unique_indices = inverse = torch.arange(self.max_id)

--- a/src/pykeen/nn/sim.py
+++ b/src/pykeen/nn/sim.py
@@ -60,8 +60,7 @@ class ExpectedLikelihood(KG2ESimilarity):
         \right)
     """
 
-    # docstr-coverage: inherited
-    def forward(self, h: GaussianDistribution, r: GaussianDistribution, t: GaussianDistribution) -> FloatTensor:
+    def forward(self, h: GaussianDistribution, r: GaussianDistribution, t: GaussianDistribution) -> FloatTensor:  # noqa: D102
         var = tensor_sum(*(d.diagonal_covariance for d in (h, r, t)))
         mean = tensor_sum(h.mean, -t.mean, -r.mean)
 
@@ -112,8 +111,7 @@ class NegativeKullbackLeiblerDivergence(KG2ESimilarity):
         <https://en.wikipedia.org/wiki/Multivariate_normal_distribution#Kullback%E2%80%93Leibler_divergence>`_
     """
 
-    # docstr-coverage: inherited
-    def forward(self, h: GaussianDistribution, r: GaussianDistribution, t: GaussianDistribution) -> FloatTensor:
+    def forward(self, h: GaussianDistribution, r: GaussianDistribution, t: GaussianDistribution) -> FloatTensor:  # noqa: D102
         e_var = h.diagonal_covariance + t.diagonal_covariance
         r_var_safe = at_least_eps(r.diagonal_covariance)
         terms = []

--- a/src/pykeen/nn/text/cache.py
+++ b/src/pykeen/nn/text/cache.py
@@ -51,7 +51,6 @@ class IdentityCache(TextCache):
     Mostly used for testing.
     """
 
-    # docstr-coverage: inherited
     def get_texts(self, identifiers: Sequence[str]) -> Sequence[str | None]:  # noqa: D102
         return identifiers
 

--- a/src/pykeen/nn/text/encoder.py
+++ b/src/pykeen/nn/text/encoder.py
@@ -162,7 +162,6 @@ class CharacterEmbeddingTextEncoder(TextEncoder):
             character_representation, max_id=num_real_tokens + 2, shape=dim
         )
 
-    # docstr-coverage: inherited
     def forward_normalized(self, texts: Sequence[str]) -> FloatTensor:  # noqa: D102
         # tokenize
         token_ids = [[self.token_to_id.get(c, self.unknown_idx) for c in text] for text in texts]
@@ -218,7 +217,6 @@ class TransformerTextEncoder(TextEncoder):
         )
         self.max_length = max_length or 512
 
-    # docstr-coverage: inherited
     def forward_normalized(self, texts: Sequence[str]) -> FloatTensor:  # noqa: D102
         return self.model(
             **self.tokenizer(

--- a/src/pykeen/nn/vision/representation.py
+++ b/src/pykeen/nn/vision/representation.py
@@ -83,7 +83,6 @@ class VisionDataset(torch.utils.data.Dataset):
         transforms.append(vision_transforms.ConvertImageDtype(torch.get_default_dtype()))
         self.transforms = vision_transforms.Compose(transforms=transforms)
 
-    # docstr-coverage: inherited
     def __getitem__(self, item: int) -> torch.Tensor:  # noqa:D105
         _ensure_vision(self, Image)
         image = self.images[item]
@@ -95,7 +94,6 @@ class VisionDataset(torch.utils.data.Dataset):
         assert isinstance(image, torch.Tensor | Image.Image)
         return self.transforms(image)
 
-    # docstr-coverage: inherited
     def __len__(self) -> int:  # noqa:D105
         return len(self.images)
 
@@ -186,7 +184,6 @@ class VisualRepresentation(Representation):
         """
         return pool(encoder(images)["feature"])
 
-    # docstr-coverage: inherited
     def _plain_forward(self, indices: LongTensor | None = None) -> FloatTensor:  # noqa: D102
         dataset = self.images
         if indices is not None:

--- a/src/pykeen/nn/weighting.py
+++ b/src/pykeen/nn/weighting.py
@@ -108,7 +108,7 @@ class InverseInDegreeEdgeWeighting(EdgeWeighting):
         target: LongTensor,
         message: FloatTensor | None = None,
         x_e: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         weight = _inverse_frequency_weighting(idx=target)
         if message is not None:
             return message * weight.unsqueeze(dim=-1)
@@ -124,7 +124,7 @@ class InverseOutDegreeEdgeWeighting(EdgeWeighting):
         target: LongTensor,
         message: FloatTensor | None = None,
         x_e: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         weight = _inverse_frequency_weighting(idx=source)
         if message is not None:
             return message * weight.unsqueeze(dim=-1)
@@ -140,7 +140,7 @@ class SymmetricEdgeWeighting(EdgeWeighting):
         target: LongTensor,
         message: FloatTensor | None = None,
         x_e: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         weight = (_inverse_frequency_weighting(idx=source) * _inverse_frequency_weighting(idx=target)).sqrt()
         if message is not None:
             return message * weight.unsqueeze(dim=-1)
@@ -183,7 +183,7 @@ class AttentionEdgeWeighting(EdgeWeighting):
         target: LongTensor,
         message: FloatTensor | None = None,
         x_e: FloatTensor | None = None,
-    ) -> FloatTensor:  # noqa: D102
+    ) -> FloatTensor:
         if message is None or x_e is None:
             raise ValueError(f"{self.__class__.__name__} requires message and x_e.")
 

--- a/src/pykeen/nn/weighting.py
+++ b/src/pykeen/nn/weighting.py
@@ -102,8 +102,7 @@ def _inverse_frequency_weighting(idx: LongTensor) -> FloatTensor:
 class InverseInDegreeEdgeWeighting(EdgeWeighting):
     """Normalize messages by inverse in-degree."""
 
-    # docstr-coverage: inherited
-    def forward(
+    def forward(  # noqa: D102
         self,
         source: LongTensor,
         target: LongTensor,
@@ -119,8 +118,7 @@ class InverseInDegreeEdgeWeighting(EdgeWeighting):
 class InverseOutDegreeEdgeWeighting(EdgeWeighting):
     """Normalize messages by inverse out-degree."""
 
-    # docstr-coverage: inherited
-    def forward(
+    def forward(  # noqa: D102
         self,
         source: LongTensor,
         target: LongTensor,
@@ -136,8 +134,7 @@ class InverseOutDegreeEdgeWeighting(EdgeWeighting):
 class SymmetricEdgeWeighting(EdgeWeighting):
     """Normalize messages by product of inverse sqrt of in-degree and out-degree."""
 
-    # docstr-coverage: inherited
-    def forward(
+    def forward(  # noqa: D102
         self,
         source: LongTensor,
         target: LongTensor,
@@ -180,8 +177,7 @@ class AttentionEdgeWeighting(EdgeWeighting):
         self.attention_dim = message_dim // num_heads
         self.dropout = nn.Dropout(dropout)
 
-    # docstr-coverage: inherited
-    def forward(
+    def forward(  # noqa: D102
         self,
         source: LongTensor,
         target: LongTensor,

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -620,7 +620,7 @@ class CountScoreConsumer(ScoreConsumer):
         batch: PredictionBatch,
         target: Target,
         scores: FloatTensor,
-    ) -> None:  # noqa: D102
+    ) -> None:
         self.batch_count += batch.shape[0]
         self.score_count += scores.numel()
 
@@ -650,7 +650,7 @@ class TopKScoreConsumer(ScoreConsumer):
         batch: PredictionBatch,
         target: Target,
         scores: FloatTensor,
-    ) -> None:  # noqa: D102
+    ) -> None:
         batch_size, num_scores = scores.shape
         assert batch.shape == (batch_size, 2)
 
@@ -727,7 +727,7 @@ class AllScoreConsumer(ScoreConsumer):
         batch: PredictionBatch,
         target: Target,
         scores: FloatTensor,
-    ) -> None:  # noqa: D102
+    ) -> None:
         j = 0
         selectors: list[slice | LongTensor] = []
         for col in COLUMN_LABELS:

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -386,14 +386,12 @@ class Predictions(ABC):
 class TriplePredictions(Predictions):
     """Triples with their predicted scores."""
 
-    # docstr-coverage: inherited
     def __post_init__(self):  # noqa: D105
         super().__post_init__()
         columns = {f"{column}_id" for column in COLUMN_LABELS}
         if not columns.issubset(self.df.columns):
             raise ValueError(f"df must have a columns named {columns}, but df.columns={self.df.columns}")
 
-    # docstr-coverage: inherited
     def _contains(self, df: pandas.DataFrame, mapped_triples: MappedTriples, invert: bool = False) -> numpy.ndarray:  # noqa: D102
         contained = (
             isin_many_dim(
@@ -421,13 +419,11 @@ class TargetPredictions(Predictions):
     #: the other column's fixed IDs
     other_columns_fixed_ids: tuple[int, int]
 
-    # docstr-coverage: inherited
     def __post_init__(self):  # noqa: D105
         super().__post_init__()
         if f"{self.target}_id" not in self.df.columns:
             raise ValueError(f"df must have a column named '{self.target}_id', but df.columns={self.df.columns}")
 
-    # docstr-coverage: inherited
     def _contains(self, df: pandas.DataFrame, mapped_triples: MappedTriples, invert: bool = False) -> numpy.ndarray:  # noqa: D102
         col = TARGET_TO_INDEX[self.target]
         other_cols = sorted(set(range(mapped_triples.shape[1])).difference({col}))
@@ -760,12 +756,10 @@ class PredictionDataset(torch.utils.data.Dataset):
         # TODO: variable targets across batches/samples?
         self.target = target
 
-    # docstr-coverage: inherited
     @abstractmethod
     def __getitem__(self, item: int) -> PredictionBatch:  # noqa: D105
         raise NotImplementedError
 
-    # docstr-coverage: inherited
     @abstractmethod
     def __len__(self) -> int:  # noqa: D105
         raise NotImplementedError
@@ -792,13 +786,11 @@ class AllPredictionDataset(PredictionDataset):
         # (h, r, ?) => h.stride > r.stride
         self.divisor = num_relations if self.target == LABEL_TAIL else num_entities
 
-    # docstr-coverage: inherited
     def __len__(self) -> int:  # noqa: D105
         if self.target == LABEL_RELATION:
             return self.num_entities**2
         return self.num_entities * self.num_relations
 
-    # docstr-coverage: inherited
     def __getitem__(self, item: int) -> LongTensor:  # noqa: D105
         quotient, remainder = divmod(item, self.divisor)
         return torch.as_tensor([quotient, remainder])
@@ -886,11 +878,9 @@ class PartiallyRestrictedPredictionDataset(PredictionDataset):
         assert len(parts) == 2
         self.parts = (parts[0], parts[1])  # for mypy
 
-    # docstr-coverage: inherited
     def __len__(self) -> int:  # noqa: D105
         return math.prod(map(len, self.parts))
 
-    # docstr-coverage: inherited
     def __getitem__(self, item: int) -> PredictionBatch:  # noqa: D105
         remainder, quotient = divmod(item, len(self.parts[0]))
         return torch.as_tensor([self.parts[0][quotient], self.parts[1][remainder]])

--- a/src/pykeen/predict.py
+++ b/src/pykeen/predict.py
@@ -619,8 +619,7 @@ class CountScoreConsumer(ScoreConsumer):
         self.batch_count = 0
         self.score_count = 0
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self,
         batch: PredictionBatch,
         target: Target,
@@ -650,8 +649,7 @@ class TopKScoreConsumer(ScoreConsumer):
         self.result = torch.empty(0, 3, dtype=torch.long, device=device)
         self.scores = torch.empty(0, device=device)
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self,
         batch: PredictionBatch,
         target: Target,
@@ -728,8 +726,7 @@ class AllScoreConsumer(ScoreConsumer):
             dim=-1,
         ).view(-1, 3)
 
-    # docstr-coverage: inherited
-    def __call__(
+    def __call__(  # noqa: D102
         self,
         batch: PredictionBatch,
         target: Target,

--- a/src/pykeen/regularizers.py
+++ b/src/pykeen/regularizers.py
@@ -137,12 +137,10 @@ class NoRegularizer(Regularizer):
     #: The default strategy for optimizing the no-op regularizer's hyper-parameters
     hpo_default: ClassVar[Mapping[str, Any]] = {}
 
-    # docstr-coverage: inherited
     def update(self, *tensors: FloatTensor) -> None:  # noqa: D102
         # no need to compute anything
         pass
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         # always return zero
         return torch.zeros(1, dtype=x.dtype, device=x.device)
@@ -191,7 +189,6 @@ class LpRegularizer(Regularizer):
         self.normalize = normalize
         self.p = p
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         return lp_norm(x=x, p=self.p, dim=self.dim, normalize=self.normalize).mean()
 
@@ -235,7 +232,6 @@ class PowerSumRegularizer(Regularizer):
         self.normalize = normalize
         self.p = p
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         return powersum_norm(x, p=self.p, dim=self.dim, normalize=self.normalize).mean()
 
@@ -281,7 +277,6 @@ class NormLimitRegularizer(Regularizer):
         self.max_norm = max_norm
         self.power_norm = power_norm
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         if self.power_norm:
             norm = powersum_norm(x, p=self.p, dim=self.dim, normalize=False)
@@ -318,11 +313,9 @@ class OrthogonalityRegularizer(Regularizer):
         super().__init__(weight=weight, **kwargs, apply_only_once=apply_only_once)
         self.epsilon = epsilon
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         raise NotImplementedError(f"{self.__class__.__name__} regularizer is order-sensitive!")
 
-    # docstr-coverage: inherited
     def update(self, *tensors: FloatTensor) -> None:  # noqa: D102
         if len(tensors) != 2:
             raise ValueError("Expects exactly two tensors")
@@ -373,12 +366,10 @@ class CombinedRegularizer(Regularizer):
             ).reciprocal(),
         )
 
-    # docstr-coverage: inherited
     @property
     def normalize(self):  # noqa: D102
         return any(r.normalize for r in self.regularizers)
 
-    # docstr-coverage: inherited
     def forward(self, x: FloatTensor) -> FloatTensor:  # noqa: D102
         return self.normalization_factor * sum(r.weight * r.forward(x) for r in self.regularizers)
 

--- a/src/pykeen/sampling/basic_negative_sampler.py
+++ b/src/pykeen/sampling/basic_negative_sampler.py
@@ -98,7 +98,6 @@ class BasicNegativeSampler(NegativeSampler):
         # Set the indices
         self._corruption_indices = [TARGET_TO_INDEX[side] for side in self.corruption_scheme]
 
-    # docstr-coverage: inherited
     def corrupt_batch(self, positive_batch: LongTensor) -> LongTensor:  # noqa: D102
         batch_shape = positive_batch.shape[:-1]
 
@@ -123,7 +122,6 @@ class BasicNegativeSampler(NegativeSampler):
 
         return negative_batch.view(*batch_shape, self.num_negs_per_pos, 3)
 
-    # docstr-coverage: inherited
     def corrupt_batch_grouped(self, positive_batch: LongTensor) -> GroupedNegatives:  # noqa: D102
         num_targets = len(self.corruption_scheme)
         base, remainder = divmod(self.num_negs_per_pos, num_targets)

--- a/src/pykeen/sampling/bernoulli_negative_sampler.py
+++ b/src/pykeen/sampling/bernoulli_negative_sampler.py
@@ -72,7 +72,6 @@ class BernoulliNegativeSampler(NegativeSampler):
             # Set parameter for Bernoulli distribution
             self.corrupt_head_probability[r] = tph / (tph + hpt)
 
-    # docstr-coverage: inherited
     def corrupt_batch(self, positive_batch: LongTensor) -> LongTensor:  # noqa: D102
         batch_shape = positive_batch.shape[:-1]
 

--- a/src/pykeen/sampling/filtering.py
+++ b/src/pykeen/sampling/filtering.py
@@ -201,7 +201,6 @@ class PythonSetFilterer(Filterer):
         # store set of triples
         self.triples = triple_tensor_to_set(mapped_triples)
 
-    # docstr-coverage: inherited
     def contains(self, batch: MappedTriples) -> BoolTensor:  # noqa: D102
         return torch.as_tensor(
             data=[tuple(triple) in self.triples for triple in batch.view(-1, 3).tolist()],

--- a/src/pykeen/sampling/pseudo_type.py
+++ b/src/pykeen/sampling/pseudo_type.py
@@ -91,7 +91,6 @@ class PseudoTypedNegativeSampler(NegativeSampler):
         super().__init__(mapped_triples=mapped_triples, **kwargs)
         self.data, self.offsets = create_index(mapped_triples=mapped_triples, num_relations=self.num_relations)
 
-    # docstr-coverage: inherited
     def corrupt_batch(self, positive_batch: LongTensor):  # noqa: D102
         batch_size = positive_batch.shape[0]
 

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -101,8 +101,7 @@ class PythonResultTracker(ResultTracker):
             params = {f"{prefix}.{key}": value for key, value in params.items()}
         self.configuration.update(params)
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,
@@ -171,8 +170,7 @@ class ConsoleResultTracker(ResultTracker):
             if not self.parameter_filter or self.parameter_filter.match(key):
                 self.write(f"Parameter: {key} = {value}")
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,
@@ -225,8 +223,7 @@ class MultiResultTracker(ResultTracker):
         for tracker in self.trackers:
             tracker.log_params(params=params, prefix=prefix)
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -104,7 +104,7 @@ class PythonResultTracker(ResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         if not self.store_metrics:
             return
 
@@ -171,7 +171,7 @@ class ConsoleResultTracker(ResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         if not self.track_metrics:
             return
 
@@ -221,7 +221,7 @@ class MultiResultTracker(ResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         for tracker in self.trackers:
             tracker.log_metrics(metrics=metrics, step=step, prefix=prefix)
 

--- a/src/pykeen/trackers/base.py
+++ b/src/pykeen/trackers/base.py
@@ -91,11 +91,9 @@ class PythonResultTracker(ResultTracker):
         self.metrics = defaultdict(dict)
         self.run_name = None
 
-    # docstr-coverage: inherited
     def start_run(self, run_name: str | None = None) -> None:  # noqa: D102
         self.run_name = run_name
 
-    # docstr-coverage: inherited
     def log_params(self, params: Mapping[str, Any], prefix: str | None = None) -> None:  # noqa: D102
         if prefix is not None:
             params = {f"{prefix}.{key}": value for key, value in params.items()}
@@ -156,12 +154,10 @@ class ConsoleResultTracker(ResultTracker):
         elif writer == "logging":
             self.write = logging.getLogger("pykeen").info
 
-    # docstr-coverage: inherited
     def start_run(self, run_name: str | None = None) -> None:  # noqa: D102
         if run_name is not None and self.start_end_run:
             self.write(f"Starting run: {run_name}")
 
-    # docstr-coverage: inherited
     def log_params(self, params: Mapping[str, Any], prefix: str | None = None) -> None:  # noqa: D102
         if not self.track_parameters:
             return
@@ -184,7 +180,6 @@ class ConsoleResultTracker(ResultTracker):
             if not self.metric_filter or self.metric_filter.match(key):
                 self.write(f"Metric: {key} = {value}")
 
-    # docstr-coverage: inherited
     def end_run(self, success: bool = True) -> None:  # noqa: D102
         if not success:
             self.write("Run failed.")
@@ -213,12 +208,10 @@ class MultiResultTracker(ResultTracker):
         else:
             self.trackers = list(trackers)
 
-    # docstr-coverage: inherited
     def start_run(self, run_name: str | None = None) -> None:  # noqa: D102
         for tracker in self.trackers:
             tracker.start_run(run_name=run_name)
 
-    # docstr-coverage: inherited
     def log_params(self, params: Mapping[str, Any], prefix: str | None = None) -> None:  # noqa: D102
         for tracker in self.trackers:
             tracker.log_params(params=params, prefix=prefix)
@@ -232,7 +225,6 @@ class MultiResultTracker(ResultTracker):
         for tracker in self.trackers:
             tracker.log_metrics(metrics=metrics, step=step, prefix=prefix)
 
-    # docstr-coverage: inherited
     def end_run(self, success: bool = True) -> None:  # noqa: D102
         for tracker in self.trackers:
             tracker.end_run(success=success)

--- a/src/pykeen/trackers/file.py
+++ b/src/pykeen/trackers/file.py
@@ -114,7 +114,7 @@ class CSVResultTracker(FileResultTracker):
         self,
         params: Mapping[str, Any],
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         self._write(dictionary=params, label="parameter", step=0, prefix=prefix)
 
     def log_metrics(  # noqa: D102
@@ -122,7 +122,7 @@ class CSVResultTracker(FileResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         self._write(dictionary=metrics, label="metric", step=step, prefix=prefix)
 
 
@@ -145,7 +145,7 @@ class JSONResultTracker(FileResultTracker):
         self,
         params: Mapping[str, Any],
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         self._write({"params": params, "prefix": prefix})
 
     def log_metrics(  # noqa: D102
@@ -153,5 +153,5 @@ class JSONResultTracker(FileResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         self._write({"metrics": metrics, "prefix": prefix, "step": step})

--- a/src/pykeen/trackers/file.py
+++ b/src/pykeen/trackers/file.py
@@ -61,7 +61,6 @@ class FileResultTracker(ResultTracker):
         logger.info(f"Logging to {path.as_uri()}.")
         self.file = path.open(mode="w", newline="", encoding="utf8")
 
-    # docstr-coverage: inherited
     def end_run(self, success: bool = True) -> None:  # noqa: D102
         self.file.close()
 
@@ -97,11 +96,9 @@ class CSVResultTracker(FileResultTracker):
         super().__init__(path=path, name=name)
         self.csv_writer = csv.writer(self.file, **kwargs)
 
-    # docstr-coverage: inherited
     def start_run(self, run_name: str | None = None) -> None:  # noqa: D102
         self.csv_writer.writerow(self.HEADER)
 
-    # docstr-coverage: inherited
     def _write(
         self,
         dictionary: Mapping[str, Any],

--- a/src/pykeen/trackers/file.py
+++ b/src/pykeen/trackers/file.py
@@ -113,16 +113,14 @@ class CSVResultTracker(FileResultTracker):
         self.csv_writer.writerows((label, step, key, value) for key, value in dictionary.items())
         self.file.flush()
 
-    # docstr-coverage: inherited
-    def log_params(
+    def log_params(  # noqa: D102
         self,
         params: Mapping[str, Any],
         prefix: str | None = None,
     ) -> None:  # noqa: D102
         self._write(dictionary=params, label="parameter", step=0, prefix=prefix)
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,
@@ -146,16 +144,14 @@ class JSONResultTracker(FileResultTracker):
     def _write(self, obj) -> None:
         print(json.dumps(obj), file=self.file, flush=True)  # noqa:T201
 
-    # docstr-coverage: inherited
-    def log_params(
+    def log_params(  # noqa: D102
         self,
         params: Mapping[str, Any],
         prefix: str | None = None,
     ) -> None:  # noqa: D102
         self._write({"params": params, "prefix": prefix})
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,

--- a/src/pykeen/trackers/mlflow.py
+++ b/src/pykeen/trackers/mlflow.py
@@ -52,7 +52,7 @@ class MLFlowResultTracker(ResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         metrics = flatten_dictionary(dictionary=metrics, prefix=prefix)
         self.mlflow.log_metrics(metrics=metrics, step=step)
 

--- a/src/pykeen/trackers/mlflow.py
+++ b/src/pykeen/trackers/mlflow.py
@@ -42,7 +42,6 @@ class MLFlowResultTracker(ResultTracker):
         if experiment_name is not None:
             self.mlflow.set_experiment(experiment_name)
 
-    # docstr-coverage: inherited
     def start_run(self, run_name: str | None = None) -> None:  # noqa: D102
         self.mlflow.start_run(run_name=run_name)
         if self.tags is not None:
@@ -57,12 +56,10 @@ class MLFlowResultTracker(ResultTracker):
         metrics = flatten_dictionary(dictionary=metrics, prefix=prefix)
         self.mlflow.log_metrics(metrics=metrics, step=step)
 
-    # docstr-coverage: inherited
     def log_params(self, params: Mapping[str, Any], prefix: str | None = None) -> None:  # noqa: D102
         params = flatten_dictionary(dictionary=params, prefix=prefix)
         self.mlflow.log_params(params=params)
 
-    # docstr-coverage: inherited
     def end_run(self, success: bool = True) -> None:  # noqa: D102
         status = self.mlflow.entities.RunStatus.FINISHED if success else self.mlflow.entities.RunStatus.FAILED
         self.mlflow.end_run(status=self.mlflow.entities.RunStatus.to_string(status))

--- a/src/pykeen/trackers/mlflow.py
+++ b/src/pykeen/trackers/mlflow.py
@@ -48,8 +48,7 @@ class MLFlowResultTracker(ResultTracker):
         if self.tags is not None:
             self.mlflow.set_tags(tags=self.tags)
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,

--- a/src/pykeen/trackers/neptune.py
+++ b/src/pykeen/trackers/neptune.py
@@ -71,8 +71,7 @@ class NeptuneResultTracker(ResultTracker):
         if tags:
             self.experiment.append_tags(*tags)
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,

--- a/src/pykeen/trackers/neptune.py
+++ b/src/pykeen/trackers/neptune.py
@@ -81,7 +81,6 @@ class NeptuneResultTracker(ResultTracker):
         for k, v in metrics.items():
             self._help_log(k, step, v)
 
-    # docstr-coverage: inherited
     def log_params(self, params: Mapping[str, Any], prefix: str | None = None) -> None:  # noqa: D102
         params = flatten_dictionary(params, prefix=prefix)
         for k, v in params.items():

--- a/src/pykeen/trackers/neptune.py
+++ b/src/pykeen/trackers/neptune.py
@@ -76,7 +76,7 @@ class NeptuneResultTracker(ResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         metrics = flatten_dictionary(metrics, prefix=prefix)
         for k, v in metrics.items():
             self._help_log(k, step, v)

--- a/src/pykeen/trackers/tensorboard.py
+++ b/src/pykeen/trackers/tensorboard.py
@@ -49,7 +49,7 @@ class TensorBoardResultTracker(ResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         metrics = flatten_dictionary(dictionary=metrics, prefix=prefix)
         for key, value in metrics.items():
             self.writer.add_scalar(tag=key, scalar_value=value, global_step=step)

--- a/src/pykeen/trackers/tensorboard.py
+++ b/src/pykeen/trackers/tensorboard.py
@@ -55,14 +55,12 @@ class TensorBoardResultTracker(ResultTracker):
             self.writer.add_scalar(tag=key, scalar_value=value, global_step=step)
         self.writer.flush()
 
-    # docstr-coverage: inherited
     def log_params(self, params: Mapping[str, Any], prefix: str | None = None) -> None:  # noqa: D102
         params = flatten_dictionary(dictionary=params, prefix=prefix)
         for key, value in params.items():
             self.writer.add_text(tag=str(key), text_string=str(value))
         self.writer.flush()
 
-    # docstr-coverage: inherited
     def end_run(self, success: bool = True) -> None:  # noqa: D102
         self.writer.flush()
         self.writer.close()

--- a/src/pykeen/trackers/tensorboard.py
+++ b/src/pykeen/trackers/tensorboard.py
@@ -44,8 +44,7 @@ class TensorBoardResultTracker(ResultTracker):
         #  via self.writer.log_dir
         self.writer = torch.utils.tensorboard.SummaryWriter(log_dir=experiment_path)
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,

--- a/src/pykeen/trackers/wandb.py
+++ b/src/pykeen/trackers/wandb.py
@@ -62,7 +62,7 @@ class WANDBResultTracker(ResultTracker):
         metrics: Mapping[str, float],
         step: int | None = None,
         prefix: str | None = None,
-    ) -> None:  # noqa: D102
+    ) -> None:
         if self.run is None:
             raise AssertionError("start_run must be called before logging any metrics")
         metrics = flatten_dictionary(dictionary=metrics, prefix=prefix)

--- a/src/pykeen/trackers/wandb.py
+++ b/src/pykeen/trackers/wandb.py
@@ -59,8 +59,7 @@ class WANDBResultTracker(ResultTracker):
         self.run.finish(exit_code=0 if success else -1)
         self.run = None
 
-    # docstr-coverage: inherited
-    def log_metrics(
+    def log_metrics(  # noqa: D102
         self,
         metrics: Mapping[str, float],
         step: int | None = None,

--- a/src/pykeen/trackers/wandb.py
+++ b/src/pykeen/trackers/wandb.py
@@ -50,11 +50,9 @@ class WANDBResultTracker(ResultTracker):
         self.kwargs = kwargs
         self.run = None
 
-    # docstr-coverage: inherited
     def start_run(self, run_name: str | None = None) -> None:  # noqa: D102
         self.run = self.wandb.init(project=self.project, name=run_name, **self.kwargs)
 
-    # docstr-coverage: inherited
     def end_run(self, success: bool = True) -> None:  # noqa: D102
         self.run.finish(exit_code=0 if success else -1)
         self.run = None
@@ -70,7 +68,6 @@ class WANDBResultTracker(ResultTracker):
         metrics = flatten_dictionary(dictionary=metrics, prefix=prefix)
         self.run.log(metrics, step=step)
 
-    # docstr-coverage: inherited
     def log_params(self, params: Mapping[str, Any], prefix: str | None = None) -> None:  # noqa: D102
         if self.run is None:
             raise AssertionError("start_run must be called before logging any metrics")

--- a/src/pykeen/training/callbacks.py
+++ b/src/pykeen/training/callbacks.py
@@ -158,7 +158,6 @@ class TrackerTrainingCallback(TrainingCallback):
     It logs the loss after each epoch to the given result tracker,
     """
 
-    # docstr-coverage: inherited
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         self.result_tracker.log_metrics({"loss": epoch_loss}, step=epoch)
 
@@ -179,7 +178,6 @@ class GradientNormClippingTrainingCallback(TrainingCallback):
         self.max_norm = max_norm
         self.norm_type = norm_type or 2.0
 
-    # docstr-coverage: inherited
     def pre_step(self, **kwargs: Any) -> None:  # noqa: D102
         clip_grad_norm_(
             parameters=self.model.get_grad_params(),
@@ -203,7 +201,6 @@ class GradientAbsClippingTrainingCallback(TrainingCallback):
         super().__init__()
         self.clip_value = clip_value
 
-    # docstr-coverage: inherited
     def pre_step(self, **kwargs: Any) -> None:  # noqa: D102
         clip_grad_value_(self.model.get_grad_params(), clip_value=self.clip_value)
 
@@ -271,7 +268,6 @@ class EvaluationTrainingCallback(TrainingCallback):
         self.kwargs = kwargs
         self.batch_size = self.kwargs.pop("batch_size", None)
 
-    # docstr-coverage: inherited
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         if epoch % self.frequency:
             return
@@ -339,7 +335,6 @@ class EvaluationLoopTrainingCallback(TrainingCallback):
             )
         return self._evaluation_loop
 
-    # docstr-coverage: inherited
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         if epoch % self.frequency:
             return
@@ -376,7 +371,6 @@ class StopperTrainingCallback(TrainingCallback):
         self.last_best_epoch = last_best_epoch
         self.best_epoch_model_file_path = best_epoch_model_file_path
 
-    # docstr-coverage: inherited
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         if self.stopper.should_evaluate(epoch):
             # TODO how to pass inductive mode
@@ -406,7 +400,6 @@ class OptimizerTrainingCallback(TrainingCallback):
         self.only_size_probing = only_size_probing
         self.pre_step_callbacks = tuple(pre_step_callbacks or [])
 
-    # docstr-coverage: inherited
     def pre_batch(self, **kwargs: Any) -> None:  # noqa: D102
         # Recall that torch *accumulates* gradients. Before passing in a
         # new instance, you need to zero out the gradients from the old instance
@@ -414,7 +407,6 @@ class OptimizerTrainingCallback(TrainingCallback):
         # note: we want to run this step during size probing to cleanup any remaining grads
         self.optimizer.zero_grad(set_to_none=True)
 
-    # docstr-coverage: inherited
     def post_batch(self, epoch: int, batch, **kwargs: Any) -> None:  # noqa: D102
         # pre-step callbacks
         for cb in self.pre_step_callbacks:
@@ -435,7 +427,6 @@ class OptimizerTrainingCallback(TrainingCallback):
 class LearningRateSchedulerTrainingCallback(TrainingCallback):
     """Update learning rate scheduler."""
 
-    # docstr-coverage: inherited
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         if self.training_loop.lr_scheduler is None:
             raise ValueError(f"{self} can only be called when a learning rate schedule is used.")
@@ -538,12 +529,10 @@ class EvaluationLossTrainingCallback(TrainingCallback):
         self.maximum_batch_size = maximum_batch_size
         self.callback = MultiTrainingCallback(callbacks=callbacks, callbacks_kwargs=callbacks_kwargs)
 
-    # docstr-coverage: inherited
     def register_training_loop(self, training_loop: training.TrainingLoop) -> None:  # noqa: D102
         super().register_training_loop(training_loop)
         self.callback.register_training_loop(training_loop=training_loop)
 
-    # docstr-coverage: inherited
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         from .lcwa import LCWATrainingLoop
 
@@ -604,7 +593,6 @@ class MultiTrainingCallback(TrainingCallback):
         super().__init__()
         self.callbacks = callback_resolver.make_many(callbacks, callbacks_kwargs) if callbacks else []
 
-    # docstr-coverage: inherited
     def register_training_loop(self, training_loop: training.TrainingLoop) -> None:  # noqa: D102
         super().register_training_loop(training_loop=training_loop)
         for callback in self.callbacks:
@@ -616,32 +604,26 @@ class MultiTrainingCallback(TrainingCallback):
         if self._training_loop is not None:
             callback.register_training_loop(self._training_loop)
 
-    # docstr-coverage: inherited
     def pre_batch(self, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
             callback.pre_batch(**kwargs)
 
-    # docstr-coverage: inherited
     def on_batch(self, epoch: int, batch, batch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
             callback.on_batch(epoch=epoch, batch=batch, batch_loss=batch_loss, **kwargs)
 
-    # docstr-coverage: inherited
     def post_batch(self, epoch: int, batch, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
             callback.post_batch(epoch=epoch, batch=batch, **kwargs)
 
-    # docstr-coverage: inherited
     def pre_step(self, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
             callback.pre_step(**kwargs)
 
-    # docstr-coverage: inherited
     def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
             callback.post_epoch(epoch=epoch, epoch_loss=epoch_loss, **kwargs)
 
-    # docstr-coverage: inherited
     def post_train(self, losses: list[float], **kwargs: Any) -> None:  # noqa: D102
         for callback in self.callbacks:
             callback.post_train(losses=losses, **kwargs)

--- a/src/pykeen/training/callbacks.py
+++ b/src/pykeen/training/callbacks.py
@@ -694,8 +694,7 @@ class CheckpointTrainingCallback(TrainingCallback):
         self.name_template = name_template
         self.root.mkdir(parents=True, exist_ok=True)
 
-    # docstr-coverage: inherited
-    def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:
+    def post_epoch(self, epoch: int, epoch_loss: float, **kwargs: Any) -> None:  # noqa: D102
         # use 1-based epochs
         epoch += 1
         if not self.schedule(epoch):

--- a/src/pykeen/training/lcwa.py
+++ b/src/pykeen/training/lcwa.py
@@ -74,7 +74,6 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch]):
         # of total entities from another inductive inference factory
         self.num_targets = self.model.num_relations if self.target == 1 else self.model._get_entity_len(mode=self.mode)
 
-    # docstr-coverage: inherited
     def _create_training_data_loader(
         self, triples_factory: CoreTriplesFactory, sampler: str | None, **kwargs
     ) -> DataLoader[LCWABatch]:  # noqa: D102
@@ -93,7 +92,6 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch]):
         return DataLoader(dataset=dataset, **kwargs)
 
     @staticmethod
-    # docstr-coverage: inherited
     def _get_batch_size(batch: LCWABatch) -> int:  # noqa: D102
         return batch["pairs"].shape[0]
 
@@ -134,7 +132,6 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch]):
             + model.collect_regularization_term()
         )
 
-    # docstr-coverage: inherited
     def _process_batch(
         self,
         batch: LCWABatch,
@@ -156,7 +153,6 @@ class LCWATrainingLoop(TrainingLoop[LCWABatch]):
             slice_size=slice_size,
         )
 
-    # docstr-coverage: inherited
     def _slice_size_search(
         self,
         *,
@@ -250,14 +246,12 @@ class SymmetricLCWATrainingLoop(TrainingLoop[tuple[MappedTriples]]):
         head+relation pairs. Thus, the name might be suboptimal and change in the future.
     """
 
-    # docstr-coverage: inherited
     def _create_training_data_loader(
         self, triples_factory: CoreTriplesFactory, sampler: str | None, **kwargs
     ) -> DataLoader[tuple[MappedTriples]]:  # noqa: D102
         assert sampler is None
         return DataLoader(dataset=TensorDataset(triples_factory.mapped_triples), **kwargs)
 
-    # docstr-coverage: inherited
     def _process_batch(
         self,
         batch: tuple[MappedTriples],
@@ -294,7 +288,6 @@ class SymmetricLCWATrainingLoop(TrainingLoop[tuple[MappedTriples]]):
         )
 
     @staticmethod
-    # docstr-coverage: inherited
     def _get_batch_size(batch: tuple[MappedTriples]) -> int:  # noqa: D102
         assert len(batch) == 1
         return batch[0].shape[0]

--- a/src/pykeen/training/slcwa.py
+++ b/src/pykeen/training/slcwa.py
@@ -85,7 +85,6 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch | GroupedSLCWABatch]):
                     f"{sampler_cls.__name__} does not."
                 )
 
-    # docstr-coverage: inherited
     def _create_training_data_loader(
         self,
         triples_factory: CoreTriplesFactory,
@@ -122,7 +121,6 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch | GroupedSLCWABatch]):
         )
 
     @staticmethod
-    # docstr-coverage: inherited
     def _get_batch_size(batch: SLCWABatch | GroupedSLCWABatch) -> int:  # noqa: D102
         return batch["positives"].shape[0]
 
@@ -274,7 +272,6 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch | GroupedSLCWABatch]):
             + model.collect_regularization_term()
         )
 
-    # docstr-coverage: inherited
     def _process_batch(
         self,
         batch: SLCWABatch | GroupedSLCWABatch,
@@ -294,7 +291,6 @@ class SLCWATrainingLoop(TrainingLoop[SLCWABatch | GroupedSLCWABatch]):
             slice_size=slice_size,
         )
 
-    # docstr-coverage: inherited
     def _slice_size_search(
         self,
         *,

--- a/src/pykeen/triples/instances.py
+++ b/src/pykeen/triples/instances.py
@@ -250,7 +250,6 @@ class BaseBatchedSLCWAInstances(
 class BatchedSLCWAInstances(BaseBatchedSLCWAInstances):
     """Random pre-batched training instances for the sLCWA training loop."""
 
-    # docstr-coverage: inherited
     def iter_triple_ids(self) -> Iterable[list[int]]:  # noqa: D102
         yield from data.BatchSampler(
             sampler=data.RandomSampler(data_source=split_workload(len(self.mapped_triples))),
@@ -325,7 +324,6 @@ class SubGraphSLCWAInstances(BaseBatchedSLCWAInstances):
             node_weights[other_vertex] -= 1
         return result
 
-    # docstr-coverage: inherited
     def iter_triple_ids(self) -> Iterable[list[int]]:  # noqa: D102
         yield from (self.subgraph_sample() for _ in split_workload(len(self)))
 

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -318,8 +318,7 @@ class RandomizedCleaner(Cleaner):
     3. Continue until ``move_id_mask`` has no true bits
     """
 
-    # docstr-coverage: inherited
-    def cleanup_pair(
+    def cleanup_pair(  # noqa: D102
         self,
         reference: MappedTriples,
         other: MappedTriples,
@@ -350,8 +349,7 @@ class RandomizedCleaner(Cleaner):
 class DeterministicCleaner(Cleaner):
     """Cleanup a triples array (testing) with respect to another (training)."""
 
-    # docstr-coverage: inherited
-    def cleanup_pair(
+    def cleanup_pair(  # noqa: D102
         self,
         reference: MappedTriples,
         other: MappedTriples,
@@ -454,8 +452,7 @@ class CleanupSplitter(Splitter):
         """
         self.cleaner = cleaner_resolver.make(cleaner)
 
-    # docstr-coverage: inherited
-    def split_absolute_size(
+    def split_absolute_size(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         sizes: Sequence[int],
@@ -472,8 +469,7 @@ class CleanupSplitter(Splitter):
 class CoverageSplitter(Splitter):
     """This splitter greedily selects training triples such that each entity is covered and then splits the rest."""
 
-    # docstr-coverage: inherited
-    def split_absolute_size(
+    def split_absolute_size(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         sizes: Sequence[int],

--- a/src/pykeen/triples/splitting.py
+++ b/src/pykeen/triples/splitting.py
@@ -323,7 +323,7 @@ class RandomizedCleaner(Cleaner):
         reference: MappedTriples,
         other: MappedTriples,
         random_state: TorchRandomHint,
-    ) -> tuple[MappedTriples, MappedTriples]:  # noqa: D102
+    ) -> tuple[MappedTriples, MappedTriples]:
         generator = ensure_torch_random_state(random_state)
         move_id_mask = _prepare_cleanup(reference, other)
 
@@ -354,7 +354,7 @@ class DeterministicCleaner(Cleaner):
         reference: MappedTriples,
         other: MappedTriples,
         random_state: TorchRandomHint,
-    ) -> tuple[MappedTriples, MappedTriples]:  # noqa: D102
+    ) -> tuple[MappedTriples, MappedTriples]:
         move_id_mask = _prepare_cleanup(reference, other)
         reference = torch.cat([reference, other[move_id_mask]])
         other = other[~move_id_mask]
@@ -457,7 +457,7 @@ class CleanupSplitter(Splitter):
         mapped_triples: MappedTriples,
         sizes: Sequence[int],
         generator: torch.Generator,
-    ) -> Sequence[MappedTriples]:  # noqa: D102
+    ) -> Sequence[MappedTriples]:
         triples_groups = _split_triples(mapped_triples, sizes=sizes, generator=generator)
         # Make sure that the first element has all the right stuff in it
         logger.debug("cleaning up groups")
@@ -474,7 +474,7 @@ class CoverageSplitter(Splitter):
         mapped_triples: MappedTriples,
         sizes: Sequence[int],
         generator: torch.Generator,
-    ) -> Sequence[MappedTriples]:  # noqa: D102
+    ) -> Sequence[MappedTriples]:
         seed_mask = _get_cover_deterministic(triples=mapped_triples)
         train_seed = mapped_triples[seed_mask]
         remaining_triples = mapped_triples[~seed_mask]

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1367,8 +1367,7 @@ class TriplesFactory(CoreTriplesFactory):
             data[name] = dict(zip(df["label"], df["id"], strict=False))
         return data
 
-    # docstr-coverage: inherited
-    def clone_and_exchange_triples(
+    def clone_and_exchange_triples(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         extra_metadata: dict[str, Any] | None = None,
@@ -1536,8 +1535,7 @@ class TriplesFactory(CoreTriplesFactory):
 
         return SVG(data=svg_str)
 
-    # docstr-coverage: inherited
-    def tensor_to_df(
+    def tensor_to_df(  # noqa: D102
         self,
         tensor: LongTensor,
         **kwargs: torch.Tensor | np.ndarray | Sequence,
@@ -1561,8 +1559,7 @@ class TriplesFactory(CoreTriplesFactory):
         columns = list(TRIPLES_DF_COLUMNS) + old_col[3:]
         return data.loc[:, columns]
 
-    # docstr-coverage: inherited
-    def new_with_restriction(
+    def new_with_restriction(  # noqa: D102
         self,
         entities: None | Collection[int] | Collection[str] = None,
         relations: None | Collection[int] | Collection[str] = None,

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1369,7 +1369,7 @@ class TriplesFactory(CoreTriplesFactory):
         extra_metadata: dict[str, Any] | None = None,
         keep_metadata: bool = True,
         create_inverse_triples: bool | None = None,
-    ) -> Self:  # noqa: D102
+    ) -> Self:
         if create_inverse_triples is None:
             create_inverse_triples = self.create_inverse_triples
         return TriplesFactory(  # type: ignore[return-value]
@@ -1533,7 +1533,7 @@ class TriplesFactory(CoreTriplesFactory):
         self,
         tensor: LongTensor,
         **kwargs: torch.Tensor | np.ndarray | Sequence,
-    ) -> pd.DataFrame:  # noqa: D102
+    ) -> pd.DataFrame:
         data = super().tensor_to_df(tensor=tensor, **kwargs)
         old_col = list(data.columns)
 
@@ -1559,7 +1559,7 @@ class TriplesFactory(CoreTriplesFactory):
         relations: None | Collection[int] | Collection[str] = None,
         invert_entity_selection: bool = False,
         invert_relation_selection: bool = False,
-    ) -> Self:  # noqa: D102
+    ) -> Self:
         if entities is None and relations is None:
             return self
         if entities is not None:

--- a/src/pykeen/triples/triples_factory.py
+++ b/src/pykeen/triples/triples_factory.py
@@ -1019,7 +1019,6 @@ class CoreTriplesFactory(KGInfo):
         )
 
     @classmethod
-    # docstr-coverage: inherited
     def from_path_binary(
         cls,
         path: str | pathlib.Path | TextIO,
@@ -1292,7 +1291,6 @@ class TriplesFactory(CoreTriplesFactory):
             and (self.relation_to_id == __o.relation_to_id)
         )
 
-    # docstr-coverage: inherited
     def apply_condenser(self, condenser: TripleCondenser) -> Self:  # noqa: D102
         if not condenser:
             return self
@@ -1307,7 +1305,6 @@ class TriplesFactory(CoreTriplesFactory):
             metadata=self.metadata,
         )
 
-    # docstr-coverage: inherited
     def merge(self, *others: Self) -> Self:  # noqa: D102
         for i, other in enumerate(others):
             if other.entity_to_id != self.entity_to_id:
@@ -1332,7 +1329,6 @@ class TriplesFactory(CoreTriplesFactory):
             metadata=self.metadata,
         )
 
-    # docstr-coverage: inherited
     def to_path_binary(self, path: str | pathlib.Path | TextIO) -> pathlib.Path:  # noqa: D102
         path = super().to_path_binary(path=path)
         # store entity/relation to ID
@@ -1458,11 +1454,9 @@ class TriplesFactory(CoreTriplesFactory):
             axis=1,
         )
 
-    # docstr-coverage: inherited
     def entities_to_ids(self, entities: Iterable[int] | Iterable[str]) -> Sequence[int]:  # noqa: D102
         return _ensure_ids(labels_or_ids=entities, label_to_id=self.entity_labeling.label_to_id)
 
-    # docstr-coverage: inherited
     def relations_to_ids(self, relations: Iterable[int] | Iterable[str]) -> Sequence[int]:  # noqa: D102
         return _ensure_ids(labels_or_ids=relations, label_to_id=self.relation_labeling.label_to_id)
 

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -111,7 +111,6 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         """Return the shape of the literals."""
         return self.numeric_literals.shape[1:]
 
-    # docstr-coverage: inherited
     def iter_extra_repr(self) -> Iterable[str]:  # noqa: D102
         yield from super().iter_extra_repr()
         yield f"num_literals={len(self.literals_to_id)}"
@@ -138,7 +137,6 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
             literals_to_id=self.literals_to_id,
         )
 
-    # docstr-coverage: inherited
     def to_path_binary(self, path: str | pathlib.Path | TextIO) -> pathlib.Path:  # noqa: D102
         path = super().to_path_binary(path=path)
         # save literal-to-id mapping

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -72,7 +72,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         *,
         path_to_numeric_triples: None | str | pathlib.Path | TextIO = None,
         **kwargs,
-    ) -> "TriplesNumericLiteralsFactory":  # noqa: D102
+    ) -> "TriplesNumericLiteralsFactory":
         if path_to_numeric_triples is None:
             raise ValueError(f"{cls.__name__} requires path_to_numeric_triples.")
         numeric_triples = load_triples(path_to_numeric_triples)
@@ -86,7 +86,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         *,
         numeric_triples: LabeledTriples | None = None,
         **kwargs,
-    ) -> "TriplesNumericLiteralsFactory":  # noqa: D102
+    ) -> "TriplesNumericLiteralsFactory":
         if numeric_triples is None:
             raise ValueError(f"{cls.__name__} requires numeric_triples.")
         base = TriplesFactory.from_labeled_triples(triples=triples, **kwargs)
@@ -121,7 +121,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         extra_metadata: dict[str, Any] | None = None,
         keep_metadata: bool = True,
         create_inverse_triples: bool | None = None,
-    ) -> "TriplesNumericLiteralsFactory":  # noqa: D102
+    ) -> "TriplesNumericLiteralsFactory":
         if create_inverse_triples is None:
             create_inverse_triples = self.create_inverse_triples
         return TriplesNumericLiteralsFactory(

--- a/src/pykeen/triples/triples_numeric_literals_factory.py
+++ b/src/pykeen/triples/triples_numeric_literals_factory.py
@@ -65,9 +65,8 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         self.numeric_literals = numeric_literals
         self.literals_to_id = literals_to_id
 
-    # docstr-coverage: inherited
     @classmethod
-    def from_path(
+    def from_path(  # noqa: D102
         cls,
         path: str | pathlib.Path | TextIO,
         *,
@@ -80,9 +79,8 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         triples = load_triples(path)
         return cls.from_labeled_triples(triples=triples, numeric_triples=numeric_triples, **kwargs)
 
-    # docstr-coverage: inherited
     @classmethod
-    def from_labeled_triples(
+    def from_labeled_triples(  # noqa: D102
         cls,
         triples: LabeledTriples,
         *,
@@ -118,8 +116,7 @@ class TriplesNumericLiteralsFactory(TriplesFactory):
         yield from super().iter_extra_repr()
         yield f"num_literals={len(self.literals_to_id)}"
 
-    # docstr-coverage: inherited
-    def clone_and_exchange_triples(
+    def clone_and_exchange_triples(  # noqa: D102
         self,
         mapped_triples: MappedTriples,
         extra_metadata: dict[str, Any] | None = None,

--- a/src/pykeen/triples/weights.py
+++ b/src/pykeen/triples/weights.py
@@ -80,8 +80,7 @@ class RelationLossWeighter(LossWeighter):
         super().__init__()
         self.weights = weights
 
-    # docstr-coverage: inherited
-    def __call__(self, h: LongTensor | None, r: LongTensor | None, t: LongTensor | None) -> FloatTensor:
+    def __call__(self, h: LongTensor | None, r: LongTensor | None, t: LongTensor | None) -> FloatTensor:  # noqa: D102
         if r is None:
             return self.weights
         return self.weights[r]

--- a/src/pykeen/utils.py
+++ b/src/pykeen/utils.py
@@ -1594,7 +1594,6 @@ def add_cudnn_error_hint(func: Callable[P, X]) -> Callable[P, X]:
         a decorated function
     """
 
-    # docstr-coverage: excused `wrapped`
     @functools.wraps(func)
     def wrapped(*args: P.args, **kwargs: P.kwargs) -> X:
         try:
@@ -1667,12 +1666,10 @@ def circular_correlation(a: FloatTensor, b: FloatTensor) -> FloatTensor:
     return torch.fft.irfft(p_fft, n=a.shape[-1], dim=-1)
 
 
-# docstr-coverage:excused `overload`
 @overload
 def merge_kwargs(kwargs: Sequence[OptionalKwargs], **extra_kwargs: Any | None) -> Sequence[OptionalKwargs]: ...
 
 
-# docstr-coverage:excused `overload`
 @overload
 def merge_kwargs(kwargs: OptionalKwargs, **extra_kwargs: Any | None) -> OptionalKwargs: ...
 

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -265,7 +265,6 @@ def iter_hpo_configs(hpo_default: Mapping[str, Mapping[str, Any]]) -> Iterable[M
 class LossWeightTestCase(GenericTestCase[LossWeighter]):
     """Base unittest for loss weighters."""
 
-    # docstr-coverage: inherited
     def pre_setup_hook(self) -> None:
         super().pre_setup_hook()
         self.batch_size = 3
@@ -2370,7 +2369,6 @@ class RankBasedMetricTestCase(unittest_templates.GenericTestCase[RankBasedMetric
 class ZRankBasedMetricTestCase(RankBasedMetricTestCase):
     """Test cases for z-normalized metrics."""
 
-    # docstr-coverage: inherited
     def test_weights_coherence(self):  # noqa: D102
         raise unittest.SkipTest("Z-normalized metrics do not work well with the sampling weight interpretation.")
 

--- a/tests/test_datasets/test_combination.py
+++ b/tests/test_datasets/test_combination.py
@@ -15,7 +15,6 @@ class DisjointGraphPairCombinatorTestCase(cases.GraphPairCombinatorTestCase):
 
     cls = pykeen.datasets.ea.combination.DisjointGraphPairCombinator
 
-    # docstr-coverage: inherited
     def _verify_manual(self, combined_tf: CoreTriplesFactory):  # noqa: D102
         # assumes deterministic entity to id mapping
         expected_triples = {
@@ -41,7 +40,6 @@ class ExtraRelationGraphPairCombinatorTestCase(cases.GraphPairCombinatorTestCase
     cls = pykeen.datasets.ea.combination.ExtraRelationGraphPairCombinator
     same_as_rel_name = cls.ALIGNMENT_RELATION_NAME
 
-    # docstr-coverage: inherited
     def _verify_manual(self, combined_tf: CoreTriplesFactory):  # noqa: D102
         same_as_id = combined_tf.relation_to_id[self.__class__.same_as_rel_name]
         assert isinstance(same_as_id, int)
@@ -73,7 +71,6 @@ class CollapseGraphPairCombinatorTestCase(cases.GraphPairCombinatorTestCase):
 
     cls = pykeen.datasets.ea.combination.CollapseGraphPairCombinator
 
-    # docstr-coverage: inherited
     def _verify_manual(self, combined_tf: CoreTriplesFactory):  # noqa: D102
         # assumes deterministic entity to id mapping
         expected_triples = {
@@ -96,7 +93,6 @@ class SwapGraphPairCombinatorTestCase(cases.GraphPairCombinatorTestCase):
 
     cls = pykeen.datasets.ea.combination.SwapGraphPairCombinator
 
-    # docstr-coverage: inherited
     def _verify_manual(self, combined_tf: CoreTriplesFactory):  # noqa: D102
         # assumes deterministic entity to id mapping
         expected_triples = {

--- a/tests/test_evaluation/test_evaluators.py
+++ b/tests/test_evaluation/test_evaluators.py
@@ -377,7 +377,6 @@ class EvaluatorUtilsTests(unittest.TestCase):
 class DummyMetricResults(MetricResults[Target]):
     """Dummy metric results."""
 
-    # docstr-coverage: inherited
     @classmethod
     def key_from_string(cls, s: str | None) -> Target:  # noqa: D102
         return normalize_target(s)
@@ -391,7 +390,6 @@ class DummyEvaluator(Evaluator[Target]):
         super().__init__(*args, **kwargs)
         self.counter: Counter[Target] = Counter()
 
-    # docstr-coverage: inherited
     def process_scores_(
         self,
         hrt_batch: MappedTriples,
@@ -402,11 +400,9 @@ class DummyEvaluator(Evaluator[Target]):
     ) -> None:  # noqa: D102
         self.counter.update((target,))
 
-    # docstr-coverage: inherited
     def clear(self) -> None:  # noqa: D102
         self.counter.clear()
 
-    # docstr-coverage: inherited
     def finalize(self) -> MetricResults[Target]:  # noqa: D102
         return DummyMetricResults(data={target: float(count) for target, count in self.counter.items()})
 

--- a/tests/test_evaluation/test_rank_based_metrics.py
+++ b/tests/test_evaluation/test_rank_based_metrics.py
@@ -139,7 +139,6 @@ class MedianAbsoluteDeviationTests(cases.RankBasedMetricTestCase):
 
     cls = pykeen.metrics.ranking.MedianAbsoluteDeviation
 
-    # docstr-coverage: inherited
     def test_weights_coherence(self):  # noqa: D102
         raise unittest.SkipTest("Does not work well with the sampling weight interpretation.")
 

--- a/tests/test_nn/test_representation.py
+++ b/tests/test_nn/test_representation.py
@@ -299,7 +299,6 @@ class WikidataVisualRepresentationTestCase(cases.RepresentationTestCase):
         ],
     }
 
-    # docstr-coverage: inherited
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs)
         kwargs.pop("max_id")
@@ -336,7 +335,6 @@ class WikidataTextRepresentationTests(cases.RepresentationTestCase):
         "encoder": "character-embedding",
     }
 
-    # docstr-coverage: inherited
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs)
         # the representation module infers the max_id from the provided labels
@@ -361,7 +359,6 @@ class BiomedicalCURIERepresentationTests(cases.RepresentationTestCase):
         "encoder": "character-embedding",
     }
 
-    # docstr-coverage: inherited
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs)
         # the representation module infers the max_id from the provided labels
@@ -510,7 +507,6 @@ class TransformedRepresentationTest(cases.RepresentationTestCase):
         "base_kwargs": {"shape": (5,)},
     }
 
-    # docstr-coverage: inherited
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs)
         kwargs["transformation"] = torch.nn.Linear(5, 7)
@@ -529,7 +525,6 @@ class EmbeddingBagRepresentation(cases.RepresentationTestCase):
     cls = pykeen.nn.representation.EmbeddingBagRepresentation
     kwargs = {"shape": (5,)}
 
-    # docstr-coverage: inherited
     def _pre_instantiation_hook(self, kwargs: MutableMapping[str, Any]) -> MutableMapping[str, Any]:  # noqa: D102
         kwargs = super()._pre_instantiation_hook(kwargs)
         max_id = kwargs["max_id"]

--- a/tests/test_regression/test_losses.py
+++ b/tests/test_regression/test_losses.py
@@ -42,7 +42,6 @@ class LCWALossCalculator(LossCalculator):
 
     weighted: bool = False
 
-    # docstr-coverage: inherited
     def __call__(self, instance: Loss, generator: torch.Generator) -> torch.Tensor:
         predictions = torch.rand(self.batch_size, self.num_entities, generator=generator)
         labels = (
@@ -71,7 +70,6 @@ class SLCWALossCalculator(LossCalculator):
 
     weighted: bool = False
 
-    # docstr-coverage: inherited
     def __call__(self, instance: Loss, generator: torch.Generator) -> torch.Tensor:
         positive_scores = torch.rand(self.batch_size, 1, generator=generator)
         negative_scores = torch.rand(self.batch_size, self.num_negatives, generator=generator)

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -22,7 +22,6 @@ class NoRegularizerTest(cases.RegularizerTestCase):
     def _expected_penalty(self, x: torch.FloatTensor) -> torch.FloatTensor:  # noqa: D102
         return torch.zeros(1, device=x.device, dtype=x.dtype)
 
-    # docstr-coverage: inherited
     def test_apply_only_once(self):  # noqa: D102
         raise unittest.SkipTest
 
@@ -115,7 +114,6 @@ class OrthogonalityRegularizerTest(cases.RegularizerTestCase):
         "apply_only_once": False,
     }
 
-    # docstr-coverage: inherited
     def _generate_update_input(self, requires_grad: bool = False) -> Sequence[torch.FloatTensor]:  # noqa: D102
         # same size tensors
         return (
@@ -123,16 +121,13 @@ class OrthogonalityRegularizerTest(cases.RegularizerTestCase):
             rand(self.batch_size, 12, generator=self.generator, device=self.device).requires_grad_(requires_grad),
         )
 
-    # docstr-coverage: inherited
     def _expected_updated_term(self, inputs: Sequence[torch.FloatTensor]) -> torch.FloatTensor:  # noqa: D102
         assert len(inputs) == 2
         return functional.cosine_similarity(*inputs).pow(2).subtract(self.instance_kwargs["epsilon"]).relu().sum()
 
-    # docstr-coverage: inherited
     def test_forward(self) -> None:  # noqa: D102
         raise unittest.SkipTest(f"{self.cls.__name__} cannot be applied to a single tensor.")
 
-    # docstr-coverage: inherited
     def test_model(self) -> None:  # noqa: D102
         raise unittest.SkipTest(f"{self.cls.__name__} is not supported by all models.")
 

--- a/tox.ini
+++ b/tox.ini
@@ -121,14 +121,6 @@ commands =
     # darglint2 --strictness short --docstring-style sphinx -v 2 src/ tests/ notebooks/ docs/source/examples
 description = Check code quality using ruff and other tools. See https://github.com/akaihola/darglint2
 
-[testenv:docstr-coverage]
-skip_install = true
-deps =
-    docstr-coverage
-commands =
-    docstr-coverage --skip-private --skip-magic src/pykeen
-description = Run the docstr-coverage tool to check documentation coverage
-
 [testenv:mypy]
 deps =
     mypy


### PR DESCRIPTION
## Summary

`docstr-coverage` (used to enforce docstring presence in CI) hasn't been updated in 2 years. Ruff's pydocstyle `D` rules were already selected in this repo's config and cover the same ground — only `D102` (missing docstring in public method) was carved out as ignored.

## Changes

- Enable `D102` by dropping its ignore in `pyproject.toml`. Ignore `D102` for `tests/**/*.py` instead — test methods document intent via their name, not a docstring.
- Replace the `# docstr-coverage: inherited` pragma with `# noqa: D102` at each call site ruff now flags — ruff has no equivalent exemption for methods that intentionally inherit their docstring from a parent class without repeating it. For a multi-line signature, the `noqa` goes on the `def` line itself: ruff attributes the diagnostic there, not the closing bracket line.
- `__call__` overrides are flagged by ruff as `D102` (public method) rather than `D105` (magic method, already ignored); noqa'd with a comment noting why. This is a known upstream ruff limitation: [astral-sh/ruff#8085](https://github.com/astral-sh/ruff/issues/8085) — `__call__` and `__new__` aren't treated as magic methods for docstring purposes, open since 2023 with no fix yet.
- Drop all remaining `# docstr-coverage: ...` pragma comments (`inherited`, `excused overload`, `excused wrapped`) repo-wide — the tool is gone, so these no longer suppress anything.
- Remove 97 pre-existing `# noqa: D102` comments that sat on the closing-bracket line of a multi-line signature. Those predate this PR, from a time `D102` was globally ignored, so they were never exercised against a live rule and turned out to be non-functional duplicates of the ones this PR adds on the `def` line.
- Remove the `docstr-coverage` tox environment and its CI step.

## Test plan

- [x] `ruff check` passes clean on the full repo
- [x] `ruff format --check` passes clean on the full repo