### PR TITLE
🔧🚄 Replace mypy with ty for static type checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Check static typing with MyPy
-        run: tox -e mypy
+      - name: Check static typing with ty
+        run: tox -e ty
 
   lint-single-version:
     name: Lint Single Version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,10 +144,6 @@ pykeen = "pykeen.cli:main"
 [tool.cruft]
 skip = ["**/__init__.py", "tests/*"]
 
-# MyPy, see https://mypy.readthedocs.io/en/stable/config_file.html
-[tool.mypy]
-plugins = []
-
 # Doc8, see https://doc8.readthedocs.io/en/stable/readme.html#ini-file-usage
 [tool.doc8]
 max-line-length = 120

--- a/src/pykeen/evaluation/classification_evaluator.py
+++ b/src/pykeen/evaluation/classification_evaluator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import itertools
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, MutableMapping
-from typing import NamedTuple, cast
+from typing import NamedTuple
 
 import numpy
 import numpy as np
@@ -137,7 +137,6 @@ class ClassificationEvaluator(Evaluator[ClassificationMetricKey]):
         for i in range(keys.shape[0]):
             key = tuple(map(int, keys[i]))
             assert len(key) == 2
-            key = cast(tuple[int, int], key)
             self.all_scores[target][key] = scores_np[i]
             self.all_positives[target][key] = dense_positive_mask_np[i]
 

--- a/src/pykeen/pipeline/api.py
+++ b/src/pykeen/pipeline/api.py
@@ -126,7 +126,6 @@ from dataclasses import dataclass, field
 from typing import (
     Any,
     ClassVar,
-    cast,
 )
 
 import pandas as pd
@@ -1146,7 +1145,7 @@ def _handle_model(
         )
 
     if isinstance(model, Model):
-        model_instance = cast(Model, model)
+        model_instance = model
         # TODO should training be reset?
         # TODO should kwargs for loss and regularizer be checked and raised for?
     else:

--- a/src/pykeen/typing.py
+++ b/src/pykeen/typing.py
@@ -160,7 +160,7 @@ def normalize_rank_type(rank: str | None) -> RankType:
     rank = RANK_TYPE_SYNONYMS.get(rank, rank)
     if rank not in RANK_TYPES:
         raise ValueError(f"Invalid target={rank}. Possible values: {RANK_TYPES}")
-    return cast(RankType, rank)
+    return rank
 
 
 TargetBoth = Literal["both"]

--- a/tox.ini
+++ b/tox.ini
@@ -129,9 +129,9 @@ commands =
     docstr-coverage --skip-private --skip-magic src/pykeen
 description = Run the docstr-coverage tool to check documentation coverage
 
-[testenv:mypy]
+[testenv:ty]
 deps =
-    mypy
+    ty
     types-requests
     types-setuptools
     types-tabulate
@@ -152,8 +152,8 @@ extras =
     wordcloud
     tests
 skip_install = true
-commands = mypy --install-types --non-interactive --ignore-missing-imports src/ docs/source/examples
-description = Run the mypy tool to check static typing on the project.
+commands = ty check --ignore unresolved-import src/ docs/source/examples
+description = Run the ty tool to check static typing on the project.
 
 [testenv:pyroma]
 deps =


### PR DESCRIPTION
## Summary

- Swaps the `mypy` tox env/CI step for `ty` (Astral's type checker), keeping the same minimal dependency set and `skip_install` setup.
- `ty` type-checks first-party code even when third-party imports are unresolved (they resolve to `Unknown` rather than being ignored), so it catches real issues that mypy's `--ignore-missing-imports` setup was missing entirely.
- Applies `ty check --fix`'s auto-fixes for now-redundant casts, and cleans up the resulting no-op assignments and unused `cast` imports.

The gate is not relaxed (no `--exit-zero`): the tox env currently fails with the diagnostics `ty` still finds beyond the auto-fixed ones. Those are being triaged and fixed as follow-up commits on this branch.

## Test plan

- [x] `tox -e ty` — currently fails, tracks remaining diagnostics to fix
- [x] Full test suite passes for the files touched by the auto-fixes (`tests/test_evaluation/test_evaluators.py -k Classification`, `tests/test_pipeline.py`)